### PR TITLE
Remove boost::filesystem dependency

### DIFF
--- a/modules/Setup/CMakeLists.txt
+++ b/modules/Setup/CMakeLists.txt
@@ -17,5 +17,5 @@ target_sources(${MODULE_NAME}
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
-# insert other things like install cmds etc here
+target_compile_features(${MODULE_NAME} PRIVATE cxx_std_17)
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/Setup/Setup.cpp
+++ b/modules/Setup/Setup.cpp
@@ -3,16 +3,17 @@
 #include "Setup.hpp"
 
 #include <algorithm>
-#include <boost/filesystem.hpp>
-#include <boost/process.hpp>
 #include <cstdlib>
-#include <fmt/core.h>
 #include <fstream>
 #include <locale>
 
+#include <boost/process.hpp>
+
+#include <fmt/core.h>
+
 namespace module {
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 void to_json(json& j, const NetworkDeviceInfo& k) {
     j = json::object({{"interface", k.interface},
@@ -779,11 +780,11 @@ std::vector<WifiInfo> Setup::scan_wifi(const std::vector<NetworkDeviceInfo>& dev
     return wifi_info;
 }
 
-CmdOutput Setup::run_application(boost::filesystem::path file, std::vector<std::string> args) {
-    const auto path = boost::process::search_path(file);
+CmdOutput Setup::run_application(const std::string& name, std::vector<std::string> args) {
+    const auto path = boost::process::search_path(name);
 
-    if (!boost::filesystem::exists(path)) {
-        EVLOG_debug << fmt::format("The provided file '{}' does not exist", file.string());
+    if (path.empty()) {
+        EVLOG_debug << fmt::format("The application '{}' could not be found", name);
         return CmdOutput{"", {}, 1};
     }
 

--- a/modules/Setup/Setup.hpp
+++ b/modules/Setup/Setup.hpp
@@ -211,7 +211,7 @@ private:
 
     void populate_ip_addresses(std::vector<NetworkDeviceInfo>& device_info);
     std::vector<WifiInfo> scan_wifi(const std::vector<NetworkDeviceInfo>& device_info);
-    CmdOutput run_application(boost::filesystem::path path, std::vector<std::string> args);
+    CmdOutput run_application(const std::string& name, std::vector<std::string> args);
     std::vector<std::string> parse_wpa_cli_flags(std::string flags);
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };

--- a/modules/System/CMakeLists.txt
+++ b/modules/System/CMakeLists.txt
@@ -29,6 +29,8 @@ target_sources(${MODULE_NAME}
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 # insert other things like install cmds etc here
+target_compile_features(${MODULE_NAME} PRIVATE cxx_std_17)
+
 install(
     PROGRAMS
         constants.env

--- a/modules/System/main/systemImpl.hpp
+++ b/modules/System/main/systemImpl.hpp
@@ -14,6 +14,8 @@
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
+#include <filesystem>
+
 #include <everest/timer.hpp>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
@@ -119,16 +121,16 @@ private:
      * @param firmware_file_path
      */
     void initialize_firmware_installation(const types::system::FirmwareUpdateRequest& firmware_update_request,
-                                          const boost::filesystem::path& firmware_file_path);
-    
+                                          const std::filesystem::path& firmware_file_path);
+
     /**
-     * @brief Executes the installation of the firmware specified in the given \p firmware_update_request . 
-     * 
-     * @param firmware_update_reqeust 
-     * @param firmware_file_path 
+     * @brief Executes the installation of the firmware specified in the given \p firmware_update_request .
+     *
+     * @param firmware_update_reqeust
+     * @param firmware_file_path
      */
     void install_signed_firmware(const types::system::FirmwareUpdateRequest& firmware_update_reqeust,
-                                 const boost::filesystem::path& firmware_file_path);
+                                 const std::filesystem::path& firmware_file_path);
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 


### PR DESCRIPTION
- using std::filesystem instead
- boost::filesystem::unique_file has no equivalent in std::filesystem for reasons.  Create replacement function called create_temp_file, which uses POSIX mkstemp (NOTE: mkstemp doesn't allow filename endings)
- changed some path objects to strings, because they're not used as an path at all

Signed-off-by: aw <aw@pionix.de>