### PR TITLE
API: prevent iterator invalidation

### DIFF
--- a/modules/API/API.cpp
+++ b/modules/API/API.cpp
@@ -181,10 +181,8 @@ void API::init() {
     std::string var_connectors = api_base + "connectors";
 
     for (auto& evse : this->r_evse_manager) {
-        this->info.push_back(std::make_unique<SessionInfo>());
-        auto& session_info = this->info.back();
-        this->hw_capabilities_json.push_back(json{});
-        auto& hw_caps = this->hw_capabilities_json.back();
+        auto& session_info = this->info.emplace_back(std::make_unique<SessionInfo>());
+        auto& hw_caps = this->hw_capabilities_json.emplace_back(json{});
         std::string evse_base = api_base + evse->module_id;
         connectors.push_back(evse->module_id);
 

--- a/modules/API/API.hpp
+++ b/modules/API/API.hpp
@@ -18,11 +18,13 @@
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
-#include <date/date.h>
-#include <date/tz.h>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <sstream>
+
+#include <date/date.h>
+#include <date/tz.h>
 
 namespace module {
 
@@ -106,8 +108,9 @@ private:
     // insert your private definitions here
     std::vector<std::thread> api_threads;
     bool running = true;
-    std::vector<std::unique_ptr<SessionInfo>> info;
-    std::vector<json> hw_capabilities_json;
+
+    std::list<std::unique_ptr<SessionInfo>> info;
+    std::list<json> hw_capabilities_json;
     std::string selected_protocol;
     json charger_information;
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1


### PR DESCRIPTION
When defining more than 1 container the API node crahes.

The cause it that as the vector grows its iterators may get invalidated. The std::list offers stable iterators. 
The overhead between the vector and list in this case should not affect us since we're never iterating over `info` or `hw_capabilities_json`. 