### PR TITLE
don't build tests in `./lib`  by default

### DIFF
--- a/lib/staging/can_dpm1000/CMakeLists.txt
+++ b/lib/staging/can_dpm1000/CMakeLists.txt
@@ -10,4 +10,6 @@ target_sources(can_dpm1000
         src/dpm1000.cpp
 )
 
-add_subdirectory(tests)
+if(BUILD_DEV_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/lib/staging/slac/CMakeLists.txt
+++ b/lib/staging/slac/CMakeLists.txt
@@ -1,4 +1,7 @@
 add_subdirectory(io)
 add_subdirectory(fsm/ev)
 add_subdirectory(fsm/evse)
-add_subdirectory(test)
+
+if(BUILD_DEV_TESTS)
+  add_subdirectory(test)
+endif()


### PR DESCRIPTION
fixes EV-284