### PR TITLE
Use module info everest_prefix to access filesystem

### DIFF
--- a/config/config-sil-ocpp.yaml
+++ b/config/config-sil-ocpp.yaml
@@ -129,8 +129,7 @@ active_modules:
   ocpp:
     module: OCPP
     config_module:
-      OcppMainPath: share/everest/ocpp
-      ChargePointConfigPath: ../../../libocpp/aux/config-docker.json
+      ChargePointConfigPath: config-docker.json
     connections:
       evse_manager:
         - module_id: evse_manager_1
@@ -177,4 +176,5 @@ active_modules:
           implementation_id: evse
   system:
     module: System
+
 x-module-layout: {}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 ---
 everest-framework:
   git: https://github.com/EVerest/everest-framework.git
-  git_tag: v0.1.0
+  git_tag: v0.2.0
 sigslot:
   git: https://github.com/palacaze/sigslot
   git_tag: v1.2.0
@@ -32,4 +32,4 @@ RISE-V2G:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.3.0
+  git_tag: v0.4.0

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -23,6 +23,7 @@
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
+#include <filesystem>
 #include <chrono>
 #include <date/date.h>
 #include <date/tz.h>
@@ -98,6 +99,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+    std::filesystem::path ocpp_share_path;
     void publish_charging_schedules();
     std::thread upload_diagnostics_thread;
     std::thread upload_logs_thread;

--- a/modules/OCPP/manifest.yaml
+++ b/modules/OCPP/manifest.yaml
@@ -1,17 +1,13 @@
 description: A OCPP charge point / charging station module, currently targeting OCPP-J 1.6
 config:
-  OcppMainPath:
-    description: Main path of OCPP module
-    type: string
-    default: share/everest/ocpp
   ChargePointConfigPath:
     description: Path to the configuration file
     type: string
-    default: charge_point_config.json
+    default: ocpp-config.json
   UserConfigPath:
     description: Path to the file of the OCPP user config
     type: string
-    default: share/everest/ocpp/user_config.json
+    default: user_config.json
   DatabasePath:
     description: Path to the persistent SQLite database folder
     type: string

