### PR TITLE
Do not terminate connection on failed response

### DIFF
--- a/modules/EvseV2G/EvseV2G.hpp
+++ b/modules/EvseV2G/EvseV2G.hpp
@@ -27,6 +27,7 @@ struct Conf {
     bool supported_ISO15118_2;
     std::string highlevel_authentication_mode;
     std::string tls_security;
+    bool terminate_connection_on_failed_response;
 };
 
 class EvseV2G : public Everest::ModuleBase {

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -47,6 +47,8 @@ void ISO15118_chargerImpl::init() {
         v2g_ctx->tls_security = TLS_SECURITY_PROHIBIT;
         dlog(DLOG_LEVEL_DEBUG, "tls_security prohibit");
     }
+
+    v2g_ctx->terminate_connection_on_failed_response = mod->config.terminate_connection_on_failed_response;
 }
 
 void ISO15118_chargerImpl::ready() {

--- a/modules/EvseV2G/din_server.cpp
+++ b/modules/EvseV2G/din_server.cpp
@@ -104,17 +104,16 @@ static v2g_event din_validate_response_code(dinresponseCodeType* const din_respo
                              ? dinresponseCodeType_FAILED_UnknownSession
                              : *din_response_code;
 
-    if (*din_response_code >= dinresponseCodeType_FAILED) {
+    if ((conn->ctx->terminate_connection_on_failed_response == true) &&
+        (*din_response_code >= dinresponseCodeType_FAILED)) {
         nextEvent = V2G_EVENT_SEND_AND_TERMINATE; // [V2G-DC-665]
-        /* set return value to 1 if the EVSE cannot process this request message */
-        if (*din_response_code >= dinresponseCodeType_FAILED &&
-            *din_response_code <= dinresponseCodeType_FAILED_WrongEnergyTransferType) {
-            dlog(DLOG_LEVEL_ERROR, "Failed response code detected for message \"%s\", error: %s",
-                 v2g_msg_type[conn->ctx->current_v2g_msg], dinResponse[*din_response_code]);
-        } else {
-            dlog(DLOG_LEVEL_ERROR, "Failed response code detected for message \"%s\", Invalid response code: %d",
-                 v2g_msg_type[conn->ctx->current_v2g_msg], *din_response_code);
-        }
+    }
+
+    /* log failed response code message */
+    if (*din_response_code >= dinresponseCodeType_FAILED &&
+        *din_response_code <= dinresponseCodeType_FAILED_WrongEnergyTransferType) {
+        dlog(DLOG_LEVEL_ERROR, "Failed response code detected for message \"%s\", error: %s",
+             v2g_msg_type[conn->ctx->current_v2g_msg], dinResponse[*din_response_code]);
     }
 
     return nextEvent;

--- a/modules/EvseV2G/manifest.yaml
+++ b/modules/EvseV2G/manifest.yaml
@@ -35,6 +35,13 @@ config:
     - allow
     - force
     default: prohibit
+  terminate_connection_on_failed_response:
+    description: >-
+      Controls how to handle a failed response code of the EVSE. If true the
+      V2G connection is terminated immediately on a failed response code, otherwise
+      the EV is responsible for closing of the V2G communication session with SessionStop.
+    type: boolean
+    default: false
 provides:
   charger:
     interface: ISO15118_charger

--- a/modules/EvseV2G/v2g.hpp
+++ b/modules/EvseV2G/v2g.hpp
@@ -232,6 +232,7 @@ struct v2g_context {
                       close tcp connection) */
     bool is_connection_terminated; /* Is set to true if the connection is terminated (CP State A/F, shutdown immediately
                                       without response message) */
+    std::atomic<bool> terminate_connection_on_failed_response;
     std::atomic<bool> contactor_is_closed; /* Actual contactor state */
 
     struct {

--- a/modules/EvseV2G/v2g_server.cpp
+++ b/modules/EvseV2G/v2g_server.cpp
@@ -318,7 +318,10 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
         (V2G_EVENT_SEND_AND_TERMINATE == next_event)) {
         conn->handshake_resp.supportedAppProtocolRes.ResponseCode = appHandresponseCodeType_Failed_NoNegotiation;
         dlog(DLOG_LEVEL_ERROR, "Abort charging session");
-        next_event = V2G_EVENT_SEND_AND_TERMINATE; // send response and terminate the tcp-connection
+
+        if (conn->ctx->terminate_connection_on_failed_response == true) {
+            next_event = V2G_EVENT_SEND_AND_TERMINATE; // send response and terminate the TCP-connection
+        }
     }
 
     /* encode response at the right buffer location */


### PR DESCRIPTION
Now the behavior in case of a failed response code is configurable in the manifest file. By default the connection is no longer terminated immediately after configuring of a failed response code.