### PR TITLE
HLC sleep mode

### DIFF
--- a/config/nodered/config-sil-dc-flow.json
+++ b/config/nodered/config-sil-dc-flow.json
@@ -1667,7 +1667,7 @@
         "label": "Simulation enable (HIL)",
         "tooltip": "",
         "group": "b364f7eb4621082b",
-        "order": 10,
+        "order": 12,
         "width": 0,
         "height": 0,
         "passthru": true,
@@ -1781,7 +1781,7 @@
         "tooltip": "",
         "place": "Select option",
         "group": "b364f7eb4621082b",
-        "order": 10,
+        "order": 13,
         "width": 0,
         "height": 0,
         "passthru": true,
@@ -1789,7 +1789,7 @@
         "options": [
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,DC_extended;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,DC_extended;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session ExternalPayment,DC_extended;iso_wait_pwr_ready;sleep 36000;",
                 "type": "str"
             }
         ],
@@ -1798,7 +1798,7 @@
         "topicType": "str",
         "className": "",
         "x": 170,
-        "y": 1040,
+        "y": 1120,
         "wires": [
             [
                 "620b0d248a89ece0"
@@ -1810,7 +1810,7 @@
         "type": "function",
         "z": "ed603c51db9dcbb9",
         "name": "Buffer sim commands",
-        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
+        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -1859,13 +1859,69 @@
         "once": true,
         "onceDelay": "1",
         "topic": "sim_commands",
-        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,DC_extended;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,DC_extended;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session ExternalPayment,DC_extended;iso_wait_pwr_ready;sleep 36000;",
         "payloadType": "str",
         "x": 150,
-        "y": 1100,
+        "y": 1180,
         "wires": [
             [
                 "f2ae0c306f3052f9"
+            ]
+        ]
+    },
+    {
+        "id": "7cedfe81979df439",
+        "type": "ui_button",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "group": "b364f7eb4621082b",
+        "order": 11,
+        "width": "3",
+        "height": "1",
+        "passthru": false,
+        "label": "EV Resume",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "resume",
+        "payloadType": "str",
+        "topic": "everest_external/nodered/#/carsim/cmd/modify_charging_session",
+        "topicType": "str",
+        "x": 170,
+        "y": 1060,
+        "wires": [
+            [
+                "620b0d248a89ece0"
+            ]
+        ]
+    },
+    {
+        "id": "9ca06173e71733b7",
+        "type": "ui_button",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "group": "b364f7eb4621082b",
+        "order": 10,
+        "width": "3",
+        "height": "1",
+        "passthru": false,
+        "label": "EV Pause",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "pause",
+        "payloadType": "str",
+        "topic": "everest_external/nodered/#/carsim/cmd/modify_charging_session",
+        "topicType": "str",
+        "x": 170,
+        "y": 1020,
+        "wires": [
+            [
+                "620b0d248a89ece0"
             ]
         ]
     }

--- a/config/nodered/config-sil-flow.json
+++ b/config/nodered/config-sil-flow.json
@@ -1789,12 +1789,12 @@
         "options": [
             {
                 "label": "AC 3ph 16A",
-                "value": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 36000#unplug",
+                "value": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 36000#unplug#pause;sleep 3600#draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             },
             {
                 "label": "AC 1ph 32A",
-                "value": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 32,1;sleep 36000#unplug",
+                "value": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 32,1;sleep 36000#unplug#pause;sleep 3600#draw_power_regulated 32,1;sleep 36000",
                 "type": "str"
             },
             {
@@ -1814,7 +1814,7 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session ExternalPayment,AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             }
         ],
@@ -1823,7 +1823,7 @@
         "topicType": "str",
         "className": "",
         "x": 170,
-        "y": 1040,
+        "y": 1120,
         "wires": [
             [
                 "620b0d248a89ece0"
@@ -1835,7 +1835,7 @@
         "type": "function",
         "z": "ed603c51db9dcbb9",
         "name": "Buffer sim commands",
-        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
+        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -1884,13 +1884,69 @@
         "once": true,
         "onceDelay": "1",
         "topic": "sim_commands",
-        "payload": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 36000#unplug",
+        "payload": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 36000#unplug#pause;sleep 3600#draw_power_regulated 16,3;sleep 36000",
         "payloadType": "str",
         "x": 150,
-        "y": 1100,
+        "y": 1180,
         "wires": [
             [
                 "f2ae0c306f3052f9"
+            ]
+        ]
+    },
+    {
+        "id": "37f4d2b3eb016e86",
+        "type": "ui_button",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "group": "b364f7eb4621082b",
+        "order": 9,
+        "width": "3",
+        "height": "1",
+        "passthru": false,
+        "label": "EV Pause",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "pause",
+        "payloadType": "str",
+        "topic": "everest_external/nodered/#/carsim/cmd/modify_charging_session",
+        "topicType": "str",
+        "x": 170,
+        "y": 1020,
+        "wires": [
+            [
+                "620b0d248a89ece0"
+            ]
+        ]
+    },
+    {
+        "id": "9bd61f4219350918",
+        "type": "ui_button",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "group": "b364f7eb4621082b",
+        "order": 9,
+        "width": "3",
+        "height": "1",
+        "passthru": false,
+        "label": "EV Resume",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "resume",
+        "payloadType": "str",
+        "topic": "everest_external/nodered/#/carsim/cmd/modify_charging_session",
+        "topicType": "str",
+        "x": 170,
+        "y": 1060,
+        "wires": [
+            [
+                "620b0d248a89ece0"
             ]
         ]
     }

--- a/config/nodered/config-sil-two-evse-flow.json
+++ b/config/nodered/config-sil-two-evse-flow.json
@@ -2111,12 +2111,12 @@
         "options": [
             {
                 "label": "AC 3ph 16A",
-                "value": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 36000#unplug",
+                "value": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 36000#unplug#pause;sleep 3600#draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             },
             {
                 "label": "AC 1ph 32A",
-                "value": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 32,1;sleep 36000#unplug",
+                "value": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 32,1;sleep 36000#unplug#pause;sleep 3600#draw_power_regulated 32,1;sleep 36000",
                 "type": "str"
             },
             {
@@ -2136,12 +2136,12 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session ExternalPayment,AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             },
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,DC_extended;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session ExternalPayment,DC_extended;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session ExternalPayment,DC_extended;iso_wait_pwr_ready;sleep 36000;",
                 "type": "str"
             }
         ],
@@ -2149,7 +2149,7 @@
         "topic": "sim_commands",
         "topicType": "str",
         "x": 180,
-        "y": 1040,
+        "y": 1120,
         "wires": [
             [
                 "620b0d248a89ece0"
@@ -2161,7 +2161,7 @@
         "type": "function",
         "z": "ed603c51db9dcbb9",
         "name": "Buffer sim commands",
-        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
+        "func": "if (msg.topic.indexOf('sim_commands') > -1) {\n    const s = msg.payload.split('#');\n    flow.set('sim_commands_start', s[0]);\n    flow.set('sim_commands_stop', s[1]);\n    flow.set('sim_commands_pause', s[2]);\n    flow.set('sim_commands_resume', s[3]);\n} else if (msg.payload == 'start') {\n    msg.payload = flow.get('sim_commands_start');\n    return msg;\n} else if (msg.payload == 'stop') {\n    msg.payload = flow.get('sim_commands_stop');\n    return msg;\n} else if (msg.payload == 'pause') {\n    msg.payload = flow.get('sim_commands_pause');\n    return msg;\n} else if (msg.payload == 'resume') {\n    msg.payload = flow.get('sim_commands_resume');\n    return msg;\n} else {\n    msg.payload = 'NONE';\n    return msg;\n}\n",
         "outputs": 1,
         "noerr": 0,
         "initialize": "",
@@ -2213,13 +2213,86 @@
         "once": true,
         "onceDelay": "1",
         "topic": "sim_commands",
-        "payload": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 36000#unplug",
+        "payload": "sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 36000#unplug#pause;sleep 3600#draw_power_regulated 16,3;sleep 36000",
         "payloadType": "str",
         "x": 150,
-        "y": 1100,
+        "y": 1180,
         "wires": [
             [
                 "f2ae0c306f3052f9"
+            ]
+        ]
+    },
+    {
+        "id": "cc42c210398a8d50",
+        "type": "debug",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "topic",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 900,
+        "y": 960,
+        "wires": []
+    },
+    {
+        "id": "29aced2052ea8795",
+        "type": "ui_button",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "group": "b364f7eb4621082b",
+        "order": 9,
+        "width": "3",
+        "height": "1",
+        "passthru": false,
+        "label": "EV Pause",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "pause",
+        "payloadType": "str",
+        "topic": "everest_external/nodered/#/carsim/cmd/modify_charging_session",
+        "topicType": "str",
+        "x": 160,
+        "y": 1020,
+        "wires": [
+            [
+                "620b0d248a89ece0"
+            ]
+        ]
+    },
+    {
+        "id": "f39e2131a37761a6",
+        "type": "ui_button",
+        "z": "ed603c51db9dcbb9",
+        "name": "",
+        "group": "b364f7eb4621082b",
+        "order": 9,
+        "width": "3",
+        "height": "1",
+        "passthru": false,
+        "label": "EV Resume",
+        "tooltip": "",
+        "color": "",
+        "bgcolor": "",
+        "className": "",
+        "icon": "",
+        "payload": "resume",
+        "payloadType": "str",
+        "topic": "everest_external/nodered/#/carsim/cmd/modify_charging_session",
+        "topicType": "str",
+        "x": 170,
+        "y": 1060,
+        "wires": [
+            [
+                "620b0d248a89ece0"
             ]
         ]
     },
@@ -2979,22 +3052,5 @@
                 "3ce436b7f3df46a5"
             ]
         ]
-    },
-    {
-        "id": "cc42c210398a8d50",
-        "type": "debug",
-        "z": "ed603c51db9dcbb9",
-        "name": "",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": false,
-        "complete": "topic",
-        "targetType": "msg",
-        "statusVal": "",
-        "statusType": "auto",
-        "x": 900,
-        "y": 960,
-        "wires": []
     }
 ]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -42,7 +42,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: ce70c62
