### PR TITLE
OCPP Module sets Auth connection timeout on startup

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -32,4 +32,4 @@ RISE-V2G:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.2.0
+  git_tag: v0.3.0

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -415,6 +415,7 @@ void OCPP::ready() {
     invoke_ready(*p_auth_validator);
     invoke_ready(*p_auth_provider);
 
+    this->charge_point->call_set_connection_timeout();
     int connector = 1;
     for (const auto& evse : this->r_evse_manager) {
         if (connector != evse->call_get_id()) {


### PR DESCRIPTION
Connection timeout of ocpp config file is now set within Auth module on startup. Before that change, the configured ConnectionTimeout in the ocpp config file was not used to set this parameter in the Auth module. OCPP configuration now basically overrides Auth module configuration if OCPP module is loaded.

Signed-off-by: pietfried <piet.goempel@pionix.de>