### PR TITLE
OCPP Database Integration and new argument for stop_transaction cmd

### DIFF
--- a/interfaces/evse_manager.json
+++ b/interfaces/evse_manager.json
@@ -70,10 +70,10 @@
         "stop_transaction": {
             "description": "Stops transaction and cancels charging externally, charging can only be resumed by replugging car. EVSE will also stop transaction automatically e.g. on disconnect, so this only needs to be called if the transaction should end before.",
             "arguments": {
-                "reason": {
-                    "description": "Reason for stopping the transaction",
-                    "type": "string",
-                    "$ref": "/evse_manager#/StopTransactionReason"
+                "request": {
+                    "description": "Request to stop the transaction.",
+                    "type": "object",
+                    "$ref": "/evse_manager#/StopTransactionRequest"
                 }
             },
             "result": {

--- a/modules/Auth/Auth.cpp
+++ b/modules/Auth/Auth.cpp
@@ -45,8 +45,8 @@ void Auth::ready() {
             return validation_results;
         });
         this->auth_handler->register_stop_transaction_callback(
-            [this](const int32_t evse_index, const StopTransactionReason& reason) {
-                this->r_evse_manager.at(evse_index)->call_stop_transaction(reason);
+            [this](const int32_t evse_index, const StopTransactionRequest& request) {
+                this->r_evse_manager.at(evse_index)->call_stop_transaction(request);
             });
         evse_manager->subscribe_session_event([this, connector_id](SessionEvent session_event) {
             this->auth_handler->handle_session_event(connector_id, session_event);

--- a/modules/Auth/Auth.hpp
+++ b/modules/Auth/Auth.hpp
@@ -65,7 +65,7 @@ public:
 
     /**
      * @brief Set the connection timeout for the auth handler
-     * 
+     *
      * @param connection_timeout timeout in seconds
      */
     void set_connection_timeout(int& connection_timeout);

--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -152,7 +152,7 @@ public:
      * @param callback
      */
     void register_stop_transaction_callback(
-        const std::function<void(const int evse_index, const StopTransactionReason& reason)>& callback);
+        const std::function<void(const int evse_index, const StopTransactionRequest& request)>& callback);
 
     /**
      * @brief Registers the given \p callback to signal a reservation to an EvseManager.
@@ -188,7 +188,7 @@ private:
     std::function<void(const int evse_index, const std::string& id_token)> authorize_callback;
     std::function<void(const int evse_index)> withdraw_authorization_callback;
     std::function<std::vector<ValidationResult>(const std::string& id_token)> validate_token_callback;
-    std::function<void(const int evse_index, const StopTransactionReason& reason)> stop_transaction_callback;
+    std::function<void(const int evse_index, const StopTransactionRequest& request)> stop_transaction_callback;
     std::function<void(const Array& reservations)> reservation_update_callback;
     std::function<void(const int& evse_index, const int& reservation_id)> reserved_callback;
     std::function<void(const int& evse_index)> reservation_cancelled_callback;

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -85,8 +85,11 @@ TokenHandlingResult AuthHandler::handle_token(const ProvidedIdToken& provided_to
     const auto connector_used_for_transaction =
         this->used_for_transaction(referenced_connectors, provided_token.id_token);
     if (connector_used_for_transaction != -1) {
+        StopTransactionRequest req;
+        req.reason = StopTransactionReason::Local;
+        req.id_tag.emplace(provided_token.id_token);
         this->stop_transaction_callback(this->connectors.at(connector_used_for_transaction)->evse_index,
-                                        StopTransactionReason::Local);
+                                        req);
         EVLOG_info << "Transaction was stopped because id_token was used for transaction";
         return TokenHandlingResult::USED_TO_STOP_TRANSACTION;
     }
@@ -124,8 +127,11 @@ TokenHandlingResult AuthHandler::handle_token(const ProvidedIdToken& provided_to
                     if (!connector.transaction_active) {
                         return TokenHandlingResult::ALREADY_IN_PROCESS;
                     } else {
+                        StopTransactionRequest req;
+                        req.reason = StopTransactionReason::Local;
+                        req.id_tag.emplace(provided_token.id_token);
                         this->stop_transaction_callback(this->connectors.at(connector_used_for_transaction)->evse_index,
-                                                        StopTransactionReason::Local);
+                                                        req);
                         EVLOG_info << "Transaction was stopped because parent_id_token was used for transaction";
                         return TokenHandlingResult::USED_TO_STOP_TRANSACTION;
                     }
@@ -438,7 +444,7 @@ void AuthHandler::register_validate_token_callback(
     this->validate_token_callback = callback;
 }
 void AuthHandler::register_stop_transaction_callback(
-    const std::function<void(const int evse_index, const StopTransactionReason& reason)>& callback) {
+    const std::function<void(const int evse_index, const StopTransactionRequest& request)>& callback) {
     this->stop_transaction_callback = callback;
 }
 

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -112,7 +112,8 @@ public:
     bool resumeChargingPowerAvailable();
     bool getPausedByEVSE();
 
-    bool cancelTransaction(const types::evse_manager::StopTransactionReason& reason); // cancel transaction ahead of time when car is still plugged
+    bool cancelTransaction(const types::evse_manager::StopTransactionRequest& request); // cancel transaction ahead of time when car is still plugged
+    std::string getStopTransactionIdTag();
     types::evse_manager::StopTransactionReason getTransactionFinishedReason(); // get reason for last finished event
     types::evse_manager::StartSessionReason getSessionStartedReason(); // get reason for last session start event
 
@@ -230,6 +231,7 @@ private:
     bool transactionActive();
     bool transaction_active;
     bool session_active;
+    std::string stop_transaction_id_tag;
     types::evse_manager::StopTransactionReason last_stop_transaction_reason;
     types::evse_manager::StartSessionReason last_start_session_reason;
 

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -34,6 +34,8 @@ void EvseManager::init() {
 }
 
 void EvseManager::ready() {
+    charger = std::unique_ptr<Charger>(new Charger(r_bsp));
+
     if (get_hlc_enabled()) {
 
         // Set up EVSE ID
@@ -193,8 +195,6 @@ void EvseManager::ready() {
     } else if (hw_capabilities.max_phase_count == 3) {
         local_three_phases = true; // other configonfigurations currently not supported by HW
     }
-
-    charger = std::unique_ptr<Charger>(new Charger(r_bsp));
 
     r_bsp->subscribe_event([this](const types::board_support::Event event) {
         charger->processEvent(event);

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -174,8 +174,12 @@ void evse_managerImpl::ready() {
             }
 
             auto reason = mod->charger->getTransactionFinishedReason();
+            const auto id_tag = mod->charger->getStopTransactionIdTag();
 
             transaction_finished.reason.emplace(reason);
+            if (!id_tag.empty()) {
+                transaction_finished.id_tag.emplace(id_tag);
+            }
 
             double energy_import = transaction_finished.energy_Wh_import;
 
@@ -263,12 +267,12 @@ bool evse_managerImpl::handle_resume_charging() {
     return mod->charger->resumeCharging();
 };
 
-bool evse_managerImpl::handle_stop_transaction(types::evse_manager::StopTransactionReason& reason) {
+bool evse_managerImpl::handle_stop_transaction(types::evse_manager::StopTransactionRequest& request) {
 
     if (mod->get_hlc_enabled()) {
         mod->r_hlc[0]->call_stop_charging(true);
     }
-    return mod->charger->cancelTransaction(reason);
+    return mod->charger->cancelTransaction(request);
 };
 
 bool evse_managerImpl::handle_force_unlock() {

--- a/modules/EvseManager/evse/evse_managerImpl.hpp
+++ b/modules/EvseManager/evse/evse_managerImpl.hpp
@@ -44,7 +44,7 @@ protected:
     virtual void handle_set_faulted() override;
     virtual bool handle_pause_charging() override;
     virtual bool handle_resume_charging() override;
-    virtual bool handle_stop_transaction(types::evse_manager::StopTransactionReason& reason) override;
+    virtual bool handle_stop_transaction(types::evse_manager::StopTransactionRequest& request) override;
     virtual bool handle_force_unlock() override;
     virtual types::evse_manager::SetLocalMaxCurrentResult handle_set_local_max_current(double& max_current) override;
     virtual types::evse_manager::SwitchThreePhasesWhileChargingResult

--- a/types/evse_manager.json
+++ b/types/evse_manager.json
@@ -1,6 +1,25 @@
 {
     "description": "EVSE manager types",
     "types": {
+        "StopTransactionRequest": {
+            "description": "Request for a stop transaction containing the reason and an optional id tag",
+            "type": "object",
+            "required": [
+                "reason"
+            ],
+            "properties": {
+                "reason": {
+                    "description": "Reason for stopping the transaction",
+                    "type": "string",
+                    "$ref": "/evse_manager#/StopTransactionReason"
+                },
+                "id_tag": {
+                    "description": "Id tag that was used to stop the transaction.",
+                    "type": "string"
+                }
+            }
+            
+        },
         "StopTransactionReason": {
             "description": "Reason for stopping transaction",
             "documenation": [
@@ -205,6 +224,10 @@
                     "description": "Reason for stopping transaction",
                     "type": "string",
                     "$ref": "/evse_manager#/StopTransactionReason"
+                },
+                "id_tag": {
+                    "description": "Id tag that was used to stop the transaction",
+                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
- added sql init path to constructor of chargepoint in OCPP module
- stop_transaction cmd of evse_manager interface now takes a StopTransactionRequest as argument that includes the reason and an optional id tag to stop transaction

Signed-off-by: pietfried <piet.goempel@pionix.de>