### PR TITLE
Update everest-framework to 0.7.1 and require ev-cli 0.0.21

### DIFF
--- a/cmake/ev-project-bootstrap.cmake
+++ b/cmake/ev-project-bootstrap.cmake
@@ -5,7 +5,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/config-run-script.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/config-run-nodered-script.cmake)
 
 # dependencies
-require_ev_cli_version("0.0.20")
+require_ev_cli_version("0.0.21")
 
 # source generate scripts / setup
 include(${CMAKE_CURRENT_LIST_DIR}/everest-generate.cmake)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,7 +1,7 @@
 ---
 everest-framework:
   git: https://github.com/EVerest/everest-framework.git
-  git_tag: 3887a64
+  git_tag: v0.7.1
 sigslot:
   git: https://github.com/palacaze/sigslot
   git_tag: v1.2.0


### PR DESCRIPTION
This fixes issues with integers in variants, which can be used by the PersistentStore module