### PR TITLE
service name string length was not initialized which causes EXI encod…

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -368,6 +368,8 @@ void ISO15118_chargerImpl::handle_set_Certificate_Service_Supported(bool& status
         memcpy(cert_service.ServiceName.characters, reinterpret_cast<const char*>(service_name.data()),
                service_name.length());
 
+        cert_service.ServiceName.charactersLen = service_name.length();
+
         add_service_to_service_list(v2g_ctx, cert_service, cert_parameter_set_id,
                                     sizeof(cert_parameter_set_id) / sizeof(cert_parameter_set_id[0]));
     }


### PR DESCRIPTION
…e errors if it is not 0 by sheer luck