### PR TITLE
Adding module info access to PyJosev

### DIFF
--- a/modules/PyJosev/module.py
+++ b/modules/PyJosev/module.py
@@ -42,12 +42,14 @@ def run():
 setup_ = None
 module_config_ = None
 impl_configs_ = None
+module_info_ = None
 
-def pre_init(setup, module_config, impl_configs):
-    global setup_, module_config_, impl_configs_
+def pre_init(setup, module_config, impl_configs, _module_info):
+    global setup_, module_config_, impl_configs_, module_info_
     setup_ = setup
     module_config_ = module_config
     impl_configs_ = impl_configs
+    module_info_ = _module_info
     init_Setup(setup_)
 
 def init():


### PR DESCRIPTION
Signed-off-by: Sebastian Lukas <sebastian.lukas@pionix.de>

Testing with this PR: [EVerest Python module can now also access the module info](https://github.com/EVerest/everest-framework/pull/70)