### PR TITLE
Support for retries and retry_interval of Log Uploads / Firmware Updates

### DIFF
--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -42,6 +42,8 @@ struct Conf {
     std::string SchemasPath;
     std::string ScriptsPath;
     bool EnableExternalWebsocketControl;
+    int32_t DefaultRetries;
+    int32_t DefaultRetryInterval;
 };
 
 class OCPP : public Everest::ModuleBase {

--- a/modules/OCPP/constants.env
+++ b/modules/OCPP/constants.env
@@ -23,5 +23,5 @@ INVALID_SIGNATURE="InvalidSignature"
 SIGNATURE_VERIFIED="SignatureVerified"
 
 UPLOADED="Uploaded"
-UPLOAD_FAILED="UploadFailed"
+UPLOAD_FAILURE="UploadFailure"
 UPLOADING="Uploading"

--- a/modules/OCPP/diagnostics_uploader.sh
+++ b/modules/OCPP/diagnostics_uploader.sh
@@ -8,11 +8,13 @@ curl --progress-bar --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
 curl_exit_code=$?
 if [[ $curl_exit_code -eq 0 ]]; then
     echo "$UPLOADED"
-elif [[ $curl_exit_code -eq 67 ]] || [[ $curl_exit_code -eq 69 ]] || [[ $curl_exit_code -eq 9 ]]; then
+elif [[ $curl_exit_code -eq 67 ]] || [[ $curl_exit_code -eq 35 ]] || [[ $curl_exit_code -eq 69 ]] ||
+    [[ $curl_exit_code -eq 9 ]]; then
     echo "$PERMISSION_DENIED"
-elif [[ $curl_exit_code -eq 1 ]] || [[ $curl_exit_code -eq 3 ]] || [[ $curl_exit_code -eq 6 ]]; then
+elif [[ $curl_exit_code -eq 3 ]] || [[ $curl_exit_code -eq 6 ]] || [[ $curl_exit_code -eq 10 ]] ||
+    [[ $curl_exit_code -eq 87 ]]; then
     echo "$BAD_MESSAGE"
-elif [[ $curl_exit_code -eq 7 ]]; then
+elif [[ $curl_exit_code -eq 1 ]]; then
     echo "$NOT_SUPPORTED_OPERATION"
 else
     echo "$UPLOAD_FAILURE"

--- a/modules/OCPP/firmware_updater.sh
+++ b/modules/OCPP/firmware_updater.sh
@@ -12,7 +12,10 @@ else
     echo "$DOWNLOAD_FAILED"
 fi
 sleep 2
-echo "$INSTALLING"
-sleep 2
-echo "$INSTALLED"
-sleep 2
+
+if [[ $curl_exit_code -eq 0 ]]; then
+    echo "$INSTALLING"
+    sleep 2
+    echo "$INSTALLED"
+    sleep 2
+fi

--- a/modules/OCPP/manifest.json
+++ b/modules/OCPP/manifest.json
@@ -30,6 +30,16 @@
             "description": "If true websocket can be disconnected and connected externally",
             "type": "boolean",
             "default": false
+        },
+        "DefaultRetries": {
+            "description": "Specifies how many times Charge Point tries to upload or download files on previous failure.",
+            "type": "number",
+            "default": 1
+        },
+        "DefaultRetryInterval": {
+            "description": "Specifies in seconds after which time a retry of an upload or download on previous failure may be attempted.",
+            "type": "number",
+            "default": 1
         }
     },
     "provides": {


### PR DESCRIPTION
CSMS OCPP requests for log uploads / firmware updates optionally contain the fields retries and retry_interval. Those are now considered when uploading / downloading files. Changes have been added to the respective callback functions.

In addition:
- added more curl_exit_codes to diagnostics_uploader.sh
- only outputing Installing/Installed when download was successful in firmware_updater.sh
- added DefaultRetries and DefaultRetryInterval in OCPP module manifest
- added const keyword to constants

Signed-off-by: pietfried <piet.goempel@pionix.de>