### PR TITLE
Remove minProperty from type message

### DIFF
--- a/types/yeti.yaml
+++ b/types/yeti.yaml
@@ -4,6 +4,15 @@ types:
     description: simulation data
     type: object
     additionalProperties: false
+    required:
+      - cp_voltage
+      - pp_resistor
+      - rcd_current
+      - diode_fail
+      - error_e
+      - currents
+      - voltages
+      - frequencies
     properties:
       cp_voltage:
         description: CP Voltage level [V]

--- a/types/yeti.yaml
+++ b/types/yeti.yaml
@@ -4,7 +4,6 @@ types:
     description: simulation data
     type: object
     additionalProperties: false
-    minProperties: 8
     properties:
       cp_voltage:
         description: CP Voltage level [V]


### PR DESCRIPTION
I believe this to be a copy & pasto from everest-framework/schemas/manifest.yaml where this shows in the context of outlining a schema. I would not understand what this defines for a data type, hence I believe it should be removed.