### PR TITLE
Bump libocpp version to v0.2.0 because of an API change

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -32,4 +32,4 @@ RISE-V2G:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.1.0
+  git_tag: v0.2.0


### PR DESCRIPTION
Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>