### PR TITLE
Extend setup module, add API documentation

### DIFF
--- a/modules/Setup/README.md
+++ b/modules/Setup/README.md
@@ -147,5 +147,11 @@ To remove a wifi network a payload with the following format must be published t
 ### everest_api/setup/cmd/remove_all_networks
 If any arbitrary payload is published to this topic all wifi networks will be removed.
 
+### everest_api/setup/cmd/check_online_status
+If any arbitrary payload is published to this topic a ping will be sent to the host configured in the configuration key "online_check_host". Depending on the success of this ping a status of "online" or "offline" will be reported on the following topic:
+
+__everest_api/setup/var/online_status__
+
+
 ### everest_api/setup/cmd/reboot
 If any arbitrary payload is published to this topic the system will reboot.

--- a/modules/Setup/README.md
+++ b/modules/Setup/README.md
@@ -14,7 +14,6 @@ This variable is published periodically and contains a JSON object with the supp
 ## Commands and variables published in response
 ### everest_api/setup/cmd/scan_wifi
 If any arbitrary payload is published to this topic a list of available wifi networks is published on the following topic:
-
 __everest_api/setup/var/wifi_info__
 
 with the following payload format:
@@ -43,7 +42,6 @@ with the following payload format:
 ]
 ```
 additionally general network device information is published on the following topic:
-
 __everest_api/setup/var/network_device_info__
 
 with the following payload format:
@@ -69,7 +67,6 @@ with the following payload format:
 ```
 
 additionally the list of configured wifi networks is published to the following topic:
-
 __everest_api/setup/var/configured_networks__
 
 with the following payload format:
@@ -176,16 +173,13 @@ If any arbitrary payload is published to this topic all wifi networks will be re
 
 ### everest_api/setup/cmd/check_online_status
 If any arbitrary payload is published to this topic a ping will be sent to the host configured in the configuration key "online_check_host". Depending on the success of this ping a status of "online" or "offline" will be reported on the following topic:
-
 __everest_api/setup/var/online_status__
 
 
 ### everest_api/setup/cmd/reboot
 If any arbitrary payload is published to this topic the system will reboot.
 
-
 ## Application Info / Localization
-
 ### everest_api/setup/cmd/set_mode
 If a mode _private_ or _public_ is published to this topic it will be stored permanently.
 
