### PR TITLE
Add PacketSniffer Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ More CPU cores will optionally boost the build process, while requiring more RAM
 #### Ubuntu 20.04
 ```bash
 sudo apt update
-sudo apt install -y python3-pip git rsync wget cmake doxygen graphviz build-essential clang-tidy cppcheck maven openjdk-11-jdk npm docker docker-compose libboost-all-dev nodejs libssl-dev libsqlite3-dev clang-format curl rfkill
+sudo apt install -y python3-pip git rsync wget cmake doxygen graphviz build-essential clang-tidy cppcheck maven openjdk-11-jdk npm docker docker-compose libboost-all-dev nodejs libssl-dev libsqlite3-dev clang-format curl rfkill libpcap-dev
 ```
 In order to build EVerest, we need clang-format version greater than 11. To date *apt* does only install an older version, so we install version 12 manually:
 ```bash
@@ -33,13 +33,13 @@ to install a newer version, minimum v12.
 ```bash
 zypper update && zypper install -y sudo shadow
 zypper install -y --type pattern devel_basis
-zypper install -y git rsync wget cmake doxygen graphviz clang-tools cppcheck boost-devel libboost_filesystem-devel libboost_log-devel libboost_program_options-devel libboost_system-devel libboost_thread-devel maven java-11-openjdk java-11-openjdk-devel nodejs nodejs-devel npm python3-pip gcc-c++ libopenssl-devel sqlite3-devel
+zypper install -y git rsync wget cmake doxygen graphviz clang-tools cppcheck boost-devel libboost_filesystem-devel libboost_log-devel libboost_program_options-devel libboost_system-devel libboost_thread-devel maven java-11-openjdk java-11-openjdk-devel nodejs nodejs-devel npm python3-pip gcc-c++ libopenssl-devel sqlite3-devel libpcap-devel
 ```
 
 #### Fedora 36
 ```bash
 sudo dnf update
