### PR TITLE
Setting the voltage and current in the dc car sim is now possible

### DIFF
--- a/config/config-sil-dc.yaml
+++ b/config/config-sil-dc.yaml
@@ -57,6 +57,8 @@ active_modules:
       auto_enable: true
       auto_exec: false
       auto_exec_commands: sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug
+      dc_target_current: 20
+      dc_target_voltage: 400
     connections:
       simulation_control:
         - module_id: yeti_driver

--- a/config/config-sil-two-evse-dc.yaml
+++ b/config/config-sil-two-evse-dc.yaml
@@ -80,6 +80,8 @@ active_modules:
       auto_enable: true
       auto_exec: false
       auto_exec_commands: sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug
+      dc_target_current: 20
+      dc_target_voltage: 400
     connections:
       simulation_control:
         - module_id: yeti_driver_1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -42,7 +42,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: 2023.6.0
+  git_tag: cb9e679
 # OpenV2G
 ext-openv2g:
   git: https://github.com/EVerest/ext-openv2g.git

--- a/interfaces/ISO15118_ev.yaml
+++ b/interfaces/ISO15118_ev.yaml
@@ -30,6 +30,13 @@ cmds:
     description: >-
       TODO_SL: Set the different ev faults to communicate these errors
       to the charging station
+  set_dc_params:
+    description: Set the target parameters for a dc charging process 
+    arguments:
+      EV_Parameters:
+        description: Target parameters for dc charging
+        type: object
+        $ref: /iso15118_ev#/DC_EVParameters
 vars:
   V2G_Session_Finished:
     description: The v2g session between the charger and the car is finished

--- a/modules/PyEvJosev/module.py
+++ b/modules/PyEvJosev/module.py
@@ -108,6 +108,14 @@ class PyEVJosevModule():
     def _handler_set_fault(self, args):
         pass
 
+    def _handler_set_dc_params(self, args):
+        parameters = args['EV_Parameters']
+        self._es.dc_max_current_limit = parameters['MaxCurrentLimit']
+        self._es.dc_max_power_limit = parameters['MaxPowerLimit']
+        self._es.dc_max_voltage_limit = parameters['MaxVoltageLimit']
+        self._es.dc_energy_capacity = parameters['EnergyCapacity']
+        self._es.dc_target_current = parameters['TargetCurrent']
+        self._es.dc_target_voltage = parameters['TargetVoltage']
 
 py_ev_josev = PyEVJosevModule()
 py_ev_josev.start_evcc_handler()

--- a/modules/simulation/JsCarSimulator/index.js
+++ b/modules/simulation/JsCarSimulator/index.js
@@ -113,6 +113,7 @@ boot_module(async ({
 }).then((mod) => {
   registerAllCmds(mod);
   mod.enabled = false;
+  if (mod.uses_list.ev.length > 0) mod.uses_list.ev[0].call.set_dc_params(get_hlc_dc_parameters(mod));
   if (globalconf.module.auto_enable) enable(mod, { value: true });
   if (globalconf.module.auto_exec) execute_charging_session(mod, { value: globalconf.module.auto_exec_commands });
 });
@@ -517,6 +518,19 @@ function registerAllCmds(mod) {
 
 function registerCmd(mod, name, numargs, execfunction) {
   mod.registeredCmds[name] = { cmd: name, numargs, exec: execfunction };
+}
+
+function get_hlc_dc_parameters(mod) {
+  return {
+    EV_Parameters: {
+      MaxCurrentLimit: mod.config.module.dc_max_current_limit,
+      MaxPowerLimit: mod.config.module.dc_max_power_limit,
+      MaxVoltageLimit: mod.config.module.dc_max_voltage_limit,
+      EnergyCapacity: mod.config.module.dc_energy_capacity,
+      TargetCurrent: mod.config.module.dc_target_current,
+      TargetVoltage: mod.config.module.dc_target_voltage,
+    }
+  };
 }
 
 /*

--- a/modules/simulation/JsCarSimulator/manifest.yaml
+++ b/modules/simulation/JsCarSimulator/manifest.yaml
@@ -19,6 +19,30 @@ config:
       Simulation commands, e.g. sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug
     type: string
     default: ""
+  dc_max_current_limit:
+    description: Maximum current allowed by the EV
+    type: integer
+    default: 300
+  dc_max_power_limit:
+    description: Maximum power allowed by the EV
+    type: integer
+    default: 150000
+  dc_max_voltage_limit:
+    description: Maximum voltage allowed by the EV
+    type: integer
+    default: 900
+  dc_energy_capacity:
+    description: Energy capacity of the EV
+    type: integer
+    default: 60000
+  dc_target_current:
+    description: Target current requested by the EV
+    type: integer
+    default: 5
+  dc_target_voltage:
+    description: Target voltage requested by the EV
+    type: integer
+    default: 200
 provides:
   main:
     interface: car_simulator

--- a/modules/simulation/JsDCSupplySimulator/index.js
+++ b/modules/simulation/JsDCSupplySimulator/index.js
@@ -115,7 +115,10 @@ boot_module(async ({
     settings_connector_max_export_current = current;
     settings_connector_export_voltage = voltage;
 
-    if (mode === 'Export') connector_voltage = settings_connector_export_voltage;
+    if (mode === 'Export') {
+      connector_voltage = settings_connector_export_voltage;
+      connector_current = settings_connector_max_export_current;
+    }
   });
 
   setup.provides.main.register.setImportVoltageCurrent((mod, args) => {

--- a/types/iso15118_ev.yaml
+++ b/types/iso15118_ev.yaml
@@ -1,0 +1,37 @@
+description: ISO15118 ev types
+types:
+  DC_EVParameters:
+    description: Target settings for dc charging
+    type: object
+    additionalProperties: false
+    properties:
+      MaxCurrentLimit:
+        description: "[A] Maximum current allowed by the EV"
+        type: number
+        minumum: 0
+        maximum: 1000
+      MaxPowerLimit:
+        description: "[W] Maximum power allowed by the EV"
+        type: number
+        minumum: 0
+        maximum: 500000
+      MaxVoltageLimit:
+        description: "[V] Maximum voltage allowed by the EV"
+        type: number
+        minumum: 0
+        maximum: 1500
+      EnergyCapacity:
+        description: "[Wh] Energy capacity of the EV"
+        type: number
+        minumum: 0
+        maximum: 100000
+      TargetCurrent:
+        description: "[A] Target current requested by the EV"
+        type: number
+        minumum: 0
+        maximum: 1000
+      TargetVoltage:
+        description: "[V] Target voltage requested by the EV"
+        type: number
+        minumum: 0
+        maximum: 1500


### PR DESCRIPTION
This PR is dependent on this PR: [Enabling the setting of the EV DC parameters #15](https://github.com/EVerest/ext-switchev-iso15118/pull/15)

Signed-off-by: Sebastian Lukas <sebastian.lukas@pionix.de>