### PR TITLE
EvseManager signals "ready" 

### DIFF
--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -179,3 +179,6 @@ vars:
     description: Enforced limits for this node (coming from the EnergyManager)
     type: object
     $ref: /energy#/EnforcedLimits
+  ready:
+    description: Signals that the EVSE Manager is ready to start charging
+    type: boolean

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -825,6 +825,7 @@ void EvseManager::ready() {
     charger->run();
     charger->enable();
 
+    this->p_evse->publish_ready(true);
     EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
                               "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
 }

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -120,6 +120,10 @@ private:
     EvseConnectorMap evse_connector_map; // provides access to OCPP connector id by using EVerests evse and connector id
     std::map<int32_t, int32_t>
         connector_evse_index_map;        // provides access to r_evse_manager index by using OCPP connector id
+    std::map<int32_t, bool> evse_ready_map;
+    std::mutex evse_ready_mutex;
+    std::condition_variable evse_ready_cv;
+    bool all_evse_ready();
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -85,6 +85,11 @@ private:
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
     std::filesystem::path ocpp_share_path;
+
+    std::map<int32_t, bool> evse_ready_map;
+    std::mutex evse_ready_mutex;
+    std::condition_variable evse_ready_cv;
+    bool all_evse_ready();
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 


### PR DESCRIPTION
EvseManager now signals ready when its ready function ends and OCPP1.6 and OCPP2.0.1 modules wait for so this signal before starting up. This prevents OCPP calling cmds at at the EvseManager before its set up.