+  git_tag: 43828f6
 # OpenV2G
 ext-openv2g:
   git: https://github.com/EVerest/ext-openv2g.git

--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -279,6 +279,13 @@ cmds:
         description: The response raw exi stream and the status from the CSMS system
         type: object
         $ref: /iso15118_charger#/Response_Exi_Stream_Status
+  dlink_ready:
+    description: >-
+      Signals dlink_ready from SLAC layer according to ISO15118-3
+    arguments:
+      value:
+        description: Set to true when link becomes ready, false when the link is terminated
+        type: boolean
 vars:
   Require_Auth_EIM:
     description: An EIM authorization is requiered
@@ -290,17 +297,17 @@ vars:
     type: object
     $ref: /authorization#/ProvidedIdToken
   AC_Close_Contactor:
-    description: If true, the contactor should be closed
-    type: boolean
+    description: The contactor should be closed
+    type: "null"
   AC_Open_Contactor:
-    description: If true, the contactor should be opened
-    type: boolean
+    description: The contactor should be opened
+    type: "null"
   Start_CableCheck:
     description: The charger should now start a cable check
     type: "null"
   DC_Open_Contactor:
-    description: If true, the contactor should be opened
-    type: boolean
+    description: The contactor should be opened
+    type: "null"
   V2G_Setup_Finished:
     description: >-
       V2G_Setup_Finished from ISO15118-3. Trigger when EV sends a PowerDeliveryReq
