### PR TITLE
AuthModule: Clear Error on SessionFinished event 

### DIFF
--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -408,6 +408,7 @@ void AuthHandler::handle_session_event(const int connector_id, const SessionEven
         this->connectors.at(connector_id)->connector.is_reservable = true;
         this->connectors.at(connector_id)->connector.identifier = boost::none;
         this->connectors.at(connector_id)->connector.submit_event(Event_Session_Finished());
+        this->connectors.at(connector_id)->connector.submit_event(Event_Error_Cleared());
         this->connectors.at(connector_id)->timeout_timer.stop();
         break;
     case SessionEventEnum::PermanentFault:


### PR DESCRIPTION
State machine needs error cleared event for the connector to become available for new tokens again

Signed-off-by: pietfried <piet.goempel@pionix.de>