### PR TITLE
ISO15118 PnC Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ cd ~/checkout/everest-workspace/Josev
 python3 -m pip install -r requirements.txt
 ```
 
+For ISO15118 communication including Plug&Charge you need to install the required CA certificates inside [config/certs/ca](config/certs/ca) and client certificates, private keys and password files inside [config/certs/client](config/certs/client/). Run the following commands to generate and install all necessary certificates and keys:
+
+```bash
+cd ~/checkout/everest-workspace/Josev/iso15118/shared/pki
+./create_certs.sh -v iso-2 -i ~/checkout/everest-workspace/everest-core
+```
+
+Note that this will generate an example PKI setup that can only be used for testing and simulation purposes. It will not work and is not recommended for production!
+
 Now we can build EVerest!
 
 ```bash

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -7,12 +7,20 @@ generate_config_run_script(CONFIG sil-two-evse-dc)
 generate_config_run_script(CONFIG sil-energy-management)
 generate_config_run_script(CONFIG hil)
 generate_config_run_script(CONFIG sil-gen-pm)
+generate_config_run_script(CONFIG sil-ocpp)
 
 # install configs
 install(
     DIRECTORY "."
     DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/everest"
     FILES_MATCHING PATTERN "*.yaml"
+)
+
+# install certificates
+install(
+    DIRECTORY "certs"
+    DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/everest"
+    FILES_MATCHING PATTERN "*.pem" PATTERN "*.key" PATTERN "*.der" PATTERN "*.txt"
 )
 
 install(

--- a/config/certs/.gitignore
+++ b/config/certs/.gitignore
@@ -1,0 +1,13 @@
+*
+!.gitignore
+!README.md
+
+!ca
+!client
+!cps
+!csms
+!cso
+!mf
+!mo
+!oem
+!v2g

--- a/config/certs/ca/csms/.gitignore
+++ b/config/certs/ca/csms/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/ca/cso/.gitignore
+++ b/config/certs/ca/cso/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/ca/mf/.gitignore
+++ b/config/certs/ca/mf/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/ca/mo/.gitignore
+++ b/config/certs/ca/mo/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/ca/oem/.gitignore
+++ b/config/certs/ca/oem/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/ca/v2g/.gitignore
+++ b/config/certs/ca/v2g/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/client/cps/.gitignore
+++ b/config/certs/client/cps/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/client/csms/.gitignore
+++ b/config/certs/client/csms/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/client/cso/.gitignore
+++ b/config/certs/client/cso/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/client/mf/.gitignore
+++ b/config/certs/client/mf/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/client/mo/.gitignore
+++ b/config/certs/client/mo/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/client/oem/.gitignore
+++ b/config/certs/client/oem/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 ---
 everest-framework:
   git: https://github.com/EVerest/everest-framework.git
-  git_tag: v0.4.0
+  git_tag: v0.4.1
 sigslot:
   git: https://github.com/palacaze/sigslot
   git_tag: v1.2.0
@@ -33,13 +33,13 @@ libfsm:
 # JsCarV2G and JsRiseV2G module
 RISE-V2G:
   git: https://github.com/EVerest/ext-RISE-V2G.git
-  git_tag: 2022.09.0
+  git_tag: 2023.3.0
 
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.5.2
+  git_tag: v0.6.1
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: 2023.1.0
+  git_tag: 2023.3.0

--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -268,21 +268,15 @@ cmds:
       status:
         description: "True: The service is supported"
         type: boolean
-  set_Response_Certificate_Install:
+  set_Get_Certificate_Response:
     description: >-
-      CertificateInstallationRes - The new Contract Certificate (including the certificate chain)
-      and the corresponding encrypted private key are sent via the SECC to the vehicle
+      CertificateInstallationRes/CertificateUpdateRes - The new/updated
+       Contract Certificate (including the certificate chain)
+      and the corresponding encrypted private key are sent via the SECC to the EVCC
+      This is an async response to a previously published Certificate_Request
     arguments:
       Existream_Status:
         description: The response raw exi stream and the status from the CSMS system
-        type: object
-        $ref: /iso15118_charger#/Response_Exi_Stream_Status
-  set_Response_Certificate_Update:
-    description: CertificateUpdateRes - The updated Contract Certificate (including the certificate chain)
-      and the corresponding encrypted private key are sent via the SECC to the vehicle
-    arguments:
-      Existream_Status:
-        description: The response raw exi stream and the status n from the CSMS system
         type: object
         $ref: /iso15118_charger#/Response_Exi_Stream_Status
 vars:
@@ -425,16 +419,11 @@ vars:
     description: Estimated or calculated time until bulk and full charge is complete
     type: object
     $ref: /iso15118_charger#/DC_EVRemainingTime
-  Install_Request_Certificate:
+  Certificate_Request:
     description: >-
       The vehicle requests the SECC to deliver the certificate that belong 
       to the currently valid contract of the vehicle.
-    type: object
-    $ref: /iso15118_charger#/Request_Exi_Stream_Schema
-  Update_Request_Certificate:
-    description: >-
-      The vehicle requests the SECC to deliver new certificate that belongs to
-      the currently valid contract of the vehicle.
+      Response will be reported async via  set_Get_Certificate_Response
     type: object
     $ref: /iso15118_charger#/Request_Exi_Stream_Schema
   EV_AppProtocol:

--- a/interfaces/auth_token_validator.yaml
+++ b/interfaces/auth_token_validator.yaml
@@ -3,16 +3,13 @@ cmds:
   validate_token:
     description: Validate auth token and return result (with optional reason string)
     arguments:
-      id_token:
+      provided_token:
         description: >-
-          Arbitrary id token string: this has to be printable case insensitive
-          ascii: !!!FIXME!!! write a regex to allow only printable ascii
-        type: string
-        minLength: 1
-        maxLength: 20
+          Contains information about the authorization request
+        type: object
+        $ref: /authorization#/ProvidedIdToken
     result:
       description: >-
-        Result object containing validation result enum value (key: result)
-        and optional reason string (key: reason)
+        Result object containing validation result
       type: object
       $ref: /authorization#/ValidationResult

--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -23,17 +23,20 @@ cmds:
         Returns true if evse was disabled (or was disabled before), returns
         false if it could not be disabled (i.e. due to communication error with hardware)
       type: boolean
-  authorize:
+  authorize_response:
     description: >-
-      Authorizes the evse manager to start a transaction using the given
-      id tag.
+      Reports the result of an authorization request to the EvseManagar. 
+      Contains the provided_token for which authorization was requested and
+      the validation_result
     arguments:
-      id_tag:
-        description: The authorized id tag
-        type: string
-      pnc:
-        description: true Pnc auth, false EIM auth
-        type: boolean
+      provided_token:
+        description: The token for which authorization was requested
+        type: object
+        $ref: /authorization#/ProvidedIdToken
+      validation_result:
+        description: The validation result
+        type: object
+        $ref: /authorization#/ValidationResult
   withdraw_authorization:
     description: >-
       Call to signals that EVSE is not further authorized to start a transaction
@@ -117,6 +120,16 @@ cmds:
     result:
       description: Signed meter value
       type: string
+  set_get_certificate_response:
+    description: >-
+      CertificateInstallationRes/CertificateUpdateRes - Set the new/updated Contract Certificate (including the certificate chain)
+      and the corresponding encrypted private key. Should be forwared to EVCC.
+      This is an async response to a previously published iso15118_certificate_request
+    arguments:
+      certificate_reponse:
+        description: The response raw exi stream and the status from the CSMS system
+        type: object
+        $ref: /iso15118_charger#/Response_Exi_Stream_Status
 vars:
   session_event:
     description: Emits all events related to sessions
@@ -145,3 +158,10 @@ vars:
     description: "Hardware capability/limits"
     type: object
     $ref: /board_support#/HardwareCapabilities
+  iso15118_certificate_request:
+    description: >-
+      The vehicle requests the SECC to deliver the certificate that belong 
+      to the currently valid contract of the vehicle.
+      Response will be reported async via  set_get_certificate_response
+    type: object
+    $ref: /iso15118_charger#/Request_Exi_Stream_Schema

--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -124,13 +124,13 @@ public:
     void set_prioritize_authorization_over_stopping_transaction(bool b);
 
     /**
-     * @brief Registers the given \p callback to provide authorization.
+     * @brief Registers the given \p callback to notify the evse about the processed authorization request.
      *
      * @param callback
      */
     void
-    register_authorize_callback(const std::function<void(const int evse_index, const std::string& id_token)>& callback);
-
+    register_notify_evse_callback(const std::function<void(const int evse_index, const ProvidedIdToken& provided_token,
+                                                           const ValidationResult& validation_result)>& callback);
     /**
      * @brief Registers the given \p callback to withdraw authorization.
      *
@@ -144,7 +144,7 @@ public:
      * @param callback
      */
     void register_validate_token_callback(
-        const std::function<std::vector<ValidationResult>(const std::string& id_token)>& callback);
+        const std::function<std::vector<ValidationResult>(const ProvidedIdToken& provided_token)>& callback);
 
     /**
      * @brief Registers the given \p callback to stop a transaction at an EvseManager.
@@ -186,9 +186,11 @@ private:
     std::condition_variable cv;
 
     // callbacks
-    std::function<void(const int evse_index, const std::string& id_token)> authorize_callback;
+    std::function<void(const int evse_index, const ProvidedIdToken& provided_token,
+                       const ValidationResult& validation_result)>
+        notify_evse_callback;
     std::function<void(const int evse_index)> withdraw_authorization_callback;
-    std::function<std::vector<ValidationResult>(const std::string& id_token)> validate_token_callback;
+    std::function<std::vector<ValidationResult>(const ProvidedIdToken &provided_token)> validate_token_callback;
     std::function<void(const int evse_index, const StopTransactionRequest& request)> stop_transaction_callback;
     std::function<void(const Array& reservations)> reservation_update_callback;
     std::function<void(const int& evse_index, const int& reservation_id)> reserved_callback;
@@ -213,7 +215,8 @@ private:
     void lock_plug_in_mutex(const std::vector<int>& connectors);
     void unlock_plug_in_mutex(const std::vector<int>& connectors);
     int get_latest_plugin(const std::vector<int>& connectors);
-    void authorize_evse(int connector, const Identifier& identifier);
+    void notify_evse(int connector_id, const ProvidedIdToken& provided_token,
+                     const ValidationResult& validation_result);
     Identifier get_identifier(const ValidationResult& validation_result, const std::string& id_token,
                               const TokenType& type);
 };

--- a/modules/Auth/include/Connector.hpp
+++ b/modules/Auth/include/Connector.hpp
@@ -14,6 +14,16 @@
 
 namespace module {
 
+/// \brief Validated Identifier struct. Used to keep track of active Identifiers
+struct Identifier {
+    std::string id_token; ///< Arbitrary id token string: this has to be printable case insensitive ascii
+    types::authorization::TokenType type; ///< Type of the provider of the identifier
+    boost::optional<types::authorization::AuthorizationStatus> authorization_status;
+    boost::optional<std::string> expiry_time; ///< Absolute UTC time point when reservation expires in RFC3339 format
+    boost::optional<std::string> parent_id_token; ///< Parent id token of the id token
+};
+
+
 struct Connector {
     explicit Connector(int id) : id(id), transaction_active(false), reserved(false), is_reservable(true) {
         this->state_machine.controller->reset(this->state_machine.sd_available);
@@ -25,7 +35,7 @@ struct Connector {
     ConnectorStateMachine state_machine;
 
     // identifier is set when transaction is running and none if not
-    boost::optional<types::authorization::Identifier> identifier = boost::none;
+    boost::optional<Identifier> identifier = boost::none;
 
     bool is_reservable;
     bool reserved;

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -133,6 +133,7 @@ public:
     int32_t get_reservation_id();
 
     bool get_hlc_enabled();
+    bool get_hlc_waiting_for_auth_pnc();
     sigslot::signal<types::evse_manager::SessionEvent> signalReservationEvent;
 
     void charger_was_authorized();
@@ -184,6 +185,8 @@ private:
 
     double latest_target_voltage;
     double latest_target_current;
+
+    types::authorization::ProvidedIdToken autocharge_token;
 
     void log_v2g_message(Object m);
 

--- a/modules/EvseManager/evse/evse_managerImpl.hpp
+++ b/modules/EvseManager/evse/evse_managerImpl.hpp
@@ -37,7 +37,8 @@ protected:
     virtual int handle_get_id() override;
     virtual bool handle_enable() override;
     virtual bool handle_disable() override;
-    virtual void handle_authorize(std::string& id_tag, bool& pnc) override;
+    virtual void handle_authorize_response(types::authorization::ProvidedIdToken& provided_token,
+                                           types::authorization::ValidationResult& validation_result) override;
     virtual void handle_withdraw_authorization() override;
     virtual bool handle_reserve(int& reservation_id) override;
     virtual void handle_cancel_reservation() override;
@@ -50,6 +51,8 @@ protected:
     virtual types::evse_manager::SwitchThreePhasesWhileChargingResult
     handle_switch_three_phases_while_charging(bool& three_phases) override;
     virtual std::string handle_get_signed_meter_value() override;
+    virtual void handle_set_get_certificate_response(
+        types::iso15118_charger::Response_Exi_Stream_Status& certificate_reponse) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/JsCarV2G/index.js
+++ b/modules/JsCarV2G/index.js
@@ -14,13 +14,17 @@ function JavaStartedDeferred(mqtt_base_path, module_name, mod) {
     const mqttServerPort = process.env.MQTT_SERVER_PORT || '1883';
     const cmd = 'java';
 
+    const certs_path = `${mod.info.everest_prefix}/etc/everest/certs/client/oem/`;
+    const { tls_active } = mod.config.impl.main;
+
     // FIXME: the path hierarchy should be well defined,
     //        i.e where to find 3rd party things
     const cwd = `${__dirname}/../../3rd_party/rise_v2g`;
     const args = [
       '-Djava.net.preferIPv4Stack=false', '-Djava.net.prefecom.v2gclarity.rrIPv6Addresses=true',
       '-cp', 'rise-v2g-evcc-1.2.6.jar', 'com.v2gclarity.risev2g.evcc.main.StartEVCC',
-      mqttServerAddress, mqttServerPort, mqtt_base_path, mod.payment, mod.energymode, network_interface,
+      mqttServerAddress, mqttServerPort, mqtt_base_path, mod.payment, mod.energymode, network_interface, certs_path,
+      tls_active,
     ];
 
     evlog.debug(`Starting java subprocess: '${cmd}' with args ${args} in cwd '${cwd}'`);

--- a/modules/JsCarV2G/manifest.yaml
+++ b/modules/JsCarV2G/manifest.yaml
@@ -21,6 +21,11 @@ provides:
           Ethernet device used for HLC. Any local interface that has an ipv6 link-local and a MAC addr will work.
         type: string
         default: eth0
+      tls_active:
+        description: >-
+          If true, EVCC connects to SECC as TLS client
+        type: boolean
+        default: false
   ev:
     interface: ISO15118_ev
     description: This module implements the ISO15118-2 implementation of an EV

--- a/modules/JsDummyTokenValidator/index.js
+++ b/modules/JsDummyTokenValidator/index.js
@@ -9,7 +9,7 @@ function wait(time) {
 }
 
 boot_module(async ({ setup, config }) => {
-  setup.provides.main.register.validate_token(async (mod, provided_token) => {
+  setup.provides.main.register.validate_token(async (mod, { provided_token } ) => {
     evlog.info(`Got validation request for token '${provided_token.id_token}'...`);
     await wait(config.impl.main.sleep * 1000);
     const retval = {

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -20,6 +20,7 @@
 #include <generated/interfaces/evse_manager/Interface.hpp>
 #include <generated/interfaces/reservation/Interface.hpp>
 #include <generated/interfaces/system/Interface.hpp>
+#include <generated/interfaces/ISO15118_charger/Interface.hpp>
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
@@ -29,9 +30,10 @@
 #include <everest/timer.hpp>
 #include <filesystem>
 #include <mutex>
+#include <ocpp/v16/charge_point.hpp>
+#include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/common/schemas.hpp>
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/charge_point.hpp>
 #include <ocpp/v16/types.hpp>
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 

--- a/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
@@ -3,6 +3,7 @@
 #include "auth_token_validatorImpl.hpp"
 #include <ocpp/common/types.hpp>
 #include <ocpp/v16/enums.hpp>
+#include <ocpp/v201/ocpp_types.hpp>
 
 namespace module {
 namespace auth_validator {
@@ -13,8 +14,63 @@ void auth_token_validatorImpl::init() {
 void auth_token_validatorImpl::ready() {
 }
 
-types::authorization::ValidationResult auth_token_validatorImpl::handle_validate_token(std::string& token) {
-    const auto id_tag_info = mod->charge_point->authorize_id_token(ocpp::CiString<20>(token));
+types::authorization::ValidationResult
+auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedIdToken& provided_token) {
+
+    if (provided_token.type == types::authorization::TokenType::PlugAndCharge) {
+        return validate_pnc_request(provided_token);
+    } else {
+        return validate_standard_request(provided_token);
+    }
+};
+
+types::authorization::ValidationResult
+auth_token_validatorImpl::validate_pnc_request(const types::authorization::ProvidedIdToken& provided_token) {
+
+    // preparing payload for data_transfer_pnc_authorize
+    boost::optional<std::vector<ocpp::v201::OCSPRequestData>> iso15118_certificate_hash_data_opt;
+    if (provided_token.iso15118CertificateHashData.has_value()) {
+        std::vector<ocpp::v201::OCSPRequestData> iso15118_certificate_hash_data;
+        for (const auto& certificate_hash_data : provided_token.iso15118CertificateHashData.value()) {
+            ocpp::v201::OCSPRequestData v201_certificate_hash_data;
+            v201_certificate_hash_data.hashAlgorithm = ocpp::v201::conversions::string_to_hash_algorithm_enum(
+                types::iso15118_charger::hash_algorithm_to_string(certificate_hash_data.hashAlgorithm));
+            v201_certificate_hash_data.issuerKeyHash = certificate_hash_data.issuerKeyHash;
+            v201_certificate_hash_data.issuerNameHash = certificate_hash_data.issuerNameHash;
+            v201_certificate_hash_data.responderURL = certificate_hash_data.responderURL;
+            v201_certificate_hash_data.serialNumber = certificate_hash_data.serialNumber;
+            iso15118_certificate_hash_data.push_back(v201_certificate_hash_data);
+        }
+        iso15118_certificate_hash_data_opt.emplace(iso15118_certificate_hash_data);
+    }
+
+    // this is the actual OCPP request via DataTransfer.req to CSMS according to PnC1.6 whitepaper
+    const auto authorize_response = mod->charge_point->data_transfer_pnc_authorize(
+        provided_token.id_token, provided_token.certificate, iso15118_certificate_hash_data_opt);
+
+    // preparing the validation result
+    types::authorization::ValidationResult validation_result;
+    validation_result.authorization_status = types::authorization::string_to_authorization_status(
+        ocpp::v201::conversions::authorization_status_enum_to_string(authorize_response.idTokenInfo.status));
+    validation_result.evse_ids = authorize_response.idTokenInfo.evseId;
+    if (authorize_response.certificateStatus.has_value()) {
+        validation_result.certificate_status.emplace(types::authorization::string_to_certificate_status(
+            ocpp::v201::conversions::authorize_certificate_status_enum_to_string(
+                authorize_response.certificateStatus.value())));
+    }
+    if (authorize_response.idTokenInfo.cacheExpiryDateTime.has_value()) {
+        validation_result.expiry_time.emplace(authorize_response.idTokenInfo.cacheExpiryDateTime.value().to_rfc3339());
+    }
+    if (authorize_response.idTokenInfo.groupIdToken.has_value()) {
+        validation_result.parent_id_token.emplace(authorize_response.idTokenInfo.groupIdToken.value().idToken.get());
+    }
+    validation_result.reason = "PnC OCPP1.6 Validiation result by CSMS";
+    return validation_result;
+}
+
+types::authorization::ValidationResult
+auth_token_validatorImpl::validate_standard_request(const types::authorization::ProvidedIdToken& provided_token) {
+    const auto id_tag_info = mod->charge_point->authorize_id_token(ocpp::CiString<20>(provided_token.id_token));
     types::authorization::ValidationResult result;
 
     result.authorization_status = types::authorization::string_to_authorization_status(

--- a/modules/OCPP/auth_validator/auth_token_validatorImpl.hpp
+++ b/modules/OCPP/auth_validator/auth_token_validatorImpl.hpp
@@ -33,7 +33,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual types::authorization::ValidationResult handle_validate_token(std::string& id_token) override;
+    virtual types::authorization::ValidationResult
+    handle_validate_token(types::authorization::ProvidedIdToken& provided_token) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here
@@ -48,6 +49,8 @@ private:
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here
+    types::authorization::ValidationResult validate_standard_request(const types::authorization::ProvidedIdToken& provided_token);
+    types::authorization::ValidationResult validate_pnc_request(const types::authorization::ProvidedIdToken& provided_token);
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/PyJosev/everest_iso15118.py
+++ b/modules/PyJosev/everest_iso15118.py
@@ -24,11 +24,14 @@ class Charger_Wrapper(object):
         self.debug_mode = "None"
         self.stop_charging = False
         self.auth_okay_eim = False
-        self.auth_okay_pnc = False
+        self.auth_pnc_status = "Ongoing"
+        self.auth_pnc_certificate_status = "Ongoing"
         self.EVSE_UtilityInterruptEvent = False
         self.EVSE_EmergencyShutdown = False
         self.EVSE_Malfunction = False
         self.powermeter = dict()
+        self.certificate_service_supported = False
+        self.existream_status = dict()
 
         # AC
         self.EVSENominalVoltage = 0
@@ -56,10 +59,12 @@ class Charger_Wrapper(object):
         # Common
         self.stop_charging = False
         self.auth_okay_eim = False
-        self.auth_okay_pnc = False
+        self.auth_pnc_status = "Ongoing"
+        self.auth_pnc_certificate_status = "Ongoing"
         self.EVSE_UtilityInterruptEvent = False
         self.EVSE_EmergencyShutdown = False
         self.EVSE_Malfunction = False
+        self.existream_status = dict()
 
         # AC
         self.ContactorError = False
@@ -143,11 +148,14 @@ class Charger_Wrapper(object):
     def get_Auth_Okay_EIM(self) -> bool:
         return self.auth_okay_eim
 
-    # Authorization
-    def set_Auth_Okay_PnC(self, auth_okay_pnc: bool):
-        self.auth_okay_pnc = auth_okay_pnc
-    def get_Auth_Okay_PnC(self) -> bool:
-        return self.auth_okay_pnc
+    # PaymentDetails
+    def set_Auth_PnC_Status(self, status: str, certificateStatus):
+        self.auth_pnc_status = status
+        self.auth_pnc_certificate_status = certificateStatus
+    def get_Auth_PnC_Status(self) -> str:
+        return self.auth_pnc_status
+    def get_Auth_Certificate_Status(self):
+        return self.auth_pnc_certificate_status
 
     # TODO: Not yet implemented
     def set_FAILED_ContactorError(self, ContactorError: bool):
@@ -264,6 +272,18 @@ class Charger_Wrapper(object):
         self.cableCheck_Finished = status
     def get_cableCheck_Finished(self) -> bool:
         return self.cableCheck_Finished
+
+    # ServiceDiscovery
+    def set_Certificate_Service_Supported(self, status: bool):
+        self.certificate_service_supported = status
+    def get_Certificate_Service_Supported(self) -> bool:
+        return self.certificate_service_supported
+
+    # CertificateInstallation, CertificateUpdate
+    def set_Certificate_Response(self, existream_status: dict):
+        self.existream_status = existream_status
+    def get_Certificate_Response(self) -> dict:
+        return self.existream_status
 
 
 ChargerWrapper = Charger_Wrapper()

--- a/modules/PyJosev/module.py
+++ b/modules/PyJosev/module.py
@@ -8,10 +8,13 @@ import sys
 JOSEV_WORK_DIR = Path(__file__).parent / '../../3rd_party/josev'
 sys.path.append(JOSEV_WORK_DIR.as_posix())
 
+EVEREST_ETC_CERTS_PATH = "etc/everest/certs"
+
 from iso15118.secc import SECCHandler
 from iso15118.secc.controller.simulator import SimEVSEController
 from iso15118.shared.exificient_exi_codec import ExificientEXICodec
 from iso15118.secc.secc_settings import Config
+from iso15118.shared.settings import set_PKI_PATH
 
 from everest_iso15118 import init_Setup
 from everest_iso15118 import ChargerWrapper
@@ -54,6 +57,9 @@ def pre_init(setup, module_config, impl_configs, _module_info):
 
 def init():
     log.debug("init")
+
+    etc_certs_path = module_info_.everest_prefix + "/" + EVEREST_ETC_CERTS_PATH + "/"
+    set_PKI_PATH(etc_certs_path)
 
     net_iface: str = str(module_config_["device"])
     if net_iface == "auto":
@@ -103,8 +109,8 @@ def charger_enable_debug_mode(debug_mode: str):
 def charger_set_Auth_Okay_EIM(auth_okay_eim: bool):
     ChargerWrapper.set_Auth_Okay_EIM(auth_okay_eim)
 
-def charger_set_Auth_Okay_PnC(auth_okay_pnc: bool):
-    ChargerWrapper.set_Auth_Okay_PnC(auth_okay_pnc)
+def charger_set_Auth_Okay_PnC(status: str, certificateStatus: str):
+    ChargerWrapper.set_Auth_PnC_Status(status, certificateStatus)
 
 def charger_set_FAILED_ContactorError(ContactorError: bool):
     ChargerWrapper.set_FAILED_ContactorError(ContactorError)
@@ -152,8 +158,14 @@ def charger_contactor_closed(status: bool):
 def charger_contactor_open(status: bool):
     ChargerWrapper.contactor_open(status)
 
-def charger_cableCheck_Finished(status):
+def charger_cableCheck_Finished(status: bool):
     ChargerWrapper.set_cableCheck_Finished(status)
+
+def charger_set_Certificate_Service_Supported(status: bool):
+    ChargerWrapper.set_Certificate_Service_Supported(status)
+
+def charger_set_Get_Certificate_Response(Existream_Status: dict):
+    ChargerWrapper.set_Certificate_Response(Existream_Status)
 
 def check_network_interfaces(net_iface: str) -> bool:
     if (net_iface in netifaces.interfaces()) is True:

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -25,36 +25,6 @@ types:
       - NoCertificateAvailable
       - CertChainError
       - ContractCancelled
-  Identifier:
-    description: Contains meta information about the identifier
-    type: object
-    additionalProperties: false
-    required:
-      - id_token
-      - type
-    properties:
-      id_token:
-        description: >-
-          Arbitrary id token string: this has to be printable case insensitive
-          ascii
-        type: string
-        minLength: 1
-        maxLength: 20
-      type:
-        description: >-
-          Type of the provider of the identifier
-        type: string
-        $ref: /authorization#/TokenType
-      authorization_status:
-        type: string
-        $ref: /authorization#/AuthorizationStatus
-      expiry_time:
-        description: Absolute UTC time point when reservation expires in RFC3339 format
-        type: string
-        format: date-time
-      parent_id_token:
-        description: Parent id token of the id token
-        type: string
   ProvidedIdToken:
     description: Type for Token provided by auth token providers
     type: object
@@ -127,6 +97,15 @@ types:
         type: string
         minLength: 1
         maxLength: 20
+      evse_ids:
+        description: >-
+          Only used when the id token is valid for one or more specific evses, 
+          not for the whole charging station. Indicates for which evse ids the
+          provided token is valid
+        type: array
+        items:
+          minimum: 1
+          type: integer
   SelectionAlgorithm:
     description: >-
       The selection algorithm defines the logic to select one connector

--- a/types/iso15118_charger.yaml
+++ b/types/iso15118_charger.yaml
@@ -345,6 +345,7 @@ types:
     additionalProperties: false
     required:
       - status
+      - certificateAction
     properties:
       status:
         description: >-
@@ -361,6 +362,10 @@ types:
           as exi stream (Base64 encoded)
         type: string
         maxLength: 5600
+      certificateAction:
+        description: Type of the certificate request
+        type: string
+        $ref: /iso15118_charger#/CertificateActionEnum
   Request_Exi_Stream_Schema:
     description: The request raw exi stream and the schema version for the CSMS system
     type: object
@@ -368,6 +373,7 @@ types:
     required:
       - exiRequest
       - iso15118SchemaVersion
+      - certificateAction
     properties:
       exiRequest:
         description: >-
@@ -379,6 +385,10 @@ types:
         description: Schema Version used for CertificateReq message between EV and Charger
         type: string
         maxLength: 50 
+      certificateAction:
+        description: Type of the certificate request
+        type: string
+        $ref: /iso15118_charger#/CertificateActionEnum
   CertificateHashDataInfo:
     description: Contains the certificate information
     type: object
@@ -413,3 +423,10 @@ types:
         description: This contains the responder URL
         type: string
         maxLength: 512
+  CertificateActionEnum:
+    description: Specifies the type of a certificate request
+    type: string
+    enum:
+      - Install
+      - Update
+


### PR DESCRIPTION
Changes for ISO15118 Plug&Charge touching modules Auth, EvseManager, OCPP, JsDummyTokenValidator, PyJosev  including respective types and interfaces

**everest-core**: 
* Added certs/ca and certs/client folder to everest-core config directory
* if present, certificates will be installed into etc/everest/certs

**ISO15118_charger**: 
* combined cmds and vars in for requesting install/update of ISO15118 EV certificate in the interface

**EvseManager**:
* Extended evse_managaer interface in order to forward request for install/update of ISO15118 EV certificate
* renamed cmd authorize to authorize_response: This cmd now takes a ProvidedIdToken and a ValdiationResult as arguments
* authorize_response now differentiates between PnC authorization and standard authorization and handles the response
* EvseManager subscribes to iso15118_certificate_request of iso15118_charger interface and publishes the request in order to inform OCPP module
* EvseManager calls set_Auth_Okay_PnC when it receives valid authorization for PnC

**OCPP**:
* Added certs path arg to module config
* OCPP module now registers callbacks within libocpp for install/update of ISO15118 EV certificate response
* OCPP module now subscribes to EvseManager iso15118_certificate_request in order to use the DataTransfer.req to forward t he request to CSMS
* auth_token_validator implementation of OCPP now differntiates between standard and pnc validations

**Auth**:
* Extended auth module to handle PnC authorization requests
* Extended test cases for new use cases
* Auth module now checks for intersection of referenced_connectors and those that were listed within ValidationResult

**PyJosev**:
* PyJosev adapted to PnC extension + config of the JsCarV2G module extended with cert_path and tls_active parameter