@@ -389,12 +396,6 @@ vars:
     description: Current status of the EV
     type: object
     $ref: /iso15118_charger#/DC_EVStatusType
-  EV_ChargingSession:
-    description: >-
-      ChargingSession indicates the intention of the EVCC to either pause
-      or terminate a V2G Communication Session
-    type: string
-    $ref: /iso15118_charger#/ChargingSession
   DC_BulkChargingComplete:
     description: >-
       Optional: If set to TRUE, the EV indicates that bulk charge (approx.
@@ -426,6 +427,15 @@ vars:
       Response will be reported async via  set_Get_Certificate_Response
     type: object
     $ref: /iso15118_charger#/Request_Exi_Stream_Schema
+  dlink_terminate:
+    description: Terminate the data link and become UNMATCHED.
+    type: "null"
+  dlink_error:
+    description: Terminate the data link and restart the matching process.
+    type: "null"
+  dlink_pause:
+    description: Request power saving mode, while staying MATCHED.
+    type: "null"
   EV_AppProtocol:
     description: >-
       Debug_Lite - This request message provides a list of charging protocols

--- a/interfaces/ISO15118_ev.yaml
+++ b/interfaces/ISO15118_ev.yaml
@@ -26,6 +26,8 @@ cmds:
       type: boolean
   stop_charging:
     description: Stop the ev charging communication process
+  pause_charging:
+    description: Pause the ev charging communication process  
   set_fault:
     description: >-
       TODO_SL: Set the different ev faults to communicate these errors

--- a/modules/DummyV2G/DummyV2G.hpp
+++ b/modules/DummyV2G/DummyV2G.hpp
@@ -27,8 +27,8 @@ public:
     DummyV2G(const ModuleInfo& info, std::unique_ptr<ISO15118_chargerImplBase> p_main, Conf& config) :
         ModuleBase(info), p_main(std::move(p_main)), config(config){};
 
-    const Conf& config;
     const std::unique_ptr<ISO15118_chargerImplBase> p_main;
+    const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     // insert your public definitions here

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
@@ -134,5 +134,8 @@ void ISO15118_chargerImpl::handle_set_Get_Certificate_Response(
     // your code for cmd set_Get_Certificate_Response goes here
 };
 
+void ISO15118_chargerImpl::handle_dlink_ready(bool& value) {
+}
+
 } // namespace main
 } // namespace module

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
@@ -67,6 +67,7 @@ protected:
     virtual void handle_set_Certificate_Service_Supported(bool& status) override;
     virtual void
     handle_set_Get_Certificate_Response(types::iso15118_charger::Response_Exi_Stream_Status& Existream_Status) override;
+    virtual void handle_dlink_ready(bool& value) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -177,7 +177,7 @@ private:
     const float EVSE_ABSOLUTE_MAX_CURRENT = 80.0;
     bool slac_enabled;
 
-    std::atomic_bool contactor_open{false};
+    std::atomic_bool contactor_open{true};
 
     std::mutex hlc_mutex;
 
@@ -226,6 +226,8 @@ private:
     void imd_stop();
     void imd_start();
     Everest::Thread telemetryThreadHandle;
+
+    void fail_session();
 
     static constexpr auto CABLECHECK_CONTACTORS_CLOSE_TIMEOUT{std::chrono::seconds(5)};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1

