### PR TITLE
Rust: add config support

### DIFF
--- a/modules/rust_examples/RsExample/manifest.yaml
+++ b/modules/rust_examples/RsExample/manifest.yaml
@@ -1,8 +1,26 @@
 description: Simple example module written in Rust
+config:
+  some_string_config:
+    description: A module level string config.
+    type: string
+    default: Hello world
+  some_number_config:
+    description: A module level number config.
+    type: number
+    default: 42
 provides:
   foobar:
     interface: example
     description: This implements an example interface that uses multiple framework features
+    config:
+      some_bool_config:
+        description: An interface level bool config
+        type: boolean
+        default: true
+      some_integer_config:
+        description: An interface level integer config.
+        type: integer
+        default: 1234
   my_store:
     interface: kvs
     description: This implements the kvs interface, mostly for testing multiple interfaces in one manifest

--- a/modules/rust_examples/RsExample/src/eventually_generated.rs
+++ b/modules/rust_examples/RsExample/src/eventually_generated.rs
@@ -16,6 +16,71 @@ use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 
+/// Struct holding the config for the `foobar` interface.
+#[derive(Debug)]
+pub struct FoobarConfig {
+    /// An interface level bool config.
+    pub some_bool_config: bool,
+
+    /// An interface level integer config.
+    pub some_integer_config: i64,
+}
+
+/// Struct holding the module level config.
+#[derive(Debug)]
+pub struct ModuleConfig {
+    /// A module level string config.
+    pub some_string_config: String,
+
+    /// A module level number config   
+    pub some_number_config: f64,
+
+    /// The config for the `foobar` interface.
+    pub foobar_config: FoobarConfig,
+}
+
+/// Returns the config for the whole module. You can call this function at any
+/// time in your code.
+pub fn get_config() -> ModuleConfig {
+    let raw_config = everestrs::get_module_configs();
+    let foobar_config = FoobarConfig {
+        some_bool_config: raw_config
+            .get("foobar")
+            .unwrap()
+            .get("some_bool_config")
+            .unwrap()
+            .try_into()
+            .unwrap(),
+
+        some_integer_config: raw_config
+            .get("foobar")
+            .unwrap()
+            .get("some_integer_config")
+            .unwrap()
+            .try_into()
+            .unwrap(),
+    };
+
+    ModuleConfig {
+        some_string_config: raw_config
+            .get("!module")
+            .unwrap()
+            .get("some_string_config")
+            .unwrap()
+            .try_into()
+            .unwrap(),
+
+        some_number_config: raw_config
+            .get("!module")
+            .unwrap()
+            .get("some_number_config")
+            .unwrap()
+            .try_into()
+            .unwrap(),
+        foobar_config,
+    }
+}
+
 /// The trait for the user to provide. Always part of the generated code.
 pub trait OnReadySubscriber: Sync + Send {
     fn on_ready(&self, pub_impl: &ModulePublisher);

--- a/modules/rust_examples/RsExample/src/main.rs
+++ b/modules/rust_examples/RsExample/src/main.rs
@@ -4,8 +4,8 @@
 
 mod eventually_generated;
 use eventually_generated::{
-    ExampleServiceSubscriber, KvsClientSubscriber, KvsServiceSubscriber, Module, ModulePublisher,
-    OnReadySubscriber,
+    get_config, ExampleServiceSubscriber, KvsClientSubscriber, KvsServiceSubscriber, Module,
+    ModulePublisher, OnReadySubscriber,
 };
 use std::sync::Arc;
 use std::{thread, time};
@@ -73,6 +73,8 @@ impl OnReadySubscriber for OneClass {
 }
 
 fn main() {
+    let config = get_config();
+    println!("Received the config {config:?}");
     let one_class = Arc::new(OneClass {});
     let _module = Module::new(
         one_class.clone(),


### PR DESCRIPTION
Adds rust support for config handling.

The interface for getting the config is a stand alone function allowing the user to get the config before instantiating the user's objects. The PR goes together with the PR into `everest-framework` https://github.com/EVerest/everest-framework/pull/113