--- a/modules/System/main/systemImpl.cpp
+++ b/modules/System/main/systemImpl.cpp
@@ -16,6 +16,13 @@
 namespace module {
 namespace main {
 
+const std::string CONSTANTS = "constants.env";
+const std::string DIAGNOSTICS_UPLOADER = "diagnostics_uploader.sh";
+const std::string FIRMWARE_UPDATER = "firmware_updater.sh";
+const std::string SIGNED_FIRMWARE_DOWNLOADER = "signed_firmware_downloader.sh";
+const std::string SIGNED_FIRMWARE_INSTALLER = "signed_firmware_installer.sh";
+const std::string EVEREST_LIBEXEC_MODULES_PATH = "libexec/everest/modules";
+
 namespace fs = std::filesystem;
 
 // FIXME (aw): this function needs to be refactored into some kind of utility library
@@ -38,6 +45,7 @@ fs::path create_temp_file(const fs::path& dir, const std::string& prefix) {
 }
 
 void systemImpl::init() {
+    this->scripts_path = fs::path(mod->info.everest_prefix) / EVEREST_LIBEXEC_MODULES_PATH / mod->info.name;
     this->log_upload_running = false;
     this->firmware_download_running = false;
     this->firmware_installation_running = false;
@@ -55,10 +63,10 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
     const auto date_time = Everest::Date::to_rfc3339(date::utc_clock::now());
 
     const auto firmware_file_path = create_temp_file(fs::temp_directory_path(), "firmware-" + date_time);
-    const auto constants = fs::path("libexec/everest/modules/System/constants.env");
+    const auto constants = this->scripts_path / CONSTANTS;
 
     this->update_firmware_thread = std::thread([this, firmware_update_request, firmware_file_path, constants]() {
-        const auto firmware_updater = "libexec/everest/modules/System/firmware_updater.sh";
+        const auto firmware_updater = this->scripts_path / FIRMWARE_UPDATER;
 
         const std::vector<std::string> args = {constants.string(), firmware_update_request.location,
                                                firmware_file_path.string()};
@@ -75,7 +83,7 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
         while (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
                retries <= total_retries) {
             boost::process::ipstream stream;
-            boost::process::child cmd(firmware_updater, boost::process::args(args), boost::process::std_out > stream);
+            boost::process::child cmd(firmware_updater.string(), boost::process::args(args), boost::process::std_out > stream);
             std::string temp;
             retries += 1;
             while (std::getline(stream, temp)) {
@@ -174,8 +182,8 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
     const auto date_time = Everest::Date::to_rfc3339(date::utc_clock::now());
     const auto firmware_file_path = create_temp_file(fs::temp_directory_path(), "signed_firmware-" + date_time);
 
-    const auto firmware_downloader = "libexec/everest/modules/System/signed_firmware_downloader.sh";
-    const auto constants = fs::path("libexec/everest/modules/System/constants.env");
+    const auto firmware_downloader = this->scripts_path / SIGNED_FIRMWARE_DOWNLOADER;
+    const auto constants = this->scripts_path / CONSTANTS;
 
     const std::vector<std::string> download_args = {
         constants.string(), firmware_update_request.location, firmware_file_path.string(),
@@ -193,7 +201,7 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
     while (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
            retries <= total_retries && !this->interrupt_firmware_download) {
         boost::process::ipstream download_stream;
-        boost::process::child download_cmd(firmware_downloader, boost::process::args(download_args),
+        boost::process::child download_cmd(firmware_downloader.string(), boost::process::args(download_args),
                                            boost::process::std_out > download_stream);
         std::string temp;
         retries += 1;
@@ -253,10 +261,10 @@ void systemImpl::install_signed_firmware(const types::system::FirmwareUpdateRequ
     if (!this->firmware_installation_running) {
         this->firmware_installation_running = true;
         boost::process::ipstream install_stream;
-        const auto firmware_installer = "libexec/everest/modules/System/signed_firmware_installer.sh";
-        const auto constants = fs::path("libexec/everest/modules/System/constants.env");
+        const auto firmware_installer = this->scripts_path / SIGNED_FIRMWARE_INSTALLER;
+        const auto constants = this->scripts_path / CONSTANTS;
         const std::vector<std::string> install_args = {constants.string()};
-        boost::process::child install_cmd(firmware_installer, boost::process::args(install_args),
+        boost::process::child install_cmd(firmware_installer.string(), boost::process::args(install_args),
                                           boost::process::std_out > install_stream);
         std::string temp;
         while (std::getline(install_stream, temp)) {
@@ -315,8 +323,8 @@ systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_req
         EVLOG_info << "Starting upload of log file";
         this->interrupt_log_upload.exchange(false);
         this->log_upload_running = true;
-        const auto diagnostics_uploader = "libexec/everest/modules/System/diagnostics_uploader.sh";
-        const auto constants = fs::path("libexec/everest/modules/System/constants.env");
+        const auto diagnostics_uploader = this->scripts_path / DIAGNOSTICS_UPLOADER;
+        const auto constants = this->scripts_path / CONSTANTS;
 
         std::vector<std::string> args = {constants.string(), upload_logs_request.location, diagnostics_file_name,
                                          diagnostics_file_path.string()};
@@ -330,7 +338,7 @@ systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_req
         while (!uploaded && retries <= total_retries && !this->interrupt_log_upload) {
 
             boost::process::ipstream stream;
-            boost::process::child cmd(diagnostics_uploader, boost::process::args(args),
+            boost::process::child cmd(diagnostics_uploader.string(), boost::process::args(args),
                                       boost::process::std_out > stream);
             std::string temp;
             retries += 1;

--- a/modules/System/main/systemImpl.hpp
+++ b/modules/System/main/systemImpl.hpp
@@ -58,6 +58,8 @@ private:
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here
 
+    std::filesystem::path scripts_path;
+
     std::atomic<bool> interrupt_firmware_download;
     std::atomic<bool> interrupt_log_upload;
 


### PR DESCRIPTION
- Now using module info everest prefix to access filesystem paths in System and OCPP module
- replaced boost::filesystem by std::filesystem in OCPP module
- removed OcppMainPath from OCPP config options

Signed-off-by: pietfried <piet.goempel@pionix.de>