### PR TITLE
Add JsEnergyManager status output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,60 @@ zypper install -y --type pattern devel_basis
 zypper install -y git rsync wget cmake doxygen graphviz clang-tools cppcheck boost-devel libboost_filesystem-devel libboost_log-devel libboost_program_options-devel libboost_system-devel libboost_thread-devel maven java-11-openjdk java-11-openjdk-devel nodejs nodejs-devel npm python3-pip gcc-c++ libopenssl-devel sqlite3-devel
 ```
 
-## Development tools:
- [Everest Dependency Manager](https://github.com/EVerest/everest-dev-environment/blob/main/dependency_manager/README.md)
-
 ### Build & Install:
 
-[everest-cpp - Init Script](https://github.com/EVerest/everest-utils/tree/main/everest-cpp)
+It is required that you have uploaded your public [ssh key](https://www.atlassian.com/git/tutorials/git-ssh) to [github](https://github.com/settings/keys).
+
+To install the [Everest Dependency Manager](https://github.com/EVerest/everest-dev-environment/blob/main/dependency_manager/README.md), follow these steps:
+
+Install required python packages:
+```bash
+python3 -m pip install --upgrade pip setuptools wheel
+```
+Get EDM source files and change into the directory:
+```bash
+git clone git@github.com:EVerest/everest-dev-environment.git
+cd everest-dev-environment/dependency_manager
+```
+Install EDM:
+```bash
+python3 -m pip install .
+```
+Setup Everest workspace: 
+```bash
+edm --register-cmake-module --config ../everest-complete.yaml --workspace ~/checkout/everest-workspace
+```
+Set environmental variable for [CPM](https://github.com/cpm-cmake/CPM.cmake/blob/master/README.md#CPM_SOURCE_CACHE) cache:
+```bash
+export CPM_SOURCE_CACHE=$HOME/.cache/CPM
+```
+Install [ev-cli](https://github.com/EVerest/everest-utils/tree/main/ev-dev-tools):
+
+Change into the directory and install ev-cli:
+```bash
+cd ~/checkout/everest-workspace/everest-utils/ev-dev-tools
+python3 -m pip install .
+```
+
+Now we can build everest!
+
+Create build directory and change directory:
+```bash
+mkdir -p ~/checkout/everest-workspace/everest-core/build
+cd ~/checkout/everest-workspace/everest-core/build
+```
+Build everest:
+```bash
+cmake ..
+make install
+```
+Done!
+
+<!--- WIP: [everest-cpp - Init Script](https://github.com/EVerest/everest-utils/tree/main/everest-cpp) -->
 
 ### Simulation
+
+In order to test your build of Everest you can simulate the code on your local machine!
 
 Docker container for local MQTT broker, node-red etc.
 ```bash
@@ -41,9 +87,8 @@ cd ~/checkout/everest-workspace/everest-core/build
 .././run_sil.sh
 ```
 
-#### HIL
+#### HIL (WIP!)
 ```bash
 cd ~/checkout/everest-workspace/everest-core/build
 .././run_hil.sh
-#WIP
 ```

--- a/interfaces/energy_manager.json
+++ b/interfaces/energy_manager.json
@@ -4,6 +4,10 @@
         "logging":{
             "description": "Various data logging",
             "type": "object"
+        },
+        "emgr_running": {
+            "description": "(read) Status of the module EnergyManager: true -> running; false -> deactivated",
+            "type": "boolean"
         }
     }
 }

--- a/interfaces/energy_manager.json
+++ b/interfaces/energy_manager.json
@@ -5,8 +5,8 @@
             "description": "Various data logging",
             "type": "object"
         },
-        "emgr_running": {
-            "description": "(read) Status of the module EnergyManager: true -> running; false -> deactivated",
+        "emgr_is_active": {
+            "description": "(read) Status of the module EnergyManager: true -> active; false -> deactivated",
             "type": "boolean"
         }
     }

--- a/modules/JsEnergyManager/index.js
+++ b/modules/JsEnergyManager/index.js
@@ -134,7 +134,7 @@ function on_set_s(mod, val) {
 }
 
 function on_start(mod, val) {
-    if (true == running) {
+    if (true === running) {
         evlog.info("PID-Controller is already running..");
         return;
     }

--- a/modules/YetiDriver/board_support/board_support_ACImpl.cpp
+++ b/modules/YetiDriver/board_support/board_support_ACImpl.cpp
@@ -45,7 +45,7 @@ void board_support_ACImpl::init() {
     // FIXME
     // Everything used here should be moved out of debug update in protobuf
     mod->serial.signalDebugUpdate.connect([this](DebugUpdate d) {
-         publish_nr_of_phases_available(d.use_three_phases); 
+         publish_nr_of_phases_available((d.use_three_phases?3:1)); 
     });
 }
 


### PR DESCRIPTION
Obtaining running status information on the Energy Manager has been impossible before. This change adds a status flag to the JsEnergyManager module which gets published both to the `external` mqtt topic (for legacy reasons; will be removed in future) and the module-specific `energy_manager:JsEnergyManager` topic.

changes:
- add wrapper functions for enabling/disabling JsEnergyManager `running` var to publish the var's state via mqtt
- add `emgr_running` var to manifest

Signed-off-by: LAD101work <96466764+LAD101work@users.noreply.github.com>