### PR TITLE
EvseV2G: fix runtime bug passing non-trivial type to variadic `dlog()` macro

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -93,7 +93,7 @@ void ISO15118_chargerImpl::handle_set_PaymentOptions(Array& PaymentOptions) {
                         iso1paymentOptionType_ExternalPayment;
                     v2g_ctx->evse_v2g_data.payment_option_list_len++;
                 } else if (v2g_ctx->evse_v2g_data.payment_option_list_len == 0) {
-                    dlog(DLOG_LEVEL_WARNING, "Unable to configure PaymentOptions %s", element.get<std::string>());
+                    dlog(DLOG_LEVEL_WARNING, "Unable to configure PaymentOptions %s", element.get<std::string>().c_str());
                 }
             }
         }
@@ -139,7 +139,7 @@ void ISO15118_chargerImpl::handle_set_SupportedEnergyTransferMode(Array& Support
                 default:
                     if (energyArrayLen == 0) {
                         dlog(DLOG_LEVEL_WARNING, "Unable to configure SupportedEnergyTransferMode %s",
-                             element.get<std::string>());
+                             element.get<std::string>().c_str());
                     }
                     break;
                 }


### PR DESCRIPTION
`clang-15` throws this error (emphasis by me):

> error: cannot pass object of non-trivial type 'decltype(std::declval<const nlohmann::basic_json<>::basic_json_t &>().template get_impl<std::basic_string<char>>(detail::priority_tag<4>{}))' (aka 'std::basic_string<char>') through variadic function; **call will abort at runtime** [-Wnon-pod-varargs]