### PR TITLE
The json v2g messages can be logged and saved in the log file

### DIFF
--- a/interfaces/ISO15118_charger.json
+++ b/interfaces/ISO15118_charger.json
@@ -769,6 +769,11 @@
                     "type": "string",
                     "minLength": 0
                 },
+                "V2G_Message_JSON": {
+                    "description": "Contains the decoded EXI stream as V2G message JSON file",
+                    "type": "string",
+                    "minLength": 0
+                },
                 "V2G_Message_EXI_Hex": {
                     "description": "Contains the EXI stream as hex string",
                     "type": "string",

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -600,13 +600,21 @@ bool EvseManager::get_hlc_enabled() {
 void EvseManager::log_v2g_message(Object m) {
     std::string msg = m["V2G_Message_ID"];
 
+    std::string xml = "";
+    std::string json_str = "";
+    if (m["V2G_Message_XML"].is_null() && m["V2G_Message_JSON"].is_string()) {
+        json_str = m["V2G_Message_JSON"];
+    } else if (m["V2G_Message_XML"].is_string()) {
+        xml = m["V2G_Message_XML"];
+    }
+
     // All messages from EVSE contain Req and all originating from Car contain Res
     if (msg.find("Res") == std::string::npos) {
-        session_log.car(true, fmt::format("V2G {}", msg), m["V2G_Message_XML"], m["V2G_Message_EXI_Hex"],
-                        m["V2G_Message_EXI_Base64"]);
+        session_log.car(true, fmt::format("V2G {}", msg), xml, m["V2G_Message_EXI_Hex"],
+                        m["V2G_Message_EXI_Base64"], json_str);
     } else {
-        session_log.evse(true, fmt::format("V2G {}", msg), m["V2G_Message_XML"], m["V2G_Message_EXI_Hex"],
-                         m["V2G_Message_EXI_Base64"]);
+        session_log.evse(true, fmt::format("V2G {}", msg), xml, m["V2G_Message_EXI_Hex"],
+                         m["V2G_Message_EXI_Base64"], json_str);
     }
 }
 

--- a/modules/EvseManager/SessionLog.cpp
+++ b/modules/EvseManager/SessionLog.cpp
@@ -102,30 +102,33 @@ void SessionLog::stopSession() {
 }
 
 void SessionLog::evse(bool iso15118, const std::string& msg) {
-    evse(iso15118, msg, "", "", "");
+    evse(iso15118, msg, "", "", "", "");
 }
 
 void SessionLog::car(bool iso15118, const std::string& msg) {
-    car(iso15118, msg, "", "", "");
+    car(iso15118, msg, "", "", "", "");
 }
 
-void SessionLog::evse(bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64) {
-    output(0, iso15118, msg, xml, xml_hex, xml_base64);
+void SessionLog::evse(bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64, const std::string& json_str) {
+    output(0, iso15118, msg, xml, xml_hex, xml_base64, json_str);
 }
 
-void SessionLog::car(bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64) {
-    output(1, iso15118, msg, xml, xml_hex, xml_base64);
+void SessionLog::car(bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64, const std::string& json_str) {
+    output(1, iso15118, msg, xml, xml_hex, xml_base64, json_str);
 }
 
-void SessionLog::output(unsigned int typ, bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64) {
+void SessionLog::output(unsigned int typ, bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64, const std::string& json_str) {
     if (enabled && session_active) {
         std::string ts = Everest::Date::to_rfc3339(date::utc_clock::now());
 
         std::string xml_pretty;
+        v2g_message v2g;
         if (!xml.empty()) {
-            v2g_message v2g;
             v2g.from_xml(xml);
             xml_pretty = v2g.to_xml();
+        } else if (!json_str.empty()) {
+            v2g.from_json(json_str);
+            xml_pretty = v2g.to_json();
         }
 
         // output to EVerest log
@@ -167,7 +170,7 @@ void SessionLog::xmlOutput(bool e) {
 }
 
 void SessionLog::sys(const std::string& msg) {
-    output(2, false, msg, "", "", "");
+    output(2, false, msg, "", "", "", "");
 }
 
 std::string SessionLog::html_encode(const std::string& msg) {

--- a/modules/EvseManager/SessionLog.hpp
+++ b/modules/EvseManager/SessionLog.hpp
@@ -22,17 +22,17 @@ public:
     void stopSession();
 
     void car(bool iso15118, const std::string& msg);
-    void car(bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64);
+    void car(bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64, const std::string& json_str);
 
     void evse(bool iso15118, const std::string& msg);
-    void evse(bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64);
+    void evse(bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64, const std::string& json_str);
 
     void xmlOutput(bool e);
 
     void sys(const std::string& msg);
 
 private:
-    void output(unsigned int evse, bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64);
+    void output(unsigned int evse, bool iso15118, const std::string& msg, const std::string& xml, const std::string& xml_hex, const std::string& xml_base64, const std::string& json_str);
     std::string html_encode(const std::string& msg);
     bool xmloutput;
     bool session_active;

--- a/modules/EvseManager/v2gMessage.cpp
+++ b/modules/EvseManager/v2gMessage.cpp
@@ -24,4 +24,12 @@ std::string v2g_message::to_xml() {
     return ss.str();
 }
 
+void v2g_message::from_json(const std::string& json_str) {
+    j = nlohmann::json::parse(json_str);
+}
+
+std::string v2g_message::to_json() {
+    return j.dump(4);
+}
+
 } // namespace module

--- a/modules/EvseManager/v2gMessage.hpp
+++ b/modules/EvseManager/v2gMessage.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <pugixml.hpp>
+#include <nlohmann/json.hpp>
 
 namespace module {
 /*
@@ -16,9 +17,12 @@ public:
     v2g_message();
     bool from_xml(const std::string& xml);
     std::string to_xml();
+    void from_json(const std::string& json_str);
+    std::string to_json();
 
 private:
     pugi::xml_document doc;
+    nlohmann::json j;
 };
 
 } // namespace module


### PR DESCRIPTION
Now also the json v2g messages from the future PyJosev module will be logged and saved in the log file.
For testing you need the PyJosev module from the Branch sl-josev-integration and the Josev library.

Signed-off-by: Sebastian Lukas <sebastian.lukas@pionix.de>