@@ -203,7 +197,6 @@ You can set a [three-letter language code](https://en.wikipedia.org/wiki/List_of
 
 ### everest_api/setup/cmd/get_application_info
 If any arbitrary payload is published to this topic a application info object is published to the following topic:
-
 __everest_api/setup/var/application_info__
 
 with the following payload format:

--- a/modules/Setup/README.md
+++ b/modules/Setup/README.md
@@ -101,7 +101,6 @@ If a rfkill_id is published to this topic the wifi interface with this id will b
 
 ### everest_api/setup/cmd/list_configured_networks
 If any arbitrary payload is published to this topic the list of configured wifi networks is published to the following topic:
-
 __everest_api/setup/var/configured_networks__
 
 with the following payload format:
@@ -174,7 +173,6 @@ If any arbitrary payload is published to this topic all wifi networks will be re
 ### everest_api/setup/cmd/check_online_status
 If any arbitrary payload is published to this topic a ping will be sent to the host configured in the configuration key "online_check_host". Depending on the success of this ping a status of "online" or "offline" will be reported on the following topic:
 __everest_api/setup/var/online_status__
-
 
 ### everest_api/setup/cmd/reboot
 If any arbitrary payload is published to this topic the system will reboot.

--- a/modules/Setup/README.md
+++ b/modules/Setup/README.md
@@ -1,0 +1,151 @@
+# Setup module API documentation
+
+## Periodically published variables
+### everest_api/setup/var/supported_setup_features
+This variable is published periodically and contains a JSON object with the supported features in the following form:
+```json
+{
+    "localization": true,
+    "setup_simulation": true,
+    "setup_wifi": true
+}
+```
+
+## Commands and variables published in response
+### everest_api/setup/cmd/scan_wifi
+If any arbitrary payload is published to this topic a list of available wifi networks is published on the following topic:
+
+__everest_api/setup/var/wifi_info__
+
+with the following payload format:
+```json
+[
+    {
+        "bssid": "00:11:22:33:44:55",
+        "flags": [
+            "WPA2-PSK-CCMP",
+            "ESS"
+        ],
+        "frequency": 2437,
+        "signal_level": -41,
+        "ssid": "Example"
+    },
+    {
+        "bssid": "66:77:88:99:aa:bb",
+        "flags": [
+            "WPA2-PSK-CCMP",
+            "ESS"
+        ],
+        "frequency": 5180,
+        "signal_level": -56,
+        "ssid": "Example2"
+    }
+]
+```
+additionally general network device information is published on the following topic:
+
+__everest_api/setup/var/network_device_info__
+
+with the following payload format:
+```json
+[
+    {
+        "blocked": false,
+        "interface": "wlan0",
+        "ipv4": "192.0.2.23",
+        "ipv6": "",
+        "rfkill_id": "0",
+        "wireless": true
+    },
+    {
+        "blocked": false,
+        "interface": "eth0",
+        "ipv4": "192.0.2.42",
+        "ipv6": "",
+        "rfkill_id": "",
+        "wireless": false
+    }
+]
+```
+
+additionally the list of configured wifi networks is published to the following topic:
+
+__everest_api/setup/var/configured_networks__
+
+with the following payload format:
+```json
+[
+    {
+        "connected": true,
+        "interface": "wlan0",
+        "network_id": 0,
+        "ssid": "Example"
+    },
+    {
+        "connected": false,
+        "interface": "wlan0",
+        "network_id": 1,
+        "ssid": "Example2"
+    }
+]
+```
+
+### everest_api/setup/cmd/enable_wifi_scanning
+If any arbitrary payload is published to this topic the list of available wifi networks and general network device information just mentioned is published periodically.
+
+### everest_api/setup/cmd/disable_wifi_scanning
+If any arbitrary payload is published to this topic the list of available wifi networks and general network device information stops being periodically published.
+
+### everest_api/setup/cmd/rfkill_unblock
+If a rfkill_id is published to this topic the wifi interface with this id will be unblocked.
+
+### everest_api/setup/cmd/rfkill_block
+If a rfkill_id is published to this topic the wifi interface with this id will be blocked.
+
+### everest_api/setup/cmd/list_configured_networks
+If any arbitrary payload is published to this topic the list of configured wifi networks is published to the following topic:
+
+__everest_api/setup/var/configured_networks__
+
+with the following payload format:
+```json
+[
+    {
+        "connected": true,
+        "interface": "wlan0",
+        "network_id": 0,
+        "ssid": "Example"
+    },
+    {
+        "connected": false,
+        "interface": "wlan0",
+        "network_id": 1,
+        "ssid": "Example2"
+    }
+]
+```
+
+### everest_api/setup/cmd/add_network
+To add a wifi network a payload with the following format must be published to this topic:
+```json
+{
+    "interface": "wlan0",
+    "ssid": "Example",
+    "psk": "a_valid_pre_shared_key"
+}
+```
+
+### everest_api/setup/cmd/remove_network
+To remove a wifi network a payload with the following format must be published to this topic:
+```json
+{
+    "interface": "wlan0",
+    "network_id": 0
+}
+```
+
+### everest_api/setup/cmd/remove_all_networks
+If any arbitrary payload is published to this topic all wifi networks will be removed.
+
+### everest_api/setup/cmd/reboot
+If any arbitrary payload is published to this topic the system will reboot.

--- a/modules/Setup/README.md
+++ b/modules/Setup/README.md
@@ -182,3 +182,36 @@ __everest_api/setup/var/online_status__
 
 ### everest_api/setup/cmd/reboot
 If any arbitrary payload is published to this topic the system will reboot.
+
+
+## Application Info / Localization
+
+### everest_api/setup/cmd/set_mode
+If a mode _private_ or _public_ is published to this topic it will be stored permanently.
+
+### everest_api/setup/cmd/set_initialized
+If any arbitrary payload is published to this topic the system will be marked as "initialized" permanently.
+
+### everest_api/setup/cmd/reset_initialized
+If any arbitrary payload is published to this topic the system will be marked as "uninitialized" permanently.
+
+### everest_api/setup/cmd/change_default_language
+You can set a [three-letter language code](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) to be set as the default language which will be stored permanently.
+
+### everest_api/setup/cmd/change_current_language
+You can set a [three-letter language code](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes) to be set as the current language.
+
+### everest_api/setup/cmd/get_application_info
+If any arbitrary payload is published to this topic a application info object is published to the following topic:
+
+__everest_api/setup/var/application_info__
+
+with the following payload format:
+```json
+{
+    "initialized": true,
+    "mode": "private",
+    "default_language": "eng",
+    "current_language": "ger"
+}
+```

--- a/modules/Setup/README.md
+++ b/modules/Setup/README.md
@@ -135,6 +135,33 @@ To add a wifi network a payload with the following format must be published to t
 }
 ```
 
+### everest_api/setup/cmd/enable_network
+To enable a wifi network a payload with the following format must be published to this topic:
+```json
+{
+    "interface": "wlan0",
+    "network_id": 0
+}
+```
+
+### everest_api/setup/cmd/disable_network
+To disable a wifi network a payload with the following format must be published to this topic:
+```json
+{
+    "interface": "wlan0",
+    "network_id": 0
+}
+```
+
+### everest_api/setup/cmd/select_network
+To select a wifi network a payload with the following format must be published to this topic:
+```json
+{
+    "interface": "wlan0",
+    "network_id": 0
+}
+```
+
 ### everest_api/setup/cmd/remove_network
 To remove a wifi network a payload with the following format must be published to this topic:
 ```json