--- a/modules/EvseSlac/main/slacImpl.cpp
+++ b/modules/EvseSlac/main/slacImpl.cpp
@@ -113,18 +113,32 @@ bool slacImpl::handle_leave_bcd() {
 };
 
 bool slacImpl::handle_dlink_terminate() {
-    EVLOG_AND_THROW(Everest::EverestInternalError("dlink_terminate() not implemented yet"));
-    return false;
+    // With receiving a D-LINK_TERMINATE.request from HLE, the communication node
+    // shall leave the logical network within TP_match_leave. All parameters related
+    // to the current link shall be set to the default value and shall change to the status "Unmatched".
+    EVLOG_info << "D-LINK_TERMINATE.request received, leaving network.";
+    fsm_ctrl->signal_reset();
+    return true;
 };
 
 bool slacImpl::handle_dlink_error() {
-    EVLOG_AND_THROW(Everest::EverestInternalError("dlink_error() not implemented yet"));
-    return false;
+    // The D-LINK_ERROR.request requests lower layers to terminate the data link and restart the matching
+    // process by a control pilot transition through state E (on EVSE side this should be state F though)
+    // CP signal is handled by EvseManager, so we just need to reset the SLAC state machine here.
+    // DLINK_ERROR will be send from HLC layers when they detect that the connection is dead.
+    EVLOG_warning << "D-LINK_ERROR.request received";
+    fsm_ctrl->signal_reset();
+    return true;
 };
 
 bool slacImpl::handle_dlink_pause() {
-    EVLOG_AND_THROW(Everest::EverestInternalError("dlink_pause() not implemented yet"));
-    return false;
+    // The D-LINK_PAUSE.request requests lower layers to enter a power saving mode. While being in this
+    // mode, the state will be kept to "Matched".
+    // So we don't need to do anything here as we do not support low power mode to power down the PLC modem.
+    // This is optional in ISO15118-3.
+    EVLOG_info << "D-LINK_PAUSE.request received. Staying in MATCHED, PLC chip stays powered on (low power mode "
+                  "optional in -3)";
+    return true;
 };
 
 } // namespace main

--- a/modules/EvseV2G/EvseV2G.hpp
+++ b/modules/EvseV2G/EvseV2G.hpp
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2022-2023 chargebyte GmbH
 // Copyright (C) 2022-2023 Contributors to EVerest
+
 #ifndef EVSE_V2G_HPP
 #define EVSE_V2G_HPP
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 1
+// template version 2
 //
 
 #include "ld-ev.hpp"
@@ -41,9 +42,9 @@ public:
             std::unique_ptr<ISO15118_chargerImplBase> p_charger, Conf& config) :
         ModuleBase(info), mqtt(mqtt_provider), p_charger(std::move(p_charger)), config(config){};
 
-    const Conf& config;
     Everest::MqttProvider& mqtt;
     const std::unique_ptr<ISO15118_chargerImplBase> p_charger;
