### PR TITLE
Bump libocpp version to 0.5.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -38,7 +38,7 @@ RISE-V2G:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.5.1
+  git_tag: v0.5.2
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git


### PR DESCRIPTION
Bugfix within Session Logging of libocpp included in 0.5.2 version