### PR TITLE
Stop and Restart of OCPP Service

### DIFF
--- a/interfaces/ocpp_1_6_charge_point.json
+++ b/interfaces/ocpp_1_6_charge_point.json
@@ -1,3 +1,19 @@
 {
-    "description": "This interface defines a OCPP 1.6 charge point"
+    "description": "This interface defines a OCPP 1.6 charge point",
+    "cmds": {
+        "stop": {
+            "description": "Disconnects the websocket connection and stops the OCPP communication. No OCPP messages will be stored and sent after a restart.",
+            "result": {
+                "type": "boolean",
+                "description": "Returns true if the service could be stopped successfully, else false"
+            }
+        },
+        "restart": {
+            "description": "Connects the websocket and enables OCPP communication after a previous stop call.",
+            "result": {
+                "type": "boolean",
+                "description": "Returns true if the service could be restarted successfully, else false"
+            }
+        }
+    }
 }

--- a/modules/OCPP/main/ocpp_1_6_charge_pointImpl.cpp
+++ b/modules/OCPP/main/ocpp_1_6_charge_pointImpl.cpp
@@ -11,6 +11,12 @@ void ocpp_1_6_charge_pointImpl::init() {
 void ocpp_1_6_charge_pointImpl::ready() {
 }
 
+bool ocpp_1_6_charge_pointImpl::handle_stop() {
+    return mod->charge_point->stop();
+}
+bool ocpp_1_6_charge_pointImpl::handle_restart() {
+    return mod->charge_point->restart();
+}
 
 } // namespace main
 } // namespace module

--- a/modules/OCPP/main/ocpp_1_6_charge_pointImpl.hpp
+++ b/modules/OCPP/main/ocpp_1_6_charge_pointImpl.hpp
@@ -32,7 +32,9 @@ public:
     // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
 
 protected:
-    // no commands defined for this interface
+    // command handler functions (virtual)
+    virtual bool handle_stop() override;
+    virtual bool handle_restart() override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here


### PR DESCRIPTION
With these changes it is possible to disconnect the websocket and stop the OCPP communication permanently. No messages will be queued after a stop call. The communication can be enabled again when calling restart.

Should be merged with PR:  https://github.com/EVerest/libocpp/pull/39