### PR TITLE
Fix typo in type definition of everest_manager.json

### DIFF
--- a/types/evse_manager.json
+++ b/types/evse_manager.json
@@ -22,7 +22,7 @@
         },
         "StopTransactionReason": {
             "description": "Reason for stopping transaction",
-            "documenation": [
+            "documentation": [
                 "Reason for stopping the transaction:",
                 "EmergencyStop: Emergency stop button was used",
                 "EVDisconnected: Disconnecting of cable, vehicle moved away from inductive charge unit.",


### PR DESCRIPTION
This fix is needed for the auto generated documentation

Signed-off-by: Andreas Heinrich <andreas.heinrich@rwth-aachen.de>