### PR TITLE
Add config options to enable/disable certain setup features

### DIFF
--- a/config/config-sil.json
+++ b/config/config-sil.json
@@ -140,6 +140,11 @@
         }
     },
     "setup": {
-        "module": "Setup"
+        "module": "Setup",
+        "config_module": {
+            "setup_wifi": true,
+            "localization": true,
+            "setup_simulation": true
+        }
     }
 }

--- a/modules/Setup/Setup.cpp
+++ b/modules/Setup/Setup.cpp
@@ -69,6 +69,7 @@ void Setup::ready() {
     this->discover_network_thread = std::thread([this]() {
         while (true) {
             this->discover_network();
+            this->publish_supported_features();
             std::this_thread::sleep_for(std::chrono::seconds(5));
         }
     });
@@ -97,7 +98,9 @@ void Setup::ready() {
             this->publish_configured_networks();
         });
     }
+}
 
+void Setup::publish_supported_features() {
     SupportedSetupFeatures supported_setup_features;
     supported_setup_features.setup_wifi = this->config.setup_wifi;
     supported_setup_features.localization = this->config.localization;

--- a/modules/Setup/Setup.hpp
+++ b/modules/Setup/Setup.hpp
@@ -138,6 +138,7 @@ private:
     std::string var_base = api_base + "var/";
     std::string cmd_base = api_base + "cmd/";
     std::thread discover_network_thread;
+    void publish_supported_features();
     void discover_network();
     std::vector<NetworkDeviceInfo> get_network_devices();
     void populate_rfkill_status(std::vector<NetworkDeviceInfo>& device_info);

--- a/modules/Setup/Setup.hpp
+++ b/modules/Setup/Setup.hpp
@@ -78,6 +78,19 @@ struct NetworkDeviceInfo {
 };
 void to_json(json& j, const NetworkDeviceInfo& k);
 
+struct SupportedSetupFeatures {
+    bool setup_wifi;
+    bool localization;
+    bool setup_simulation;
+
+    operator std::string() {
+        json supported_setup_features = *this;
+
+        return supported_setup_features.dump();
+    }
+};
+void to_json(json& j, const SupportedSetupFeatures& k);
+
 struct CmdOutput {
     std::string output;
     std::vector<std::string> split_output;
@@ -88,7 +101,11 @@ struct CmdOutput {
 
 namespace module {
 
-struct Conf {};
+struct Conf {
+    bool setup_wifi;
+    bool localization;
+    bool setup_simulation;
+};
 
 class Setup : public Everest::ModuleBase {
 public:

--- a/modules/Setup/manifest.json
+++ b/modules/Setup/manifest.json
@@ -1,6 +1,22 @@
 {
     "description": "The EVerest Setup module for setting up a LAN or WIFI network connection. This module needs privileged access and should not run during normal operations",
-    "config": {},
+    "config": {
+        "setup_wifi": {
+            "description": "Allow wifi setup",
+            "type": "boolean",
+            "default": false
+        },
+        "localization": {
+            "description": "Enable localization support",
+            "type": "boolean",
+            "default": false
+        },
+        "setup_simulation": {
+            "description": "Allow simulation setup",
+            "type": "boolean",
+            "default": false
+        }
+    },
     "provides": {
         "main": {
             "description": "EVerest Setup",


### PR DESCRIPTION
Right now "setup_wifi" controls if wifi networks can be configured, "localization" controls if localization options are available and "setup_simulation" controls if simulation options can be accessed.

Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>