### PR TITLE
Use cmake PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -19,5 +19,5 @@ add_custom_command(
         ${EV_CLI} interface generate-headers --framework-dir ${everest-framework_SOURCE_DIR} --output-dir ${GENERATED_HEADER_DIR}/generated
     COMMAND
         ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/.interfaces_generated
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -48,7 +48,7 @@ endforeach()
 
 add_custom_target(force_update_all_modules
     ${FORCE_UPDATE_COMMANDS}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )
 
 macro(cpp_module_setup)
@@ -63,7 +63,7 @@ macro(cpp_module_setup)
             ${EV_CLI} module generate-loader --framework-dir ${everest-framework_SOURCE_DIR} --output-dir ${GENERATED_MODULE_DIR} ${MODULE_NAME}
         DEPENDS
             manifest.json
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT
             "Generating ld-ev for module ${MODULE_NAME}"
     )


### PR DESCRIPTION
This makes it possible to have this repository as a dependency and not break the interfaces and modules generation

Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>