### PR TITLE
Add command to system interface to explicity allow firmware updates

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -38,7 +38,7 @@ libcurl:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 4551bfa
+  git_tag: 07295a8
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git

--- a/interfaces/system.yaml
+++ b/interfaces/system.yaml
@@ -11,6 +11,8 @@ cmds:
       description: Returns the result of the attempt to update the firmware
       type: string
       $ref: /system#/UpdateFirmwareResponse
+  allow_firmware_installation:
+    description: Call to allow a firmware installation to proceed
   upload_logs:
     description: Call to start a log upload
     arguments:

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -434,6 +434,11 @@ void OCPP::ready() {
             types::system::update_firmware_response_to_string(system_response));
     });
 
+    this->charge_point->register_all_connectors_unavailable_callback([this]() {
+        EVLOG_info << "All connectors unavailable, proceed with firmware installation";
+        this->r_system->call_allow_firmware_installation();
+    });
+
     this->r_system->subscribe_log_status([this](types::system::LogStatus log_status) {
         this->charge_point->on_log_status_notification(log_status.request_id,
                                                        types::system::log_status_enum_to_string(log_status.log_status));

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -765,6 +765,11 @@ void OCPP201::ready() {
     callbacks.configure_network_connection_profile_callback =
         [this](const ocpp::v201::NetworkConnectionProfile& network_connection_profile) { return true; };
 
+    callbacks.all_connectors_unavailable_callback = [this]() {
+        EVLOG_info << "All connectors unavailable, proceed with firmware installation";
+        this->r_system->call_allow_firmware_installation();
+    };
+
     const auto sql_init_path = this->ocpp_share_path / INIT_SQL;
 
     this->init_evses();

--- a/modules/System/main/systemImpl.cpp
+++ b/modules/System/main/systemImpl.cpp
@@ -286,6 +286,10 @@ systemImpl::handle_update_firmware(types::system::FirmwareUpdateRequest& firmwar
     }
 };
 
+void systemImpl::handle_allow_firmware_installation() {
+    // TODO: implement me
+}
+
 types::system::UploadLogsResponse
 systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_request) {
 

--- a/modules/System/main/systemImpl.hpp
+++ b/modules/System/main/systemImpl.hpp
@@ -38,6 +38,7 @@ protected:
     // command handler functions (virtual)
     virtual types::system::UpdateFirmwareResponse
     handle_update_firmware(types::system::FirmwareUpdateRequest& firmware_update_request) override;
+    virtual void handle_allow_firmware_installation() override;
     virtual types::system::UploadLogsResponse
     handle_upload_logs(types::system::UploadLogsRequest& upload_logs_request) override;
     virtual bool handle_is_reset_allowed(types::system::ResetType& type) override;


### PR DESCRIPTION
This is used by OCPP and OCPP201 to make sure that firmware updates are only installed when no transactions are active

This needs [#libocpp](https://github.com/EVerest/libocpp/pull/252)