### PR TITLE
Auth: FindFirst Selection Algorithm

### DIFF
--- a/config/config-sil-dc.yaml
+++ b/config/config-sil-dc.yaml
@@ -73,7 +73,7 @@ active_modules:
     module: Auth
     config_module:
       connection_timeout: 10
-      selection_algorithm: PlugEvents
+      selection_algorithm: FindFirst
     connections:
       token_provider:
         - module_id: token_provider

--- a/config/config-sil-ocpp-custom-extension.yaml
+++ b/config/config-sil-ocpp-custom-extension.yaml
@@ -108,7 +108,7 @@ active_modules:
     module: Auth
     config_module:
       connection_timeout: 10
-      selection_algorithm: PlugEvents
+      selection_algorithm: FindFirst
     connections:
       token_provider:
         - module_id: token_provider_1

--- a/config/config-sil-ocpp.yaml
+++ b/config/config-sil-ocpp.yaml
@@ -108,7 +108,7 @@ active_modules:
     module: Auth
     config_module:
       connection_timeout: 10
-      selection_algorithm: PlugEvents
+      selection_algorithm: FindFirst
     connections:
       token_provider:
         - module_id: token_provider_1

--- a/config/config-sil-ocpp201.yaml
+++ b/config/config-sil-ocpp201.yaml
@@ -133,7 +133,7 @@ active_modules:
     module: Auth
     config_module:
       connection_timeout: 60
-      selection_algorithm: PlugEvents
+      selection_algorithm: FindFirst
     connections:
       token_provider:
         - module_id: token_provider_1

--- a/config/config-sil-two-evse-dc.yaml
+++ b/config/config-sil-two-evse-dc.yaml
@@ -106,7 +106,7 @@ active_modules:
     module: Auth
     config_module:
       connection_timeout: 10
-      selection_algorithm: PlugEvents
+      selection_algorithm: FindFirst
     connections:
       token_provider:
         - module_id: token_provider_1

--- a/config/config-sil-two-evse.yaml
+++ b/config/config-sil-two-evse.yaml
@@ -96,7 +96,7 @@ active_modules:
     module: Auth
     config_module:
       connection_timeout: 10
-      selection_algorithm: PlugEvents
+      selection_algorithm: FindFirst
     connections:
       token_provider:
         - module_id: token_provider_1

--- a/config/config-sil.yaml
+++ b/config/config-sil.yaml
@@ -11,7 +11,7 @@ active_modules:
     config_module:
       connection_timeout: 10
       prioritize_authorization_over_stopping_transaction: true
-      selection_algorithm: PlugEvents
+      selection_algorithm: FindFirst
     connections:
       evse_manager:
         - implementation_id: evse

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -317,6 +317,7 @@ int AuthHandler::select_connector(const std::vector<int>& connectors) {
     if (this->selection_algorithm == SelectionAlgorithm::PlugEvents) {
         this->lock_plug_in_mutex(connectors);
         if (this->get_latest_plugin(connectors) == -1) {
+            // no EV has been plugged in yet at the referenced connectors
             this->unlock_plug_in_mutex(connectors);
             EVLOG_debug << "No connector in authorization queue. Waiting for a plug in...";
             std::unique_lock<std::mutex> lk(this->plug_in_mutex);
@@ -329,12 +330,27 @@ int AuthHandler::select_connector(const std::vector<int>& connectors) {
         }
         const auto connector_id = this->get_latest_plugin(connectors);
         return connector_id;
-    } else if (this->selection_algorithm == SelectionAlgorithm::UserInput) {
-        EVLOG_warning << "SelectionAlgorithm UserInput not yet implemented. Selecting first available connector";
-        return connectors.at(0);
-
+    } else if (this->selection_algorithm == SelectionAlgorithm::FindFirst) {
+        EVLOG_debug
+            << "SelectionAlgorithm FindFirst: Selecting first available connector without an active transaction";
+        this->lock_plug_in_mutex(connectors);
+        const auto selected_connector_id = this->get_latest_plugin(connectors);
+        if (selected_connector_id != -1 and !this->connectors.at(selected_connector_id)->connector.transaction_active) {
+            // an EV has been plugged in yet at the referenced connectors
+            return this->get_latest_plugin(connectors);
+        } else {
+            // no EV has been plugged in yet at the referenced connectors; choosing the first one where no transaction
+            // is active
+            for (const auto connector_id : connectors) {
+                const auto connector = this->connectors.at(connector_id)->connector;
+                if (!connector.transaction_active) {
+                    return connector_id;
+                }
+            }
+        }
+        return -1;
     } else {
-        throw std::runtime_error("No known SelectionAlgorithm provided: " +
+        throw std::runtime_error("SelectionAlgorithm not implemented: " +
                                  selection_algorithm_to_string(this->selection_algorithm));
     }
 }

--- a/modules/Auth/manifest.yaml
+++ b/modules/Auth/manifest.yaml
@@ -5,7 +5,7 @@ config:
   selection_algorithm:
     description: The algorithm that is used to map an incoming token to a connector
     type: string
-    default: PlugEvents
+    default: FindFirst
   connection_timeout:
     description: >-
       Defines how many seconds an authorization is valid before it is discarded.

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -122,10 +122,12 @@ types:
       SelectionAlgorithm enum:
         UserInput: This algorithm waits for a user to input for which connector the authorization is provided
         PlugEvents: This algorithms derives the selected connector based on the order of plug in events of EVs
+        FindFirst: This algorithm chooses the first referenced EVSE that is available
     type: string
     enum:
       - UserInput
       - PlugEvents
+      - FindFirst
   AuthorizationType:
     description: >-
       Type of authorization of the provided token


### PR DESCRIPTION
added FindFirst selection algorithm to Auth module. This is also the new default and all configs are updated. The FindFirst selection algorithm will still respect PlugIn events but in case no EV has been plugged in it will simply provide authorization to the first available EVSE when there has been a ProvidedIdToken that refers to multiple EVSEs. If there is only one EVSE referenced by the ProvidedIdToken nothing changes.