### PR TITLE
Fix parity option

### DIFF
--- a/modules/SerialCommHub/main/serial_communication_hubImpl.cpp
+++ b/modules/SerialCommHub/main/serial_communication_hubImpl.cpp
@@ -37,7 +37,7 @@ void serial_communication_hubImpl::init() {
     rxtx_gpio_settings.line_number = config.rxtx_gpio_line;
     rxtx_gpio_settings.inverted = config.rxtx_gpio_tx_high;
 
-    if (!modbus.open_device(config.serial_port, config.baudrate, config.ignore_echo, rxtx_gpio_settings)) {
+    if (!modbus.open_device(config.serial_port, config.baudrate, config.ignore_echo, rxtx_gpio_settings, static_cast<tiny_modbus::Parity>(config.parity))) {
         EVLOG_AND_THROW(Everest::EverestConfigError(fmt::format("Cannot open serial port {}.", config.serial_port)));
     }
 }
@@ -134,9 +134,9 @@ types::serial_comm_hub_requests::StatusCodeEnum serial_communication_hubImpl::ha
         uint8_t retry_counter{this->num_resends_on_error};
         while (retry_counter-- > 0) {
 
-            // EVLOG_info << fmt::format("Try {} Call modbus_client->write_multiple_registers(id {} addr {} len {})",
-            //                           (int)retry_counter, (uint8_t)target_device_id,
-            //                           (uint16_t)first_register_address, (uint16_t)data.size());
+            EVLOG_info << fmt::format("Try {} Call modbus_client->write_multiple_registers(id {} addr {} len {})",
+                                      (int)retry_counter, (uint8_t)target_device_id,
+                                      (uint16_t)first_register_address, (uint16_t)data.size());
 
             response = modbus.txrx(target_device_id, tiny_modbus::FunctionCode::WRITE_MULTIPLE_HOLDING_REGISTERS,
                                    first_register_address, data.size(), true, data);

--- a/modules/SerialCommHub/tiny_modbus_rtu.hpp
+++ b/modules/SerialCommHub/tiny_modbus_rtu.hpp
@@ -34,6 +34,12 @@ constexpr int MODBUS_BASE_PAYLOAD_SIZE = 8;
 constexpr int MODBUS_RX_INITIAL_TIMEOUT_MS = 500;
 constexpr int MODBUS_RX_WITHIN_MESSAGE_TIMEOUT_MS = 100;
 
+enum class Parity : uint8_t {
+    NONE = 0,
+    ODD = 1,
+    EVEN = 2
+};
+
 enum FunctionCode : uint8_t {
     READ_COILS = 0x01,
     READ_DISCRETE_INPUTS = 0x02,
@@ -51,7 +57,7 @@ public:
     ~TinyModbusRTU();
 
     bool open_device(const std::string& device, int baud, bool ignore_echo,
-                     const Everest::GpioSettings& rxtx_gpio_settings);
+                     const Everest::GpioSettings& rxtx_gpio_settings, const Parity parity);
     std::vector<uint16_t> txrx(uint8_t device_address, FunctionCode function, uint16_t first_register_address,
                                uint16_t register_quantity, bool wait_for_reply = true,
                                std::vector<uint16_t> request = std::vector<uint16_t>());


### PR DESCRIPTION
The option to set parity in SerialCommHub, though still available in the configuration, was not implemented in the `tiny_modbus` submodule. This PR fixes that and restores parity functionality.