### PR TITLE
Removed EvseV2G config option highlevel_authentication_mode

### DIFF
--- a/modules/EvseV2G/EvseV2G.hpp
+++ b/modules/EvseV2G/EvseV2G.hpp
@@ -25,7 +25,6 @@ struct Conf {
     std::string device;
     bool supported_DIN70121;
     bool supported_ISO15118_2;
-    std::string highlevel_authentication_mode;
     std::string tls_security;
     bool terminate_connection_on_failed_response;
     bool tls_key_logging;

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -21,17 +21,6 @@ void ISO15118_chargerImpl::init() {
     /* Configure if_name and auth_mode */
     v2g_ctx->if_name = mod->config.device.data();
     dlog(DLOG_LEVEL_DEBUG, "if_name %s", v2g_ctx->if_name);
-    dlog(DLOG_LEVEL_DEBUG, "auth_mode %s", mod->config.highlevel_authentication_mode.data());
-    if (mod->config.highlevel_authentication_mode == "eim") {
-        v2g_ctx->evse_v2g_data.payment_option_list[v2g_ctx->evse_v2g_data.payment_option_list_len] =
-            iso1paymentOptionType_ExternalPayment;
-        v2g_ctx->evse_v2g_data.payment_option_list_len++;
-    }
-    if (mod->config.highlevel_authentication_mode == "pnc") {
-        v2g_ctx->evse_v2g_data.payment_option_list[v2g_ctx->evse_v2g_data.payment_option_list_len] =
-            iso1paymentOptionType_Contract;
-        v2g_ctx->evse_v2g_data.payment_option_list_len++;
-    }
 
     /* Configure hlc_protocols */
     if (mod->config.supported_DIN70121 == true) {

--- a/modules/EvseV2G/manifest.yaml
+++ b/modules/EvseV2G/manifest.yaml
@@ -16,16 +16,6 @@ config:
     description: The EVSE supports ISO15118-2
     type: boolean
     default: true
-  highlevel_authentication_mode:
-    description: >-
-      Specify the authentication mode for the high level charging session.
-      In case charging type is basic this parameter doesn't have any effect
-    type: string
-    enum:
-    - eim
-    - pnc
-    - eim+pnc
-    default: eim
   tls_security:
     description: >-
       Controls how to handle encrypted communication


### PR DESCRIPTION
Since it can lead to a confusion where the payment methods are configured, the config option of the EvseV2G has been deleted.
The payment options are only now communicated via the EvseManager and the iso15118_charger interface.

Signed-off-by: Sebastian Lukas <sebastian.lukas@pionix.de>