+    const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     ~EvseV2G();

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -75,67 +75,74 @@ void ISO15118_chargerImpl::handle_set_EVSEID(std::string& EVSEID, std::string& E
 };
 
 void ISO15118_chargerImpl::handle_set_PaymentOptions(Array& PaymentOptions) {
-    v2g_ctx->evse_v2g_data.payment_option_list_len = 0;
+    
+    if (v2g_ctx->hlc_pause_active != true) {
 
-    for (auto& element : PaymentOptions) {
-        if (element.is_string()) {
-            types::iso15118_charger::PaymentOption payment_option =
-                types::iso15118_charger::string_to_payment_option(element.get<std::string>());
-            if (payment_option == types::iso15118_charger::PaymentOption::Contract) {
-                v2g_ctx->evse_v2g_data.payment_option_list[v2g_ctx->evse_v2g_data.payment_option_list_len] =
-                    iso1paymentOptionType_Contract;
-                v2g_ctx->evse_v2g_data.payment_option_list_len++;
-            } else if (payment_option == types::iso15118_charger::PaymentOption::ExternalPayment) {
-                v2g_ctx->evse_v2g_data.payment_option_list[v2g_ctx->evse_v2g_data.payment_option_list_len] =
-                    iso1paymentOptionType_ExternalPayment;
-                v2g_ctx->evse_v2g_data.payment_option_list_len++;
-            } else if (v2g_ctx->evse_v2g_data.payment_option_list_len == 0) {
-                dlog(DLOG_LEVEL_WARNING, "Unable to configure PaymentOptions %s", element.get<std::string>());
+        v2g_ctx->evse_v2g_data.payment_option_list_len = 0;
+
+        for (auto& element : PaymentOptions) {
+            if (element.is_string()) {
+                types::iso15118_charger::PaymentOption payment_option =
+                    types::iso15118_charger::string_to_payment_option(element.get<std::string>());
+                if (payment_option == types::iso15118_charger::PaymentOption::Contract) {
+                    v2g_ctx->evse_v2g_data.payment_option_list[v2g_ctx->evse_v2g_data.payment_option_list_len] =
+                        iso1paymentOptionType_Contract;
+                    v2g_ctx->evse_v2g_data.payment_option_list_len++;
+                } else if (payment_option == types::iso15118_charger::PaymentOption::ExternalPayment) {
+                    v2g_ctx->evse_v2g_data.payment_option_list[v2g_ctx->evse_v2g_data.payment_option_list_len] =
+                        iso1paymentOptionType_ExternalPayment;
+                    v2g_ctx->evse_v2g_data.payment_option_list_len++;
+                } else if (v2g_ctx->evse_v2g_data.payment_option_list_len == 0) {
+                    dlog(DLOG_LEVEL_WARNING, "Unable to configure PaymentOptions %s", element.get<std::string>());
+                }
             }
         }
     }
 }
 
 void ISO15118_chargerImpl::handle_set_SupportedEnergyTransferMode(Array& SupportedEnergyTransferMode) {
-    uint16_t& energyArrayLen =
-        (v2g_ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.arrayLen);
-    iso1EnergyTransferModeType* energyArray =
-        v2g_ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.array;
-    energyArrayLen = 0;
 
-    v2g_ctx->is_dc_charger = true;
+    if (v2g_ctx->hlc_pause_active != true) {
+        uint16_t& energyArrayLen =
+            (v2g_ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.arrayLen);
+        iso1EnergyTransferModeType* energyArray =
+            v2g_ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.array;
+        energyArrayLen = 0;
 
-    for (auto& element : SupportedEnergyTransferMode) {
-        if (element.is_string()) {
-            types::iso15118_charger::EnergyTransferMode energy_transfer_mode =
-                types::iso15118_charger::string_to_energy_transfer_mode(element.get<std::string>());
-            switch (energy_transfer_mode) {
-            case types::iso15118_charger::EnergyTransferMode::AC_single_phase_core:
-                energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_AC_single_phase_core;
-                v2g_ctx->is_dc_charger = false;
-                break;
-            case types::iso15118_charger::EnergyTransferMode::AC_three_phase_core:
-                energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_AC_three_phase_core;
-                v2g_ctx->is_dc_charger = false;
-                break;
-            case types::iso15118_charger::EnergyTransferMode::DC_core:
-                energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_DC_core;
-                break;
-            case types::iso15118_charger::EnergyTransferMode::DC_extended:
-                energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_DC_extended;
-                break;
-            case types::iso15118_charger::EnergyTransferMode::DC_combo_core:
-                energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_DC_combo_core;
-                break;
-            case types::iso15118_charger::EnergyTransferMode::DC_unique:
-                energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_DC_unique;
-                break;
-            default:
-                if (energyArrayLen == 0) {
-                    dlog(DLOG_LEVEL_WARNING, "Unable to configure SupportedEnergyTransferMode %s",
-                         element.get<std::string>());
+        v2g_ctx->is_dc_charger = true;
+
+        for (auto& element : SupportedEnergyTransferMode) {
+            if (element.is_string()) {
+                types::iso15118_charger::EnergyTransferMode energy_transfer_mode =
+                    types::iso15118_charger::string_to_energy_transfer_mode(element.get<std::string>());
+                switch (energy_transfer_mode) {
+                case types::iso15118_charger::EnergyTransferMode::AC_single_phase_core:
+                    energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_AC_single_phase_core;
+                    v2g_ctx->is_dc_charger = false;
+                    break;
+                case types::iso15118_charger::EnergyTransferMode::AC_three_phase_core:
+                    energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_AC_three_phase_core;
+                    v2g_ctx->is_dc_charger = false;
+                    break;
+                case types::iso15118_charger::EnergyTransferMode::DC_core:
+                    energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_DC_core;
+                    break;
+                case types::iso15118_charger::EnergyTransferMode::DC_extended:
+                    energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_DC_extended;
+                    break;
+                case types::iso15118_charger::EnergyTransferMode::DC_combo_core:
+                    energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_DC_combo_core;
+                    break;
+                case types::iso15118_charger::EnergyTransferMode::DC_unique:
+                    energyArray[(energyArrayLen)++] = iso1EnergyTransferModeType_DC_unique;
+                    break;
+                default:
+                    if (energyArrayLen == 0) {
+                        dlog(DLOG_LEVEL_WARNING, "Unable to configure SupportedEnergyTransferMode %s",
+                            element.get<std::string>());
+                    }
+                    break;
                 }
-                break;
             }
         }
     }
@@ -162,7 +169,9 @@ void ISO15118_chargerImpl::handle_set_ReceiptRequired(bool& ReceiptRequired) {
 };
 
 void ISO15118_chargerImpl::handle_set_FreeService(bool& FreeService) {
-    v2g_ctx->evse_v2g_data.charge_service.FreeService = (int)FreeService;
+    if (v2g_ctx->hlc_pause_active != true) {
+        v2g_ctx->evse_v2g_data.charge_service.FreeService = (int)FreeService;
+    }
 };
 
 void ISO15118_chargerImpl::handle_set_EVSEEnergyToBeDelivered(double& EVSEEnergyToBeDelivered) {
@@ -350,14 +359,17 @@ void ISO15118_chargerImpl::handle_set_Certificate_Service_Supported(bool& status
         // For setting "Certificate" in ServiceList in ServiceDiscoveryRes
         struct iso1ServiceType cert_service;
         const std::string service_name = "Certificate";
-        const int16_t cert_parameter_set_id[] = {1}; // parameter-set-ID 1: "Installation" service. TODO: Support of the "Update" service (parameter-set-ID 2)
+        const int16_t cert_parameter_set_id[] = {1}; // parameter-set-ID 1: "Installation" service. TODO: Support of the
+                                                     // "Update" service (parameter-set-ID 2)
 
-        cert_service.FreeService = 1; // true
-        cert_service.ServiceID = 2; // as defined in ISO 15118-2
+        cert_service.FreeService = 1;                // true
+        cert_service.ServiceID = 2;                  // as defined in ISO 15118-2
         cert_service.ServiceCategory = iso1serviceCategoryType_ContractCertificate;
-        memcpy(cert_service.ServiceName.characters, reinterpret_cast<const char*>(service_name.data()), service_name.length());
+        memcpy(cert_service.ServiceName.characters, reinterpret_cast<const char*>(service_name.data()),
+               service_name.length());
 
-        add_service_to_service_list(v2g_ctx, cert_service, cert_parameter_set_id, sizeof(cert_parameter_set_id) / sizeof(cert_parameter_set_id[0]));
+        add_service_to_service_list(v2g_ctx, cert_service, cert_parameter_set_id,
+                                    sizeof(cert_parameter_set_id) / sizeof(cert_parameter_set_id[0]));
     }
 }
 
@@ -365,10 +377,15 @@ void ISO15118_chargerImpl::handle_set_Get_Certificate_Response(
     types::iso15118_charger::Response_Exi_Stream_Status& Existream_Status) {
     pthread_mutex_lock(&v2g_ctx->mqtt_lock);
     v2g_ctx->evse_v2g_data.cert_install_res_b64_buffer = std::string(*Existream_Status.exiResponse);
-    v2g_ctx->evse_v2g_data.cert_install_status = (Existream_Status.status == types::iso15118_charger::Status::Accepted) ? true : false;
+    v2g_ctx->evse_v2g_data.cert_install_status =
+        (Existream_Status.status == types::iso15118_charger::Status::Accepted) ? true : false;
     pthread_cond_signal(&v2g_ctx->mqtt_cond);
     /* unlock */
     pthread_mutex_unlock(&v2g_ctx->mqtt_lock);
+}
+
+void ISO15118_chargerImpl::handle_dlink_ready(bool& value) {
+    // FIXME: do something with this information
 }
 
 } // namespace charger

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
@@ -69,6 +69,7 @@ protected:
     virtual void handle_set_Certificate_Service_Supported(bool& status) override;
     virtual void
     handle_set_Get_Certificate_Response(types::iso15118_charger::Response_Exi_Stream_Status& Existream_Status) override;
+    virtual void handle_dlink_ready(bool& value) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/EvseV2G/connection.cpp
+++ b/modules/EvseV2G/connection.cpp
@@ -461,9 +461,9 @@ static void connection_teardown(struct v2g_connection* conn) {
         conn->ctx->p_charger->publish_currentDemand_Finished(nullptr);
 
         if (conn->ctx->is_dc_charger == true) {
-            conn->ctx->p_charger->publish_DC_Open_Contactor(true);
+            conn->ctx->p_charger->publish_DC_Open_Contactor(nullptr);
         } else {
-            conn->ctx->p_charger->publish_AC_Open_Contactor(true);
+            conn->ctx->p_charger->publish_AC_Open_Contactor(nullptr);
         }
     }
 

--- a/modules/EvseV2G/din_server.cpp
+++ b/modules/EvseV2G/din_server.cpp
@@ -632,7 +632,7 @@ static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
 
     if (req->ReadyToChargeState == (int)0) {
         conn->ctx->p_charger->publish_currentDemand_Finished(nullptr);
-        conn->ctx->p_charger->publish_DC_Open_Contactor(true);
+        conn->ctx->p_charger->publish_DC_Open_Contactor(nullptr);
         conn->ctx->session.is_charging = false;
     }
 
@@ -898,8 +898,7 @@ static enum v2g_event handle_din_session_stop(struct v2g_connection* conn) {
     struct dinSessionStopResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.SessionStopRes;
 
     /* At first, publish charging session state */
-    conn->ctx->p_charger->publish_EV_ChargingSession(
-        static_cast<types::iso15118_charger::ChargingSession>(iso1chargingSessionType_Terminate));
+    conn->ctx->p_charger->publish_dlink_terminate(NULL);
 
     /* Now fill the EVSE response message */
     res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]

--- a/modules/EvseV2G/v2g.hpp
+++ b/modules/EvseV2G/v2g.hpp
@@ -334,6 +334,8 @@ struct v2g_context {
         float remaining_time_to_bulk_soc;
         float remaining_time_to_full_soc;
     } ev_v2g_data;
+
+    bool hlc_pause_active;
 };
 
 enum mqtt_dlink_action {

--- a/modules/EvseV2G/v2g_ctx.cpp
+++ b/modules/EvseV2G/v2g_ctx.cpp
@@ -139,8 +139,10 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     static bool initialize_once = false;
     const char init_service_name[] = {"EVCharging_Service"};
 
-    ctx->evse_v2g_data.session_id =
+    if (ctx->hlc_pause_active != true) {
+        ctx->evse_v2g_data.session_id =
         (uint64_t)0; /* store associated session id, this is zero until SessionSetupRes is sent */
+    }
     ctx->evse_v2g_data.notification_max_delay = (uint32_t)0;
     ctx->evse_v2g_data.evse_isolation_status = (uint8_t)iso1isolationLevelType_Invalid;
     ctx->evse_v2g_data.evse_isolation_status_is_used = (unsigned int)1; // Shall be used in DIN
@@ -152,15 +154,16 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     memset(ctx->evse_v2g_data.evse_processing, iso1EVSEProcessingType_Ongoing, PHASE_LENGTH);
     ctx->evse_v2g_data.evse_processing[PHASE_PARAMETER] = iso1EVSEProcessingType_Finished; // Skip parameter phase
 
-    ctx->evse_v2g_data.charge_service.ServiceCategory = iso1serviceCategoryType_EVCharging;
-    ctx->evse_v2g_data.charge_service.ServiceID = (uint16_t)1;
-    memcpy(ctx->evse_v2g_data.charge_service.ServiceName.characters, init_service_name, sizeof(init_service_name));
-    ctx->evse_v2g_data.charge_service.ServiceName.charactersLen = sizeof(init_service_name);
-    ctx->evse_v2g_data.charge_service.ServiceName_isUsed = 0;
-    // ctx->evse_v2g_data.chargeService.ServiceScope.characters
-    // ctx->evse_v2g_data.chargeService.ServiceScope.charactersLen
-    ctx->evse_v2g_data.charge_service.ServiceScope_isUsed = (unsigned int)0;
-
+    if (ctx->hlc_pause_active != true) {
+        ctx->evse_v2g_data.charge_service.ServiceCategory = iso1serviceCategoryType_EVCharging;
+        ctx->evse_v2g_data.charge_service.ServiceID = (uint16_t)1;
+        memcpy(ctx->evse_v2g_data.charge_service.ServiceName.characters, init_service_name, sizeof(init_service_name));
+        ctx->evse_v2g_data.charge_service.ServiceName.charactersLen = sizeof(init_service_name);
+        ctx->evse_v2g_data.charge_service.ServiceName_isUsed = 0;
+        // ctx->evse_v2g_data.chargeService.ServiceScope.characters
+        // ctx->evse_v2g_data.chargeService.ServiceScope.charactersLen
+        ctx->evse_v2g_data.charge_service.ServiceScope_isUsed = (unsigned int)0;
+    }
     ctx->meter_info.meter_info_is_used = false;
 
     ctx->evse_v2g_data.evse_service_list_len = (uint16_t)0;
@@ -214,36 +217,39 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     init_physical_value(&ctx->evse_v2g_data.evse_present_voltage, iso1unitSymbolType_V);
     init_physical_value(&ctx->evse_v2g_data.evse_present_current, iso1unitSymbolType_A);
 
-    // SAScheduleTupleID#PMaxScheduleTupleID#Start#Duration#PMax#
-    init_physical_value(
-        &ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].PMaxSchedule.PMaxScheduleEntry.array[0].PMax,
-        iso1unitSymbolType_W);
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
-        .PMaxSchedule.PMaxScheduleEntry.array[0]
-        .RelativeTimeInterval.duration = (uint32_t)0;
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
-        .PMaxSchedule.PMaxScheduleEntry.array[0]
-        .RelativeTimeInterval.duration_isUsed = (unsigned int)1;
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
-        .PMaxSchedule.PMaxScheduleEntry.array[0]
-        .RelativeTimeInterval.start = (uint32_t)0;
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
-        .PMaxSchedule.PMaxScheduleEntry.array[0]
-        .RelativeTimeInterval_isUsed = (unsigned int)1; // Optional: In DIN/ISO it must be set to 1
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
-        .PMaxSchedule.PMaxScheduleEntry.array[0]
-        .TimeInterval_isUsed = (unsigned int)0;
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].PMaxSchedule.PMaxScheduleEntry.arrayLen = 1;
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].SalesTariff_isUsed = (unsigned int)0;
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].SAScheduleTupleID =
-        (uint8_t)1; // [V2G2-773]  1 to 255
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.arrayLen = (uint16_t)1;
-    ctx->evse_v2g_data.evse_sa_schedule_list_is_used = false;
+    if (ctx->hlc_pause_active != true) {
+        // SAScheduleTupleID#PMaxScheduleTupleID#Start#Duration#PMax#
+        init_physical_value(
+            &ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].PMaxSchedule.PMaxScheduleEntry.array[0].PMax,
+            iso1unitSymbolType_W);
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
+            .PMaxSchedule.PMaxScheduleEntry.array[0]
+            .RelativeTimeInterval.duration = (uint32_t)0;
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
+            .PMaxSchedule.PMaxScheduleEntry.array[0]
+            .RelativeTimeInterval.duration_isUsed = (unsigned int)1;
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
+            .PMaxSchedule.PMaxScheduleEntry.array[0]
+            .RelativeTimeInterval.start = (uint32_t)0;
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
+            .PMaxSchedule.PMaxScheduleEntry.array[0]
+            .RelativeTimeInterval_isUsed = (unsigned int)1; // Optional: In DIN/ISO it must be set to 1
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
+            .PMaxSchedule.PMaxScheduleEntry.array[0]
+            .TimeInterval_isUsed = (unsigned int)0;
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].PMaxSchedule.PMaxScheduleEntry.arrayLen = 1;
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].SalesTariff_isUsed = (unsigned int)0;
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].SAScheduleTupleID =
+            (uint8_t)1; // [V2G2-773]  1 to 255
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.arrayLen = (uint16_t)1;
+        ctx->evse_v2g_data.evse_sa_schedule_list_is_used = false;
 
