### PR TITLE
Add libcurl4-openssl-dev to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ More CPU cores will optionally boost the build process, while requiring more RAM
 #### Ubuntu 20.04
 ```bash
 sudo apt update
-sudo apt install -y python3-pip git rsync wget cmake doxygen graphviz build-essential clang-tidy cppcheck maven openjdk-11-jdk npm docker docker-compose libboost-all-dev nodejs libssl-dev libsqlite3-dev clang-format curl
+sudo apt install -y python3-pip git rsync wget cmake doxygen graphviz build-essential clang-tidy cppcheck maven openjdk-11-jdk npm docker docker-compose libboost-all-dev nodejs libssl-dev libsqlite3-dev clang-format curl libcurl4-openssl-dev
 ```
 In order to build EVerest, we need clang-format version greater than 11. To date *apt* does only install an older version, so we install version 12 manually:
 ```bash


### PR DESCRIPTION
Not sure if curl is missing in the package list for OpenSuSE as well. Maybe someone else knows?

Signed-off-by: LAD101work <96466764+LAD101work@users.noreply.github.com>