--- a/modules/Setup/README.md
+++ b/modules/Setup/README.md
@@ -1,4 +1,5 @@
 # Setup module API documentation
+This module is responsible for setup tasks that might need privileged access, for example wifi configuration.
 
 ## Periodically published variables
 ### everest_api/setup/var/supported_setup_features

--- a/modules/Setup/Setup.cpp
+++ b/modules/Setup/Setup.cpp
@@ -230,7 +230,7 @@ std::string Setup::get_default_language() {
     return boost::get<std::string>(language);
 }
 
-void Setup::set_current_language(std::string language) {
+void Setup::set_current_language(const std::string& language) {
     this->current_language = language;
 }
 

--- a/modules/Setup/Setup.cpp
+++ b/modules/Setup/Setup.cpp
@@ -130,6 +130,9 @@ void Setup::ready() {
 
         std::string reboot_cmd = this->cmd_base + "reboot";
         this->mqtt.subscribe(reboot_cmd, [this](const std::string& data) { this->reboot(); });
+
+        std::string check_online_status_cmd = this->cmd_base + "check_online_status";
+        this->mqtt.subscribe(check_online_status_cmd, [this](const std::string& data) { this->check_online_status(); });
     }
 }
 
@@ -552,6 +555,26 @@ bool Setup::reboot() {
         success = false;
     }
     return success;
