### PR TITLE
SerialCommHub: support longer transactions and chunking

### DIFF
--- a/modules/SerialCommHub/main/serial_communication_hubImpl.cpp
+++ b/modules/SerialCommHub/main/serial_communication_hubImpl.cpp
@@ -66,7 +66,7 @@ serial_communication_hubImpl::handle_modbus_read_holding_registers(int& target_d
             //                           (uint16_t)first_register_address, (uint16_t)num_registers_to_read);
 
             response = modbus.txrx(target_device_id, tiny_modbus::FunctionCode::READ_MULTIPLE_HOLDING_REGISTERS,
-                                   first_register_address, num_registers_to_read);
+                                   first_register_address, num_registers_to_read, config.max_packet_size);
             if (response.size() > 0) {
                 break;
             }
@@ -102,7 +102,7 @@ serial_communication_hubImpl::handle_modbus_read_input_registers(int& target_dev
             //                           (uint16_t)first_register_address, (uint16_t)num_registers_to_read);
 
             response = modbus.txrx(target_device_id, tiny_modbus::FunctionCode::READ_INPUT_REGISTERS,
-                                   first_register_address, num_registers_to_read);
+                                   first_register_address, num_registers_to_read, config.max_packet_size);
             if (response.size() > 0) {
                 break;
             }
@@ -140,7 +140,7 @@ types::serial_comm_hub_requests::StatusCodeEnum serial_communication_hubImpl::ha
                                        (uint16_t)data.size());
 
             response = modbus.txrx(target_device_id, tiny_modbus::FunctionCode::WRITE_MULTIPLE_HOLDING_REGISTERS,
-                                   first_register_address, data.size(), true, data);
+                                   first_register_address, data.size(), config.max_packet_size, true, data);
             if (response.size() > 0) {
                 break;
             }

