### PR TITLE
change EVCCID/MAC addresses to uppercase

### DIFF
--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -315,9 +315,9 @@ vars:
   EVCCIDD:
     description:
       Specifies the EVs identification in a readable format. It contains
-      the MAC address of the EVCC
+      the MAC address of the EVCC in uppercase
     type: string
-    pattern: ^[A-Fa-f0-9]{2}(:[A-Fa-f0-9]{2}){5}$
+    pattern: ^[A-F0-9]{2}(:[A-F0-9]{2}){5}$
   SelectedPaymentOption:
     description: This element is used for indicating the payment type
     type: string

--- a/interfaces/slac.yaml
+++ b/interfaces/slac.yaml
@@ -55,5 +55,6 @@ vars:
     type: 'null'
   ev_mac_address:
     description: >-
-      Inform higher layers about the MAC address of the vehicle.
+      Inform higher layers about the MAC address of the vehicle (upper case)
     type: string
+    pattern: ^[A-F0-9]{2}(:[A-F0-9]{2}){5}$

--- a/modules/EvseSlac/main/context.cpp
+++ b/modules/EvseSlac/main/context.cpp
@@ -8,14 +8,14 @@
 
 void Context::signal_cm_slac_parm_req(const uint8_t* mac) {
     if (callbacks.signal_ev_mac_address_parm_req) {
-        auto mac_string = fmt::format("{:02x}", fmt::join(mac, mac + ETH_ALEN, ":"));
+        auto mac_string = fmt::format("{:02X}", fmt::join(mac, mac + ETH_ALEN, ":"));
         callbacks.signal_ev_mac_address_parm_req(mac_string);
     }
 }
 
 void Context::signal_cm_slac_match_cnf(const uint8_t* mac) {
     if (callbacks.signal_ev_mac_address_match_cnf) {
-        auto mac_string = fmt::format("{:02x}", fmt::join(mac, mac + ETH_ALEN, ":"));
+        auto mac_string = fmt::format("{:02X}", fmt::join(mac, mac + ETH_ALEN, ":"));
         callbacks.signal_ev_mac_address_match_cnf(mac_string);
     }
 }

