### PR TITLE
TokenType for differentiation of authorization media source 

### DIFF
--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -128,8 +128,8 @@ public:
      *
      * @param callback
      */
-    void register_authorize_callback(
-        const std::function<void(const int evse_index, const std::string& id_token)>& callback);
+    void
+    register_authorize_callback(const std::function<void(const int evse_index, const std::string& id_token)>& callback);
 
     /**
      * @brief Registers the given \p callback to withdraw authorization.
@@ -159,8 +159,8 @@ public:
      *
      * @param callback
      */
-    void register_reserved_callback(
-        const std::function<void(const int& evse_index, const int& reservation_id)>& callback);
+    void
+    register_reserved_callback(const std::function<void(const int& evse_index, const int& reservation_id)>& callback);
 
     /**
      * @brief Registers the given \p callback to signal a reservation has been cancelled to the EvseManager.
@@ -196,7 +196,7 @@ private:
 
     std::vector<int> get_referenced_connectors(const ProvidedIdToken& provided_token);
     int used_for_transaction(const std::vector<int>& connectors, const std::string& id_token);
-    bool is_token_already_in_process(const std::string& id_token, const std::vector<int> &referenced_connectors);
+    bool is_token_already_in_process(const std::string& id_token, const std::vector<int>& referenced_connectors);
     bool any_connector_available(const std::vector<int>& connectors);
 
     TokenHandlingResult handle_token(const ProvidedIdToken& provided_token);
@@ -214,7 +214,8 @@ private:
     void unlock_plug_in_mutex(const std::vector<int>& connectors);
     int get_latest_plugin(const std::vector<int>& connectors);
     void authorize_evse(int connector, const Identifier& identifier);
-    Identifier get_identifier(const ValidationResult& validation_result, const std::string& id_token);
+    Identifier get_identifier(const ValidationResult& validation_result, const std::string& id_token,
+                              const TokenType& type);
 };
 
 } // namespace module

--- a/modules/JsDummyTokenProvider/manifest.yaml
+++ b/modules/JsDummyTokenProvider/manifest.yaml
@@ -16,7 +16,7 @@ provides:
         type: string
         minLength: 2
         maxLength: 32
-        default: dummy
+        default: RFID
       timeout:
         description: Time our dummy token is valid (in s)
         type: number

--- a/modules/JsDummyTokenProviderManual/manifest.yaml
+++ b/modules/JsDummyTokenProviderManual/manifest.yaml
@@ -15,7 +15,7 @@ provides:
         type: string
         minLength: 2
         maxLength: 32
-        default: dummy
+        default: RFID
       timeout:
         description: Time our dummy token is valid (in s)
         type: number

--- a/modules/JsPN532TokenProvider/index.js
+++ b/modules/JsPN532TokenProvider/index.js
@@ -28,7 +28,7 @@ boot_module(async ({ setup, config }) => {
             // emit new token into the everest system
             const data = {
                 token: tag.uid,
-                type: "rfid",
+                type: "RFID",
                 timeout: mod.config.impl.main.timeout,
             };
             evlog.info('Publishing new rfid/nfc token: ', data);

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -259,7 +259,7 @@ void OCPP::init() {
         [this](const std::string& id_token, std::vector<int32_t> referenced_connectors, bool prevalidated) {
             types::authorization::ProvidedIdToken provided_token;
             provided_token.id_token = id_token;
-            provided_token.type = "OCPP_AUTHORIZED";
+            provided_token.type = types::authorization::TokenType::OCPP;
             provided_token.connectors.emplace(referenced_connectors);
             provided_token.prevalidated.emplace(prevalidated);
             this->p_auth_provider->publish_provided_token(provided_token);
@@ -303,7 +303,6 @@ void OCPP::init() {
 
     this->charge_point->register_signal_set_charging_profiles_callback(
         [this]() { this->publish_charging_schedules(); });
-
 
     this->charge_point->register_is_reset_allowed_callback([this](ocpp1_6::ResetType type) {
         const auto reset_type = types::system::string_to_reset_type(ocpp1_6::conversions::reset_type_to_string(type));

--- a/modules/PN532TokenProvider/main/auth_token_providerImpl.cpp
+++ b/modules/PN532TokenProvider/main/auth_token_providerImpl.cpp
@@ -57,7 +57,7 @@ void auth_token_providerImpl::ready() {
                 EVLOG_debug << "Got raw rfid/nfc tag: " << entry.getNFCID();
                 types::authorization::ProvidedIdToken provided_token;
                 provided_token.id_token = entry.getNFCID();
-                provided_token.type = "rfid";
+                provided_token.type = types::authorization::TokenType::RFID;
                 EVLOG_debug << "Publishing new rfid/nfc token: " << provided_token;
                 this->publish_provided_token(provided_token);
             }

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -14,6 +14,7 @@ types:
     additionalProperties: false
     required:
       - id_token
+      - type
     properties:
       id_token:
         description: >-
@@ -22,6 +23,11 @@ types:
         type: string
         minLength: 1
         maxLength: 20
+      type:
+        description: >-
+          Type of the provider of the identifier
+        type: string
+        $ref: /authorization#/TokenType
       authorization_status:
         type: string
         $ref: /authorization#/AuthorizationStatus
@@ -48,8 +54,9 @@ types:
         minLength: 1
         maxLength: 20
       type:
-        description: Type of token provider
+        description: Type of the token
         type: string
+        $ref: /authorization#/TokenType
         minLength: 2
         maxLength: 32
       connectors:
@@ -97,3 +104,12 @@ types:
     enum:
       - UserInput
       - PlugEvents
+  TokenType:
+    description: >-
+      Type of the provided token
+    type: string
+    enum:
+      - OCPP
+      - RFID
+      - Autocharge
+      - PlugAndCharge


### PR DESCRIPTION
- Added type TokenType to differentiate between sources of provided authorization media (RFID, Autocharge, OCPP, PlugAndCharge)
- Only TokenType RFID can be used to stop transactions

Signed-off-by: pietfried <piet.goempel@pionix.de>