### PR TITLE
Generate random NMK key for every SLAC session

### DIFF
--- a/modules/EvseSlac/main/evse_fsm.hpp
+++ b/modules/EvseSlac/main/evse_fsm.hpp
@@ -94,7 +94,7 @@ public:
     }
 
     void set_five_percent_mode(bool value);
-    void set_nmk(const uint8_t* nmk);
+    void generate_nmk();
 
     explicit EvseFSM(SlacIO& slac_io);
 

--- a/modules/EvseSlac/main/slacImpl.cpp
+++ b/modules/EvseSlac/main/slacImpl.cpp
@@ -82,8 +82,7 @@ void slacImpl::run() {
 
     EVLOG_debug << "Starting the SLAC state machine";
 
-    // FIXME: need to set different session key for each session!
-    fsm.set_nmk((uint8_t*)"1234567890ABCDEF");
+    fsm.generate_nmk();
 
     bool matched = false;
     auto cur_state_id = fsm.get_initial_state().id.id;


### PR DESCRIPTION
According to the ISO15118-3 standard, the NMK key should be randomly generated once in each SLAC session.