### PR TITLE
Add JsEnergyManager status output

### DIFF
--- a/interfaces/energy_manager.json
+++ b/interfaces/energy_manager.json
@@ -4,6 +4,10 @@
         "logging":{
             "description": "Various data logging",
             "type": "object"
+        },
+        "emgr_running": {
+            "description": "(read) Status of the module EnergyManager: true -> running; false -> deactivated",
+            "type": "boolean"
         }
     }
 }


### PR DESCRIPTION
Obtaining running status information on the Energy Manager has been impossible before. This change adds a status flag to the JsEnergyManager module which gets published both to the 'external' mqtt topic (for legacy reasons; will be removed in future) and the module-specific 'energy_manager:JsEnergyManager' topic. 

changes:
- add wrapper functions for enabling/disabling JsEnergyManager 'running' var to publish the var's state via mqtt
- add 'emgr_running' var to manifest