### PR TITLE
Various fixes and improvements from 11-2022 OCPP Plugfest

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -891,6 +891,9 @@ void Charger::Authorize(bool a, const std::string& userid, bool pnc) {
 
         auth_tag = userid;
     } else {
+        if (sessionActive()) {
+            stopSession();
+        }
         std::lock_guard<std::recursive_mutex> lock(configMutex);
         authorized = false;
     }

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -256,12 +256,11 @@ void OCPP::init() {
         });
 
     this->charge_point->register_provide_token_callback(
-        [this](const std::string& id_token, int32_t connector, bool prevalidated) {
+        [this](const std::string& id_token, std::vector<int32_t> referenced_connectors, bool prevalidated) {
             types::authorization::ProvidedIdToken provided_token;
             provided_token.id_token = id_token;
             provided_token.type = "OCPP_AUTHORIZED";
-            const std::vector<int32_t> connectors{connector};
-            provided_token.connectors.emplace(connectors);
+            provided_token.connectors.emplace(referenced_connectors);
             provided_token.prevalidated.emplace(prevalidated);
             this->p_auth_provider->publish_provided_token(provided_token);
         });


### PR DESCRIPTION
Auth Module:
- Before setting timer for plug in timeout check if SessionStarted event has reason Plug In reason
- Now stopping timeout timer on SessionFinished event

Evse Manager:
- Now stopping session when evse receives call_authorize with value false when a session is active

OCPP Module:
- Provided_token_callback changed in libocpp. Argument is now vector<int> of connectors instead of int to support RemoteStartTransaction.req for no given connector