### PR TITLE
Add option to disable auth in EvseManager

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -386,9 +386,7 @@ void EvseManager::ready() {
 
         r_hlc[0]->call_set_ReceiptRequired(config.ev_receipt_required);
 
-        // We always go through the auth step with EIM even if it is free. This way EVerest auth manager has full
-        // control.
-        r_hlc[0]->call_set_FreeService(false);
+        r_hlc[0]->call_set_FreeService(config.disable_authentication);
 
         // set up debug mode for HLC
         if (config.session_logging) {

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -79,6 +79,7 @@ struct Conf {
     double soft_over_current_tolerance_percent;
     double soft_over_current_measurement_noise_A;
     bool hack_fix_hlc_integer_current_requests;
+    bool disable_authentication;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -137,6 +137,15 @@ void evse_managerImpl::ready() {
 
             auto reason = mod->charger->getSessionStartedReason();
 
+            if (mod->config.disable_authentication && reason == types::evse_manager::StartSessionReason::EVConnected) {
+                // Free service, authorize immediately
+                types::authorization::ProvidedIdToken provided_token;
+                provided_token.authorization_type = types::authorization::AuthorizationType::RFID;
+                provided_token.id_token = "FREESERVICE";
+                mod->charger->Authorize(true, provided_token);
+                mod->charger_was_authorized();
+            }
+
             session_started.reason = reason;
 
             set_session_uuid();

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -142,6 +142,7 @@ void evse_managerImpl::ready() {
                 types::authorization::ProvidedIdToken provided_token;
                 provided_token.authorization_type = types::authorization::AuthorizationType::RFID;
                 provided_token.id_token = "FREESERVICE";
+                provided_token.prevalidated = true;
                 mod->charger->Authorize(true, provided_token);
                 mod->charger_was_authorized();
             }

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -176,6 +176,13 @@ config:
       between EV requested current (integer) and HLC current limit is less then 1.0
     type: boolean
     default: false
+  disable_authentication:
+    description: >-
+      Do not wait for authorization from Auth module, offer a free service. Start charging immediately after plug in.
+      Do not use with Auth manager or OCPP, this option is only to allow charging with a standalone EvseManager that is not connected to an Auth manager.
+      Use DummyTokenProvider/Validator when testing with Auth module and/or OCPP.
+    type: boolean
+    default: false
 provides:
   evse:
     interface: evse_manager


### PR DESCRIPTION
This allows EvseManager to be used without the Auth module for simple free charging applications.