-sudo dnf install make automake gcc gcc-c++ kernel-devel python3-pip git rsync wget cmake doxygen graphviz clang-tools-extra cppcheck maven java-11-openjdk java-11-openjdk-devel boost-devel nodejs nodejs-devel npm openssl-devel libsqlite3x-devel curl rfkill
+sudo dnf install make automake gcc gcc-c++ kernel-devel python3-pip git rsync wget cmake doxygen graphviz clang-tools-extra cppcheck maven java-11-openjdk java-11-openjdk-devel boost-devel nodejs nodejs-devel npm openssl-devel libsqlite3x-devel curl rfkill libpcap-devel
 ```
 
 ### Build & Install:

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -23,6 +23,7 @@ ev_add_js_module(JsSlacSimulator)
 
 ev_add_cpp_module(OCPP)
 ev_add_cpp_module(OCPP201)
+ev_add_cpp_module(PacketSniffer)
 ev_add_cpp_module(PersistentStore)
 ev_add_cpp_module(PN532TokenProvider)
 

--- a/modules/PacketSniffer/CMakeLists.txt
+++ b/modules/PacketSniffer/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+# template version 3
+#
+
+# module setup:
+#   - ${MODULE_NAME}: module name
+ev_setup_cpp_module()
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+# insert your custom targets and additional config variables here
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+find_package(PCAP REQUIRED)
+
+target_link_libraries(${MODULE_NAME}
+    PRIVATE
+        ${PCAP_LIBRARY}
+)
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+
+target_sources(${MODULE_NAME}
+    PRIVATE
+        "main/emptyImpl.cpp"
+)
+
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/PacketSniffer/PacketSniffer.cpp
+++ b/modules/PacketSniffer/PacketSniffer.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "PacketSniffer.hpp"
+
+#include <fmt/core.h>
+
+namespace module {
+
+const bool PROMISC_MODE = true;
+const int PACKET_BUFFER_TIMEOUT_MS = 1000;
+const int ALL_PACKETS_PROCESSED = -1;
+const int WAIT_FOR_MS = 1;
+const int BUFFERSIZE = 8192;
+
+void PacketSniffer::init() {
+    invoke_init(*p_main);
+
+    capturing_stopped = false;
+    already_started = false;
+
+    p_handle = pcap_open_live(config.device.c_str(), BUFFERSIZE, PROMISC_MODE, PACKET_BUFFER_TIMEOUT_MS, errbuf);
+    if (p_handle == nullptr) {
+        EVLOG_AND_THROW(Everest::EverestConfigError(
+            fmt::format("Could not open device {}", config.device)));
+        return;
+    }
+
+    if (pcap_datalink(p_handle) != DLT_EN10MB) {
+        EVLOG_AND_THROW(Everest::EverestConfigError(
+            fmt::format("Device {} doesn't provide Ethernet headers - not supported", config.device)));
+        return;
+    }
+
+    r_evse_manager->subscribe_session_event([this](types::evse_manager::SessionEvent session_event) {
+
+        std::lock_guard<std::mutex> lock(this->capture_mutex);
+        if (session_event.event == types::evse_manager::SessionEventEnum::SessionStarted) {
+            if (!already_started) {
+                already_started = true;
+                capturing_stopped = false;
+                std::thread(&PacketSniffer::capture, this, config.session_logging_path, session_event.uuid).detach();
+            } else {
+                EVLOG_warning << fmt::format("Capturing already started. Ignoring this SessionStarted event");
+            }
+        } else if (session_event.event == types::evse_manager::SessionEventEnum::SessionFinished) {
+            capturing_stopped = true;
+            already_started = false;
+        }
+    });
+}
+
+void PacketSniffer::ready() {
+    invoke_ready(*p_main);
+}
+
+void PacketSniffer::capture(const std::string& logpath, const std::string& session_id) {
+
+    const std::string fn = fmt::format("{}/everest-session-{}.dump",
+                                        logpath, session_id);
+
+    if ((pdumpfile = pcap_dump_open(p_handle, fn.c_str())) == nullptr) {
+        EVLOG_error << fmt::format("Error opening savefile {} for writing: {}", 
+                                    fn, pcap_geterr(p_handle));
+        return;
+    }
+
+    while (!capturing_stopped) {
+        if (pcap_dispatch(p_handle, ALL_PACKETS_PROCESSED, &pcap_dump, (u_char *)pdumpfile) <= PCAP_ERROR) {
+            EVLOG_error << fmt::format("Error reading packets from interface: {}, error: {}",
+                                        config.device, pcap_geterr(p_handle));
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_FOR_MS));
+    }
+     
+    pcap_dump_close(pdumpfile);
+}
+
+} // namespace module

--- a/modules/PacketSniffer/PacketSniffer.hpp
+++ b/modules/PacketSniffer/PacketSniffer.hpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef PACKET_SNIFFER_HPP
+#define PACKET_SNIFFER_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 1
+//
+
+#include "ld-ev.hpp"
+
+// headers for provided interface implementations
+#include <generated/interfaces/empty/Implementation.hpp>
+
+// headers for required interface implementations
+#include <generated/interfaces/evse_manager/Interface.hpp>
+
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+// insert your custom include headers here
+#include <pcap.h>
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
+
+struct Conf {
+    std::string device;
+    std::string session_logging_path;
+};
+
+class PacketSniffer : public Everest::ModuleBase {
+public:
+    PacketSniffer() = delete;
+    PacketSniffer(const ModuleInfo& info, std::unique_ptr<emptyImplBase> p_main,
+                  std::unique_ptr<evse_managerIntf> r_evse_manager, Conf& config) :
+        ModuleBase(info), p_main(std::move(p_main)), r_evse_manager(std::move(r_evse_manager)), config(config){};
+
+    const Conf& config;
+    const std::unique_ptr<emptyImplBase> p_main;
+    const std::unique_ptr<evse_managerIntf> r_evse_manager;
+
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+
+protected:
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+    // insert your protected definitions here
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+
+private:
+    friend class LdEverest;
+    void init();
+    void ready();
+
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+    // insert your private definitions here
+    void capture(const std::string& logpath, const std::string& session_id);
+    pcap_t *p_handle {nullptr};
+    pcap_dumper_t *pdumpfile {nullptr};
+    char errbuf[PCAP_ERRBUF_SIZE];
+    bool capturing_stopped; 
+    std::mutex capture_mutex;
+    bool already_started;
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+};
+
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+// insert other definitions here
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+
+} // namespace module
+
+#endif // PACKET_SNIFFER_HPP

--- a/modules/PacketSniffer/cmake/FindPCAP.cmake
+++ b/modules/PacketSniffer/cmake/FindPCAP.cmake
@@ -1,0 +1,118 @@
+# FindPCAP.cmake
+# ===========================================
+# See https://github.com/zeek/cmake/FindPCAP.cmake for usage and update instructions.
+#
+# BSD License
+# -----------
+#[[
+  Copyright (c) 1995-2017, The Regents of the University of California
+  through the Lawrence Berkeley National Laboratory and the
+  International Computer Science Institute. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  (1) Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+  (2) Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  (3) Neither the name of the University of California, Lawrence Berkeley
+      National Laboratory, U.S. Dept. of Energy, International Computer
+      Science Institute, nor the names of contributors may be used to endorse
+      or promote products derived from this software without specific prior
+      written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+  Note that some files in the distribution may carry their own copyright
+  notices.
+]]
+
+# - Try to find libpcap include dirs and libraries
+#
+# Usage of this module as follows:
+#
+#     find_package(PCAP)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  PCAP_ROOT_DIR             Set this variable to the root installation of
+#                            libpcap if the module has problems finding the
+#                            proper installation path.
+#
+# Variables defined by this module:
+#
+#  PCAP_FOUND                System has libpcap, include and library dirs found
+#  PCAP_INCLUDE_DIR          The libpcap include directories.
+#  PCAP_LIBRARY              The libpcap library (possibly includes a thread
+#                            library e.g. required by pf_ring's libpcap)
+#  HAVE_PF_RING              If a found version of libpcap supports PF_RING
+
+find_path(PCAP_ROOT_DIR
+    NAMES include/pcap.h
+)
+
+find_path(PCAP_INCLUDE_DIR
+    NAMES pcap.h
+    HINTS ${PCAP_ROOT_DIR}/include
+)
+
+find_library(PCAP_LIBRARY
+    NAMES pcap
+    HINTS ${PCAP_ROOT_DIR}/lib
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PCAP DEFAULT_MSG
+    PCAP_LIBRARY
+    PCAP_INCLUDE_DIR
+)
+
+include(CheckCSourceCompiles)
+set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARY})
+check_c_source_compiles("int main() { return 0; }" PCAP_LINKS_SOLO)
+set(CMAKE_REQUIRED_LIBRARIES)
+
+# check if linking against libpcap also needs to link against a thread library
+if (NOT PCAP_LINKS_SOLO)
+    find_package(Threads)
+    if (THREADS_FOUND)
+        set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+        check_c_source_compiles("int main() { return 0; }" PCAP_NEEDS_THREADS)
+        set(CMAKE_REQUIRED_LIBRARIES)
+    endif ()
+    if (THREADS_FOUND AND PCAP_NEEDS_THREADS)
+        set(_tmp ${PCAP_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+        list(REMOVE_DUPLICATES _tmp)
+        set(PCAP_LIBRARY ${_tmp}
+            CACHE STRING "Libraries needed to link against libpcap" FORCE)
+    else ()
+        message(FATAL_ERROR "Couldn't determine how to link against libpcap")
+    endif ()
+endif ()
+
+include(CheckFunctionExists)
+set(CMAKE_REQUIRED_LIBRARIES ${PCAP_LIBRARY})
+check_function_exists(pcap_get_pfring_id HAVE_PF_RING)
+check_function_exists(pcap_dump_open_append HAVE_PCAP_DUMP_OPEN_APPEND)
+set(CMAKE_REQUIRED_LIBRARIES)
+
+mark_as_advanced(
+    PCAP_ROOT_DIR
+    PCAP_INCLUDE_DIR
+    PCAP_LIBRARY
+)

--- a/modules/PacketSniffer/main/emptyImpl.cpp
+++ b/modules/PacketSniffer/main/emptyImpl.cpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "emptyImpl.hpp"
+
+namespace module {
+namespace main {
+
+void emptyImpl::init() {
+}
+
+void emptyImpl::ready() {
+}
+
+} // namespace main
+} // namespace module

--- a/modules/PacketSniffer/main/emptyImpl.hpp
+++ b/modules/PacketSniffer/main/emptyImpl.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef MAIN_EMPTY_IMPL_HPP
+#define MAIN_EMPTY_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/empty/Implementation.hpp>
+
+#include "../PacketSniffer.hpp"
+
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+// insert your custom include headers here
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+
+namespace module {
+namespace main {
+
+struct Conf {};
+
+class emptyImpl : public emptyImplBase {
+public:
+    emptyImpl() = delete;
+    emptyImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<PacketSniffer>& mod, Conf& config) :
+        emptyImplBase(ev, "main"), mod(mod), config(config){};
+
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+    // insert your public definitions here
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+
+protected:
+    // no commands defined for this interface
+
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+    // insert your protected definitions here
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+
+private:
+    const Everest::PtrContainer<PacketSniffer>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+    // insert your private definitions here
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+};
+
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+// insert other definitions here
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+
+} // namespace main
+} // namespace module
+
+#endif // MAIN_EMPTY_IMPL_HPP

--- a/modules/PacketSniffer/manifest.yaml
+++ b/modules/PacketSniffer/manifest.yaml
@@ -1,0 +1,24 @@
+description: >-
+  Using the "PacketSniffer" EVerest module it is possible to capture and
+  store the different packets on the PLC interface.
+config:
+  device:
+    description: >-
+      The ethernet device on which the messages are to be captured
+    type: string
+    default: eth1
+  session_logging_path:
+    description: Output directory for session capture dump files
+    type: string
+    default: /tmp
+provides:
+  main:
+    description: EVerest API
+    interface: empty
+requires:
+  evse_manager:
+    interface: evse_manager
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Sebastian Lukas


### PR DESCRIPTION
With this module it is possible to capture and store the different ethernet packets on the PLC interface.
Testable only with hardware or a BelayBox, because admin rights are needed for capturing on the socket.

Signed-off-by: Sebastian Lukas <sebastian.lukas@pionix.de>