+}
+
+bool Setup::is_online() {
+    bool success = true;
+    auto reboot_output = this->run_application("ping", {"-c", "1", this->config.online_check_host});
+    if (reboot_output.exit_code != 0) {
+        success = false;
+    }
+    return success;
+}
+
+void Setup::check_online_status() {
+    std::string online_status_var = this->var_base + "online_status";
+
+    if (this->is_online()) {
+
+        this->mqtt.publish(online_status_var, "online");
+    } else {
+        this->mqtt.publish(online_status_var, "offline");
+    }
 }
 
 void Setup::populate_ip_addresses(std::vector<NetworkDeviceInfo>& device_info) {

--- a/modules/Setup/Setup.hpp
+++ b/modules/Setup/Setup.hpp
@@ -53,6 +53,7 @@ struct WifiList {
     std::string interface;
     int network_id;
     std::string ssid;
+    bool connected;
 
     operator std::string() {
         json wifi_list = *this;
@@ -61,6 +62,19 @@ struct WifiList {
     }
 };
 void to_json(json& j, const WifiList& k);
+
+struct RemoveWifi {
+    std::string interface;
+    int network_id;
+
+    operator std::string() {
+        json remove_wifi = *this;
+
+        return remove_wifi.dump();
+    }
+};
+void to_json(json& j, const RemoveWifi& k);
+void from_json(const json& j, RemoveWifi& k);
 
 struct NetworkDeviceInfo {
     std::string interface;
@@ -138,6 +152,7 @@ private:
     std::string var_base = api_base + "var/";
     std::string cmd_base = api_base + "cmd/";
     std::thread discover_network_thread;
+    bool wifi_scan_enabled = false;
     void publish_supported_features();
     void discover_network();
     std::vector<NetworkDeviceInfo> get_network_devices();
@@ -158,6 +173,7 @@ private:
     bool remove_networks(std::string interface);
     bool remove_all_networks();
     bool save_config(std::string interface);
+    bool reboot();
 
     void populate_ip_addresses(std::vector<NetworkDeviceInfo>& device_info);
     std::vector<WifiInfo> scan_wifi(const std::vector<NetworkDeviceInfo>& device_info);

--- a/modules/Setup/Setup.hpp
+++ b/modules/Setup/Setup.hpp
@@ -14,7 +14,7 @@
 #include <generated/interfaces/empty/Implementation.hpp>
 
 // headers for required interface implementations
-#include <generated/kvs/Interface.hpp>
+#include <generated/interfaces/kvs/Interface.hpp>
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here

--- a/modules/Setup/Setup.hpp
+++ b/modules/Setup/Setup.hpp
@@ -63,7 +63,7 @@ struct WifiList {
 };
 void to_json(json& j, const WifiList& k);
 
-struct RemoveWifi {
+struct InterfaceAndNetworkId {
     std::string interface;
     int network_id;
 
@@ -73,8 +73,8 @@ struct RemoveWifi {
         return remove_wifi.dump();
     }
 };
-void to_json(json& j, const RemoveWifi& k);
-void from_json(const json& j, RemoveWifi& k);
+void to_json(json& j, const InterfaceAndNetworkId& k);
+void from_json(const json& j, InterfaceAndNetworkId& k);
 
 struct NetworkDeviceInfo {
     std::string interface;
@@ -170,6 +170,7 @@ private:
     bool set_network(std::string interface, int network_id, std::string ssid, std::string psk);
     bool enable_network(std::string interface, int network_id);
     bool disable_network(std::string interface, int network_id);
+    bool select_network(std::string interface, int network_id);
     bool remove_network(std::string interface, int network_id);
     bool remove_networks(std::string interface);
     bool remove_all_networks();

--- a/modules/Setup/Setup.hpp
+++ b/modules/Setup/Setup.hpp
@@ -179,7 +179,7 @@ private:
     void set_default_language(std::string language);
     std::string get_default_language();
     std::string current_language;
-    void set_current_language(std::string language);
+    void set_current_language(const std::string& language);
     std::string get_current_language();
     void set_mode(std::string mode);
     std::string get_mode();

--- a/modules/Setup/Setup.hpp
+++ b/modules/Setup/Setup.hpp
@@ -119,6 +119,7 @@ struct Conf {
     bool setup_wifi;
     bool localization;
     bool setup_simulation;
+    std::string online_check_host;
 };
 
 class Setup : public Everest::ModuleBase {
@@ -174,6 +175,8 @@ private:
     bool remove_all_networks();
     bool save_config(std::string interface);
     bool reboot();
+    bool is_online();
+    void check_online_status();
 
     void populate_ip_addresses(std::vector<NetworkDeviceInfo>& device_info);
     std::vector<WifiInfo> scan_wifi(const std::vector<NetworkDeviceInfo>& device_info);

--- a/modules/Setup/manifest.json
+++ b/modules/Setup/manifest.json
@@ -20,6 +20,11 @@
             "description": "Hostname or IP to use to check for internet connectivity",
             "type": "string",
             "default": "lfenergy.org"
+        },
+        "initialized_by_default": {
+            "description": "Always report as if the charger was initialized",
+            "type": "boolean",
+            "default": true
         }
     },
     "provides": {
@@ -28,7 +33,11 @@
             "interface": "empty"
         }
     },
-    "requires": {},
+    "requires": {
+        "store": {
+            "interface": "kvs"
+        }
+    },
     "enable_external_mqtt": true,
     "metadata": {
         "license": "https://opensource.org/licenses/Apache-2.0",

--- a/modules/Setup/manifest.json
+++ b/modules/Setup/manifest.json
@@ -15,6 +15,11 @@
             "description": "Allow simulation setup",
             "type": "boolean",
             "default": false
+        },
+        "online_check_host": {
+            "description": "Hostname or IP to use to check for internet connectivity",
+            "type": "string",
+            "default": "lfenergy.org"
         }
     },
     "provides": {


### PR DESCRIPTION
- Only scan wifi when instructed, allow removal of individual networks
- Add a command to check if the host is "online"
- Add commands to enable/disable/select a network
- Add persistently stored language, mode and initialization status
The persistency functionality needs a PersistentStore module connected to the Setup module!