### PR TITLE
Fix Generator expression for building rust modules

### DIFF
--- a/cmake/everest-generate.cmake
+++ b/cmake/everest-generate.cmake
@@ -169,8 +169,8 @@ if (EVEREST_ENABLE_RS_SUPPORT)
             ${CMAKE_COMMAND} -E env
             EVEREST_RS_FRAMEWORK_SOURCE_LOCATION="${everest-framework_SOURCE_DIR}"
             EVEREST_RS_FRAMEWORK_BINARY_LOCATION="${everest-framework_BINARY_DIR}"
-            $<IF:$<STREQUAL:${CMAKE_BUILD_TYPE},"Release">,--release,>
             ${CARGO_EXECUTABLE} build
+            $<IF:$<STREQUAL:${CMAKE_BUILD_TYPE},Release>,--release,>
         WORKING_DIRECTORY
             ${RUST_WORKSPACE_DIR}
         DEPENDS


### PR DESCRIPTION
Running `cmake -DEVEREST_ENABLE_RS_SUPPORT=ON .. && make && make install` fails because our generator expression is ill formed. The quotes are redundant [see here](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#string-comparisons) and the `--release` argument must be passed to the `cargo` binary. 

