### PR TITLE
Improving start of charge performance for AC BASIC charging

### DIFF
--- a/modules/EnergyManager/manifest.yaml
+++ b/modules/EnergyManager/manifest.yaml
@@ -6,17 +6,17 @@ config:
     type: number
     default: 230.0
   update_interval:
-    description: Update interval for energy distribution [ms]
+    description: Update interval for energy distribution [s]
     type: integer
     default: 1
   schedule_interval_duration:
     description: Duration of the schedule interval for forecast [min]
     type: integer
-    default: 15
+    default: 60
   schedule_total_duration:
     description: Total duration of schedule forcast [h]
     type: integer
-    default: 24
+    default: 1
   slice_ampere:
     description: Ampere slice for trading. Lower values will give more even distribution but increase processing time [A].
     type: number

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -306,7 +306,7 @@ private:
     types::iso15118_charger::DC_EVSEMaximumLimits currentEvseMaxLimits;
 
     static constexpr auto SLEEP_BEFORE_ENABLING_PWM_HLC_MODE = std::chrono::seconds(1);
-    static constexpr auto MAINLOOP_UPDATE_RATE = std::chrono::milliseconds(50);
+    static constexpr auto MAINLOOP_UPDATE_RATE = std::chrono::milliseconds(100);
 
     float soft_over_current_tolerance_percent{10.};
     float soft_over_current_measurement_noise_A{0.5};

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -896,7 +896,7 @@ void EvseManager::ready() {
 
     //  start with a limit of 0 amps. We will get a budget from EnergyManager that is locally limited by hw
     //  caps.
-    charger->setMaxCurrent(0.0F, date::utc_clock::now());
+    charger->setMaxCurrent(0.0F, date::utc_clock::now() + std::chrono::seconds(10));
     charger->run();
     charger->enable(0);
 

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -82,6 +82,7 @@ struct Conf {
     bool disable_authentication;
     bool sae_j2847_2_bpt_enabled;
     std::string sae_j2847_2_bpt_mode;
+    bool request_zero_power_in_idle;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EvseManager/energy_grid/energyImpl.cpp
@@ -203,7 +203,7 @@ void energyImpl::request_energy_from_energy_manager() {
         }
 
         publish_energy_flow_request(energy_flow_request);
-        //EVLOG_info << "Outgoing request " << energy_flow_request;
+        // EVLOG_info << "Outgoing request " << energy_flow_request;
     }
 }
 

