### PR TITLE
modules: fix warnings for `printf`-format

### DIFF
--- a/modules/MicroMegaWattBSP/umwc_fwupdate/main.cpp
+++ b/modules/MicroMegaWattBSP/umwc_fwupdate/main.cpp
@@ -18,7 +18,7 @@ using namespace std::chrono_literals;
 volatile bool sw_version_received = false;
 
 void recvKeepAliveLo(KeepAliveLo s) {
-    printf("Current uMWC SW Version: %s (Protocol %i.%0.2i)\n", s.sw_version_string, s.protocol_version_major,
+    printf("Current uMWC SW Version: %s (Protocol %i.%i)\n", s.sw_version_string, s.protocol_version_major,
            s.protocol_version_minor);
     sw_version_received = true;
 }

--- a/modules/YetiDriver/yeti_fwupdate/main.cpp
+++ b/modules/YetiDriver/yeti_fwupdate/main.cpp
@@ -14,7 +14,7 @@
 volatile bool sw_version_received = false;
 
 void recvKeepAliveLo(KeepAliveLo s) {
-    printf("Current Yeti SW Version: %s (Protocol %i.%0.2i)\n", s.sw_version_string, s.protocol_version_major,
+    printf("Current Yeti SW Version: %s (Protocol %i.%i)\n", s.sw_version_string, s.protocol_version_major,
            s.protocol_version_minor);
     sw_version_received = true;
 }


### PR DESCRIPTION
To resolve 2 warnings #1warninglessperday
```
warning: '0' flag ignored with precision and ‘%i’ gnu_printf format [-Wformat=]
```

Is it only me seeing this? :thinking: