### PR TITLE
Add TLS v1.2 support to EvseV2G module

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ cd ~/checkout/everest-workspace/Josev/iso15118/shared/pki
 
 Note that this will generate an example PKI setup that can only be used for testing and simulation purposes. It will not work and is not recommended for production!
 
+The script for setting up PKI can also be used with the EvseV2G module.
+
 Now we can build EVerest!
 
 ```bash

--- a/modules/EvseV2G/EvseV2G.hpp
+++ b/modules/EvseV2G/EvseV2G.hpp
@@ -28,6 +28,8 @@ struct Conf {
     std::string highlevel_authentication_mode;
     std::string tls_security;
     bool terminate_connection_on_failed_response;
+    bool tls_key_logging;
+    std::string tls_key_logging_path;
 };
 
 class EvseV2G : public Everest::ModuleBase {

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -5,6 +5,8 @@
 #include "log.hpp"
 #include "v2g_ctx.hpp"
 
+const std::string EVEREST_ETC_CERTS_PATH = "etc/everest/certs"; // relativ path of the certs
+
 using namespace std::chrono_literals;
 
 namespace module {
@@ -16,6 +18,7 @@ void ISO15118_chargerImpl::init() {
         return;
     }
 
+    /* Configure if_name and auth_mode */
     v2g_ctx->if_name = mod->config.device.data();
     dlog(DLOG_LEVEL_DEBUG, "if_name %s", v2g_ctx->if_name);
     dlog(DLOG_LEVEL_DEBUG, "auth_mode %s", mod->config.highlevel_authentication_mode.data());
@@ -51,6 +54,20 @@ void ISO15118_chargerImpl::init() {
     }
 
     v2g_ctx->terminate_connection_on_failed_response = mod->config.terminate_connection_on_failed_response;
+
+    v2g_ctx->tls_key_logging = mod->config.tls_key_logging;
+    v2g_ctx->tls_key_logging_path = mod->config.tls_key_logging_path;
+
+    if (mod->config.tls_key_logging == true) {
+        dlog(DLOG_LEVEL_DEBUG, "tls-key-logging enabled (path: %s)", mod->config.tls_key_logging_path.c_str());
+    }
+
+    /*  Determine certs path */
+    if (mod->info.everest_prefix != "/usr") {
+        v2g_ctx->certs_path = mod->info.everest_prefix + "/" + EVEREST_ETC_CERTS_PATH;
+    } else {
+        v2g_ctx->certs_path = "/" + EVEREST_ETC_CERTS_PATH;
+    }
 }
 
 void ISO15118_chargerImpl::ready() {

--- a/modules/EvseV2G/din_server.cpp
+++ b/modules/EvseV2G/din_server.cpp
@@ -343,7 +343,8 @@ static enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
 
     dlog(DLOG_LEVEL_INFO, "Created new session with id 0x%08" PRIu64, conn->ctx->evse_v2g_data.session_id);
 
-    res->EVSEID.bytesLen = min(conn->ctx->evse_v2g_data.evse_id.bytesLen, dinSessionSetupResType_EVSEID_BYTES_SIZE);
+    res->EVSEID.bytesLen =
+        std::min((int)conn->ctx->evse_v2g_data.evse_id.bytesLen, dinSessionSetupResType_EVSEID_BYTES_SIZE);
     memcpy(res->EVSEID.bytes, conn->ctx->evse_v2g_data.evse_id.bytes, res->EVSEID.bytesLen);
 
     res->DateTimeNow_isUsed = conn->ctx->evse_v2g_data.date_time_now_is_used;

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -604,9 +604,9 @@ static bool publish_iso_payment_details_req(struct iso1PaymentDetailsReqType con
                 goto exit;
             }
 
-            if ((NULL == base64Buffer) ||
-                (0 != mbedtls_base64_encode(base64Buffer, olen, &olen, subCertTmp->Certificate.array[idx].bytes,
-                                            static_cast<size_t>(subCertTmp->Certificate.array[idx].bytesLen)))) {
+            if ((base64Buffer == NULL) ||
+                (mbedtls_base64_encode(base64Buffer, olen, &olen, subCertTmp->Certificate.array[idx].bytes,
+                                       static_cast<size_t>(subCertTmp->Certificate.array[idx].bytesLen)) != 0)) {
                 rv = false;
                 dlog(DLOG_LEVEL_ERROR, "Unable to encode contract sub certificate #%d", idx);
                 goto exit;

--- a/modules/EvseV2G/manifest.yaml
+++ b/modules/EvseV2G/manifest.yaml
@@ -42,10 +42,24 @@ config:
       the EV is responsible for closing of the V2G communication session with SessionStop.
     type: boolean
     default: false
+  tls_key_logging:
+    description: >-
+      Enable/Disable the export of TLS session keys (pre-master-secret)
+      during a TLS handshake. This log file can be used to decrypt TLS
+      sessions. Note that this option is for testing and simulation
+      purpose only
+    type: boolean
+    default: false
+  tls_key_logging_path:
+    description:  >-
+      Output directory for the TLS key log file
+    type: string
+    default: /tmp
 provides:
   charger:
     interface: ISO15118_charger
-    description: This module implements the ISO15118-2 implementation of
+    description: >-
+      This module implements the ISO15118-2 implementation of
       an AC or DC charger
 enable_external_mqtt: true
 metadata:

--- a/modules/EvseV2G/tools.cpp
+++ b/modules/EvseV2G/tools.cpp
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022-2023 chargebyte GmbH
 // Copyright (C) 2022-2023 Contributors to EVerest
+#include "tools.hpp"
+#include "log.hpp"
 #include <arpa/inet.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <ifaddrs.h>
+#include <iomanip>
 #include <math.h>
+#include <sstream>
 #include <stdio.h>
 #include <string>
 #include <string.h>
@@ -14,8 +18,6 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
-#include "log.hpp"
-#include "tools.hpp"
 
 ssize_t safe_read(int fd, void* buf, size_t count) {
     for (;;) {
@@ -301,7 +303,7 @@ uint8_t get_dir_numbered_file_names(char file_names[MAX_PKI_CA_LENGTH][MAX_FILE_
                             strcpy(file_names[idx], dir->d_name);
                             // dlog(DLOG_LEVEL_ERROR,"Cert-file found: %s", &AFileNames[idx]);
                             num_of_files++;
-                            min_idx = min(min_idx, idx);
+                            min_idx = std::min(min_idx, idx);
                         } else {
                             dlog(DLOG_LEVEL_ERROR, "Max. file-name size exceeded. Only %i characters supported",
                                  MAX_FILE_NAME_LENGTH);
@@ -328,4 +330,14 @@ exit:
     closedir(d);
 
     return num_of_files + offset;
+}
+
+std::string convert_to_hex_str(const uint8_t* data, int len) {
+    std::stringstream string_stream;
+    string_stream << std::hex;
+
+    for (int idx = 0; idx < len; ++idx)
+        string_stream << std::setw(2) << std::setfill('0') << (int)data[idx];
+
+    return string_stream.str();
 }

--- a/modules/EvseV2G/tools.hpp
+++ b/modules/EvseV2G/tools.hpp
@@ -9,25 +9,12 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string>
 #include <sys/time.h>
 #include <time.h>
 
 #define MAX_FILE_NAME_LENGTH 100
 #define MAX_PKI_CA_LENGTH    4 /* leaf up to root certificate */
-
-#define max(a, b)                                                                                                      \
-    ({                                                                                                                 \
-        __typeof__(a) _a = (a);                                                                                        \
-        __typeof__(b) _b = (b);                                                                                        \
-        _a > _b ? _a : _b;                                                                                             \
-    })
-
-#define min(a, b)                                                                                                      \
-    ({                                                                                                                 \
-        __typeof__(a) _a = (a);                                                                                        \
-        __typeof__(b) _b = (b);                                                                                        \
-        _a < _b ? _a : _b;                                                                                             \
-    })
 
 #ifndef ARRAY_SIZE
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
@@ -121,5 +108,13 @@ bool get_dir_filename(char* file_name, uint8_t file_name_len, const char* path, 
 uint8_t get_dir_numbered_file_names(char file_names[MAX_PKI_CA_LENGTH][MAX_FILE_NAME_LENGTH], const char* path,
                                     const char* prefix, const char* suffix, const uint8_t offset,
                                     const uint8_t max_idx);
+
+/*!
+ * \brief convert_to_hex_str This function converts a array of binary data to hex string.
+ * \param data is the array of binary data.
+ * \param len is length of the array.
+ * \return Returns the converted string.
+ */
+std::string convert_to_hex_str(const uint8_t* data, int len);
 
 #endif /* TOOLS_H */

--- a/modules/EvseV2G/v2g.hpp
+++ b/modules/EvseV2G/v2g.hpp
@@ -184,10 +184,11 @@ struct v2g_context {
     struct sockaddr_in6* local_tcp_addr;
     struct sockaddr_in6* local_tls_addr;
 
-    char* privateKeyFilePath;
-    char* certFilePath;
+    std::string certs_path;
+    std::string tls_key_logging_path;
 
-    uint32_t network_read_timeout; /* in milli seconds */
+    uint32_t network_read_timeout;     /* in milli seconds */
+    uint32_t network_read_timeout_tls; /* in milli seconds */
 
     enum tls_security_level tls_security;
 
@@ -202,7 +203,7 @@ struct v2g_context {
     mbedtls_x509_crt v2g_root_crt;
     mbedtls_net_context tls_socket;
     keylogDebugCtx tls_log_ctx;
-    bool end_tls_debug_by_sessionStop;
+    bool tls_key_logging;
     pthread_t tls_thread;
 
     mbedtls_x509_crt mop_root_ca_list;
@@ -213,8 +214,7 @@ struct v2g_context {
 
     struct {
         float evse_ac_current_limit; // default is 0
-        char keyFilePw[MAX_V2G_ROOT_CERTS][MAX_KEY_PW_LEN];
-    } basic_config; // This config will not reseted after beginning of a new charging session
+    } basic_config;                  // This config will not reseted after beginning of a new charging session
 
     /* actual charging state */
     enum V2gMsgTypeId last_v2g_msg;    /* holds the current v2g msg type */

--- a/modules/EvseV2G/v2g_server.cpp
+++ b/modules/EvseV2G/v2g_server.cpp
@@ -618,13 +618,13 @@ uint64_t v2g_session_id_from_exi(bool is_iso, void* exi_in) {
          * send our full session id back to us; this is why we init the id with 0 above
          * and only copy the provided byte len
          */
-        memcpy(&session_id, &hdr->SessionID.bytes, min(sizeof(session_id), hdr->SessionID.bytesLen));
+        memcpy(&session_id, &hdr->SessionID.bytes, std::min((int)sizeof(session_id), (int)hdr->SessionID.bytesLen));
     } else {
         struct dinEXIDocument* req = static_cast<struct dinEXIDocument*>(exi_in);
         struct dinMessageHeaderType* hdr = &req->V2G_Message.Header;
 
         /* see comment above */
-        memcpy(&session_id, &hdr->SessionID.bytes, min(sizeof(session_id), hdr->SessionID.bytesLen));
+        memcpy(&session_id, &hdr->SessionID.bytes, std::min((int)sizeof(session_id), (int)hdr->SessionID.bytesLen));
     }
 
     return session_id;


### PR DESCRIPTION
Now the module supports TLS v1.2. The TLS support can be configured in the manifest.yaml file of the module. Session key logging can also be activated in the manifest.yaml file.