-    // ctx->evse_v2g_data.evseSAScheduleTuple.SalesTariff
-    ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].SalesTariff_isUsed =
-        (unsigned int)0; // Not supported in DIN
-
+        // ctx->evse_v2g_data.evseSAScheduleTuple.SalesTariff
+        ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0].SalesTariff_isUsed =
+            (unsigned int)0; // Not supported in DIN
+    } else {
+        ctx->evse_v2g_data.evse_sa_schedule_list_is_used = true;
+    }
     if (ctx->evse_v2g_data.cert_install_res_b64_buffer.empty() == false) {
         ctx->evse_v2g_data.cert_install_res_b64_buffer.clear();
     }
@@ -257,7 +263,12 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     memset(&ctx->ev_v2g_data, 0xff, sizeof(ctx->ev_v2g_data));
 
     /* Init session values */
-    ctx->session.iso_selected_payment_option = iso1paymentOptionType_ExternalPayment;
+    if (ctx->hlc_pause_active != true) {
+        ctx->session.iso_selected_payment_option = iso1paymentOptionType_ExternalPayment;
+    } else {
+        ctx->evse_v2g_data.payment_option_list[0] = ctx->session.iso_selected_payment_option;
+        ctx->evse_v2g_data.payment_option_list_len = (uint8_t)1; // One option must be set
+    }
     memset(ctx->session.gen_challenge, 0, sizeof(ctx->session.gen_challenge));
 
     initialize_once = true;