--- a/modules/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EvseManager/energy_grid/energyImpl.cpp
@@ -86,116 +86,125 @@ void energyImpl::clear_request_schedules() {
 }
 
 void energyImpl::ready() {
-
+    hw_caps = mod->get_hw_capabilities();
     clear_request_schedules();
 
-    // start thread to publish our energy object
+    // request energy now
+    request_energy_from_energy_manager();
+
+    // request energy every second
     std::thread([this] {
-        auto hw_caps = mod->get_hw_capabilities();
-
         while (true) {
+            request_energy_from_energy_manager();
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }).detach();
 
-            auto s = mod->charger->getCurrentState();
+    // request energy at the start and end of a charging session
+    mod->charger->signalState.connect([this](Charger::EvseState s) {
+        if (s == Charger::EvseState::WaitingForAuthentication || s == Charger::EvseState::Finished) {
+            request_energy_from_energy_manager();
+        }
+    });
+}
 
-            {
-                std::lock_guard<std::mutex> lock(this->energy_mutex);
-                clear_import_request_schedule();
-                clear_export_request_schedule();
+void energyImpl::request_energy_from_energy_manager() {
+    auto s = mod->charger->getCurrentState();
+    {
+        std::lock_guard<std::mutex> lock(this->energy_mutex);
+        clear_import_request_schedule();
+        clear_export_request_schedule();
 
-                // If we need energy, copy local limit schedules to energy_flow_request.
-                if (s == Charger::EvseState::Charging || s == Charger::EvseState::PrepareCharging ||
-                    s == Charger::EvseState::WaitingForEnergy || s == Charger::EvseState::WaitingForAuthentication ||
-                    s == Charger::EvseState::ChargingPausedEV) {
+        // If we need energy, copy local limit schedules to energy_flow_request.
+        if (s == Charger::EvseState::Charging || s == Charger::EvseState::PrepareCharging ||
+            s == Charger::EvseState::WaitingForEnergy || s == Charger::EvseState::WaitingForAuthentication ||
+            s == Charger::EvseState::ChargingPausedEV || !mod->config.request_zero_power_in_idle) {
 
-                    // copy complete external limit schedules
-                    if (mod->getLocalEnergyLimits().schedule_import.has_value() &&
-                        !mod->getLocalEnergyLimits().schedule_import.value().empty()) {
-                        energy_flow_request.schedule_import = mod->getLocalEnergyLimits().schedule_import;
-                    }
+            // copy complete external limit schedules
+            if (mod->getLocalEnergyLimits().schedule_import.has_value() &&
+                !mod->getLocalEnergyLimits().schedule_import.value().empty()) {
+                energy_flow_request.schedule_import = mod->getLocalEnergyLimits().schedule_import;
+            }
 
-                    // apply our local hardware limits on root side
-                    for (auto& e : energy_flow_request.schedule_import.value()) {
-                        if (!e.limits_to_root.ac_max_current_A.has_value() ||
-                            e.limits_to_root.ac_max_current_A.value() > hw_caps.max_current_A_import) {
-                            e.limits_to_root.ac_max_current_A = hw_caps.max_current_A_import;
+            // apply our local hardware limits on root side
+            for (auto& e : energy_flow_request.schedule_import.value()) {
+                if (!e.limits_to_root.ac_max_current_A.has_value() ||
+                    e.limits_to_root.ac_max_current_A.value() > hw_caps.max_current_A_import) {
+                    e.limits_to_root.ac_max_current_A = hw_caps.max_current_A_import;
 
-                            // are we in EV pause mode? -> Reduce requested current to minimum just to see when car
-                            // wants to start charging again. The energy manager may pause us externally to reduce to
-                            // zero
-                            if (s == Charger::EvseState::ChargingPausedEV) {
-                                e.limits_to_root.ac_max_current_A = hw_caps.min_current_A_import;
-                            }
-                        }
-
-                        if (!e.limits_to_root.ac_max_phase_count.has_value() ||
-                            e.limits_to_root.ac_max_phase_count.value() > hw_caps.max_phase_count_import)
-                            e.limits_to_root.ac_max_phase_count = hw_caps.max_phase_count_import;
-
-                        // copy remaining hw limits on root side
-                        e.limits_to_root.ac_min_phase_count = hw_caps.min_phase_count_import;
-                        e.limits_to_root.ac_min_current_A = hw_caps.min_current_A_import;
-                        e.limits_to_root.ac_supports_changing_phases_during_charging =
-                            hw_caps.supports_changing_phases_during_charging;
-                    }
-
-                    if (mod->getLocalEnergyLimits().schedule_export.has_value() &&
-                        !mod->getLocalEnergyLimits().schedule_export.value().empty()) {
-                        energy_flow_request.schedule_export = mod->getLocalEnergyLimits().schedule_export;
-                    }
-
-                    // apply our local hardware limits on root side
-                    for (auto& e : energy_flow_request.schedule_export.value()) {
-                        if (!e.limits_to_root.ac_max_current_A.has_value() ||
-                            e.limits_to_root.ac_max_current_A.value() > hw_caps.max_current_A_export) {
-                            e.limits_to_root.ac_max_current_A = hw_caps.max_current_A_export;
-
-                            // are we in EV pause mode? -> Reduce requested current to minimum just to see when car
-                            // wants to start discharging again. The energy manager may pause us externally to reduce to
-                            // zero
-                            if (s == Charger::EvseState::ChargingPausedEV) {
-                                e.limits_to_root.ac_max_current_A = hw_caps.min_current_A_export;
-                            }
-                        }
-
-                        if (!e.limits_to_root.ac_max_phase_count.has_value() ||
-                            e.limits_to_root.ac_max_phase_count.value() > hw_caps.max_phase_count_export)
-                            e.limits_to_root.ac_max_phase_count = hw_caps.max_phase_count_export;
-
-                        // copy remaining hw limits on root side
-                        e.limits_to_root.ac_min_phase_count = hw_caps.min_phase_count_export;
-                        e.limits_to_root.ac_min_current_A = hw_caps.min_current_A_export;
-                        e.limits_to_root.ac_supports_changing_phases_during_charging =
-                            hw_caps.supports_changing_phases_during_charging;
-                    }
-
-                    if (mod->config.charge_mode == "DC") {
-                        // For DC mode remove amp limit on leave side if any
-                        for (auto& e : energy_flow_request.schedule_import.value()) {
-                            e.limits_to_leaves.ac_max_current_A.reset();
-                        }
-                        for (auto& e : energy_flow_request.schedule_export.value()) {
-                            e.limits_to_leaves.ac_max_current_A.reset();
-                        }
-                    }
-
-                } else {
-                    if (mod->config.charge_mode == "DC") {
-                        // we dont need power at the moment
-                        energy_flow_request.schedule_import.value()[0].limits_to_leaves.total_power_W = 0.;
-                        energy_flow_request.schedule_export.value()[0].limits_to_leaves.total_power_W = 0.;
-                    } else {
-                        energy_flow_request.schedule_import.value()[0].limits_to_leaves.ac_max_current_A = 0.;
-                        energy_flow_request.schedule_export.value()[0].limits_to_leaves.ac_max_current_A = 0.;
+                    // are we in EV pause mode? -> Reduce requested current to minimum just to see when car
+                    // wants to start charging again. The energy manager may pause us externally to reduce to
+                    // zero
+                    if (s == Charger::EvseState::ChargingPausedEV && mod->config.request_zero_power_in_idle) {
+                        e.limits_to_root.ac_max_current_A = hw_caps.min_current_A_import;
                     }
                 }
 
-                publish_energy_flow_request(energy_flow_request);
-                // EVLOG_info << "Outgoing request " << energy_flow_request;
+                if (!e.limits_to_root.ac_max_phase_count.has_value() ||
+                    e.limits_to_root.ac_max_phase_count.value() > hw_caps.max_phase_count_import)
+                    e.limits_to_root.ac_max_phase_count = hw_caps.max_phase_count_import;
+
+                // copy remaining hw limits on root side
+                e.limits_to_root.ac_min_phase_count = hw_caps.min_phase_count_import;
+                e.limits_to_root.ac_min_current_A = hw_caps.min_current_A_import;
+                e.limits_to_root.ac_supports_changing_phases_during_charging =
+                    hw_caps.supports_changing_phases_during_charging;
             }
 
-            sleep(1);
+            if (mod->getLocalEnergyLimits().schedule_export.has_value() &&
+                !mod->getLocalEnergyLimits().schedule_export.value().empty()) {
+                energy_flow_request.schedule_export = mod->getLocalEnergyLimits().schedule_export;
+            }
+
+            // apply our local hardware limits on root side
+            for (auto& e : energy_flow_request.schedule_export.value()) {
+                if (!e.limits_to_root.ac_max_current_A.has_value() ||
+                    e.limits_to_root.ac_max_current_A.value() > hw_caps.max_current_A_export) {
+                    e.limits_to_root.ac_max_current_A = hw_caps.max_current_A_export;
+
+                    // are we in EV pause mode? -> Reduce requested current to minimum just to see when car
+                    // wants to start discharging again. The energy manager may pause us externally to reduce to
+                    // zero
+                    if (s == Charger::EvseState::ChargingPausedEV) {
+                        e.limits_to_root.ac_max_current_A = hw_caps.min_current_A_export;
+                    }
+                }
+
+                if (!e.limits_to_root.ac_max_phase_count.has_value() ||
+                    e.limits_to_root.ac_max_phase_count.value() > hw_caps.max_phase_count_export)
+                    e.limits_to_root.ac_max_phase_count = hw_caps.max_phase_count_export;
+
+                // copy remaining hw limits on root side
+                e.limits_to_root.ac_min_phase_count = hw_caps.min_phase_count_export;
+                e.limits_to_root.ac_min_current_A = hw_caps.min_current_A_export;
+                e.limits_to_root.ac_supports_changing_phases_during_charging =
+                    hw_caps.supports_changing_phases_during_charging;
+            }
+
+            if (mod->config.charge_mode == "DC") {
+                // For DC mode remove amp limit on leave side if any
+                for (auto& e : energy_flow_request.schedule_import.value()) {
+                    e.limits_to_leaves.ac_max_current_A.reset();
+                }
+                for (auto& e : energy_flow_request.schedule_export.value()) {
+                    e.limits_to_leaves.ac_max_current_A.reset();
+                }
+            }
+
+        } else {
+            if (mod->config.charge_mode == "DC") {
+                // we dont need power at the moment
+                energy_flow_request.schedule_import.value()[0].limits_to_leaves.total_power_W = 0.;
+                energy_flow_request.schedule_export.value()[0].limits_to_leaves.total_power_W = 0.;
+            } else {
+                energy_flow_request.schedule_import.value()[0].limits_to_leaves.ac_max_current_A = 0.;
+                energy_flow_request.schedule_export.value()[0].limits_to_leaves.ac_max_current_A = 0.;
+            }
         }
-    }).detach();
+
+        publish_energy_flow_request(energy_flow_request);
+        //EVLOG_info << "Outgoing request " << energy_flow_request;
+    }
 }
 
 void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
@@ -243,7 +252,6 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
         }
 
         // update limit at the charger
-        // EVLOG_warning << "charger->setMaxCurrent" << limit;
         if (limit >= 0) {
             // import
             mod->charger->setMaxCurrent(limit, Everest::Date::from_rfc3339(value.valid_until));

--- a/modules/EvseManager/energy_grid/energyImpl.hpp
+++ b/modules/EvseManager/energy_grid/energyImpl.hpp
@@ -57,6 +57,8 @@ private:
     void clear_import_request_schedule();
     void clear_export_request_schedule();
     void clear_request_schedules();
+    void request_energy_from_energy_manager();
+    types::board_support::HardwareCapabilities hw_caps;
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -193,7 +193,15 @@ config:
     enum:
       - V2H
       - V2G
-    default: V2G 
+    default: V2G
+  request_zero_power_in_idle:
+    description: >-
+      "true: In Idle mode (no car connected), request 0A from energy management. In installations with many charging stations this should be set"
+      "to allow the power to be distributed to the chargers that are connected to a car."
+      "false: Request the normal current even if no car is connected. This speeds up the start of charging on AC BASIC charging as"
+      "EvseManager does not need to wait for energy from the energy manager after plug in."
+    type: boolean
+    default: false
 provides:
   evse:
     interface: evse_manager


### PR DESCRIPTION
It took quite some time to enable PWM after plugin even in simple scenarios where no OCPP auth is neccessary and no power balancing is required.

This improves the following:
- Reducing time to PWM on by avoiding unneccesary calls to BSP to set PWM
- EvseManager now by default always requests the full amount of energy from the EnergyManager even if no car is plugged. In load balancing this can be disabled by setting config option "request_zero_power_in_idle" to true. This will add a slight delay to the start of charging as energy will need to be reserved by the EnergyManager first.