### PR TITLE
Feature/powermeter interface adaptions

### DIFF
--- a/interfaces/powermeter.yaml
+++ b/interfaces/powermeter.yaml
@@ -9,7 +9,8 @@ cmds:
         $ref: /powermeter#/TransactionReq
     result:
       description: True on success, False if transaction could not be started in the power meter
-      type: boolean
+      type: object
+      $ref: /powermeter#/TransactionStartResponse
   stop_transaction:
     description: Stop the transaction on the power meter and return the signed metering information
     arguments:
@@ -17,8 +18,9 @@ cmds:
         description: Transaction id
         type: string
     result:
-      description: Returns OCMF signed meter values
-      type: string
+      description: <Returns OCMF signed meter values
+      type: object
+      $ref: /powermeter#/TransactionStopResponse
 vars:
   powermeter:
     description: Measured dataset

--- a/interfaces/powermeter.yaml
+++ b/interfaces/powermeter.yaml
@@ -18,7 +18,7 @@ cmds:
         description: Transaction id
         type: string
     result:
-      description: <Returns OCMF signed meter values
+      description: Response to transaction stop request including OCMF string.
       type: object
       $ref: /powermeter#/TransactionStopResponse
 vars:

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -49,13 +49,13 @@ void powermeterImpl::ready() {
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
     return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            .error = "Generic powermeter does not support the stop_transaction command" };
+            .error = "Generic powermeter does not support the stop_transaction command"};
 };
 
 types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
     return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            .error = "Generic powermeter does not support the start_transaction command" };
+            .error = "Generic powermeter does not support the start_transaction command"};
 }
 
 void powermeterImpl::init_default_values() {

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -48,7 +48,8 @@ void powermeterImpl::ready() {
 }
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED, {},
+    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            {},
             "Generic powermeter does not support the stop_transaction command"};
 };
 

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -48,14 +48,14 @@ void powermeterImpl::ready() {
 }
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            .error = "Generic powermeter does not support the stop_transaction command"};
+    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED, {},
+            "Generic powermeter does not support the stop_transaction command"};
 };
 
 types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            .error = "Generic powermeter does not support the start_transaction command"};
+    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            "Generic powermeter does not support the start_transaction command"};
 }
 
 void powermeterImpl::init_default_values() {

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -47,12 +47,15 @@ void powermeterImpl::ready() {
     }
 }
 
-std::string powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return "NOT_SUPPORTED";
+types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
+    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            .error = "Generic powermeter does not support the stop_transaction command" };
 };
 
-bool powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return false;
+types::powermeter::TransactionStartResponse
+powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
+    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            .error = "Generic powermeter does not support the start_transaction command" };
 }
 
 void powermeterImpl::init_default_values() {

--- a/modules/GenericPowermeter/main/powermeterImpl.hpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.hpp
@@ -37,8 +37,9 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual bool handle_start_transaction(types::powermeter::TransactionReq& value) override;
-    virtual std::string handle_stop_transaction(std::string& transaction_id) override;
+    virtual types::powermeter::TransactionStartResponse
+    handle_start_transaction(types::powermeter::TransactionReq& value) override;
+    virtual types::powermeter::TransactionStopResponse handle_stop_transaction(std::string& transaction_id) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/MicroMegaWattBSP/powermeter/powermeterImpl.cpp
+++ b/modules/MicroMegaWattBSP/powermeter/powermeterImpl.cpp
@@ -36,12 +36,15 @@ void powermeterImpl::init() {
 void powermeterImpl::ready() {
 }
 
-std::string powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return "NOT_SUPPORTED";
+types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
+    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            .error = "MicroMegaWattBSP powermeter does not support the stop_transaction command"};
 };
 
-bool powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return false;
+types::powermeter::TransactionStartResponse
+powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
+    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            .error = "MicroMegaWattBSP powermeter does not support the start_transaction command"};
 }
 
 } // namespace powermeter

