### PR TITLE
EvseManager now signals Enabled event when ready

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -552,8 +552,7 @@ void EvseManager::ready() {
     if (r_powermeter_billing().size() > 0) {
         r_powermeter_billing()[0]->subscribe_powermeter([this](types::powermeter::Powermeter p) {
             // Inform charger about current charging current. This is used for slow OC detection.
-            if (p.current_A && p.current_A.value().L1 &&
-                p.current_A.value().L2 && p.current_A.value().L3) {
+            if (p.current_A && p.current_A.value().L1 && p.current_A.value().L2 && p.current_A.value().L3) {
                 charger->setCurrentDrawnByVehicle(p.current_A.value().L1.value(), p.current_A.value().L2.value(),
                                                   p.current_A.value().L3.value());
             }
@@ -665,11 +664,6 @@ void EvseManager::ready() {
                        config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
                        config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A);
     }
-    //  start with a limit of 0 amps. We will get a budget from EnergyManager that is locally limited by hw
-    //  caps.
-    charger->setMaxCurrent(0.0F, date::utc_clock::now());
-    charger->run();
-    charger->enable();
 
     telemetryThreadHandle = std::thread([this]() {
         while (!telemetryThreadHandle.shouldExit()) {
@@ -774,7 +768,12 @@ void EvseManager::ready() {
         }
     });
 
-    this->charger->signalEvent(types::evse_manager::SessionEventEnum::Enabled);
+    //  start with a limit of 0 amps. We will get a budget from EnergyManager that is locally limited by hw
+    //  caps.
+    charger->setMaxCurrent(0.0F, date::utc_clock::now());
+    charger->run();
+    charger->enable();
+
     EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
                               "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
 }

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -774,6 +774,7 @@ void EvseManager::ready() {
         }
     });
 
+    this->charger->signalEvent(types::evse_manager::SessionEventEnum::Enabled);
     EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
                               "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
 }

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -87,6 +87,8 @@ public:
     // insert your public definitions here
     std::unique_ptr<ocpp::v16::ChargePoint> charge_point;
     std::unique_ptr<Everest::SteadyTimer> charging_schedules_timer;
+    bool started = false;
+    std::map<int32_t, bool> connector_ready_map;
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:
@@ -104,6 +106,8 @@ private:
     std::filesystem::path ocpp_share_path;
     void set_external_limits(const std::map<int32_t, ocpp::v16::ChargingSchedule> &charging_schedules);
     void publish_charging_schedules(const std::map<int32_t, ocpp::v16::ChargingSchedule> &charging_schedules);
+    bool all_evse_ready();
+    std::mutex evse_ready_mutex;
     std::thread upload_diagnostics_thread;
     std::thread upload_logs_thread;
     std::thread update_firmware_thread;


### PR DESCRIPTION
EvseManager now signals Enabled event when ready for charging. OCPP listens to this event and only starts up when all EvseManagers it requires are ready. This was a problem when OCPP called cmds of EvseManager when the EvseManager was not done with his ready() function