### PR TITLE
Replaced command get_id with get_evse in evse_manager interface

### DIFF
--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -2,11 +2,12 @@ description: >-
   This interface defines the evse manager. An evse manager represents the
   charging kernel of one physical connector.
 cmds:
-  get_id:
-    description: Call to get the connector id of the evse manager
+  get_evse:
+    description: Call to get information about the EVSE including its connectors
     result:
-      description: Returns the connector id of the evse manager
-      type: integer
+      description: Object that contains information of the EVSE including its connectors
+      type: object
+      $ref: /evse_manager#/Evse
   enable:
     description: Enables the evse. EVSE is available for charging after this operation
     arguments:

--- a/modules/Auth/Auth.cpp
+++ b/modules/Auth/Auth.cpp
@@ -30,7 +30,7 @@ void Auth::ready() {
 
     int32_t evse_index = 0;
     for (const auto& evse_manager : this->r_evse_manager) {
-        int32_t connector_id = evse_manager->call_get_id();
+        int32_t connector_id = evse_manager->call_get_evse().id;
         this->auth_handler->init_connector(connector_id, evse_index);
         this->auth_handler->register_notify_evse_callback([this](const int evse_index,
                                                                  const ProvidedIdToken& provided_token,

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -270,9 +270,17 @@ void evse_managerImpl::ready() {
     // /Deprecated
 }
 
-int evse_managerImpl::handle_get_id() {
-    return this->mod->config.connector_id;
-};
+types::evse_manager::Evse evse_managerImpl::handle_get_evse() {
+    types::evse_manager::Evse evse;
+    evse.id = this->mod->config.connector_id;
+
+    // EvseManager currently only supports a single connector with id: 1;
+    std::vector<types::evse_manager::Connector> connectors;
+    types::evse_manager::Connector connector;
+    connector.id = 1;
+    connectors.push_back(connector);
+    return evse;
+}
 
 bool evse_managerImpl::handle_enable(int& connector_id) {
     return mod->charger->enable();

--- a/modules/EvseManager/evse/evse_managerImpl.hpp
+++ b/modules/EvseManager/evse/evse_managerImpl.hpp
@@ -34,7 +34,7 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual int handle_get_id() override;
+    virtual types::evse_manager::Evse handle_get_evse() override;
     virtual bool handle_enable(int& connector_id) override;
     virtual bool handle_disable(int& connector_id) override;
     virtual void handle_authorize_response(types::authorization::ProvidedIdToken& provided_token,

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -559,7 +559,7 @@ void OCPP::ready() {
     this->charge_point->call_set_connection_timeout();
     int connector = 1;
     for (const auto& evse : this->r_evse_manager) {
-        if (connector != evse->call_get_id()) {
+        if (connector != evse->call_get_evse().id) {
             EVLOG_AND_THROW(std::runtime_error("Connector Ids of EVSE manager are not configured in ascending order "
                                                "starting with 1. This is mandatory when using the OCPP module"));
         }

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -341,9 +341,9 @@ void OCPP201::init() {
             this->operational_evse_states[0] = request.operationalStatus;
             for (const auto& evse : this->r_evse_manager) {
                 if (this->operational_evse_states[0] == ocpp::v201::OperationalStatusEnum::Operative and
-                    this->operational_evse_states[evse->call_get_id()] ==
+                    this->operational_evse_states[evse->call_get_evse().id] ==
                         ocpp::v201::OperationalStatusEnum::Operative and
-                    this->operational_connector_states[evse->call_get_id()] ==
+                    this->operational_connector_states[evse->call_get_evse().id] ==
                         ocpp::v201::OperationalStatusEnum::Operative) {
                     evse->call_enable(0);
                 } else if (request.operationalStatus == ocpp::v201::OperationalStatusEnum::Inoperative) {

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -383,3 +383,76 @@ types:
       - VolkswagenGroup
       - Tesla
       - Unknown
+  Connector:
+    description: >-
+      Type for a connector which is an independently operated and managed electrical outlet of an EVSE. It corresponds
+      to a single physical connector
+    type: object
+    additionalProperties: false
+    required:
+      - id
+    properties:
+      id:
+        description: Id of the connector. Connectors should be numbered starting with 1 counting upwards
+        type: integer
+        minimum: 1
+      type:
+        description: Type of the connector
+        type: string
+        $ref: /evse_manager#/ConnectorTypeEnum
+  ConnectorTypeEnum:
+    description: >-
+      Type of a physical connector
+      cCCS1: Combined Charging System 1 a.k.a. Combo 1
+      cCCS2: Combined Charging System 2 a.k.a. Combo 2
+      cG105: JARI G105-1993 a.k.a. CHAdeMO
+      cTesla: Tesla Connector
+      cType1: IEC62196-2 Type 1 connector a.k.a. J1772
+      cType2: IEC62196-2 Type 2 connector a.k.a. Mennekes connector
+      s309_1P_16A: 16A 1 phase IEC60309 socket
+      s309_1P_32A: 32A 1 phase IEC60309 socket
+      s309_3P_16A: 16A 3 phase IEC60309 socket
+      s309_3P_32A: 32A 3 phase IEC60309 socket
+      sBS1361: UK domestic socket a.k.a. 13Amp
+      sCEE-7_7: CEE 7/7 16A socket a.k.a Schuko
+      sType2: IEC62196-2 Type 2 socket a.k.a. Mennekes connector
+      sType3: IEC62196-2 Type 2 socket a.k.a. Scame
+      Unknown: Unknown
+    type: string
+    enum:
+      - cCCS1
+      - cCCS2
+      - cG105
+      - cTesla
+      - cType1
+      - cType2
+      - s309_1P_16A
+      - s309_1P_32A
+      - s309_3P_16A
+      - s309_3P_32A
+      - sBS1361
+      - sCEE_7_7
+      - sType2
+      - sType3
+      - Unknown
+  Evse:
+    description: Type that defines properties of an EVSE including its connectors
+    type: object
+    required:
+      - id
+      - connectors
+    properties:
+      id:
+        description: ID of the EVSE
+        type: integer
+        minimum: 1
+        maximum: 128
+      connectors:
+        description: List of connectors of this EVSE
+        type: array
+        items:
+          description: A single connector
+          type: object
+          $ref: /evse_manager#/Connector
+        minItems: 1
+        maxItems: 128


### PR DESCRIPTION
Replaced command get_id with get_evse in evse_manager interface. 
get_evse() provides the id of the EVSE including a list of connectors (with id and type)