--- a/modules/SerialCommHub/main/serial_communication_hubImpl.cpp
+++ b/modules/SerialCommHub/main/serial_communication_hubImpl.cpp
@@ -63,9 +63,9 @@ serial_communication_hubImpl::handle_modbus_read_holding_registers(int& target_d
         auto retry_counter = this->num_resends_on_error;
         while (retry_counter > 0) {
 
-            // EVLOG_info << fmt::format("Try {} Call modbus_client->read_holding_register(id {} addr {} len {})",
-            //                           (int)retry_counter, (uint8_t)target_device_id,
-            //                           (uint16_t)first_register_address, (uint16_t)num_registers_to_read);
+            EVLOG_debug << fmt::format("Try {} Call modbus_client->read_holding_register(id {} addr {} len {})",
+                                       (int)retry_counter, (uint8_t)target_device_id, (uint16_t)first_register_address,
+                                       (uint16_t)num_registers_to_read);
 
             response = modbus.txrx(target_device_id, tiny_modbus::FunctionCode::READ_MULTIPLE_HOLDING_REGISTERS,
                                    first_register_address, num_registers_to_read, config.max_packet_size);
@@ -99,9 +99,9 @@ serial_communication_hubImpl::handle_modbus_read_input_registers(int& target_dev
         uint8_t retry_counter{this->num_resends_on_error};
         while (retry_counter-- > 0) {
 
-            // EVLOG_info << fmt::format("Try {} Call modbus_client->read_input_register(id {} addr {} len {})",
-            //                           (int)retry_counter, (uint8_t)target_device_id,
-            //                           (uint16_t)first_register_address, (uint16_t)num_registers_to_read);
+            EVLOG_debug << fmt::format("Try {} Call modbus_client->read_input_register(id {} addr {} len {})",
+                                       (int)retry_counter, (uint8_t)target_device_id, (uint16_t)first_register_address,
+                                       (uint16_t)num_registers_to_read);
 
             response = modbus.txrx(target_device_id, tiny_modbus::FunctionCode::READ_INPUT_REGISTERS,
                                    first_register_address, num_registers_to_read, config.max_packet_size);

--- a/modules/SerialCommHub/main/serial_communication_hubImpl.cpp
+++ b/modules/SerialCommHub/main/serial_communication_hubImpl.cpp
@@ -31,6 +31,7 @@ static std::vector<int> vector_to_int(const std::vector<uint16_t>& response) {
 // Implementation
 
 void serial_communication_hubImpl::init() {
+    using namespace std::chrono;
     Everest::GpioSettings rxtx_gpio_settings;
 
     rxtx_gpio_settings.chip_name = config.rxtx_gpio_chip;
@@ -38,7 +39,8 @@ void serial_communication_hubImpl::init() {
     rxtx_gpio_settings.inverted = config.rxtx_gpio_tx_high;
 
     if (!modbus.open_device(config.serial_port, config.baudrate, config.ignore_echo, rxtx_gpio_settings,
-                            static_cast<tiny_modbus::Parity>(config.parity))) {
+                            static_cast<tiny_modbus::Parity>(config.parity), milliseconds(config.initial_timeout_ms),
+                            milliseconds(config.within_message_timeout_ms))) {
         EVLOG_AND_THROW(Everest::EverestConfigError(fmt::format("Cannot open serial port {}.", config.serial_port)));
     }
 }

--- a/modules/SerialCommHub/main/serial_communication_hubImpl.hpp
+++ b/modules/SerialCommHub/main/serial_communication_hubImpl.hpp
@@ -33,6 +33,7 @@ struct Conf {
     std::string rxtx_gpio_chip;
     int rxtx_gpio_line;
     bool rxtx_gpio_tx_high;
+    int max_packet_size;
 };
 
 class serial_communication_hubImpl : public serial_communication_hubImplBase {

--- a/modules/SerialCommHub/main/serial_communication_hubImpl.hpp
+++ b/modules/SerialCommHub/main/serial_communication_hubImpl.hpp
@@ -34,6 +34,8 @@ struct Conf {
     int rxtx_gpio_line;
     bool rxtx_gpio_tx_high;
     int max_packet_size;
+    int initial_timeout_ms;
+    int within_message_timeout_ms;
 };
 
 class serial_communication_hubImpl : public serial_communication_hubImplBase {

--- a/modules/SerialCommHub/manifest.yaml
+++ b/modules/SerialCommHub/manifest.yaml
@@ -42,6 +42,14 @@ provides:
         minimum: 0
         maximum: 65536
         default: 256
+      initial_timeout_ms:
+        description: Timeout in ms for the first packet.
+        type: integer
+        default: 500
+      within_message_timeout_ms:
+        description: Timeout in ms for subsequent packets.
+        type: integer
+        default: 100
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/SerialCommHub/manifest.yaml
+++ b/modules/SerialCommHub/manifest.yaml
@@ -36,6 +36,12 @@ provides:
         description: GPIO direction, false means low for TX, true means high for TX
         type: boolean
         default: false
+      max_packet_size:
+        description: Maximum size of a packet to read/write in bytes. Payload exceeding the size will be chunked.
+        type: integer
+        minimum: 0
+        maximum: 65536
+        default: 256
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/SerialCommHub/manifest.yaml
+++ b/modules/SerialCommHub/manifest.yaml
@@ -37,7 +37,10 @@ provides:
         type: boolean
         default: false
       max_packet_size:
-        description: Maximum size of a packet to read/write in bytes. Payload exceeding the size will be chunked.
+        description: >-
+          Maximum size of a packet to read/write in bytes. Payload exceeding the size will be chunked.
+          The APU size according to [wikipedia](https://en.wikipedia.org/wiki/Modbus) is 256 bytes,
+          which is used as default here.
         type: integer
         minimum: 0
         maximum: 65536

--- a/modules/SerialCommHub/tiny_modbus_rtu.cpp
+++ b/modules/SerialCommHub/tiny_modbus_rtu.cpp
@@ -307,7 +307,7 @@ int TinyModbusRTU::read_reply(uint8_t* rxbuf, int rxbuf_len) {
             int bytes_read = read(fd, rxbuf + bytes_read_total, rxbuf_len - bytes_read_total);
             if (bytes_read > 0) {
                 bytes_read_total += bytes_read;
-                // EVLOG_info << "RECVD: " << hexdump(rxbuf, bytes_read_total);
+                EVLOG_debug << "RECVD: " << hexdump(rxbuf, bytes_read_total);
             }
         }
     }
@@ -386,7 +386,7 @@ std::vector<uint16_t> TinyModbusRTU::txrx_impl(uint8_t device_address, FunctionC
         // set checksum in the last 2 bytes
         append_checksum(req.get(), req_len);
 
-        // EVLOG_info << "SEND: " << hexdump(req.get(), req_len);
+        EVLOG_debug << "SEND: " << hexdump(req.get(), req_len);
 
         // clear input and output buffer
         tcflush(fd, TCIOFLUSH);

--- a/modules/SerialCommHub/tiny_modbus_rtu.cpp
+++ b/modules/SerialCommHub/tiny_modbus_rtu.cpp
@@ -281,7 +281,7 @@ int TinyModbusRTU::read_reply(uint8_t* rxbuf, int rxbuf_len) {
         // reduce timeout after first chunk, no unnecessary waiting at the end of the message
         timeout.tv_sec = 0;
         timeout.tv_usec = MODBUS_RX_WITHIN_MESSAGE_TIMEOUT_MS * 1000;
-        if (rv == -1) {         // error in select function call
+        if (rv == -1) { // error in select function call
             perror("txrx: select:");
             break;
         } else if (rv == 0) { // no more bytes to read within timeout, so transfer is complete

--- a/modules/SerialCommHub/tiny_modbus_rtu.hpp
+++ b/modules/SerialCommHub/tiny_modbus_rtu.hpp
@@ -58,8 +58,12 @@ public:
 
     bool open_device(const std::string& device, int baud, bool ignore_echo,
                      const Everest::GpioSettings& rxtx_gpio_settings, const Parity parity);
+    std::vector<uint16_t> txrx_impl(uint8_t device_address, FunctionCode function, uint16_t first_register_address,
+                                    uint16_t register_quantity, bool wait_for_reply = true,
+                                    std::vector<uint16_t> request = std::vector<uint16_t>());
+
     std::vector<uint16_t> txrx(uint8_t device_address, FunctionCode function, uint16_t first_register_address,
-                               uint16_t register_quantity, bool wait_for_reply = true,
+                               uint16_t register_quantity, uint16_t chunk_size, bool wait_for_reply = true,
                                std::vector<uint16_t> request = std::vector<uint16_t>());
 
 private:

--- a/modules/SerialCommHub/tiny_modbus_rtu.hpp
+++ b/modules/SerialCommHub/tiny_modbus_rtu.hpp
@@ -7,6 +7,7 @@
 #ifndef TINY_MODBUS_RTU
 #define TINY_MODBUS_RTU
 
+#include <chrono>
 #include <stdint.h>
 #include <termios.h>
 
@@ -31,9 +32,6 @@ constexpr int MODBUS_MAX_REPLY_SIZE = 255 + 6;
 constexpr int MODBUS_MIN_REPLY_SIZE = 5;
 constexpr int MODBUS_BASE_PAYLOAD_SIZE = 8;
 
-constexpr int MODBUS_RX_INITIAL_TIMEOUT_MS = 500;
-constexpr int MODBUS_RX_WITHIN_MESSAGE_TIMEOUT_MS = 100;
-
 enum class Parity : uint8_t {
     NONE = 0,
     ODD = 1,
@@ -57,7 +55,8 @@ public:
     ~TinyModbusRTU();
 
     bool open_device(const std::string& device, int baud, bool ignore_echo,
-                     const Everest::GpioSettings& rxtx_gpio_settings, const Parity parity);
+                     const Everest::GpioSettings& rxtx_gpio_settings, const Parity parity,
+                     std::chrono::milliseconds initial_timeout, std::chrono::milliseconds within_message_timeout);
     std::vector<uint16_t> txrx_impl(uint8_t device_address, FunctionCode function, uint16_t first_register_address,
                                     uint16_t register_quantity, bool wait_for_reply = true,
                                     std::vector<uint16_t> request = std::vector<uint16_t>());
@@ -73,6 +72,8 @@ private:
     int read_reply(uint8_t* rxbuf, int rxbuf_len);
 
     Everest::Gpio rxtx_gpio;
+    std::chrono::milliseconds initial_timeout;
+    std::chrono::milliseconds within_message_timeout;
 };
 
 } // namespace tiny_modbus

--- a/modules/SerialCommHub/tiny_modbus_rtu.hpp
+++ b/modules/SerialCommHub/tiny_modbus_rtu.hpp
@@ -57,9 +57,6 @@ public:
     bool open_device(const std::string& device, int baud, bool ignore_echo,
                      const Everest::GpioSettings& rxtx_gpio_settings, const Parity parity,
                      std::chrono::milliseconds initial_timeout, std::chrono::milliseconds within_message_timeout);
-    std::vector<uint16_t> txrx_impl(uint8_t device_address, FunctionCode function, uint16_t first_register_address,
-                                    uint16_t register_quantity, bool wait_for_reply = true,
-                                    std::vector<uint16_t> request = std::vector<uint16_t>());
 
     std::vector<uint16_t> txrx(uint8_t device_address, FunctionCode function, uint16_t first_register_address,
                                uint16_t register_quantity, uint16_t chunk_size, bool wait_for_reply = true,
@@ -69,6 +66,11 @@ private:
     // Serial interface
     int fd{0};
     bool ignore_echo{false};
+
+    std::vector<uint16_t> txrx_impl(uint8_t device_address, FunctionCode function, uint16_t first_register_address,
+                                    uint16_t register_quantity, bool wait_for_reply = true,
+                                    std::vector<uint16_t> request = std::vector<uint16_t>());
+
     int read_reply(uint8_t* rxbuf, int rxbuf_len);
 
     Everest::Gpio rxtx_gpio;


### PR DESCRIPTION
Pr adds support for maximum packet sizes to the SerialCommHub. The [wikipedia](https://en.wikipedia.org/wiki/Modbus) says that the the packet size is between 253 and 256 bytes

> PDU max size is 253 bytes. ADU max size on RS232/RS485 network is 256 bytes, and with TCP is 260 bytes

This pr makes the packet size configurable. If the payload exceeds the packet size we will read/write it in chunks