### PR TITLE
Use public github urls for SLAC dependencies

### DIFF
--- a/modules/EvseSlac/dependencies.yaml
+++ b/modules/EvseSlac/dependencies.yaml
@@ -1,8 +1,8 @@
 ---
 libslac:
-  git: git@github.com:EVerest/libslac.git
+  git: https://github.com/EVerest/libslac.git
   git_tag: main
 
 libfsm:
-  git: git@github.com:EVerest/libfsm.git
+  git: https://github.com/EVerest/libfsm.git
   git_tag: main


### PR DESCRIPTION
Signed-off-by: aw <aw@pionix.de>