### PR TITLE
Forward dlink_ready signals from SLAC to ISO module

### DIFF
--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -433,6 +433,15 @@ vars:
       Response will be reported async via  set_Get_Certificate_Response
     type: object
     $ref: /iso15118_charger#/Request_Exi_Stream_Schema
+  dlink_terminate:
+    description: Terminate the data link and become UNMATCHED.
+    type: "null"
+  dlink_error:
+    description: Terminate the data link and restart the matching process.
+    type: "null"
+  dlink_pause:
+    description: Request power saving mode, while staying MATCHED.
+    type: "null"
   EV_AppProtocol:
     description: >-
       Debug_Lite - This request message provides a list of charging protocols

--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -279,6 +279,13 @@ cmds:
         description: The response raw exi stream and the status from the CSMS system
         type: object
         $ref: /iso15118_charger#/Response_Exi_Stream_Status
+  dlink_ready:
+    description: >-
+      Signals dlink_ready from SLAC layer according to ISO15118-3
+    arguments:
+      value:
+        description: Set to true when link becomes ready, false when the link is terminated
+        type: boolean
 vars:
   Require_Auth_EIM:
     description: An EIM authorization is requiered

--- a/modules/DummyV2G/DummyV2G.hpp
+++ b/modules/DummyV2G/DummyV2G.hpp
@@ -27,8 +27,8 @@ public:
     DummyV2G(const ModuleInfo& info, std::unique_ptr<ISO15118_chargerImplBase> p_main, Conf& config) :
         ModuleBase(info), p_main(std::move(p_main)), config(config){};
 
-    const Conf& config;
     const std::unique_ptr<ISO15118_chargerImplBase> p_main;
+    const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     // insert your public definitions here

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
@@ -134,5 +134,8 @@ void ISO15118_chargerImpl::handle_set_Get_Certificate_Response(
     // your code for cmd set_Get_Certificate_Response goes here
 };
 
+void ISO15118_chargerImpl::handle_dlink_ready(bool& value) {
+}
+
 } // namespace main
 } // namespace module

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
@@ -67,6 +67,7 @@ protected:
     virtual void handle_set_Certificate_Service_Supported(bool& status) override;
     virtual void
     handle_set_Get_Certificate_Response(types::iso15118_charger::Response_Exi_Stream_Status& Existream_Status) override;
+    virtual void handle_dlink_ready(bool& value) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -191,6 +191,10 @@ public:
 
     void inform_new_evse_max_hlc_limits(const types::iso15118_charger::DC_EVSEMaximumLimits& l);
 
+    void dlink_pause();
+    void dlink_error();
+    void dlink_terminate();
+
 private:
     // main Charger thread
     Everest::Thread mainThreadHandle;
@@ -293,6 +297,7 @@ private:
     void update_pwm_max_every_5seconds(float dc);
     void pwm_off();
     void pwm_F();
+    bool pwm_running{false};
 
     types::iso15118_charger::DC_EVSEMaximumLimits currentEvseMaxLimits;
 

--- a/modules/EvseSlac/main/slacImpl.cpp
+++ b/modules/EvseSlac/main/slacImpl.cpp
@@ -113,18 +113,32 @@ bool slacImpl::handle_leave_bcd() {
 };
 
 bool slacImpl::handle_dlink_terminate() {
-    EVLOG_AND_THROW(Everest::EverestInternalError("dlink_terminate() not implemented yet"));
-    return false;
+    // With receiving a D-LINK_TERMINATE.request from HLE, the communication node
+    // shall leave the logical network within TP_match_leave. All parameters related
+    // to the current link shall be set to the default value and shall change to the status "Unmatched".
+    EVLOG_info << "D-LINK_TERMINATE.request received, leaving network.";
+    fsm_ctrl->signal_reset();
+    return true;
 };
 
 bool slacImpl::handle_dlink_error() {
-    EVLOG_AND_THROW(Everest::EverestInternalError("dlink_error() not implemented yet"));
-    return false;
+    // The D-LINK_ERROR.request requests lower layers to terminate the data link and restart the matching
+    // process by a control pilot transition through state E (on EVSE side this should be state F though)
+    // CP signal is handled by EvseManager, so we just need to reset the SLAC state machine here.
+    // DLINK_ERROR will be send from HLC layers when they detect that the connection is dead.
+    EVLOG_warning << "D-LINK_ERROR.request received";
+    fsm_ctrl->signal_reset();
+    return true;
 };
 
 bool slacImpl::handle_dlink_pause() {
-    EVLOG_AND_THROW(Everest::EverestInternalError("dlink_pause() not implemented yet"));
-    return false;
+    // The D-LINK_PAUSE.request requests lower layers to enter a power saving mode. While being in this
+    // mode, the state will be kept to "Matched".
+    // So we don't need to do anything here as we do not support low power mode to power down the PLC modem.
+    // This is optional in ISO15118-3.
+    EVLOG_info << "D-LINK_PAUSE.request received. Staying in MATCHED, PLC chip stays powered on (low power mode "
+                  "optional in -3)";
+    return true;
 };
 
 } // namespace main

--- a/modules/EvseV2G/EvseV2G.hpp
+++ b/modules/EvseV2G/EvseV2G.hpp
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022-2023 chargebyte GmbH
 // Copyright (C) 2022-2023 Contributors to EVerest