--- a/modules/MicroMegaWattBSP/powermeter/powermeterImpl.cpp
+++ b/modules/MicroMegaWattBSP/powermeter/powermeterImpl.cpp
@@ -37,14 +37,14 @@ void powermeterImpl::ready() {
 }
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            .error = "MicroMegaWattBSP powermeter does not support the stop_transaction command"};
+    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED, {},
+            "MicroMegaWattBSP powermeter does not support the stop_transaction command"};
 };
 
 types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            .error = "MicroMegaWattBSP powermeter does not support the start_transaction command"};
+    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            "MicroMegaWattBSP powermeter does not support the start_transaction command"};
 }
 
 } // namespace powermeter

--- a/modules/MicroMegaWattBSP/powermeter/powermeterImpl.cpp
+++ b/modules/MicroMegaWattBSP/powermeter/powermeterImpl.cpp
@@ -37,7 +37,8 @@ void powermeterImpl::ready() {
 }
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED, {},
+    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            {},
             "MicroMegaWattBSP powermeter does not support the stop_transaction command"};
 };
 

--- a/modules/MicroMegaWattBSP/powermeter/powermeterImpl.hpp
+++ b/modules/MicroMegaWattBSP/powermeter/powermeterImpl.hpp
@@ -33,7 +33,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual types::powermeter::TransactionStartResponse handle_start_transaction(types::powermeter::TransactionReq& value) override;
+    virtual types::powermeter::TransactionStartResponse
+    handle_start_transaction(types::powermeter::TransactionReq& value) override;
     virtual types::powermeter::TransactionStopResponse handle_stop_transaction(std::string& transaction_id) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1

--- a/modules/MicroMegaWattBSP/powermeter/powermeterImpl.hpp
+++ b/modules/MicroMegaWattBSP/powermeter/powermeterImpl.hpp
@@ -33,8 +33,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual bool handle_start_transaction(types::powermeter::TransactionReq& value) override;
-    virtual std::string handle_stop_transaction(std::string& transaction_id) override;
+    virtual types::powermeter::TransactionStartResponse handle_start_transaction(types::powermeter::TransactionReq& value) override;
+    virtual types::powermeter::TransactionStopResponse handle_stop_transaction(std::string& transaction_id) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/PowermeterBSM/main/powermeterImpl.cpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.cpp
@@ -45,11 +45,12 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
 
         bsm::SignedOCMFSnapshot signed_snapshot(data);
 
-        return { .status = types::powermeter::TransactionRequestStatus::OK, .ocmf  = signed_snapshot.O()};
+        return {.status = types::powermeter::TransactionRequestStatus::OK, .ocmf = signed_snapshot.O()};
 
     } catch (const std::runtime_error& e) {
         EVLOG_error << __PRETTY_FUNCTION__ << " Error: " << e.what() << std::endl;
-        return { .status =  types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, .error = "get_signed_meter_value_error"};
+        return {.status = types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR,
+                .error = "get_signed_meter_value_error"};
     }
 };
 
@@ -57,7 +58,7 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
 // on the power meter. With current implementation we do not get a start signed meter value
 types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return { .status = types::powermeter::TransactionRequestStatus::OK };
+    return {.status = types::powermeter::TransactionRequestStatus::OK};
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/modules/PowermeterBSM/main/powermeterImpl.cpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.cpp
@@ -45,12 +45,12 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
 
         bsm::SignedOCMFSnapshot signed_snapshot(data);
 
-        return {.status = types::powermeter::TransactionRequestStatus::OK, .ocmf = signed_snapshot.O()};
+        return {types::powermeter::TransactionRequestStatus::OK, signed_snapshot.O()};
 
     } catch (const std::runtime_error& e) {
         EVLOG_error << __PRETTY_FUNCTION__ << " Error: " << e.what() << std::endl;
-        return {.status = types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR,
-                .error = "get_signed_meter_value_error"};
+        return {types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {},
+                "get_signed_meter_value_error"};
     }
 };
 
@@ -58,7 +58,7 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
 // on the power meter. With current implementation we do not get a start signed meter value
 types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return {.status = types::powermeter::TransactionRequestStatus::OK};
