### PR TITLE
Improvement for the reservation of charging processes

### DIFF
--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -20,7 +20,7 @@ install(
 install(
     DIRECTORY "certs"
     DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/everest"
-    FILES_MATCHING PATTERN "*.pem" PATTERN "*.key" PATTERN "*.der" PATTERN "*.txt"
+    FILES_MATCHING PATTERN "*.pem" PATTERN "*.key" PATTERN "*.der" PATTERN "*.txt" PATTERN "*.jks" PATTERN "*.p12" 
 )
 
 install(

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -38,7 +38,7 @@ RISE-V2G:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.6.1
+  git_tag: v0.7.0
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git

--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -60,9 +60,10 @@ public:
      * @brief Function tries to cancel reservation with the given \p reservation_id .
      *
      * @param reservation_id
+     * @param execute_callback if true, cancel_reservation_callback will be executed
      * @return int -1 if reservation could not been cancelled, else the id of the connnector
      */
-    int cancel_reservation(int reservation_id);
+    int cancel_reservation(int reservation_id, bool execute_callback);
 
     /**
      * @brief Handler that is called when a reservation was started / used.

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -371,7 +371,7 @@ types::reservation::ReservationResult AuthHandler::handle_reservation(int connec
 }
 
 int AuthHandler::handle_cancel_reservation(int reservation_id) {
-    return this->reservation_handler.cancel_reservation(reservation_id);
+    return this->reservation_handler.cancel_reservation(reservation_id, true);
 }
 
 void AuthHandler::call_reserved(const int& connector_id, const int reservation_id) {
@@ -412,6 +412,7 @@ void AuthHandler::handle_session_event(const int connector_id, const SessionEven
         break;
     case SessionEventEnum::TransactionStarted:
         this->connectors.at(connector_id)->connector.transaction_active = true;
+        this->connectors.at(connector_id)->connector.reserved = false;
         this->connectors.at(connector_id)->connector.submit_event(Event_Transaction_Started());
         this->connectors.at(connector_id)->timeout_timer.stop();
         break;

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -620,7 +620,7 @@ void EvseManager::ready() {
         // Cancel reservations if charger is disabled or faulted
         if (s == types::evse_manager::SessionEventEnum::Disabled ||
             s == types::evse_manager::SessionEventEnum::PermanentFault) {
-            cancel_reservation();
+            cancel_reservation(true);
         }
         if (s == types::evse_manager::SessionEventEnum::SessionStarted ||
             s == types::evse_manager::SessionEventEnum::SessionFinished) {
@@ -912,7 +912,7 @@ bool EvseManager::reserve(int32_t id) {
     return false;
 }
 
-void EvseManager::cancel_reservation() {
+void EvseManager::cancel_reservation(bool signal_event) {
 
     std::lock_guard<std::mutex> lock(reservation_mutex);
     if (reserved) {
@@ -920,10 +920,11 @@ void EvseManager::cancel_reservation() {
         reservation_id = 0;
 
         // publish event to other modules
-        types::evse_manager::SessionEvent se;
-        se.event = types::evse_manager::SessionEventEnum::ReservationEnd;
-
-        signalReservationEvent(se);
+        if (signal_event) {
+            types::evse_manager::SessionEvent se;
+            se.event = types::evse_manager::SessionEventEnum::ReservationEnd;
+            signalReservationEvent(se);
+        }
     }
 }
 

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -130,7 +130,7 @@ public:
     types::energy::ExternalLimits getLocalEnergyLimits();
     bool getLocalThreePhases();
 
-    void cancel_reservation();
+    void cancel_reservation(bool signal_event);
     bool is_reserved();
     bool reserve(int32_t id);
     int32_t get_reservation_id();

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -157,6 +157,7 @@ void evse_managerImpl::ready() {
 
             if (mod->is_reserved()) {
                 transaction_started.reservation_id.emplace(mod->get_reservation_id());
+                mod->cancel_reservation(false);
             }
 
             transaction_started.id_tag = mod->charger->getAuthTag();
@@ -294,7 +295,7 @@ bool evse_managerImpl::handle_reserve(int& reservation_id) {
 };
 
 void evse_managerImpl::handle_cancel_reservation() {
-    mod->cancel_reservation();
+    mod->cancel_reservation(true);
 };
 
 bool evse_managerImpl::handle_disable() {


### PR DESCRIPTION
Reservation was cancelled by Auth module before reservationId could be transmitted within TransactionStarted event. This is now fixed