### PR TITLE
The JsCarV2G module now knows the right RiseV2G location

### DIFF
--- a/modules/JsCarV2G/index.js
+++ b/modules/JsCarV2G/index.js
@@ -16,7 +16,7 @@ function JavaStartedDeferred(mqtt_base_path, module_name, mod) {
 
     // FIXME: the path hierarchy should be well defined,
     //        i.e where to find 3rd party things
-    const cwd = `${process.cwd()}/rise_v2g`;
+    const cwd = `${process.cwd()}/libexec/everest/3rd_party/rise_v2g`;
     const args = [
       '-Djava.net.preferIPv4Stack=false', '-Djava.net.prefecom.v2gclarity.rrIPv6Addresses=true',
       '-cp', 'rise-v2g-evcc-1.2.6.jar', 'com.v2gclarity.risev2g.evcc.main.StartEVCC',


### PR DESCRIPTION
The correct cwd path to RiseV2g was missing.
Signed-off-by: Sebastian Lukas <sebastian.lukas@pionix.de>