### PR TITLE
Changed Authorization and EvseManager types for better support for OCPP201

### DIFF
--- a/modules/API/API.cpp
+++ b/modules/API/API.cpp
@@ -252,24 +252,24 @@ void API::init() {
                 session_info->update_state(event, "");
             }
             if (event == "TransactionStarted") {
-                auto session_started = session_event.transaction_started.value();
-                auto energy_Wh_import = session_started.energy_Wh_import;
+                auto transaction_started = session_event.transaction_started.value();
+                auto energy_Wh_import = transaction_started.meter_value.energy_Wh_import.total;
                 session_info->set_start_energy_import_wh(energy_Wh_import);
 
-                if (session_started.energy_Wh_export.has_value()) {
-                    auto energy_Wh_export = session_started.energy_Wh_export;
-                    session_info->set_start_energy_export_wh(energy_Wh_export.value());
+                if (transaction_started.meter_value.energy_Wh_export.has_value()) {
+                    auto energy_Wh_export = transaction_started.meter_value.energy_Wh_export.value().total;
+                    session_info->set_start_energy_export_wh(energy_Wh_export);
                 } else {
                     session_info->start_energy_export_wh_was_set = false;
                 }
             } else if (event == "TransactionFinished") {
-                auto session_finished = session_event.transaction_finished.value();
-                auto energy_Wh_import = session_finished.energy_Wh_import;
+                auto transaction_finished = session_event.transaction_finished.value();
+                auto energy_Wh_import = transaction_finished.meter_value.energy_Wh_import.total;
                 session_info->set_end_energy_import_wh(energy_Wh_import);
 
-                if (session_finished.energy_Wh_export.has_value()) {
-                    auto energy_Wh_export = session_finished.energy_Wh_export;
-                    session_info->set_end_energy_export_wh(energy_Wh_export.value());
+                if (transaction_finished.meter_value.energy_Wh_export.has_value()) {
+                    auto energy_Wh_export = transaction_finished.meter_value.energy_Wh_export.value().total;
+                    session_info->set_end_energy_export_wh(energy_Wh_export);
                 } else {
                     session_info->end_energy_export_wh_was_set = false;
                 }

--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -26,7 +26,8 @@ using namespace types::reservation;
 
 namespace module {
 
-enum class TokenHandlingResult {
+enum class TokenHandlingResult
+{
     ACCEPTED,
     ALREADY_IN_PROCESS,
     REJECTED,
@@ -190,7 +191,7 @@ private:
                        const ValidationResult& validation_result)>
         notify_evse_callback;
     std::function<void(const int evse_index)> withdraw_authorization_callback;
-    std::function<std::vector<ValidationResult>(const ProvidedIdToken &provided_token)> validate_token_callback;
+    std::function<std::vector<ValidationResult>(const ProvidedIdToken& provided_token)> validate_token_callback;
     std::function<void(const int evse_index, const StopTransactionRequest& request)> stop_transaction_callback;
     std::function<void(const Array& reservations)> reservation_update_callback;
     std::function<void(const int& evse_index, const int& reservation_id)> reserved_callback;
@@ -218,7 +219,7 @@ private:
     void notify_evse(int connector_id, const ProvidedIdToken& provided_token,
                      const ValidationResult& validation_result);
     Identifier get_identifier(const ValidationResult& validation_result, const std::string& id_token,
-                              const TokenType& type);
+                              const AuthorizationType& type);
 };
 
 } // namespace module

--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -26,8 +26,7 @@ using namespace types::reservation;
 
 namespace module {
 
-enum class TokenHandlingResult
-{
+enum class TokenHandlingResult {
     ACCEPTED,
     ALREADY_IN_PROCESS,
     REJECTED,

--- a/modules/Auth/include/Connector.hpp
+++ b/modules/Auth/include/Connector.hpp
@@ -10,7 +10,6 @@
 
 #include <utils/types.hpp>
 
-
 #include <ConnectorStateMachine.hpp>
 #include <generated/types/authorization.hpp>
 
@@ -19,9 +18,9 @@ namespace module {
 /// \brief Validated Identifier struct. Used to keep track of active Identifiers
 struct Identifier {
     std::string id_token; ///< Arbitrary id token string: this has to be printable case insensitive ascii
-    types::authorization::TokenType type; ///< Type of the provider of the identifier
+    types::authorization::AuthorizationType type; ///< Type of the provider of the identifier
     std::optional<types::authorization::AuthorizationStatus> authorization_status;
-    std::optional<std::string> expiry_time; ///< Absolute UTC time point when reservation expires in RFC3339 format
+    std::optional<std::string> expiry_time;     ///< Absolute UTC time point when reservation expires in RFC3339 format
     std::optional<std::string> parent_id_token; ///< Parent id token of the id token
 };
 

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -88,7 +88,7 @@ TokenHandlingResult AuthHandler::handle_token(const ProvidedIdToken& provided_to
     std::vector<int> referenced_connectors = this->get_referenced_connectors(provided_token);
 
     // Only provided token with type RFID can be used to stop a transaction
-    if (provided_token.type == TokenType::RFID) {
+    if (provided_token.authorization_type == AuthorizationType::RFID) {
         // check if id_token is used for an active transaction
         const auto connector_used_for_transaction =
             this->used_for_transaction(referenced_connectors, provided_token.id_token);
@@ -343,8 +343,9 @@ void AuthHandler::notify_evse(int connector_id, const ProvidedIdToken& provided_
     const auto evse_index = this->connectors.at(connector_id)->evse_index;
 
     if (validation_result.authorization_status == AuthorizationStatus::Accepted) {
-        Identifier identifier{provided_token.id_token, provided_token.type, validation_result.authorization_status,
-                              validation_result.expiry_time, validation_result.parent_id_token};
+        Identifier identifier{provided_token.id_token, provided_token.authorization_type,
+                              validation_result.authorization_status, validation_result.expiry_time,
+                              validation_result.parent_id_token};
         this->connectors.at(connector_id)->connector.identifier.emplace(identifier);
 
         std::lock_guard<std::mutex> timer_lk(this->timer_mutex);

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -33,7 +33,7 @@ static ProvidedIdToken get_provided_token(const std::string& id_token,
                                           std::optional<bool> prevalidated = std::nullopt) {
     ProvidedIdToken provided_token;
     provided_token.id_token = id_token;
-    provided_token.type = types::authorization::TokenType::RFID;
+    provided_token.authorization_type = types::authorization::AuthorizationType::RFID;
     if (connectors) {
         provided_token.connectors.emplace(connectors.value());
     }
@@ -153,8 +153,8 @@ TEST_F(AuthTest, test_stop_transaction) {
     SessionEvent session_event2;
     session_event2.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event;
-    transaction_event.energy_Wh_import = 0;
-    transaction_event.id_tag = provided_token.id_token;
+    transaction_event.meter_value.energy_Wh_import.total = 0;
+    transaction_event.id_tag = provided_token;
     transaction_event.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     session_event2.transaction_started = transaction_event;
 
@@ -385,16 +385,16 @@ TEST_F(AuthTest, test_transaction_finish) {
     SessionEvent session_event2;
     session_event2.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event1;
-    transaction_event1.energy_Wh_import = 0;
-    transaction_event1.id_tag = provided_token_1.id_token;
+    transaction_event1.meter_value.energy_Wh_import.total = 0;
+    transaction_event1.id_tag = provided_token_1;
     transaction_event1.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     session_event2.transaction_started = transaction_event1;
 
     SessionEvent session_event3;
     session_event3.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event2;
-    transaction_event2.energy_Wh_import = 0;
-    transaction_event2.id_tag = provided_token_2.id_token;
+    transaction_event2.meter_value.energy_Wh_import.total = 0;
+    transaction_event2.id_tag = provided_token_2;
     transaction_event2.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     session_event3.transaction_started = transaction_event2;
 
@@ -450,8 +450,8 @@ TEST_F(AuthTest, test_parent_id_finish) {
     SessionEvent session_event2;
     session_event2.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event1;
-    transaction_event1.energy_Wh_import = 0;
-    transaction_event1.id_tag = provided_token_1.id_token;
+    transaction_event1.meter_value.energy_Wh_import.total = 0;
+    transaction_event1.id_tag = provided_token_1;
     transaction_event1.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     session_event2.transaction_started = transaction_event1;
 
@@ -549,8 +549,8 @@ TEST_F(AuthTest, test_parent_id_finish_because_no_available_connector) {
     SessionEvent session_event_3;
     session_event_3.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event;
-    transaction_event.energy_Wh_import = 0;
-    transaction_event.id_tag = provided_token_1.id_token;
+    transaction_event.meter_value.energy_Wh_import.total = 0;
+    transaction_event.id_tag = provided_token_1;
     transaction_event.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     session_event_3.transaction_started = transaction_event;
     std::thread t4([this, session_event_3]() { this->auth_handler->handle_session_event(1, session_event_3); });
@@ -657,8 +657,8 @@ TEST_F(AuthTest, test_complete_event_flow) {
     SessionEvent session_event_2;
     session_event_2.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event;
-    transaction_event.energy_Wh_import = 0;
-    transaction_event.id_tag = provided_token.id_token;
+    transaction_event.energy_Wh_import.total = 0;
+    transaction_event.id_tag = provided_token;
     transaction_event.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
 
     SessionEvent session_event_3;
@@ -670,8 +670,8 @@ TEST_F(AuthTest, test_complete_event_flow) {
     SessionEvent session_event_5;
     session_event_5.event = SessionEventEnum::TransactionFinished;
     TransactionStarted transaction_finished_event;
-    transaction_finished_event.energy_Wh_import = 1000;
-    transaction_finished_event.id_tag = provided_token.id_token;
+    transaction_finished_event.meter_value.energy_Wh_import.total = 1000;
+    transaction_finished_event.id_tag = provided_token;
     transaction_finished_event.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
 
     SessionEvent session_event_6;
@@ -831,16 +831,16 @@ TEST_F(AuthTest, test_two_transactions_start_stop) {
     SessionEvent session_event2;
     session_event2.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event_1;
-    transaction_event_1.energy_Wh_import = 0;
-    transaction_event_1.id_tag = provided_token_1.id_token;
+    transaction_event_1.meter_value.energy_Wh_import.total = 0;
+    transaction_event_1.id_tag = provided_token_1;
     transaction_event_1.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
-    session_event2.transaction_started = transaction_event_1;
+    session_event2.meter_value.transaction_started = transaction_event_1;
 
     SessionEvent session_event3;
     session_event3.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event_2;
-    transaction_event_2.energy_Wh_import = 0;
-    transaction_event_2.id_tag = provided_token_2.id_token;
+    transaction_event_2.meter_value.energy_Wh_import.total = 0;
+    transaction_event_2.id_tag = provided_token_2;
     transaction_event_2.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     session_event3.transaction_started = transaction_event_2;
 
@@ -885,7 +885,7 @@ TEST_F(AuthTest, test_plug_and_charge) {
 
     ProvidedIdToken provided_token;
     provided_token.id_token = VALID_TOKEN_1;
-    provided_token.type = types::authorization::TokenType::PlugAndCharge;
+    provided_token.authorization_type = types::authorization::AuthorizationType::PlugAndCharge;
     provided_token.certificate.emplace("TestCertificate");
 
     const auto result = this->auth_handler->on_token(provided_token);
@@ -926,7 +926,7 @@ TEST_F(AuthTest, test_empty_intersection) {
     std::vector<int32_t> connectors{1};
     ProvidedIdToken provided_token;
     provided_token.id_token = VALID_TOKEN_1;
-    provided_token.type = types::authorization::TokenType::PlugAndCharge;
+    provided_token.authorization_type = types::authorization::AuthorizationType::PlugAndCharge;
     provided_token.certificate.emplace("TestCertificate");
     provided_token.connectors.emplace(connectors);
 

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -31,6 +31,7 @@
 #include <date/tz.h>
 #include <generated/interfaces/ISO15118_charger/Interface.hpp>
 #include <generated/interfaces/board_support_AC/Interface.hpp>
+#include <generated/types/authorization.hpp>
 #include <generated/types/evse_manager.hpp>
 #include <mutex>
 #include <queue>
@@ -38,7 +39,8 @@
 
 namespace module {
 
-enum class ControlPilotEvent {
+enum class ControlPilotEvent
+{
     CarPluggedIn,
     CarRequestedPower,
     PowerOn,
@@ -80,14 +82,16 @@ public:
     float getMaxCurrent();
     sigslot::signal<float> signalMaxCurrent;
 
-    enum class ChargeMode {
+    enum class ChargeMode
+    {
         AC,
         DC
     };
 
     void setup(bool three_phases, bool has_ventilation, const std::string& country_code, bool rcd_enabled,
                const ChargeMode charge_mode, bool ac_hlc_enabled, bool ac_hlc_use_5percent, bool ac_enforce_hlc,
-               bool ac_with_soc_timeout, float soft_over_current_tolerance_percent, float soft_over_current_measurement_noise_A);
+               bool ac_with_soc_timeout, float soft_over_current_tolerance_percent,
+               float soft_over_current_measurement_noise_A);
 
     bool enable();
     bool disable();
@@ -101,9 +105,9 @@ public:
     //
 
     // call when in state WaitingForAuthentication
-    void Authorize(bool a, const std::string& userid, bool pnc);
+    void Authorize(bool a, const types::authorization::ProvidedIdToken& token);
     bool DeAuthorize();
-    std::string getAuthTag();
+    types::authorization::ProvidedIdToken getIdToken();
 
     bool Authorized_PnC();
     bool Authorized_EIM();
@@ -162,7 +166,8 @@ public:
     // in the future.
     // Use new EvseEvent interface instead.
 
-    enum class EvseState {
+    enum class EvseState
+    {
         Disabled,
         Idle,
         WaitingForAuthentication,
@@ -264,7 +269,8 @@ private:
     bool authorized;
     // set to true if auth is from PnC, otherwise to false (EIM)
     bool authorized_pnc;
-    std::string auth_tag;
+
+    types::authorization::ProvidedIdToken id_token;
 
     // AC or DC
     ChargeMode charge_mode{0};

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -39,8 +39,7 @@
 
 namespace module {
 
-enum class ControlPilotEvent
-{
+enum class ControlPilotEvent {
     CarPluggedIn,
     CarRequestedPower,
     PowerOn,
@@ -82,8 +81,7 @@ public:
     float getMaxCurrent();
     sigslot::signal<float> signalMaxCurrent;
 
-    enum class ChargeMode
-    {
+    enum class ChargeMode {
         AC,
         DC
     };
@@ -166,8 +164,7 @@ public:
     // in the future.
     // Use new EvseEvent interface instead.
 
-    enum class EvseState
-    {
+    enum class EvseState {
         Disabled,
         Idle,
         WaitingForAuthentication,

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -15,7 +15,8 @@ inline static void trim_colons_from_string(std::string& text) {
 
 inline static types::authorization::ProvidedIdToken create_autocharge_token(std::string token, int connector_id) {
     types::authorization::ProvidedIdToken autocharge_token;
-    autocharge_token.type = types::authorization::TokenType::Autocharge;
+    autocharge_token.authorization_type = types::authorization::AuthorizationType::Autocharge;
+    autocharge_token.id_token_type = types::authorization::IdTokenType::MacAddress;
     trim_colons_from_string(token);
     autocharge_token.id_token = "VID:" + token;
     autocharge_token.connectors.emplace(connector_id, 1);

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -1071,7 +1071,7 @@ static enum v2g_event handle_iso_payment_service_selection(struct v2g_connection
     res->ResponseCode = (selected_services_found == false) ? iso1responseCodeType_FAILED_ServiceSelectionInvalid
                                                            : res->ResponseCode; // [V2G2-467]
     res->ResponseCode = (charge_service_found == false) ? iso1responseCodeType_FAILED_NoChargeServiceSelected
-                                                        : res->ResponseCode; // [V2G2-804]
+                                                        : res->ResponseCode;    // [V2G2-804]
 
     /* Check the current response code and check if no external error has occurred */
     next_event = (v2g_event)iso_validate_response_code(&res->ResponseCode, conn);

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -174,7 +174,8 @@ static void convertIso1ToXmldsigSignedInfoType(struct xmldsigSignedInfoType* xml
     xmld_sig_signed_info->SignatureMethod.ANY_isUsed = 0;
 }
 
-static bool load_contract_root_cert(mbedtls_x509_crt *contract_root_crt, const char* V2G_file_path, const char* MO_file_path) {
+static bool load_contract_root_cert(mbedtls_x509_crt* contract_root_crt, const char* V2G_file_path,
+                                    const char* MO_file_path) {
     int rv = 0;
 
     if (((rv = mbedtls_x509_crt_parse_file(contract_root_crt, MO_file_path)) != 0) &&
@@ -182,10 +183,10 @@ static bool load_contract_root_cert(mbedtls_x509_crt *contract_root_crt, const c
         char strerr[256];
         mbedtls_strerror(rv, strerr, 256);
         dlog(DLOG_LEVEL_ERROR, "Unable to parse V2G (%s) or MO (%s) root certificate  (err: -0x%04x - %s)",
-                V2G_file_path, MO_file_path, -rv, strerr);
+             V2G_file_path, MO_file_path, -rv, strerr);
     }
 
-    return (rv != 0)? false : true;
+    return (rv != 0) ? false : true;
 }
 
 /*!
@@ -197,24 +198,22 @@ static bool load_contract_root_cert(mbedtls_x509_crt *contract_root_crt, const c
  * \param flags
  * \return
  */
-static int debug_verify_cert( void *data, mbedtls_x509_crt *crt, int depth, uint32_t *flags )
-{
+static int debug_verify_cert(void* data, mbedtls_x509_crt* crt, int depth, uint32_t* flags) {
     char buf[1024];
-    ((void) data);
+    ((void)data);
 
-    dlog(DLOG_LEVEL_INFO, "\nVerify requested for (Depth %d):\n", depth );
-    mbedtls_x509_crt_info( buf, sizeof( buf ) - 1, "", crt );
-    dlog(DLOG_LEVEL_INFO, "%s", buf );
+    dlog(DLOG_LEVEL_INFO, "\nVerify requested for (Depth %d):\n", depth);
+    mbedtls_x509_crt_info(buf, sizeof(buf) - 1, "", crt);
+    dlog(DLOG_LEVEL_INFO, "%s", buf);
 
-    if ( ( *flags ) == 0 )
-        dlog(DLOG_LEVEL_INFO, "  This certificate has no flags\n" );
-    else
-    {
-        mbedtls_x509_crt_verify_info( buf, sizeof( buf ), "  ! ", *flags );
-        dlog(DLOG_LEVEL_INFO, "%s\n", buf );
+    if ((*flags) == 0)
+        dlog(DLOG_LEVEL_INFO, "  This certificate has no flags\n");
+    else {
+        mbedtls_x509_crt_verify_info(buf, sizeof(buf), "  ! ", *flags);
+        dlog(DLOG_LEVEL_INFO, "%s\n", buf);
     }
 
-    return( 0 );
+    return (0);
 }
 
 /*!
@@ -747,7 +746,8 @@ publish_iso_welding_detection_req(struct v2g_context* ctx,
  * the MQTT interface. \param AExiBuffer is the exi msg where the V2G EXI msg is stored. \param AExiBufferSize is the
  * size of the V2G msg. \return Returns \c true if it was successful, otherwise \c false.
  */
-static bool publish_iso_certificate_installation_exi_req(struct v2g_context* ctx, uint8_t* AExiBuffer, size_t AExiBufferSize) {
+static bool publish_iso_certificate_installation_exi_req(struct v2g_context* ctx, uint8_t* AExiBuffer,
+                                                         size_t AExiBufferSize) {
     // PnC only
 
     bool rv = true;
@@ -1071,7 +1071,7 @@ static enum v2g_event handle_iso_payment_service_selection(struct v2g_connection
     res->ResponseCode = (selected_services_found == false) ? iso1responseCodeType_FAILED_ServiceSelectionInvalid
                                                            : res->ResponseCode; // [V2G2-467]
     res->ResponseCode = (charge_service_found == false) ? iso1responseCodeType_FAILED_NoChargeServiceSelected
-                                                        : res->ResponseCode;    // [V2G2-804]
+                                                        : res->ResponseCode; // [V2G2-804]
 
     /* Check the current response code and check if no external error has occurred */
     next_event = (v2g_event)iso_validate_response_code(&res->ResponseCode, conn);
@@ -1180,14 +1180,16 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
         // Parse contract sub certificates
         if (req->ContractSignatureCertChain.SubCertificates_isUsed == 1) {
             for (int i = 0; i < req->ContractSignatureCertChain.SubCertificates.Certificate.arrayLen; i++) {
-                err = mbedtls_x509_crt_parse(&conn->ctx->session.contract.crt,
-                        req->ContractSignatureCertChain.SubCertificates.Certificate.array[i].bytes,
-                        req->ContractSignatureCertChain.SubCertificates.Certificate.array[i].bytesLen);
+                err = mbedtls_x509_crt_parse(
+                    &conn->ctx->session.contract.crt,
+                    req->ContractSignatureCertChain.SubCertificates.Certificate.array[i].bytes,
+                    req->ContractSignatureCertChain.SubCertificates.Certificate.array[i].bytesLen);
 
                 if (err != 0) {
                     char strerr[256];
                     mbedtls_strerror(err, strerr, std::string(strerr).size());
-                    dlog(DLOG_LEVEL_ERROR, "handle_payment_detail: invalid sub-certificate received in req: %s", strerr);
+                    dlog(DLOG_LEVEL_ERROR, "handle_payment_detail: invalid sub-certificate received in req: %s",
+                         strerr);
                     goto error_out;
                 }
             }
@@ -1203,14 +1205,15 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
             uint32_t flags;
 
             /* Load supported V2G/MO root certificates */
-            if (load_contract_root_cert(&contract_root_crt, v2g_root_cert_path.c_str(), mo_root_cert_path.c_str()) == false) {
+            if (load_contract_root_cert(&contract_root_crt, v2g_root_cert_path.c_str(), mo_root_cert_path.c_str()) ==
+                false) {
                 memset(res, 0, sizeof(*res));
                 res->ResponseCode = iso1responseCodeType_FAILED_NoCertificateAvailable;
                 goto error_out;
             }
             // === Verify the retrieved contract ECDSA key against the root cert ===
-            err = mbedtls_x509_crt_verify(&conn->ctx->session.contract.crt, &contract_root_crt,
-                                          NULL, NULL, &flags, (conn->ctx->debugMode == true)? debug_verify_cert : NULL, NULL);
+            err = mbedtls_x509_crt_verify(&conn->ctx->session.contract.crt, &contract_root_crt, NULL, NULL, &flags,
+                                          (conn->ctx->debugMode == true) ? debug_verify_cert : NULL, NULL);
 
             if (err != 0) {
                 printMbedVerifyErrorCode(err, flags);
@@ -1229,15 +1232,15 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
             dlog(DLOG_LEVEL_INFO, "Validation of the contract certificate was successful!");
         } else {
             // Save the certificate chain in a variable in PEM format to publish it
-            mbedtls_x509_crt *crt = &conn->ctx->session.contract.crt;
+            mbedtls_x509_crt* crt = &conn->ctx->session.contract.crt;
             unsigned char* base64Buffer = NULL;
             size_t olen;
 
-            while( crt != nullptr && crt->version != 0 )
-            {
+            while (crt != nullptr && crt->version != 0) {
                 mbedtls_base64_encode(NULL, 0, &olen, crt->raw.p, crt->raw.len);
                 base64Buffer = static_cast<unsigned char*>(malloc(olen));
-                if ((base64Buffer == NULL) || ((mbedtls_base64_encode(base64Buffer, olen, &olen,crt->raw.p, crt->raw.len)) != 0 )) {
+                if ((base64Buffer == NULL) ||
+                    ((mbedtls_base64_encode(base64Buffer, olen, &olen, crt->raw.p, crt->raw.len)) != 0)) {
                     dlog(DLOG_LEVEL_ERROR, "Unable to encode certificate chain");
                     break;
                 }
@@ -1259,7 +1262,8 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
         // to receive PnC authorization
         types::authorization::ProvidedIdToken ProvidedIdToken;
         ProvidedIdToken.id_token = std::string(cert_emaid);
-        ProvidedIdToken.type = types::authorization::TokenType::PlugAndCharge;
+        ProvidedIdToken.authorization_type = types::authorization::AuthorizationType::PlugAndCharge;
+        ProvidedIdToken.id_token_type = types::authorization::IdTokenType::eMAID;
         if (contract_cert_chain_pem.empty() == false) {
             ProvidedIdToken.certificate = contract_cert_chain_pem;
         }
@@ -1337,9 +1341,9 @@ static enum v2g_event handle_iso_authorization(struct v2g_connection* conn) {
         if (((is_payment_option_contract == false) && (conn->ctx->session.auth_timeout_eim == 0)) ||
             ((is_payment_option_contract == true) && (conn->ctx->session.auth_timeout_pnc == 0))) {
             dlog(DLOG_LEVEL_DEBUG, "Waiting for authorization forever!");
-        } else if ((getmonotonictime() - conn->ctx->session.auth_start_timeout) >= 1000 *
-                   (is_payment_option_contract ? conn->ctx->session.auth_timeout_pnc
-                                               : conn->ctx->session.auth_timeout_eim)) {
+        } else if ((getmonotonictime() - conn->ctx->session.auth_start_timeout) >=
+                   1000 * (is_payment_option_contract ? conn->ctx->session.auth_timeout_pnc
+                                                      : conn->ctx->session.auth_timeout_eim)) {
             conn->ctx->session.auth_start_timeout = getmonotonictime();
             res->ResponseCode = iso1responseCodeType_FAILED;
         }
@@ -1877,7 +1881,8 @@ static enum v2g_event handle_iso_certificate_installation(struct v2g_connection*
         pthread_mutex_unlock(&conn->ctx->mqtt_lock);
     }
 
-    if ((conn->ctx->evse_v2g_data.cert_install_res_b64_buffer.empty() == false) && (conn->ctx->evse_v2g_data.cert_install_status == true)) {
+    if ((conn->ctx->evse_v2g_data.cert_install_res_b64_buffer.empty() == false) &&
+        (conn->ctx->evse_v2g_data.cert_install_status == true)) {
         if ((rv = mbedtls_base64_decode(
                  conn->buffer + V2GTP_HEADER_LENGTH, DEFAULT_BUFFER_SIZE, &conn->buffer_pos,
                  reinterpret_cast<unsigned char*>(conn->ctx->evse_v2g_data.cert_install_res_b64_buffer.data()),
@@ -1889,7 +1894,8 @@ static enum v2g_event handle_iso_certificate_installation(struct v2g_connection*
         }
         nextEvent = V2G_EVENT_SEND_RECV_EXI_MSG;
         res->ResponseCode = iso1responseCodeType_OK; // Is irrelevant but must be valid to serve the internal validation
-        conn->buffer_pos += V2GTP_HEADER_LENGTH; // buffer_pos had only the payload, so increase it to be header + payload
+        conn->buffer_pos +=
+            V2GTP_HEADER_LENGTH; // buffer_pos had only the payload, so increase it to be header + payload
     } else {
         res->ResponseCode = iso1responseCodeType_FAILED;
     }

--- a/modules/JsDummyTokenProvider/index.js
+++ b/modules/JsDummyTokenProvider/index.js
@@ -7,7 +7,7 @@ boot_module(async ({ setup }) => {
     if (!(sessionEvent.event === undefined) && sessionEvent.event === 'AuthRequired') {
       const data = {
         id_token: mod.config.impl.main.token,
-        type: mod.config.impl.main.type,
+        authorization_type: mod.config.impl.main.type,
       };
       evlog.info('Publishing new dummy token: ', data);
       mod.provides.main.publish.provided_token(data);

--- a/modules/JsPN532TokenProvider/index.js
+++ b/modules/JsPN532TokenProvider/index.js
@@ -27,8 +27,8 @@ boot_module(async ({ setup, config }) => {
             
             // emit new token into the everest system
             const data = {
-                token: tag.uid,
-                type: "RFID",
+                id_token: tag.uid,
+                authorization_type: "RFID",
                 timeout: mod.config.impl.main.timeout,
             };
             evlog.info('Publishing new rfid/nfc token: ', data);

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -341,7 +341,7 @@ void OCPP::init() {
         [this](const std::string& id_token, std::vector<int32_t> referenced_connectors, bool prevalidated) {
             types::authorization::ProvidedIdToken provided_token;
             provided_token.id_token = id_token;
-            provided_token.type = types::authorization::TokenType::OCPP;
+            provided_token.authorization_type = types::authorization::AuthorizationType::OCPP;
             provided_token.connectors.emplace(referenced_connectors);
             provided_token.prevalidated.emplace(prevalidated);
             this->p_auth_provider->publish_provided_token(provided_token);
@@ -463,9 +463,9 @@ void OCPP::init() {
                 const auto transaction_started = session_event.transaction_started.value();
 
                 const auto timestamp = ocpp::DateTime(transaction_started.timestamp);
-                const auto energy_Wh_import = transaction_started.energy_Wh_import;
+                const auto energy_Wh_import = transaction_started.meter_value.energy_Wh_import.total;
                 const auto session_id = session_event.uuid;
-                const auto id_token = transaction_started.id_tag;
+                const auto id_token = transaction_started.id_tag.id_token;
                 const auto signed_meter_value = transaction_started.signed_meter_value;
                 std::optional<int32_t> reservation_id_opt = std::nullopt;
                 if (transaction_started.reservation_id) {
@@ -490,7 +490,7 @@ void OCPP::init() {
                             << "Received TransactionFinished";
                 const auto transaction_finished = session_event.transaction_finished.value();
                 const auto timestamp = ocpp::DateTime(transaction_finished.timestamp);
-                const auto energy_Wh_import = transaction_finished.energy_Wh_import;
+                const auto energy_Wh_import = transaction_finished.meter_value.energy_Wh_import.total;
                 const auto reason = ocpp::v16::conversions::string_to_reason(
                     types::evse_manager::stop_transaction_reason_to_string(transaction_finished.reason.value()));
                 const auto signed_meter_value = transaction_finished.signed_meter_value;

--- a/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
@@ -17,7 +17,7 @@ void auth_token_validatorImpl::ready() {
 types::authorization::ValidationResult
 auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedIdToken& provided_token) {
 
-    if (provided_token.type == types::authorization::TokenType::PlugAndCharge) {
+    if (provided_token.authorization_type == types::authorization::AuthorizationType::PlugAndCharge) {
         return validate_pnc_request(provided_token);
     } else {
         return validate_standard_request(provided_token);

--- a/modules/OCPP201/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/OCPP201/auth_validator/auth_token_validatorImpl.cpp
@@ -12,13 +12,20 @@ namespace auth_validator {
 ocpp::v201::IdToken get_id_token(const types::authorization::ProvidedIdToken& provided_token) {
     ocpp::v201::IdToken id_token;
     id_token.idToken = provided_token.id_token;
-    if (provided_token.type == types::authorization::TokenType::Autocharge) {
+
+    if (provided_token.id_token_type.has_value()) {
+        id_token.type = ocpp::v201::conversions::string_to_id_token_enum(
+            types::authorization::id_token_type_to_string(provided_token.id_token_type.value()));
+        return id_token;
+    }
+
+    if (provided_token.authorization_type == types::authorization::AuthorizationType::Autocharge) {
         id_token.type = ocpp::v201::IdTokenEnum::MacAddress;
-    } else if (provided_token.type == types::authorization::TokenType::OCPP) {
+    } else if (provided_token.authorization_type == types::authorization::AuthorizationType::OCPP) {
         id_token.type = ocpp::v201::IdTokenEnum::Central;
-    } else if (provided_token.type == types::authorization::TokenType::PlugAndCharge) {
+    } else if (provided_token.authorization_type == types::authorization::AuthorizationType::PlugAndCharge) {
         id_token.type = ocpp::v201::IdTokenEnum::eMAID;
-    } else if (provided_token.type == types::authorization::TokenType::RFID) {
+    } else if (provided_token.authorization_type == types::authorization::AuthorizationType::RFID) {
         id_token.type = ocpp::v201::IdTokenEnum::ISO14443;
     }
     return id_token;
@@ -73,7 +80,7 @@ void auth_token_validatorImpl::ready() {
 
 types::authorization::ValidationResult
 auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedIdToken& provided_token) {
-        const auto id_token = get_id_token(provided_token);
+    const auto id_token = get_id_token(provided_token);
     std::optional<ocpp::CiString<5500>> certificate_opt;
     if (provided_token.certificate.has_value()) {
         certificate_opt.emplace(provided_token.certificate.value());

--- a/modules/PN532TokenProvider/main/auth_token_providerImpl.cpp
+++ b/modules/PN532TokenProvider/main/auth_token_providerImpl.cpp
@@ -61,7 +61,7 @@ void auth_token_providerImpl::ready() {
             for (auto entry : target_data) {
                 types::authorization::ProvidedIdToken provided_token;
                 provided_token.id_token = entry.getNFCID();
-                provided_token.type = types::authorization::TokenType::RFID;
+                provided_token.authorization_type = types::authorization::AuthorizationType::RFID;
                 if (config.debug) {
                     EVLOG_info << "Publishing new rfid/nfc token: " << provided_token;
                 }

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -31,8 +31,12 @@ types:
     additionalProperties: false
     required:
       - id_token
-      - type
+      - authorization_type
     properties:
+      request_id:
+        description: >-
+          Id of the authorization request of this token. Could be used to put remoteStartId of OCPP2.0.1
+        type: integer
       id_token:
         description: >-
           Arbitrary token string: this has to be printable case insensitive
@@ -40,12 +44,16 @@ types:
         type: string
         minLength: 1
         maxLength: 36
-      type:
-        description: Type of the token
+      authorization_type:
+        description: Authorization type of the token
         type: string
-        $ref: /authorization#/TokenType
+        $ref: /authorization#/AuthorizationType
         minLength: 2
         maxLength: 32
+      id_token_type:
+        description: IdTokenType of the token
+        type: string
+        $ref: /authorization#/IdTokenType
       connectors:
         description: A list of connector ids to which the authorization can be assigned
         type: array
@@ -118,12 +126,25 @@ types:
     enum:
       - UserInput
       - PlugEvents
-  TokenType:
+  AuthorizationType:
     description: >-
-      Type of the provided token
+      Type of authorization of the provided token
     type: string
     enum:
       - OCPP
       - RFID
       - Autocharge
       - PlugAndCharge
+  IdTokenType:
+    description: >-
+      IdTokenType of the provided token
+    type: string
+    enum:
+      - Central
+      - eMAID
+      - MacAddress
+      - ISO14443
+      - ISO15693
+      - KeyCode
+      - Local
+      - NoAuthorization

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -29,6 +29,16 @@ types:
         SoftReset: A soft reset command was received
         UnlockCommand: Central System sent an Unlock Connector command
         DeAuthorized: The transaction was stopped because of the authorization status in a StartTransaction.conf
+        EnergyLimitReached: Maximum energy of charging reached. For example: in a pre-paid charging solution
+        GroundFault: A GroundFault has occurred
+        LocalOutOfCredit: A local credit limit enforced through the Charging Station has been exceeded.
+        MasterPass: The transaction was stopped using a token with a MasterPassGroupId.
+        OvercurrentFault: A larger than intended electric current has occurred
+        PowerQuality: Quality of power too low, e.g. voltage too low/high, phase imbalance, etc.
+        SOCLimitReached: Electric vehicle has reported reaching a locally enforced maximum battery State of Charge (SOC)
+        StoppedByEV: The transaction was stopped by the EV
+        TimeLimitReached: EV charging session reached a locally enforced time limit
+        Timeout: EV not connected within timeout
     type: string
     enum:
       - EmergencyStop
@@ -42,6 +52,16 @@ types:
       - SoftReset
       - UnlockCommand
       - DeAuthorized
+      - EnergyLimitReached
+      - GroundFault
+      - LocalOutOfCredit
+      - MasterPass
+      - OvercurrentFault
+      - PowerQuality
+      - SOCLimitReached
+      - StoppedByEV
+      - TimeLimitReached
+      - Timeout
   StartSessionReason:
     description: >-
       Reason for session start
@@ -141,22 +161,21 @@ types:
     additionalProperties: false
     required:
       - timestamp
-      - energy_Wh_import
+      - meter_value
       - id_tag
     properties:
       timestamp:
         description: Transaction start time in RFC3339 format
         type: string
         format: date-time
-      energy_Wh_import:
-        description: Transaction start imported meter value in Wh
-        type: number
       id_tag:
         description: The id tag assigned to this transaction
-        type: string
-      energy_Wh_export:
-        description: Transaction start exported meter value Wh
-        type: number
+        type: object
+        $ref: /authorization#/ProvidedIdToken
+      meter_value:
+        description: Transaction start exported meter value
+        type: object
+        $ref: /powermeter#/Powermeter
       signed_meter_value:
         description: Signed meter value
         type: string
@@ -169,18 +188,16 @@ types:
     additionalProperties: false
     required:
       - timestamp
-      - energy_Wh_import
+      - meter_value
     properties:
       timestamp:
         description: Transaction end time in RFC3339 format
         type: string
         format: date-time
-      energy_Wh_import:
-        description: Transaction finished imported meter value in Wh
-        type: number
-      energy_Wh_export:
-        description: Transaction finished exported meter value in Wh
-        type: number
+      meter_value:
+        description: Transaction finished meter value
+        type: object
+        $ref: /powermeter#/Powermeter
       signed_meter_value:
         description: Signed meter value
         type: string


### PR DESCRIPTION
- support for RemoteStart / RemoteStop within OCPP201
- added Powermeter type to TransactionStarted and TransactionFinished event of EvseManager
- added some more StopReasons to StopReasonEnum
- renamed property type of ProvidedIdToken to authorization_type (RFID, OCPP, PnC, Autocharge)
- added id_token_type as optional param to ProvidedIdToken (Central, eMAID, ISO14443,...)
- changed types required changes in Auth, EvseManager, EvseV2G, OCPP, OCPP201 JsDummyTokenProvider, PN532TokenProvider, and JsPN532TokenProvider
- included new Powermeter and stopreason and remote start id  in OCPP201