### PR TITLE
`nodered-sil.sh`: run as `USER root` in Dockerfile to avoid permission issues

### DIFF
--- a/cmake/assets/docker/Dockerfile
+++ b/cmake/assets/docker/Dockerfile
@@ -1,4 +1,13 @@
 FROM nodered/node-red:2.2.3
+
+# run as root because below commands (sometimes?) return:
+# 
+# npm ERR! Your cache folder contains root-owned files, due to a bug in 
+# npm ERR! previous versions of npm which has since been addressed.
+#
+# See https://github.com/node-red/node-red-docker/tree/master#user-permission-errors
+USER root
+
 RUN npm install node-red-dashboard
 RUN npm install node-red-contrib-ui-actions
 RUN npm install node-red-node-ui-table


### PR DESCRIPTION
I've stumbled upon this while following the quick-start guide, [section "software-in-the-loop", running `nodered-sil.sh`](https://everest.github.io/nightly/general/03_quick_start_guide.html#software-in-a-loop). Other new colleagues experienced this, too. And also recently [Akhila on the mailing-list](https://lists.lfenergy.org/g/everest/topic/100734106).