### PR TITLE
Improve out-of-core build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,7 @@ endif()
 
 # make own cmake modules available
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-# FIXME (aw): clean up this inclusion chain
-include(ev-cli)
-include(config-run-script)
-include(config-run-nodered-script)
+
 
 option(CREATE_SYMLINKS "Create symlinks to javascript modules and auxillary files - for development purposes" OFF)
 option(CMAKE_RUN_CLANG_TIDY "Run clang-tidy" OFF)
@@ -40,8 +37,6 @@ option(BUILD_TESTING "Run unit tests" OFF)
 # tests requires hardware.
 option(BUILD_DEV_TESTS "Build dev tests" OFF)
 
-# dependencies
-require_ev_cli_version("0.0.16")
 
 find_package(Boost
     COMPONENTS
@@ -61,61 +56,34 @@ if(NOT DISABLE_EDM)
     # FIXME (aw): we need to set this by hand due to edm
     set(EVEREST_SCHEMA_DIR ${everest-framework_SOURCE_DIR}/schemas)
 else()
-    find_package(date REQUIRED)
-    find_package(nlohmann_json REQUIRED)
-    find_package(nlohmann_json_schema_validator REQUIRED)
-    find_package(PalSigslot REQUIRED)
-
-    find_package(fmt REQUIRED)
-    find_package(fsm REQUIRED)
-    find_package(slac REQUIRED)
-
     find_package(everest-framework REQUIRED)
-    find_package(everest-log REQUIRED)
     find_package(everest-sunspec REQUIRED)
     find_package(everest-modbus REQUIRED)
     find_package(everest-ocpp REQUIRED)
-    find_package(everest-timer REQUIRED)
+
+    find_package(PalSigslot REQUIRED)
+
+    find_package(fsm REQUIRED)
+    find_package(slac REQUIRED)
 
     find_package(pugixml REQUIRED)
-
-    get_target_property(EVEREST_SCHEMA_DIR everest::framework EVEREST_DATADIR)
-    set(EVEREST_SCHEMA_DIR "${EVEREST_SCHEMA_DIR}/schemas")
 endif()
 
-# source generate scripts / setup
-include(everest-generate)
+include(ev-project-bootstrap)
 
-# auto generate headers
-add_subdirectory(types)
-add_subdirectory(interfaces)
+ev_add_project()
 
 # config
 # FIXME (aw): this should be optional
 add_subdirectory(config)
-
-# modules
-if (EVC_MAIN_PROJECT OR EVEREST_BUILD_ALL_MODULES)
-    add_subdirectory(modules)
-endif()
-
-# install types and interfaces
-install(
-    DIRECTORY "types" 
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/everest"
-    FILES_MATCHING PATTERN "*.yaml"
-)
-install(
-    DIRECTORY "interfaces"
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/everest"
-    FILES_MATCHING PATTERN "*.yaml"
-)
 
 # install docker related files
 install(
     DIRECTORY "cmake/assets/docker"
     DESTINATION "${CMAKE_INSTALL_DATADIR}/everest"
 )
+
+ev_install_project()
 
 # configure clang-tidy if requested
 if(CMAKE_RUN_CLANG_TIDY)

--- a/cmake/ev-project-bootstrap.cmake
+++ b/cmake/ev-project-bootstrap.cmake
@@ -1,0 +1,11 @@
+
+# FIXME (aw): clean up this inclusion chain
+include(${CMAKE_CURRENT_LIST_DIR}/ev-cli.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/config-run-script.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/config-run-nodered-script.cmake)
+
+# dependencies
+require_ev_cli_version("0.0.16")
+
+# source generate scripts / setup
+include(${CMAKE_CURRENT_LIST_DIR}/everest-generate.cmake)

--- a/cmake/everest-generate.cmake
+++ b/cmake/everest-generate.cmake
@@ -6,6 +6,8 @@ before including \"${CUR_FILE_NAME}\"\
     ")
 endif()
 
+set (EV_CORE_CMAKE_SCRIPT_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE FILEPATH "")
+
 # NOTE (aw): maybe this could be also implemented as an IMPORTED target?
 add_custom_target(generate_cpp_files)
 set_target_properties(generate_cpp_files
@@ -13,27 +15,93 @@ set_target_properties(generate_cpp_files
         EVEREST_SCHEMA_DIR "${EVEREST_SCHEMA_DIR}"
         EVEREST_GENERATED_OUTPUT_DIR "${CMAKE_BINARY_DIR}/generated"
         EVEREST_GENERATED_INCLUDE_DIR "${CMAKE_BINARY_DIR}/generated/include"
+        EVEREST_PROJECT_DIRS ""
 )
 
 #
 # out-of-tree interfaces/types/modules support
 #
-
 function(ev_add_project)
+    # FIXME (aw): resort to proper argument handling!
+    if (ARGC EQUAL 2)
+        set (EVEREST_PROJECT_DIR ${ARGV0})
+        set (EVEREST_PROJECT_NAME ${ARGV1})
+    endif ()
+
+    if (NOT EVEREST_PROJECT_DIR)
+        # assume current project dir
+        set (EVEREST_PROJECT_DIR ${PROJECT_SOURCE_DIR})
+        set (CALLED_FROM_WITHIN_PROJECT TRUE)
+    elseif (NOT EXISTS ${EVEREST_PROJECT_DIR})
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} got non-existing project path: ${EVEREST_PROJECT_DIR}")
+    endif ()
+
+    if (NOT EVEREST_PROJECT_NAME)
+        set (EVEREST_PROJECT_NAME ${PROJECT_NAME})
+    endif ()
+
+    # if we don't get a directory, we're assuming current source directory
     message(STATUS "APPENDING ${PROJECT_SOURCE_DIR} to EVEREST_PROJECT_DIRS")
     set_property(TARGET generate_cpp_files
-        APPEND PROPERTY EVEREST_PROJECT_DIRS "${PROJECT_SOURCE_DIR}"
+        APPEND PROPERTY EVEREST_PROJECT_DIRS ${EVEREST_PROJECT_DIR}
     )
