### PR TITLE
Remove separate OCPP run scripts

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -2,20 +2,4 @@ generate_config_run_script(CONFIG sil)
 generate_config_run_script(CONFIG sil-two-evse)
 generate_config_run_script(CONFIG hil)
 generate_config_run_script(CONFIG auth)
-
-generate_config_run_script(
-    CONFIG sil-ocpp
-    OUTPUT sil-ocpp-complete
-)
-generate_config_run_script(
-    CONFIG sil-ocpp
-    OUTPUT sil-ocpp-manager
-    ADDITIONAL_ARGUMENTS
-        --standalone charge_point
-)
-generate_config_run_script(
-    CONFIG sil-ocpp
-    OUTPUT sil-ocpp-module
-    ADDITIONAL_ARGUMENTS
-        --module charge_point
-)
+generate_config_run_script(CONFIG sil-ocpp)

--- a/config/config-sil-ocpp.json
+++ b/config/config-sil-ocpp.json
@@ -208,10 +208,10 @@
   "ocpp": {
     "module": "OCPP",
     "config_module": {
-      "OcppMainPath": "dist/share/everest/ocpp",
-      "SchemasPath": "dist/share/everest/ocpp",
-      "ChargePointConfigPath": "../../libocpp/aux/config-docker.json",
-      "ScriptsPath": "dist/libexec/modules/OCPP"
+      "OcppMainPath": "share/everest/ocpp",
+      "SchemasPath": "share/everest/ocpp",
+      "ChargePointConfigPath": "../../../libocpp/aux/config-docker.json",
+      "ScriptsPath": "libexec/modules/OCPP"
     },
     "connections": {
       "evse_manager": [

--- a/config/config-sil-ocpp.json
+++ b/config/config-sil-ocpp.json
@@ -210,8 +210,7 @@
     "config_module": {
       "OcppMainPath": "share/everest/ocpp",
       "SchemasPath": "share/everest/ocpp",
-      "ChargePointConfigPath": "../../../libocpp/aux/config-docker.json",
-      "ScriptsPath": "libexec/modules/OCPP"
+      "ChargePointConfigPath": "../../../libocpp/aux/config-docker.json"
     },
     "connections": {
       "evse_manager": [

--- a/modules/OCPP/CMakeLists.txt
+++ b/modules/OCPP/CMakeLists.txt
@@ -27,4 +27,5 @@ target_sources(${MODULE_NAME}
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -43,7 +43,6 @@ struct Conf {
     std::string ChargePointConfigPath;
     std::string DatabasePath;
     std::string SchemasPath;
-    std::string ScriptsPath;
     bool EnableExternalWebsocketControl;
 };
 

--- a/modules/OCPP/manifest.json
+++ b/modules/OCPP/manifest.json
@@ -21,11 +21,6 @@
             "type": "string",
             "default": "/tmp/ocpp_1_6_charge_point"
         },
-        "ScriptsPath": {
-            "description": "Path to the script folder in which the OCPP 1.6 scripts for firmware update und log upload reside",
-            "type": "string",
-            "default": "dist/bin"
-        },
         "EnableExternalWebsocketControl": {
             "description": "If true websocket can be disconnected and connected externally",
             "type": "boolean",


### PR DESCRIPTION
Removed generation of ocpp module and manager script - only one ocpp run script will be generated

Signed-off-by: pietfried <piet.goempel@pionix.de>