### PR TITLE
Autocharge feature

### DIFF
--- a/modules/EvseManager/CMakeLists.txt
+++ b/modules/EvseManager/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(${MODULE_NAME}
         "${MODULE_LOADER_DIR}/ld-ev.cpp"
         "evse/evse_managerImpl.cpp"
         "energy_grid/energyImpl.cpp"
+        "token_provider/auth_token_providerImpl.cpp"
         ${ADDITIONAL_MODULE_SOURCES}
 )
 

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -11,6 +11,7 @@
 #include "ld-ev.hpp"
 
 // headers for provided interface implementations
+#include <generated/auth_token_provider/Implementation.hpp>
 #include <generated/energy/Implementation.hpp>
 #include <generated/evse_manager/Implementation.hpp>
 
@@ -63,6 +64,7 @@ public:
     EvseManager() = delete;
     EvseManager(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider,
                 std::unique_ptr<evse_managerImplBase> p_evse, std::unique_ptr<energyImplBase> p_energy_grid,
+                std::unique_ptr<auth_token_providerImplBase> p_token_provider,
                 std::unique_ptr<board_support_ACIntf> r_bsp, std::unique_ptr<powermeterIntf> r_powermeter,
                 std::unique_ptr<authIntf> r_auth, std::vector<std::unique_ptr<slacIntf>> r_slac,
                 std::vector<std::unique_ptr<ISO15118_chargerIntf>> r_hlc,
@@ -71,6 +73,7 @@ public:
         mqtt(mqtt_provider),
         p_evse(std::move(p_evse)),
         p_energy_grid(std::move(p_energy_grid)),
+        p_token_provider(std::move(p_token_provider)),
         r_bsp(std::move(r_bsp)),
         r_powermeter(std::move(r_powermeter)),
         r_auth(std::move(r_auth)),
@@ -83,6 +86,7 @@ public:
     Everest::MqttProvider& mqtt;
     const std::unique_ptr<evse_managerImplBase> p_evse;
     const std::unique_ptr<energyImplBase> p_energy_grid;
+    const std::unique_ptr<auth_token_providerImplBase> p_token_provider;
     const std::unique_ptr<board_support_ACIntf> r_bsp;
     const std::unique_ptr<powermeterIntf> r_powermeter;
     const std::unique_ptr<authIntf> r_auth;

--- a/modules/EvseManager/manifest.json
+++ b/modules/EvseManager/manifest.json
@@ -119,6 +119,10 @@
 		"energy_grid": {
 			"description": "This is the tree leaf interface to build the energy supply tree",
 			"interface": "energy"
+		},
+		"token_provider": {
+			"description": "Provides authtokens for autocharge or plug and charge",
+			"interface": "auth_token_provider"
 		}
 	},
 	"requires": {


### PR DESCRIPTION
authorize directly in libslac rather than going through the EvseManager. Hence, not yet forwarding to the cloud yet though.

use the correct evse_fsm file, publish the mac address in slacImpl and later do the authentication stuff in the EnergyManager.

prepend vid

commented out json stuff EVCCIDD

only use autocharge with ISO and publish in EvseManager

clean up old changes