+    return {types::powermeter::TransactionRequestStatus::OK};
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/modules/PowermeterBSM/main/powermeterImpl.cpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.cpp
@@ -49,8 +49,7 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
 
     } catch (const std::runtime_error& e) {
         EVLOG_error << __PRETTY_FUNCTION__ << " Error: " << e.what() << std::endl;
-        return {types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {},
-                "get_signed_meter_value_error"};
+        return {types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {}, "get_signed_meter_value_error"};
     }
 };
 

--- a/modules/PowermeterBSM/main/powermeterImpl.cpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.cpp
@@ -31,7 +31,7 @@ void powermeterImpl::ready() {
     m_watchdog_thread = std::thread(&powermeterImpl::watchdog, this);
 }
 
-std::string powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
+types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
     try {
 
         std::scoped_lock lock(mod->get_device_mutex());
@@ -45,18 +45,19 @@ std::string powermeterImpl::handle_stop_transaction(std::string& transaction_id)
 
         bsm::SignedOCMFSnapshot signed_snapshot(data);
 
-        return signed_snapshot.O();
+        return { .status = types::powermeter::TransactionRequestStatus::OK, .ocmf  = signed_snapshot.O()};
 
     } catch (const std::runtime_error& e) {
         EVLOG_error << __PRETTY_FUNCTION__ << " Error: " << e.what() << std::endl;
-        return "get_signed_meter_value_error";
+        return { .status =  types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, .error = "get_signed_meter_value_error"};
     }
 };
 
 // FIXME: probably this would need to be handled differently in Bauer power meter - need to actually start a transaction
 // on the power meter. With current implementation we do not get a start signed meter value
-bool powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return true;
+types::powermeter::TransactionStartResponse
+powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
+    return { .status = types::powermeter::TransactionRequestStatus::OK };
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/modules/PowermeterBSM/main/powermeterImpl.hpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.hpp
@@ -37,8 +37,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual bool handle_start_transaction(types::powermeter::TransactionReq& value) override;
-    virtual std::string handle_stop_transaction(std::string& transaction_id) override;
+    virtual types::powermeter::TransactionStartResponse handle_start_transaction(types::powermeter::TransactionReq& value) override;
+    virtual types::powermeter::TransactionStopResponse handle_stop_transaction(std::string& transaction_id) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/PowermeterBSM/main/powermeterImpl.hpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.hpp
@@ -37,7 +37,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual types::powermeter::TransactionStartResponse handle_start_transaction(types::powermeter::TransactionReq& value) override;
+    virtual types::powermeter::TransactionStartResponse
+    handle_start_transaction(types::powermeter::TransactionReq& value) override;
     virtual types::powermeter::TransactionStopResponse handle_stop_transaction(std::string& transaction_id) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1

--- a/modules/YetiDriver/powermeter/powermeterImpl.cpp
+++ b/modules/YetiDriver/powermeter/powermeterImpl.cpp
@@ -55,7 +55,8 @@ void powermeterImpl::ready() {
 }
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED, {},
+    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            {},
             "YetiDriver powermeter does not support the stop_transaction command"};
 };
 

--- a/modules/YetiDriver/powermeter/powermeterImpl.cpp
+++ b/modules/YetiDriver/powermeter/powermeterImpl.cpp
@@ -54,12 +54,15 @@ void powermeterImpl::init() {
 void powermeterImpl::ready() {
 }
 
-std::string powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return "NOT_SUPPORTED";
+types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
+    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            .error = "YetiDriver powermeter does not support the stop_transaction command"};
 };
 
-bool powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return false;
+types::powermeter::TransactionStartResponse
+powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
+    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            .error = "YetiDriver powermeter does not support the start_transaction command"};
 }
 
 } // namespace powermeter

--- a/modules/YetiDriver/powermeter/powermeterImpl.cpp
+++ b/modules/YetiDriver/powermeter/powermeterImpl.cpp
@@ -55,14 +55,14 @@ void powermeterImpl::ready() {
 }
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            .error = "YetiDriver powermeter does not support the stop_transaction command"};
+    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED, {},
+            "YetiDriver powermeter does not support the stop_transaction command"};
 };
 
 types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return {.status = types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            .error = "YetiDriver powermeter does not support the start_transaction command"};
