### PR TITLE
Only use PP reading when connector type is a IEC 62196 Type 2 Socket

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -17,7 +17,8 @@
 
 namespace module {
 
-Charger::Charger(const std::unique_ptr<board_support_ACIntf>& r_bsp) : r_bsp(r_bsp) {
+Charger::Charger(const std::unique_ptr<board_support_ACIntf>& r_bsp, const std::string& connector_type) :
+    r_bsp(r_bsp), connector_type(connector_type) {
     maxCurrent = 6.0;
     maxCurrentCable = r_bsp->call_read_pp_ampacity();
     authorized = false;
@@ -725,9 +726,12 @@ float Charger::ampereToDutyCycle(float ampere) {
 bool Charger::setMaxCurrent(float c, std::chrono::time_point<date::utc_clock> validUntil) {
     if (c >= 0.0 && c <= CHARGER_ABSOLUTE_MAX_CURRENT) {
         std::lock_guard<std::recursive_mutex> lock(configMutex);
-        // limit to cable limit (PP reading) if that is smaller!
-        if (maxCurrentCable < c) {
-            c = maxCurrentCable;
+        // only consider PP for IEC 62196 Type 2 Socket for now
+        if (connector_type == IEC62196Type2Socket) {
+            // limit to cable limit (PP reading) if that is smaller!
+            if (maxCurrentCable < c) {
+                c = maxCurrentCable;
+            }
         }
         // is it still valid?
         // FIXME this requires local clock to be UTC
@@ -744,9 +748,12 @@ bool Charger::setMaxCurrent(float c, std::chrono::time_point<date::utc_clock> va
 bool Charger::setMaxCurrent(float c) {
     if (c >= 0.0 && c <= CHARGER_ABSOLUTE_MAX_CURRENT) {
         std::lock_guard<std::recursive_mutex> lock(configMutex);
-        // limit to cable limit (PP reading) if that is smaller!
-        if (maxCurrentCable < c) {
-            c = maxCurrentCable;
+        // only consider PP for IEC 62196 Type 2 Socket for now
+        if (connector_type == IEC62196Type2Socket) {
+            // limit to cable limit (PP reading) if that is smaller!
+            if (maxCurrentCable < c) {
+                c = maxCurrentCable;
+            }
         }
         // is it still valid?
         // FIXME this requires local clock to be UTC

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -58,9 +58,12 @@ enum class ControlPilotEvent {
     Invalid
 };
 
+const std::string IEC62196Type2Cable = "IEC62196Type2Cable";
+const std::string IEC62196Type2Socket = "IEC62196Type2Socket";
+
 class Charger {
 public:
-    Charger(const std::unique_ptr<board_support_ACIntf>& r_bsp);
+    Charger(const std::unique_ptr<board_support_ACIntf>& r_bsp, const std::string& connector_type);
     ~Charger();
 
     // Public interface to configure Charger
@@ -186,6 +189,7 @@ private:
     Everest::Thread mainThreadHandle;
 
     const std::unique_ptr<board_support_ACIntf>& r_bsp;
+    const std::string& connector_type;
 
     void mainThread();
 

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -51,7 +51,7 @@ void EvseManager::init() {
 }
 
 void EvseManager::ready() {
-    charger = std::unique_ptr<Charger>(new Charger(r_bsp));
+    charger = std::unique_ptr<Charger>(new Charger(r_bsp, config.connector_type));
 
     if (get_hlc_enabled()) {
 

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -68,6 +68,7 @@ struct Conf {
     bool switch_to_minimum_voltage_after_cable_check;
     bool hack_skoda_enyaq;
     int hack_present_current_offset;
+    std::string connector_type;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -125,6 +125,13 @@ config:
       Set to 0 unless you really know what you are doing.
     type: integer
     default: 0
+  connector_type:
+    description: Type of charging connector available at this EVSE
+    type: string
+    enum:
+      - IEC62196Type2Cable
+      - IEC62196Type2Socket
+    default: IEC62196Type2Cable
 provides:
   evse:
     interface: evse_manager


### PR DESCRIPTION
Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>