--- a/modules/EvseV2G/din_server.cpp
+++ b/modules/EvseV2G/din_server.cpp
@@ -55,11 +55,10 @@ void load_din_physical_value(struct dinPhysicalValueType* const phy_value_dest,
 
 /*!
  * \brief din_validate_state This function checks whether the received message is expected and valid at this
- * point in the communication sequence state machine. The current V2G msg type must be set with the current V2G msg state.
- * \param state is the current state of the charging session
- * \param current_v2g_msg is the current handled V2G message
- * \param state of the actual session.
- * \return Returns a dinResponseCode with sequence error if current_v2g_msg is not expected, otherwise OK.
+ * point in the communication sequence state machine. The current V2G msg type must be set with the current V2G msg
+ * state. \param state is the current state of the charging session \param current_v2g_msg is the current handled V2G
+ * message \param state of the actual session. \return Returns a dinResponseCode with sequence error if current_v2g_msg
+ * is not expected, otherwise OK.
  */
 static dinresponseCodeType din_validate_state(int state, enum V2gMsgTypeId current_v2g_msg) {
     /* if the request type has enabled (= set) bit in expected_requests, then this
@@ -70,10 +69,10 @@ static dinresponseCodeType din_validate_state(int state, enum V2gMsgTypeId curre
 }
 
 /*!
- * \brief din_validate_response_code This function checks if an external error has occurred (sequence error, user abort)... ).
- * \param din_response_code is a pointer to the current response code. The value will be modified if an external error has occurred.
- * \param conn the structure with the external error information.
- * \return Returns the next v2g-event.
+ * \brief din_validate_response_code This function checks if an external error has occurred (sequence error, user
+ * abort)... ). \param din_response_code is a pointer to the current response code. The value will be modified if an
+ * external error has occurred. \param conn the structure with the external error information. \return Returns the next
+ * v2g-event.
  */
 static v2g_event din_validate_response_code(dinresponseCodeType* const din_response_code,
                                             struct v2g_connection const* conn) {
@@ -145,9 +144,8 @@ static void publish_DIN_DC_EVStatusType(struct v2g_context* ctx, const struct di
 //=============================================
 
 /*!
- * \brief publish_din_service_discovery_req This function publishes the dinServiceDiscoveryReqType message to the MQTT interface.
- * \param ctx is the V2G context.
- * \param dinServiceDiscoveryReqType is the request message.
+ * \brief publish_din_service_discovery_req This function publishes the dinServiceDiscoveryReqType message to the MQTT
+ * interface. \param ctx is the V2G context. \param dinServiceDiscoveryReqType is the request message.
  */
 static void
 publish_din_service_discovery_req(struct v2g_context* ctx,
@@ -214,9 +212,8 @@ static void publish_din_charge_parameter_discovery_req(
 }
 
 /*!
- * \brief publish_din_power_delivery_req This function publishes the dinPowerDeliveryReqType message to the MQTT interface.
- * \param ctx is the V2G context.
- * \param din_power_delivery_req is the request message.
+ * \brief publish_din_power_delivery_req This function publishes the dinPowerDeliveryReqType message to the MQTT
+ * interface. \param ctx is the V2G context. \param din_power_delivery_req is the request message.
  */
 static void publish_din_power_delivery_req(struct v2g_context* ctx,
                                            struct dinPowerDeliveryReqType const* const v2g_power_delivery_req) {
@@ -247,9 +244,8 @@ static void publish_din_precharge_req(struct v2g_context* ctx,
 }
 
 /*!
- * \brief publish_din_current_demand_req This function publishes the dinCurrentDemandReqType message to the MQTT interface.
- * \param ctx is the V2G context.
- * \param v2g_current_demand_req is the request message.
+ * \brief publish_din_current_demand_req This function publishes the dinCurrentDemandReqType message to the MQTT
+ * interface. \param ctx is the V2G context. \param v2g_current_demand_req is the request message.
  */
 static void publish_din_current_demand_req(struct v2g_context* ctx,
                                            struct dinCurrentDemandReqType const* const v2g_current_demand_req) {
@@ -318,7 +314,7 @@ static enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
 
     /* format EVCC ID */
     for (idx = 0; idx < req->EVCCID.bytesLen; idx++) {
-        sprintf(&buffer[idx * 3], "%02" PRIx8 ":", req->EVCCID.bytes[idx]);
+        sprintf(&buffer[idx * 3], "%02" PRIX8 ":", req->EVCCID.bytes[idx]);
     }
     if (idx)
         buffer[idx * 3 - 1] = '\0';
@@ -611,7 +607,7 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
             dlog(DLOG_LEVEL_WARNING,
                  "EVSE wants to finish charge parameter phase, but status code is not set to 'ready' (1)");
         }
-        conn->ctx->state = WAIT_FOR_CABLECHECK; // [V2G-DC-453]
+        conn->ctx->state = WAIT_FOR_CABLECHECK;               // [V2G-DC-453]
     } else {
         conn->ctx->state = WAIT_FOR_CHARGEPARAMETERDISCOVERY; // [V2G-DC-498]
     }

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -53,12 +53,13 @@ static iso1responseCodeType iso_validate_state(int state, enum V2gMsgTypeId curr
 }
 
 /*!
- * \brief iso_validate_response_code This function checks if an external error has occurred (sequence error, user abort) ... ).
- * \param iso_response_code is a pointer to the current response code. The value will be modified if an external
+ * \brief iso_validate_response_code This function checks if an external error has occurred (sequence error, user abort)
+ * ... ). \param iso_response_code is a pointer to the current response code. The value will be modified if an external
  *  error has occurred.
  * \param conn the structure with the external error information.
- * \return Returns \c V2G_EVENT_SEND_AND_TERMINATE if the charging must be terminated after sending the response message,
- *  returns \c V2G_EVENT_TERMINATE_CONNECTION if charging must be aborted immediately and \c V2G_EVENT_NO_EVENT if no error
+ * \return Returns \c V2G_EVENT_SEND_AND_TERMINATE if the charging must be terminated after sending the response
+ * message, returns \c V2G_EVENT_TERMINATE_CONNECTION if charging must be aborted immediately and \c V2G_EVENT_NO_EVENT
+ * if no error
  */
 static v2g_event iso_validate_response_code(iso1responseCodeType* const v2g_response_code,
                                             struct v2g_connection const* const conn) {
@@ -801,7 +802,7 @@ static enum v2g_event handle_iso_session_setup(struct v2g_connection* conn) {
 
     /* format EVCC ID */
     for (i = 0; i < req->EVCCID.bytesLen; i++) {
-        sprintf(&buffer[i * 3], "%02" PRIx8 ":", req->EVCCID.bytes[i]);
+        sprintf(&buffer[i * 3], "%02" PRIX8 ":", req->EVCCID.bytes[i]);
     }
     if (i)
         buffer[i * 3 - 1] = '\0';
@@ -1070,7 +1071,7 @@ static enum v2g_event handle_iso_payment_service_selection(struct v2g_connection
     res->ResponseCode = (selected_services_found == false) ? iso1responseCodeType_FAILED_ServiceSelectionInvalid
                                                            : res->ResponseCode; // [V2G2-467]
     res->ResponseCode = (charge_service_found == false) ? iso1responseCodeType_FAILED_NoChargeServiceSelected
-                                                        : res->ResponseCode; // [V2G2-804]
+                                                        : res->ResponseCode;    // [V2G2-804]
 
     /* Check the current response code and check if no external error has occurred */
     next_event = (v2g_event)iso_validate_response_code(&res->ResponseCode, conn);


### PR DESCRIPTION
right now it is not specified whether mac address strings should be upper or lower case. Defining this to upper case everywhere makes it a bit easier to use.