### PR TITLE
OCPP module shares connection state of OCPP

### DIFF
--- a/interfaces/ocpp_1_6_charge_point.yaml
+++ b/interfaces/ocpp_1_6_charge_point.yaml
@@ -25,3 +25,6 @@ vars:
       object contains one composite charging schedule for each connector id starting
       from connector 0. Connector 0 contains a schedule for the whole charging station.
     type: object
+  is_connected:
+    description: Indicates if chargepoint is connected to CSMS
+    type: boolean

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -314,6 +314,10 @@ void OCPP::init() {
         this->r_system->call_reset(reset_type);
     });
 
+    this->charge_point->register_connection_state_changed_callback([this](bool is_connected) {
+        this->p_main->publish_is_connected(is_connected);
+    });
+
     int32_t connector = 1;
     for (auto& evse : this->r_evse_manager) {
         evse->subscribe_powermeter([this, connector](types::powermeter::Powermeter powermeter) {


### PR DESCRIPTION
OCPP module now registers a callback to publish connection state of ocpp when it changes

Signed-off-by: pietfried <piet.goempel@pionix.de>