+    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+            "YetiDriver powermeter does not support the start_transaction command"};
 }
 
 } // namespace powermeter

--- a/modules/YetiDriver/powermeter/powermeterImpl.hpp
+++ b/modules/YetiDriver/powermeter/powermeterImpl.hpp
@@ -33,8 +33,9 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual bool handle_start_transaction(types::powermeter::TransactionReq& value) override;
-    virtual std::string handle_stop_transaction(std::string& transaction_id) override;
+    virtual types::powermeter::TransactionStartResponse
+    handle_start_transaction(types::powermeter::TransactionReq& value) override;
+    virtual types::powermeter::TransactionStopResponse handle_stop_transaction(std::string& transaction_id) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/simulation/JsYetiSimulator/index.js
+++ b/modules/simulation/JsYetiSimulator/index.js
@@ -44,15 +44,11 @@ boot_module(async ({
   });
 
   setup.provides.yeti_extras.register.firmware_update((mod, args) => { });
-  setup.provides.powermeter.register.stop_transaction((mod, args) => {
-    return {
-      status: 'NOT_IMPLEMENTED',
-      error: 'YetiDriver does not support stop transaction request.',
-    };
-  });
-  setup.provides.powermeter.register.start_transaction((mod, args) => {
-    return { status: 'OK' };
-  });
+  setup.provides.powermeter.register.stop_transaction((mod, args) => ({
+    status: 'NOT_IMPLEMENTED',
+    error: 'YetiDriver does not support stop transaction request.',
+  }));
+  setup.provides.powermeter.register.start_transaction((mod, args) => ({ status: 'OK' }));
 
   setup.provides.board_support.register.setup((mod, args) => {
     mod.three_phases = args.three_phases;

--- a/modules/simulation/JsYetiSimulator/index.js
+++ b/modules/simulation/JsYetiSimulator/index.js
@@ -44,8 +44,8 @@ boot_module(async ({
   });
 
   setup.provides.yeti_extras.register.firmware_update((mod, args) => { });
-  setup.provides.powermeter.register.stop_transaction((mod, args) => { return "NOT_IMPLEMENTED"; });
-  setup.provides.powermeter.register.start_transaction((mod, args) => { return true; });
+  setup.provides.powermeter.register.stop_transaction((mod, args) => { return {status: "NOT_IMPLEMENTED", error: "YetiDriver does not support stop transaction request."}; });
+  setup.provides.powermeter.register.start_transaction((mod, args) => { return {status: "OK"}; });
 
   setup.provides.board_support.register.setup((mod, args) => {
     mod.three_phases = args.three_phases;

--- a/modules/simulation/JsYetiSimulator/index.js
+++ b/modules/simulation/JsYetiSimulator/index.js
@@ -45,9 +45,14 @@ boot_module(async ({
 
   setup.provides.yeti_extras.register.firmware_update((mod, args) => { });
   setup.provides.powermeter.register.stop_transaction((mod, args) => {
-    return {status: "NOT_IMPLEMENTED", error: "YetiDriver does not support stop transaction request."};
+    return {
+      status: 'NOT_IMPLEMENTED',
+      error: 'YetiDriver does not support stop transaction request.',
+    };
   });
-  setup.provides.powermeter.register.start_transaction((mod, args) => { return {status: "OK"}; });
+  setup.provides.powermeter.register.start_transaction((mod, args) => {
+    return { status: 'OK' };
+  });
 
   setup.provides.board_support.register.setup((mod, args) => {
     mod.three_phases = args.three_phases;

--- a/modules/simulation/JsYetiSimulator/index.js
+++ b/modules/simulation/JsYetiSimulator/index.js
@@ -44,7 +44,9 @@ boot_module(async ({
   });
 
   setup.provides.yeti_extras.register.firmware_update((mod, args) => { });
-  setup.provides.powermeter.register.stop_transaction((mod, args) => { return {status: "NOT_IMPLEMENTED", error: "YetiDriver does not support stop transaction request."}; });
+  setup.provides.powermeter.register.stop_transaction((mod, args) => {
+    return {status: "NOT_IMPLEMENTED", error: "YetiDriver does not support stop transaction request."};
+  });
   setup.provides.powermeter.register.start_transaction((mod, args) => { return {status: "OK"}; });
 
   setup.provides.board_support.register.setup((mod, args) => {

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -35,7 +35,6 @@ types:
     type: string
     enum:
         - OK
-        - NOT_FOUND  # Referred transaction does not exist.
         - NOT_SUPPORTED
         - UNEXPECTED_ERROR
   TransactionStartResponse:

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -23,12 +23,56 @@ types:
         type: string
       tariff_id:
         description: Tariff ID
-        type: string
+        type: integer
       cable_id:
         description: Cable ID
-        type: string
+        type: integer
       user_data:
         description: User data
+        type: string
+  TransactionRequestStatus:
+    description: Status of a transaction start or stop request.
+    type: string
+    enum:
+        - OK
+        - NOT_FOUND  # Referred transaction does not exist.
+        - NOT_SUPPORTED
+        - UNEXPECTED_ERROR
+  TransactionStartResponse:
+    description: Return value when a transaction is started.
+    type: object
+    additionalProperties: false
+    required:
+      - status
+      - transaction_id
+    properties:
+      status:
+        description: Response status that indicates whether the transaction start request could successfully be performed.
+        $ref: /powermeter#/TransactionRequestStatus
+      error:
+        description: If status is not OK, a verbose error message.
+        type: string
+      transaction_min_stop_time:
+        description: Earliest point in time the started transaction can be stopped again (if a minimum duration is required by the meter); yields a RFC3339 timestamp.
+        type: string
+      transaction_max_stop_time:
+        description:  Deadline for the transaction to be stopped again (if a minimum duration is required by the meter); yields a RFC3339 timestamp.
+        type: string
+  TransactionStopResponse:
+    description: Report returned when a OCMF transaction is requested to stop. If successful, includes the signed OCMF string. In case of an error, an additional error message can be provided.
+    type: object
+    additionalProperties: false
+    required:
+      - status
+    properties:
+      status:
+        description: Response status that indicates whether the transaction stop request could successfully be performed.
+        $ref: /powermeter#/TransactionRequestStatus
+      ocmf:
+        description: The signed OCMF report of the stopped transaction. Must be provided if status is OK.
+        type: string
+      error:
+        description: If status is not OK, a verbose error message.
         type: string
   Powermeter:
     description: Measured dataset (AC or DC)

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -43,7 +43,6 @@ types:
     additionalProperties: false
     required:
       - status
-      - transaction_id
     properties:
       status:
         description: Response status that indicates whether the transaction start request could successfully be performed.
@@ -54,9 +53,11 @@ types:
       transaction_min_stop_time:
         description: Earliest point in time the started transaction can be stopped again (if a minimum duration is required by the meter); yields a RFC3339 timestamp.
         type: string
+        format: date-time
       transaction_max_stop_time:
         description:  Deadline for the transaction to be stopped again (if a minimum duration is required by the meter); yields a RFC3339 timestamp.
         type: string
+        format: date-time
   TransactionStopResponse:
     description: Report returned when a OCMF transaction is requested to stop. If successful, includes the signed OCMF string. In case of an error, an additional error message can be provided.
     type: object


### PR DESCRIPTION
Adjusts the Powermeter Interface and types:
- Start transaction: Returns status + optional time bounds for earliest and latest stop of the transaction; optional error message
- Stop transaction: Returns status + ocmf string (if successful); optional error message
- Tarif ID and Cable ID are switch to integers (as in LEM DCBM spec)

Follow up adaptions of the mopdules
- GenericPowerMeter
- PowermeterBSM
- MicroMegaWattBSP
- YetiDriver
- JSYetiSimulator