### PR TITLE
Revert "Fix issue with multiple service list items (#260)"

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -354,16 +354,19 @@ void ISO15118_chargerImpl::handle_cableCheck_Finished(bool& status) {
 void ISO15118_chargerImpl::handle_set_Certificate_Service_Supported(bool& status) {
     if (status == true) {
         // For setting "Certificate" in ServiceList in ServiceDiscoveryRes
-        struct iso1ServiceType cert_service;
         const std::string service_name = "Certificate";
-        const int16_t cert_parameter_set_id[] = {1}; // parameter-set-ID 1: "Installation" service. TODO: Support of the "Update" service (parameter-set-ID 2)
+        uint8_t len = service_name.length();
+        v2g_ctx->evse_v2g_data.evse_service_list[v2g_ctx->evse_v2g_data.evse_service_list_len].FreeService = 1;
+        v2g_ctx->evse_v2g_data.evse_service_list[v2g_ctx->evse_v2g_data.evse_service_list_len].ServiceID = 2;
+        v2g_ctx->evse_v2g_data.evse_service_list[v2g_ctx->evse_v2g_data.evse_service_list_len].ServiceCategory = iso1serviceCategoryType_ContractCertificate;
+        memcpy(v2g_ctx->evse_v2g_data.evse_service_list[v2g_ctx->evse_v2g_data.evse_service_list_len].ServiceName.characters, reinterpret_cast<const char*>(service_name.data()), len);
+        v2g_ctx->evse_v2g_data.evse_service_list[v2g_ctx->evse_v2g_data.evse_service_list_len].ServiceName.charactersLen = len;
+        v2g_ctx->evse_v2g_data.evse_service_list_len += 1;
 
-        cert_service.FreeService = 1; // true
-        cert_service.ServiceID = 2; // as defined in ISO 15118-2
-        cert_service.ServiceCategory = iso1serviceCategoryType_ContractCertificate;
-        memcpy(cert_service.ServiceName.characters, reinterpret_cast<const char*>(service_name.data()), service_name.length());
-
-        add_service_to_service_list(v2g_ctx, cert_service, cert_parameter_set_id, sizeof(cert_parameter_set_id) / sizeof(cert_parameter_set_id[0]));
+        // For setting "Installation" in the ServiceParameterList in ServiceDetailRes
+        configure_parameter_set(&v2g_ctx->evse_v2g_data.service_parameter_list[0], 1);
+        // TODO: support "Update" in the ServiceParameterList in ServiceDetailRes
+        // configure_parameter_set(&v2g_ctx->evse_v2g_data.service_parameter_list[0], 2);
     }
 }
 

--- a/modules/EvseV2G/v2g_ctx.hpp
+++ b/modules/EvseV2G/v2g_ctx.hpp
@@ -137,24 +137,6 @@ void publish_DC_EVRemainingTime(struct v2g_context* ctx, const float& iso1_dc_ev
  */
 void log_selected_energy_transfer_type(int selected_energy_transfer_mode);
 
-/*!
- * \brief add_service_to_service_list This function adds a service list item to the service list.
- * \param v2g_ctx is a pointer of type \c v2g_context
- * \param evse_service is service which shall be provided by the EVSE in the service list.
- * \param parameter_set_id is an array of optional service parameter-set-IDs
- * \param parameter_set_id_len is the array length of parameter_set_id
- * \return Returns \c true if it was successful, otherwise \c false.
- */
-bool add_service_to_service_list(struct v2g_context* v2g_ctx, const struct iso1ServiceType& evse_service,
-                                 const int16_t* parameter_set_id = NULL, uint8_t parameter_set_id_len = 0);
-
-/*!
- * \brief configure_parameter_set This function configures the parameter-set structure of a specific service ID.
- * \param v2g_ctx is a pointer of type \c v2g_context
- * \param parameterSetId is the parameter-set-ID which belongs to the service ID.
- * \param serviceId is the service ID. Currently only service ID 2 ("Certificate") supported.
- */
-void configure_parameter_set(struct iso1ServiceParameterListType* parameterSetList, int16_t parameterSetId,
-                             uint16_t serviceId);
+void configure_parameter_set(struct iso1ServiceParameterListType* parameterSetList, int16_t parameterSetId);
 
 #endif /* V2G_CTX_H */


### PR DESCRIPTION
This reverts commit 82d827203862484b1ce8b86ba9e3404f6ab932e2. It introduced a regression with DIN spec charging: The first charging session works as expected, but the following sessions fail because context data is not fully reset in between the sessions. This needs to be fixed before we can merge it in again.