+    get_target_property(EVEREST_PROJECT_DIRS generate_cpp_files EVEREST_PROJECT_DIRS)
+
+    # check for types
+    set(TYPES_DIR "${EVEREST_PROJECT_DIR}/types")
+    if (EXISTS ${TYPES_DIR})
+        message(STATUS "Adding type definitions from ${TYPES_DIR}")
+        file(GLOB TYPES_FILES
+            ${TYPES_DIR}/*.yaml
+        )
+
+        _ev_add_types(${TYPES_FILES})
+
+        if (CALLED_FROM_WITHIN_PROJECT)
+            install(
+                DIRECTORY ${TYPES_DIR}
+                DESTINATION "${CMAKE_INSTALL_DATADIR}/everest"
+                FILES_MATCHING PATTERN "*.yaml"
+            )
+        endif ()
+    endif ()
+
+    # check for interfaces
+    set (INTERFACES_DIR "${EVEREST_PROJECT_DIR}/interfaces")
+    if (EXISTS ${INTERFACES_DIR})
+        message(STATUS "Adding interface definitions from ${INTERFACES_DIR}")
+        file(GLOB INTERFACE_FILES
+            ${INTERFACES_DIR}/*.yaml
+        )
+
+        _ev_add_interfaces(${INTERFACE_FILES})
+
+        if (CALLED_FROM_WITHIN_PROJECT)
+            install(
+                DIRECTORY ${INTERFACES_DIR}
+                DESTINATION "${CMAKE_INSTALL_DATADIR}/everest"
+                FILES_MATCHING PATTERN "*.yaml"
+            )
+        endif ()
+    endif ()
+
+    # check for modules
+    set (MODULES_DIR "${EVEREST_PROJECT_DIR}/modules")
+    if (EXISTS "${MODULES_DIR}/CMakeLists.txt")
+        # FIXME (aw): default handling of building all modules?
+        if (EVC_MAIN_PROJECT OR NOT EVEREST_DONT_BUILD_ALL_MODULES)
+            add_subdirectory(${MODULES_DIR})
+        endif()
+    endif ()
 endfunction()
 
 #
 # interfaces
 #
-
-function (ev_add_interfaces)
+function (_ev_add_interfaces)
+    # FIXME (aw): check for duplicates here!
     get_target_property(GENERATED_OUTPUT_DIR generate_cpp_files EVEREST_GENERATED_OUTPUT_DIR)
-    set(CHECK_DONE_FILE "${GENERATED_OUTPUT_DIR}/.interfaces_generated_${PROJECT_NAME}")
-    get_target_property(EVEREST_PROJECT_DIRS generate_cpp_files EVEREST_PROJECT_DIRS)
+    set(CHECK_DONE_FILE "${GENERATED_OUTPUT_DIR}/.interfaces_generated_${EVEREST_PROJECT_NAME}")
 
     add_custom_command(
         OUTPUT
@@ -42,6 +110,7 @@ function (ev_add_interfaces)
             ${ARGV}
         COMMENT
             "Generating/updating interface files ..."
+        VERBATIM
         COMMAND
             ${EV_CLI} interface generate-headers
                 --disable-clang-format
@@ -54,12 +123,12 @@ function (ev_add_interfaces)
             ${PROJECT_SOURCE_DIR}
     )
 
-    add_custom_target(generate_interfaces_cpp_${PROJECT_NAME}
+    add_custom_target(generate_interfaces_cpp_${EVEREST_PROJECT_NAME}
         DEPENDS "${CHECK_DONE_FILE}"
     )
 
     add_dependencies(generate_cpp_files
-        generate_interfaces_cpp_${PROJECT_NAME}
+        generate_interfaces_cpp_${EVEREST_PROJECT_NAME}
     )
 endfunction()
 
@@ -67,10 +136,10 @@ endfunction()
 # types
 #
 
-function (ev_add_types)
+function (_ev_add_types)
+    # FIXME (aw): check for duplicates here!
     get_target_property(GENERATED_OUTPUT_DIR generate_cpp_files EVEREST_GENERATED_OUTPUT_DIR)
-    set(CHECK_DONE_FILE "${GENERATED_OUTPUT_DIR}/.types_generated_${PROJECT_NAME}")
-    get_target_property(EVEREST_PROJECT_DIRS generate_cpp_files EVEREST_PROJECT_DIRS)
+    set(CHECK_DONE_FILE "${GENERATED_OUTPUT_DIR}/.types_generated_${EVEREST_PROJECT_NAME}")
 
     add_custom_command(
         OUTPUT
@@ -79,6 +148,7 @@ function (ev_add_types)
             ${ARGV}
         COMMENT
             "Generating/updating type files ..."
+        VERBATIM
         COMMAND
             ${EV_CLI} types generate-headers
                 --disable-clang-format
@@ -91,13 +161,13 @@ function (ev_add_types)
             ${PROJECT_SOURCE_DIR}
     )
 
-    add_custom_target(generate_types_cpp_${PROJECT_NAME}
+    add_custom_target(generate_types_cpp_${EVEREST_PROJECT_NAME}
         DEPENDS
             ${CHECK_DONE_FILE}
     )
 
     add_dependencies(generate_cpp_files
-        generate_types_cpp_${PROJECT_NAME}
+        generate_types_cpp_${EVEREST_PROJECT_NAME}
     )
 endfunction()
 
@@ -357,24 +427,37 @@ function (ev_add_py_module MODULE_NAME)
     )
 endfunction()
 
+function(ev_install_project)
+    set (LIBRARY_PACKAGE_NAME ${PROJECT_NAME})
+    
+    include(CMakePackageConfigHelpers)
 
-# FIXME (aw): this needs to be done
-#set(FORCE_UPDATE_COMMANDS "")
-#foreach(EVEREST_MODULE ${EVEREST_MODULES})
-#    if(NOT ${EVEREST_MODULE} MATCHES "^Js")
-#        list(APPEND FORCE_UPDATE_COMMANDS
-#            COMMAND ${EV_CLI} module update --framework-dir ${EVEREST_DATADIR} -f ${EVEREST_MODULE}
-#        )
-#    endif()
-#endforeach()
-#
-#add_custom_target(force_update_all_modules
-#    ${FORCE_UPDATE_COMMANDS}
-#    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-#)
+    set (EVEREST_DATADIR "${CMAKE_INSTALL_DATADIR}/everest")
+
+    configure_package_config_file(
+        ${EV_CORE_CMAKE_SCRIPT_DIR}/project-config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${LIBRARY_PACKAGE_NAME}-config.cmake
+        INSTALL_DESTINATION
+            ${CMAKE_INSTALL_LIBDIR}/cmake/${LIBRARY_PACKAGE_NAME}
+        PATH_VARS
+            EVEREST_DATADIR
+    )
+
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/${LIBRARY_PACKAGE_NAME}-config.cmake
+            ${EV_CORE_CMAKE_SCRIPT_DIR}/everest-generate.cmake
+            ${EV_CORE_CMAKE_SCRIPT_DIR}/ev-cli.cmake
+            ${EV_CORE_CMAKE_SCRIPT_DIR}/project-config.cmake.in
+            ${EV_CORE_CMAKE_SCRIPT_DIR}/ev-project-bootstrap.cmake
+            ${EV_CORE_CMAKE_SCRIPT_DIR}/config-run-script.cmake
+            ${EV_CORE_CMAKE_SCRIPT_DIR}/config-run-nodered-script.cmake
+        DESTINATION
+            ${CMAKE_INSTALL_LIBDIR}/cmake/${LIBRARY_PACKAGE_NAME}
+    )
+endfunction()
 
 # make types and interfaces known to ev-cli
-ev_add_project()
 
 set(EVEREST_EXCLUDE_MODULES "" CACHE STRING "A list of modules that will not be built")
 option(EVEREST_EXCLUDE_CPP_MODULES "Exclude all C++ modules from the build" OFF)

--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -1,0 +1,9 @@
+set(@LIBRARY_PACKAGE_NAME@_VERSION @PROJECT_VERSION@)
+
+@PACKAGE_INIT@
+
+find_package(everest-framework REQUIRED)
+
+include(${CMAKE_CURRENT_LIST_DIR}/ev-project-bootstrap.cmake)
+
+ev_add_project(@PACKAGE_EVEREST_DATADIR@ everest-core)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 ---
 everest-framework:
   git: https://github.com/EVerest/everest-framework.git
-  git_tag: v0.2.0
+  git_tag: 39cc02caec543c9950e2c432a973b3eb96aa81d6
 sigslot:
   git: https://github.com/palacaze/sigslot
   git_tag: v1.2.0

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -1,5 +1,0 @@
-file(GLOB INTERFACE_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/*.yaml
-)
-
-ev_add_interfaces(${INTERFACE_FILES})

--- a/types/CMakeLists.txt
+++ b/types/CMakeLists.txt
@@ -1,5 +1,0 @@
-file(GLOB TYPES_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/*.yaml
-)
-
-ev_add_types(${TYPES_FILES})


### PR DESCRIPTION
- creating proper cmake config file for everest-core so that it's cmake functionality for generation can be used by a depending package, which requires everest-core via find_package
- remove stale find_package(s)

Signed-off-by: aw <aw@pionix.de>