### PR TITLE
Generate run scripts for nodered.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(everest-cmake 0.10 REQUIRED
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(ev-cli)
 include(config-run-script)
+include(config-run-nodered-script)
 
 option(CREATE_SYMLINKS "Create symlinks to javascript modules and auxillary files - for development purposes" OFF)
 option(CMAKE_RUN_CLANG_TIDY "Run clang-tidy" OFF)
@@ -89,6 +90,12 @@ install(
     DIRECTORY "interfaces"
     DESTINATION "${CMAKE_INSTALL_DATADIR}/everest"
     FILES_MATCHING PATTERN "*.json"
+)
+
+# install docker related files
+install(
+    DIRECTORY "cmake/assets/docker"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/everest"
 )
 
 # configure clang-tidy if requested

--- a/cmake/assets/docker/Dockerfile
+++ b/cmake/assets/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM nodered/node-red:2.2.3
+RUN npm install node-red-dashboard
+RUN npm install node-red-contrib-ui-actions
+RUN npm install node-red-node-ui-table
+RUN npm install node-red-contrib-ui-level

--- a/cmake/assets/run_nodered_template.sh.in
+++ b/cmake/assets/run_nodered_template.sh.in
@@ -1,0 +1,3 @@
+cd @EVEREST_DOCKER_DIR@
+docker build -t everest-nodered .
+docker run --rm --network host --name everest_nodered --mount type=bind,source=@FLOW_FILE@,target=/data/flows.json everest-nodered

--- a/cmake/config-run-nodered-script.cmake
+++ b/cmake/config-run-nodered-script.cmake
@@ -1,0 +1,38 @@
+set(EVEREST_CONFIG_ASSET_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
+
+function(generate_nodered_run_script)
+
+    set(options "")
+    set(one_value_args
+        FLOW
+        OUTPUT
+    )
+    set(multi_value_args "")
+
+    cmake_parse_arguments(OPTNS "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+
+    if (OPTNS_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} got unknown argument(s): ${OPTNS_UNPARSED_ARGUMENTS}")
+    endif()
+
+    if (NOT OPTNS_FLOW)
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} requires FLOW parameter for the flow name")
+    endif()
+
+    set(FLOW_FILE "${CMAKE_CURRENT_SOURCE_DIR}/config-${OPTNS_FLOW}-flow.json")
+    if (NOT EXISTS ${FLOW_FILE})
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION}: flow file '${FLOW_FILE}' does not exist")
+    endif()
+
+    set(SCRIPT_OUTPUT_PATH "${CMAKE_BINARY_DIR}/run-scripts")
+    set(SCRIPT_OUTPUT_FILE "${SCRIPT_OUTPUT_PATH}/nodered-${OPTNS_FLOW}.sh")
+    if (OPTNS_OUTPUT)
+        set(SCRIPT_OUTPUT_FILE "${SCRIPT_OUTPUT_PATH}/nodered-${OPTNS_OUTPUT}.sh")
+    endif()
+
+    # other necessary variables
+    set(EVEREST_DOCKER_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/everest/docker")
+
+    configure_file("${EVEREST_CONFIG_ASSET_DIR}/assets/run_nodered_template.sh.in" ${SCRIPT_OUTPUT_FILE})
+
+endfunction()

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -3,3 +3,5 @@ generate_config_run_script(CONFIG sil-two-evse)
 generate_config_run_script(CONFIG hil)
 generate_config_run_script(CONFIG auth)
 generate_config_run_script(CONFIG sil-ocpp)
+
+add_subdirectory(nodered)

--- a/config/nodered/CMakeLists.txt
+++ b/config/nodered/CMakeLists.txt
@@ -1,0 +1,2 @@
+generate_nodered_run_script(FLOW sil)
+generate_nodered_run_script(FLOW sil-two-evse)


### PR DESCRIPTION
These scripts can be found in the run-scripts directory with a nodered- prefix. For example the config-sil-flow.json can be started by executing ./run-scripts/nodered-sil.sh

Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>