+
 #ifndef EVSE_V2G_HPP
 #define EVSE_V2G_HPP
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 1
+// template version 2
 //
 
 #include "ld-ev.hpp"
@@ -41,9 +42,9 @@ public:
             std::unique_ptr<ISO15118_chargerImplBase> p_charger, Conf& config) :
         ModuleBase(info), mqtt(mqtt_provider), p_charger(std::move(p_charger)), config(config){};
 
-    const Conf& config;
     Everest::MqttProvider& mqtt;
     const std::unique_ptr<ISO15118_chargerImplBase> p_charger;
+    const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     ~EvseV2G();

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -350,14 +350,17 @@ void ISO15118_chargerImpl::handle_set_Certificate_Service_Supported(bool& status
         // For setting "Certificate" in ServiceList in ServiceDiscoveryRes
         struct iso1ServiceType cert_service;
         const std::string service_name = "Certificate";
-        const int16_t cert_parameter_set_id[] = {1}; // parameter-set-ID 1: "Installation" service. TODO: Support of the "Update" service (parameter-set-ID 2)
+        const int16_t cert_parameter_set_id[] = {1}; // parameter-set-ID 1: "Installation" service. TODO: Support of the
+                                                     // "Update" service (parameter-set-ID 2)
 
-        cert_service.FreeService = 1; // true
-        cert_service.ServiceID = 2; // as defined in ISO 15118-2
+        cert_service.FreeService = 1;                // true
+        cert_service.ServiceID = 2;                  // as defined in ISO 15118-2
         cert_service.ServiceCategory = iso1serviceCategoryType_ContractCertificate;
-        memcpy(cert_service.ServiceName.characters, reinterpret_cast<const char*>(service_name.data()), service_name.length());
+        memcpy(cert_service.ServiceName.characters, reinterpret_cast<const char*>(service_name.data()),
+               service_name.length());
 
-        add_service_to_service_list(v2g_ctx, cert_service, cert_parameter_set_id, sizeof(cert_parameter_set_id) / sizeof(cert_parameter_set_id[0]));
+        add_service_to_service_list(v2g_ctx, cert_service, cert_parameter_set_id,
+                                    sizeof(cert_parameter_set_id) / sizeof(cert_parameter_set_id[0]));
     }
 }
 
@@ -365,10 +368,15 @@ void ISO15118_chargerImpl::handle_set_Get_Certificate_Response(
     types::iso15118_charger::Response_Exi_Stream_Status& Existream_Status) {
     pthread_mutex_lock(&v2g_ctx->mqtt_lock);
     v2g_ctx->evse_v2g_data.cert_install_res_b64_buffer = std::string(*Existream_Status.exiResponse);
-    v2g_ctx->evse_v2g_data.cert_install_status = (Existream_Status.status == types::iso15118_charger::Status::Accepted) ? true : false;
+    v2g_ctx->evse_v2g_data.cert_install_status =
+        (Existream_Status.status == types::iso15118_charger::Status::Accepted) ? true : false;
     pthread_cond_signal(&v2g_ctx->mqtt_cond);
     /* unlock */
     pthread_mutex_unlock(&v2g_ctx->mqtt_lock);
+}
+
+void ISO15118_chargerImpl::handle_dlink_ready(bool& value) {
+    // FIXME: do something with this information
 }
 
 } // namespace charger

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022-2023 chargebyte GmbH
 // Copyright (C) 2022-2023 Contributors to EVerest
+
 #ifndef CHARGER_ISO15118_CHARGER_IMPL_HPP
 #define CHARGER_ISO15118_CHARGER_IMPL_HPP
 
@@ -69,6 +70,7 @@ protected:
     virtual void handle_set_Certificate_Service_Supported(bool& status) override;
     virtual void
     handle_set_Get_Certificate_Response(types::iso15118_charger::Response_Exi_Stream_Status& Existream_Status) override;
+    virtual void handle_dlink_ready(bool& value) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/simulation/JsSlacSimulator/index.js
+++ b/modules/simulation/JsSlacSimulator/index.js
@@ -81,14 +81,18 @@ boot_module(async ({
 });
 
 function set_unmatched_evse(mod) {
-  state_evse = STATE_UNMATCHED;
-  mod.provides.evse.publish.state(state_to_string(state_evse));
-  mod.provides.evse.publish.dlink_ready(false);
+  if (state_evse != STATE_UNMATCHED) {
+    state_evse = STATE_UNMATCHED;
+    mod.provides.evse.publish.state(state_to_string(state_evse));
+    mod.provides.evse.publish.dlink_ready(false);
+  }
 }
 function set_unmatched_ev(mod) {
-  state_ev = STATE_UNMATCHED;
-  mod.provides.ev.publish.state(state_to_string(state_ev));
-  mod.provides.ev.publish.dlink_ready(false);
+  if (state_ev != STATE_UNMATCHED) {
+    state_ev = STATE_UNMATCHED;
+    mod.provides.ev.publish.state(state_to_string(state_ev));
+    mod.provides.ev.publish.dlink_ready(false);
+  }
 }
 
 function set_matching_evse(mod) {


### PR DESCRIPTION
This forwards dlink_ready signals from SLAC to the ISO module. The ISO module should do something with this information, this is not implemented yet. @mooraby @FaHaGit Can you check if this is useful for the state machine? E.g. close TCP and reset module when a dlink_ready(false) is received?