@@ -314,6 +325,8 @@ struct v2g_context* v2g_ctx_create(ISO15118_chargerImplBase* p_chargerImplBase) 
         goto free_out;
 
     ctx->com_setup_timeout = NULL;
+
+    ctx->hlc_pause_active = false;
 
     return ctx;
 

--- a/modules/PyEvJosev/module.py
+++ b/modules/PyEvJosev/module.py
@@ -105,6 +105,9 @@ class PyEVJosevModule():
     def _handler_stop_charging(self, args):
         self._es.StopCharging = True
 
+    def _handler_pause_charging(self, args):
+        self._es.Pause = True
+
     def _handler_set_fault(self, args):
         pass
 

--- a/modules/PyJosev/module.py
+++ b/modules/PyJosev/module.py
@@ -192,6 +192,8 @@ class PyJosevModule():
     def _handler_set_Get_Certificate_Response(self, args):
         self._cs.existream_status = args['Existream_Status']
 
+    def _handler_dlink_ready(self, args):
+        self._cs.dlink_ready = args['value']
 
 py_josev = PyJosevModule()
 py_josev.start_secc_handler()

--- a/modules/simulation/JsSlacSimulator/index.js
+++ b/modules/simulation/JsSlacSimulator/index.js
@@ -81,14 +81,18 @@ boot_module(async ({
 });
 
 function set_unmatched_evse(mod) {
-  state_evse = STATE_UNMATCHED;
-  mod.provides.evse.publish.state(state_to_string(state_evse));
-  mod.provides.evse.publish.dlink_ready(false);
+  if (state_evse !== STATE_UNMATCHED) {
+    state_evse = STATE_UNMATCHED;
+    mod.provides.evse.publish.state(state_to_string(state_evse));
+    mod.provides.evse.publish.dlink_ready(false);
+  }
 }
 function set_unmatched_ev(mod) {
-  state_ev = STATE_UNMATCHED;
-  mod.provides.ev.publish.state(state_to_string(state_ev));
-  mod.provides.ev.publish.dlink_ready(false);
+  if (state_ev !== STATE_UNMATCHED) {
+    state_ev = STATE_UNMATCHED;
+    mod.provides.ev.publish.state(state_to_string(state_ev));
+    mod.provides.ev.publish.dlink_ready(false);
+  }
 }
 
 function set_matching_evse(mod) {

--- a/types/iso15118_charger.yaml
+++ b/types/iso15118_charger.yaml
@@ -48,14 +48,6 @@ types:
       - Reserved_C
       - FAILED_ChargingSystemIncompatibility
       - NoData
-  ChargingSession:
-    description:
-      ChargingSession indicates the intention of the EVCC to either pause
-      or terminate a V2G Communication Session
-    type: string
-    enum:
-      - Terminate
-      - Pause
   V2G_Message_ID:
     description: This element contains the id of the v2g message body
     type: string


### PR DESCRIPTION
Adding hlc sleep mode and some minor fixes:
- Adding dlink signals and forwarding from slac to iso module
- Adding pause/resume in EvseV2G and Josev
- Adding BCB Detection
- Adding hlc pause/resume to nodered flows
- Fixing ISO relais closing (AC and DC)
- Improving error handling in cablecheck
- Fixing PWM off too early
- Adding emergency stop nodered external command
- Adding restart after session stop
- Adding hlc evse pause/resume. Terminate session but allow restart by B1-B2 to wakeup EV

Please use this PR/Branch from Josev:  [Adding hlc pause/resume to the evcc and secc #17](https://github.com/EVerest/ext-switchev-iso15118/pull/17)