### PR TITLE
Configurable timeout for CM_SET_KEY.REQ

### DIFF
--- a/modules/EvseSlac/main/evse_fsm.hpp
+++ b/modules/EvseSlac/main/evse_fsm.hpp
@@ -14,8 +14,7 @@
 #include "slac_io.hpp"
 
 // FIXME (aw): could we separate out the internal events, somehow?
-enum class EventID
-{
+enum class EventID {
     Reset,
     ResetDone,
     EnterBCD,
@@ -38,8 +37,7 @@ using EventLeaveBCD = EventTypeFactory::Derived<EventID::LeaveBCD>;
 using EventSlacMessage = EventTypeFactory::Derived<EventID::SlacMessage, slac::messages::HomeplugMessage&>;
 using EventLinkDetected = EventTypeFactory::Derived<EventID::LinkDetected>;
 
-enum class State
-{
+enum class State {
     Reset,
     Idle,
     WaitForMatchingStart,
@@ -96,7 +94,7 @@ public:
     void set_five_percent_mode(bool value);
     void generate_nmk();
 
-    explicit EvseFSM(SlacIO& slac_io);
+    explicit EvseFSM(SlacIO& slac_io, int _set_key_timeout);
 
 private:
     using SlacMsgType = slac::messages::HomeplugMessage;
@@ -150,6 +148,7 @@ private:
     int init_retry_count = 0;
 
     SlacIO& slac_io;
+    int set_key_timeout;
 };
 
 #endif // EVSE_FSM_HPP

--- a/modules/EvseSlac/main/slacImpl.cpp
+++ b/modules/EvseSlac/main/slacImpl.cpp
@@ -78,7 +78,7 @@ void slacImpl::run() {
             fmt::format("Couldn't open device {} for SLAC communication. Reason: {}", config.device, e.what())));
     }
 
-    EvseFSM fsm(slac_io);
+    EvseFSM fsm(slac_io, config.set_key_timeout_ms);
 
     EVLOG_debug << "Starting the SLAC state machine";
 

--- a/modules/EvseSlac/main/slacImpl.hpp
+++ b/modules/EvseSlac/main/slacImpl.hpp
@@ -25,6 +25,7 @@ struct Conf {
     std::string nid;
     int number_of_sounds;
     bool ac_mode_five_percent;
+    int set_key_timeout_ms;
 };
 
 class slacImpl : public slacImplBase {

--- a/modules/EvseSlac/manifest.yaml
+++ b/modules/EvseSlac/manifest.yaml
@@ -24,6 +24,10 @@ provides:
         description: Use 5% mode in AC (true). Set to false for DC. The only difference is the handling of retries.
         type: boolean
         default: false
+      set_key_timeout_ms:
+        description: Timeout for CM_SET_KEY.REQ. Default works for QCA7000/QCA7005/CG5317.
+        type: integer
+        default: 500 
 metadata:
   base_license: https://directory.fsf.org/wiki/License:BSD-3-Clause-Clear
   license: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
The new default value supports Lumissil CK5317.
Also adds warnings if slac packages are skipped

Signed-off-by: Cornelius Claussen <cc@pionix.de>