### PR TITLE
GenericPowerMeter: Add support for calling specialized power meter implementations

### DIFF
--- a/modules/GenericPowermeter/CMakeLists.txt
+++ b/modules/GenericPowermeter/CMakeLists.txt
@@ -24,4 +24,6 @@ target_sources(${MODULE_NAME}
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 # insert other things like install cmds etc here
 target_link_libraries(${MODULE_NAME} PRIVATE everest::framework)
+# TODO(ddo) What is the right flag for disabling tests?
+add_subdirectory(tests)
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/GenericPowermeter/CMakeLists.txt
+++ b/modules/GenericPowermeter/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(${MODULE_NAME}
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 # insert other things like install cmds etc here
 target_link_libraries(${MODULE_NAME} PRIVATE everest::framework)
-# TODO(ddo) What is the right flag for disabling tests?
-add_subdirectory(tests)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/GenericPowermeter/GenericPowermeter.hpp
+++ b/modules/GenericPowermeter/GenericPowermeter.hpp
@@ -14,6 +14,7 @@
 #include <generated/interfaces/powermeter/Implementation.hpp>
 
 // headers for required interface implementations
+#include <generated/interfaces/powermeter/Interface.hpp>
 #include <generated/interfaces/serial_communication_hub/Interface.hpp>
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
@@ -28,11 +29,17 @@ class GenericPowermeter : public Everest::ModuleBase {
 public:
     GenericPowermeter() = delete;
     GenericPowermeter(const ModuleInfo& info, std::unique_ptr<powermeterImplBase> p_main,
-                      std::unique_ptr<serial_communication_hubIntf> r_serial_comm_hub, Conf& config) :
-        ModuleBase(info), p_main(std::move(p_main)), r_serial_comm_hub(std::move(r_serial_comm_hub)), config(config){};
+                      std::unique_ptr<serial_communication_hubIntf> r_serial_comm_hub,
+                      std::vector<std::unique_ptr<powermeterIntf>> r_specific_power_meter, Conf& config) :
+        ModuleBase(info),
+        p_main(std::move(p_main)),
+        r_serial_comm_hub(std::move(r_serial_comm_hub)),
+        r_specific_power_meter(std::move(r_specific_power_meter)),
+        config(config){};
 
     const std::unique_ptr<powermeterImplBase> p_main;
     const std::unique_ptr<serial_communication_hubIntf> r_serial_comm_hub;
+    const std::vector<std::unique_ptr<powermeterIntf>> r_specific_power_meter;
     const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1

--- a/modules/GenericPowermeter/GenericPowermeter.hpp
+++ b/modules/GenericPowermeter/GenericPowermeter.hpp
@@ -30,16 +30,16 @@ public:
     GenericPowermeter() = delete;
     GenericPowermeter(const ModuleInfo& info, std::unique_ptr<powermeterImplBase> p_main,
                       std::unique_ptr<serial_communication_hubIntf> r_serial_comm_hub,
-                      std::vector<std::unique_ptr<powermeterIntf>> r_specific_power_meter, Conf& config) :
+                      std::vector<std::unique_ptr<powermeterIntf>> r_transactional_power_meter, Conf& config) :
         ModuleBase(info),
         p_main(std::move(p_main)),
         r_serial_comm_hub(std::move(r_serial_comm_hub)),
-        r_specific_power_meter(std::move(r_specific_power_meter)),
+        r_transactional_power_meter(std::move(r_transactional_power_meter)),
         config(config){};
 
     const std::unique_ptr<powermeterImplBase> p_main;
     const std::unique_ptr<serial_communication_hubIntf> r_serial_comm_hub;
-    const std::vector<std::unique_ptr<powermeterIntf>> r_specific_power_meter;
+    const std::vector<std::unique_ptr<powermeterIntf>> r_transactional_power_meter;
     const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -48,19 +48,19 @@ void powermeterImpl::ready() {
 }
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    if (mod->r_specific_power_meter.empty())
+    if (mod->r_transactional_power_meter.empty())
         return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
                 {},
                 "No specific powermeter configured to start a transaction"};
-    return mod->r_specific_power_meter.front()->call_stop_transaction(transaction_id);
+    return mod->r_transactional_power_meter.front()->call_stop_transaction(transaction_id);
 };
 
 types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    if (mod->r_specific_power_meter.empty())
+    if (mod->r_transactional_power_meter.empty())
         return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
                 "No specific powermeter configured to stop a transaction"};
-    return mod->r_specific_power_meter.front()->call_start_transaction(value);
+    return mod->r_transactional_power_meter.front()->call_start_transaction(value);
 }
 
 void powermeterImpl::init_default_values() {

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -48,15 +48,19 @@ void powermeterImpl::ready() {
 }
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            {},
-            "Generic powermeter does not support the stop_transaction command"};
+    if (mod->r_specific_power_meter.empty())
+        return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+                {},
+                "Generic powermeter does not support the stop_transaction command"};
+    return mod->r_specific_power_meter.front()->call_stop_transaction(transaction_id);
 };
 
 types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
-    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-            "Generic powermeter does not support the start_transaction command"};
+    if (mod->r_specific_power_meter.empty())
+        return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
+                "Generic powermeter does not support the start_transaction command"};
+    return mod->r_specific_power_meter.front()->call_start_transaction(value);
 }
 
 void powermeterImpl::init_default_values() {

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -51,7 +51,7 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
     if (mod->r_transactional_power_meter.empty())
         return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
                 {},
-                "No specific powermeter configured to start a transaction"};
+                "No specific powermeter configured to stop a transaction"};
     return mod->r_transactional_power_meter.front()->call_stop_transaction(transaction_id);
 };
 
@@ -59,7 +59,7 @@ types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
     if (mod->r_transactional_power_meter.empty())
         return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-                "No specific powermeter configured to stop a transaction"};
+                "No specific powermeter configured to start a transaction"};
     return mod->r_transactional_power_meter.front()->call_start_transaction(value);
 }
 

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -51,7 +51,7 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
     if (mod->r_specific_power_meter.empty())
         return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
                 {},
-                "Generic powermeter does not support the stop_transaction command"};
+                "No specific powermeter configured to start a transaction"};
     return mod->r_specific_power_meter.front()->call_stop_transaction(transaction_id);
 };
 
@@ -59,7 +59,7 @@ types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& value) {
     if (mod->r_specific_power_meter.empty())
         return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
-                "Generic powermeter does not support the start_transaction command"};
+                "No specific powermeter configured to stop a transaction"};
     return mod->r_specific_power_meter.front()->call_start_transaction(value);
 }
 

--- a/modules/GenericPowermeter/manifest.yaml
+++ b/modules/GenericPowermeter/manifest.yaml
@@ -23,7 +23,8 @@ provides:
 requires:
   serial_comm_hub:
     interface: serial_communication_hub
-  specific_power_meter:
+  transactional_power_meter:
+    # Optional power meter which supports transactions.
     interface: powermeter
     min_connections: 0
     max_connections: 1

--- a/modules/GenericPowermeter/manifest.yaml
+++ b/modules/GenericPowermeter/manifest.yaml
@@ -23,6 +23,10 @@ provides:
 requires:
   serial_comm_hub:
     interface: serial_communication_hub
+  specific_power_meter:
+    interface: powermeter
+    min_connections: 0
+    max_connections: 1
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/GenericPowermeter/models/Bauer_BSM-WS36A-H01-1311-0000.yaml
+++ b/modules/GenericPowermeter/models/Bauer_BSM-WS36A-H01-1311-0000.yaml
@@ -37,7 +37,7 @@ energy_Wh_import:
     exponent_register: 0
     function_code_exp_reg: 3
 energy_Wh_export:
-  start_register: 40137
+  start_register: 40136
   function_code_start_reg: 3
   num_registers: 2
   multiplier: 0.001
@@ -72,112 +72,112 @@ voltage_V:
   exponent_register: 0
   function_code_exp_reg: 3
   L1:
+    start_register: 40098
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
     start_register: 40099
     function_code_start_reg: 3
     num_registers: 1
     multiplier: 1
     exponent_register: 0
     function_code_exp_reg: 3
-  L2:
+  L3:
     start_register: 40100
     function_code_start_reg: 3
     num_registers: 1
     multiplier: 1
     exponent_register: 0
     function_code_exp_reg: 3
-  L3:
-    start_register: 40101
-    function_code_start_reg: 3
-    num_registers: 1
-    multiplier: 1
-    exponent_register: 0
-    function_code_exp_reg: 3
 power_W:
-  start_register: 40109
+  start_register: 40108
   function_code_start_reg: 3
   num_registers: 1
   multiplier: 1
   exponent_register: 0
   function_code_exp_reg: 3
   L1:
+    start_register: 40109
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
     start_register: 40110
     function_code_start_reg: 3
     num_registers: 1
     multiplier: 1
     exponent_register: 0
     function_code_exp_reg: 3
-  L2:
+  L3:
     start_register: 40111
     function_code_start_reg: 3
     num_registers: 1
     multiplier: 1
     exponent_register: 0
     function_code_exp_reg: 3
-  L3:
-    start_register: 40112
-    function_code_start_reg: 3
-    num_registers: 1
-    multiplier: 1
-    exponent_register: 0
-    function_code_exp_reg: 3
 reactive_power_VAR:
-  start_register: 40119
+  start_register: 40118
   function_code_start_reg: 3
   num_registers: 1
   multiplier: 1
   exponent_register: 0
   function_code_exp_reg: 3
   L1:
+    start_register: 40119
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
     start_register: 40120
     function_code_start_reg: 3
     num_registers: 1
     multiplier: 1
     exponent_register: 0
     function_code_exp_reg: 3
-  L2:
+  L3:
     start_register: 40121
     function_code_start_reg: 3
     num_registers: 1
     multiplier: 1
     exponent_register: 0
     function_code_exp_reg: 3
-  L3:
-    start_register: 40122
-    function_code_start_reg: 3
-    num_registers: 1
-    multiplier: 1
-    exponent_register: 0
-    function_code_exp_reg: 3
 current_A:
-  start_register: 40093
+  start_register: 40092
   function_code_start_reg: 3
   num_registers: 1
   multiplier: 1
   exponent_register: 0
   function_code_exp_reg: 3
   L1:
-    start_register: 40094
+    start_register: 40093
     function_code_start_reg: 3
     num_registers: 1
     multiplier: 1
     exponent_register: 0
     function_code_exp_reg: 3
   L2:
-    start_register: 40095
+    start_register: 40094
     function_code_start_reg: 3
     num_registers: 1
     multiplier: 1
     exponent_register: 0
     function_code_exp_reg: 3
   L3:
-    start_register: 40096
+    start_register: 40095
     function_code_start_reg: 3
     num_registers: 1
     multiplier: 1
     exponent_register: 0
     function_code_exp_reg: 3
 frequency_Hz:
-  start_register: 40107
+  start_register: 40106
   function_code_start_reg: 3
   num_registers: 1
   multiplier: 1

--- a/modules/GenericPowermeter/models/Bauer_BSM-WS36A-H01-1311-0000.yaml
+++ b/modules/GenericPowermeter/models/Bauer_BSM-WS36A-H01-1311-0000.yaml
@@ -1,0 +1,206 @@
+# (<start_register> of length <num_registers>) * <multiplier> * 10^(<exponent_register>)
+#
+# if <start_register> is "0", then this value does not exist in the powermeter
+#
+# use <multiplier> to manually scale (e.g. set to 0.001 if device returns "kWh", but the parameter is "Wh") and <exponent_register> to scale by device value
+#
+# if <exponent_register> is "0", then no exponent register exists and multiplier needs to be set accordingly
+# 
+# if measuring AC, the first level of registers is always "total/sum" of a certain value and the L1/2/3 registers are for the distinct phases
+# if measuring DC, only use the first level of registers
+energy_Wh_import:
+  start_register: 0
+  function_code_start_reg: 3
+  num_registers: 0
+  multiplier: 0.001
+  exponent_register: 0
+  function_code_exp_reg: 3
+  L1:
+    start_register: 0
+    function_code_start_reg: 3
+    num_registers: 0
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
+    start_register: 0
+    function_code_start_reg: 3
+    num_registers: 0
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L3:
+    start_register: 0
+    function_code_start_reg: 3
+    num_registers: 0
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+energy_Wh_export:
+  start_register: 40137
+  function_code_start_reg: 3
+  num_registers: 2
+  multiplier: 0.001
+  exponent_register: 0
+  function_code_exp_reg: 3
+  L1:
+    start_register: 0
+    function_code_start_reg: 3
+    num_registers: 0
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
+    start_register: 0
+    function_code_start_reg: 3
+    num_registers: 0
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L3:
+    start_register: 0
+    function_code_start_reg: 3
+    num_registers: 0
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+voltage_V:
+  start_register: 0
+  function_code_start_reg: 3
+  num_registers: 0
+  multiplier: 1
+  exponent_register: 0
+  function_code_exp_reg: 3
+  L1:
+    start_register: 40099
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
+    start_register: 40100
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L3:
+    start_register: 40101
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+power_W:
+  start_register: 40109
+  function_code_start_reg: 3
+  num_registers: 1
+  multiplier: 1
+  exponent_register: 0
+  function_code_exp_reg: 3
+  L1:
+    start_register: 40110
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
+    start_register: 40111
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L3:
+    start_register: 40112
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+reactive_power_VAR:
+  start_register: 40119
+  function_code_start_reg: 3
+  num_registers: 1
+  multiplier: 1
+  exponent_register: 0
+  function_code_exp_reg: 3
+  L1:
+    start_register: 40120
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
+    start_register: 40121
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L3:
+    start_register: 40122
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+current_A:
+  start_register: 40093
+  function_code_start_reg: 3
+  num_registers: 1
+  multiplier: 1
+  exponent_register: 0
+  function_code_exp_reg: 3
+  L1:
+    start_register: 40094
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
+    start_register: 40095
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L3:
+    start_register: 40096
+    function_code_start_reg: 3
+    num_registers: 1
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+frequency_Hz:
+  start_register: 40107
+  function_code_start_reg: 3
+  num_registers: 1
+  multiplier: 1
+  exponent_register: 0
+  function_code_exp_reg: 3
+  L1:
+    start_register: 0
+    function_code_start_reg: 3
+    num_registers: 0
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L2:
+    start_register: 0
+    function_code_start_reg: 3
+    num_registers: 0
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3
+  L3:
+    start_register: 0
+    function_code_start_reg: 3
+    num_registers: 0
+    multiplier: 1
+    exponent_register: 0
+    function_code_exp_reg: 3

--- a/modules/GenericPowermeter/serialization.hpp
+++ b/modules/GenericPowermeter/serialization.hpp
@@ -26,31 +26,31 @@ namespace internal {
 
 using Result = types::serial_comm_hub_requests::Result;
 
-inline void check_message(const Result& _message) {
-    if (!_message.value.has_value())
+inline void check_message(const Result& message) {
+    if (!message.value.has_value())
         throw std::invalid_argument("The `value` must be set");
 }
 
 /// @brief Deserialization for small integral types (less or equal to two bytes).
-/// @param _message The message read.
-/// @param _result The result which will contain the deserialized data.
+/// @param message The message read.
+/// @param result The result which will contain the deserialized data.
 template <typename Output, std::enable_if_t<std::is_integral<Output>::value && (sizeof(Output) <= 2), bool> = true>
-inline void deserialize(const Result& _message, Output& _result) {
-    check_message(_message);
+inline void deserialize(const Result& message, Output& result) {
+    check_message(message);
 
-    const auto& value = _message.value.value();
+    const auto& value = message.value.value();
     if (value.size() != 1)
         throw std::runtime_error("Result must have 1 entry");
 
-    _result = static_cast<Output>(value.front());
+    result = static_cast<Output>(value.front());
 }
 
 /// @brief Deserialization for large integral types (more than two bytes).
 template <typename Output, std::enable_if_t<std::is_integral<Output>::value && (sizeof(Output) > 2), bool> = true>
-inline void deserialize(const Result& _message, Output& _result) {
-    check_message(_message);
+inline void deserialize(const Result& message, Output& result) {
+    check_message(message);
 
-    const auto& value = _message.value.value();
+    const auto& value = message.value.value();
     const auto size = value.size();
     if (size != 1 && size != 2)
         throw std::runtime_error("Result must have 1 or 2 entries");
@@ -64,41 +64,41 @@ inline void deserialize(const Result& _message, Output& _result) {
     for (size_t ii = 0; ii != size; ++ii)
         out += (value.at(size - ii - 1) << 16 * ii);
 
-    _result = out;
+    result = out;
 }
 
 /// @brief Deserialization for float.
-/// @param _message The message read.
-/// @param _result The result which will contain the deserialized data.
+/// @param message The message read.
+/// @param result The result which will contain the deserialized data.
 template <typename Output, std::enable_if_t<std::is_floating_point<Output>::value, bool> = true>
-inline void deserialize(const Result& _message, Output& _result) {
+inline void deserialize(const Result& message, Output& result) {
     uint32_t out;
-    deserialize<uint32_t>(_message, out);
-    _result = static_cast<Output>(out);
+    deserialize<uint32_t>(message, out);
+    result = static_cast<Output>(out);
 }
 
 /// @brief Deserialization for string.
-/// @param _message The message read.
-/// @param _result The result which will contain the deserialized data.
-inline void deserialize(const Result& _message, std::string& _result) {
-    check_message(_message);
+/// @param message The message read.
+/// @param result The result which will contain the deserialized data.
+inline void deserialize(const Result& message, std::string& result) {
+    check_message(message);
 
-    const auto& value = _message.value.value();
+    const auto& value = message.value.value();
     // The serialized data holds data in the first 2 bytes of every element. We
     // iterate over both, naming ii after the input and oo after the output.
-    const auto old_size = _result.size();
-    _result.resize(old_size + value.size() * 2);
+    const auto old_size = result.size();
+    result.resize(old_size + value.size() * 2);
     for (size_t ii = 0, oo = old_size; ii != value.size(); ++ii, ++oo) {
-        _result.at(oo) = value.at(ii) >> 8;
-        _result.at(++oo) = value.at(ii);
+        result.at(oo) = value.at(ii) >> 8;
+        result.at(++oo) = value.at(ii);
     }
 }
 
 } // namespace internal
 
-template <typename Output> inline Output deserialize(const types::serial_comm_hub_requests::Result& _message) {
+template <typename Output> inline Output deserialize(const types::serial_comm_hub_requests::Result& message) {
     Output out;
-    internal::deserialize(_message, out);
+    internal::deserialize(message, out);
     return out;
 }
 

--- a/modules/GenericPowermeter/serialization.hpp
+++ b/modules/GenericPowermeter/serialization.hpp
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Qwello GmbH and Contributors to EVerest
+
+/// @brief Serialization and deserialization for the modbus interface.
+///
+/// The format has a major quirk: Even though our exchanged data is four bytes
+/// wide, the modbus implementation only uses the first two bytes, effectively
+/// casting every element in the exchanged data from uint32_t to uint16_t. If
+/// this ever gets changed, the code below must be equally adjusted.
+
+#include <chrono>
+#include <everest/logging.hpp>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+// TODO(ddo) We don't need the utils types but otherwise our compilation fails
+// since the generated files aren't self contained (they need json to be
+// externally included)...
+#include <utils/types.hpp>
+
+#include <generated/types/serial_comm_hub_requests.hpp>
+
+namespace internal {
+
+using Result = types::serial_comm_hub_requests::Result;
+
+inline void check_message(const Result& _message) {
+    if (!_message.value.has_value())
+        throw std::invalid_argument("The `value` must be set");
+}
+
+/// @brief Deserialization for small integral types (less or equal to two bytes).
+/// @param _message The message read.
+/// @param _result The result which will contain the deserialized data.
+template <typename Output, std::enable_if_t<std::is_integral<Output>::value && (sizeof(Output) <= 2), bool> = true>
+inline void deserialize(const Result& _message, Output& _result) {
+    check_message(_message);
+
+    const auto& value = _message.value.value();
+    if (value.size() != 1)
+        throw std::runtime_error("Result must have 1 entry");
+
+    _result = static_cast<Output>(value.front());
+}
+
+/// @brief Deserialization for large integral types (more than two bytes).
+template <typename Output, std::enable_if_t<std::is_integral<Output>::value && (sizeof(Output) > 2), bool> = true>
+inline void deserialize(const Result& _message, Output& _result) {
+    check_message(_message);
+
+    const auto& value = _message.value.value();
+    const auto size = value.size();
+    if (size != 1 && size != 2)
+        throw std::runtime_error("Result must have 1 or 2 entries");
+
+    auto out = 0;
+    // Given the values [0xdead, 0xbeef], we want to move the first entry by
+    // 16 bits to get the final value of 0xdeadbeef:
+    // 0x0000beef +
+    // 0xdead0000 =
+    // 0xdeadbeef
+    for (size_t ii = 0; ii != size; ++ii)
+        out += (value.at(size - ii - 1) << 16 * ii);
+
+    _result = out;
+}
+
+/// @brief Deserialization for float.
+/// @param _message The message read.
+/// @param _result The result which will contain the deserialized data.
+template <typename Output, std::enable_if_t<std::is_floating_point<Output>::value, bool> = true>
+inline void deserialize(const Result& _message, Output& _result) {
+    uint32_t out;
+    deserialize<uint32_t>(_message, out);
+    _result = static_cast<Output>(out);
+}
+
+/// @brief Deserialization for string.
+/// @param _message The message read.
+/// @param _result The result which will contain the deserialized data.
+inline void deserialize(const Result& _message, std::string& _result) {
+    check_message(_message);
+
+    const auto& value = _message.value.value();
+    // The serialized data holds data in the first 2 bytes of every element. We
+    // iterate over both, naming ii after the input and oo after the output.
+    const auto old_size = _result.size();
+    _result.resize(old_size + value.size() * 2);
+    for (size_t ii = 0, oo = old_size; ii != value.size(); ++ii, ++oo) {
+        _result.at(oo) = value.at(ii) >> 8;
+        _result.at(++oo) = value.at(ii);
+    }
+}
+
+} // namespace internal
+
+template <typename Output> inline Output deserialize(const types::serial_comm_hub_requests::Result& _message) {
+    Output out;
+    internal::deserialize(_message, out);
+    return out;
+}
+
+/// @brief Serialization for integral types.
+template <typename Input, std::enable_if_t<std::is_integral<Input>::value && (sizeof(Input) <= 2), bool> = true>
+inline types::serial_comm_hub_requests::VectorUint16 serialize(const Input& data) {
+    return {std::vector<int32_t>{static_cast<int32_t>(data)}};
+}
+
+/// @brief Serialization for integral types.
+template <typename Input, std::enable_if_t<std::is_integral<Input>::value && (sizeof(Input) > 2), bool> = true>
+inline types::serial_comm_hub_requests::VectorUint16 serialize(const Input& data) {
+    // The input 0xdeadbeef which is four bytes long, should be splitted into to
+    // elements [0xdead, 0xbeef], each holding only two bytes of data.
+    constexpr size_t factor = sizeof(Input) / sizeof(int16_t);
+    std::vector<int32_t> out(factor);
+    for (size_t ii = 0; ii != out.size(); ++ii)
+        out.at(ii) = static_cast<uint16_t>(data >> (factor - 1 - ii) * 16);
+
+    return {out};
+}
+
+/// @brief Serialization for vectors for signed and unsigned chars.
+template <typename Input, std::enable_if_t<std::is_integral<Input>::value && (sizeof(Input) == 1), bool> = true>
+types::serial_comm_hub_requests::VectorUint16 serialize(const std::vector<Input>& data) {
+    std::vector<int32_t> out(static_cast<size_t>(!data.empty()) * (data.size() / 2 + 1), 0);
+
+    // Drop the last bit - we handle here only bytes which can be "compacted" to
+    // to int16_t.
+    const auto size = (data.size() >> 1) << 1;
+    for (size_t ii = 0, oo = 0; ii != size; ++ii, ++oo) {
+        out.at(oo) = data.at(ii++) << 8;
+        out.at(oo) += data.at(ii);
+    }
+
+    // Handle the last byte - if any.
+    if (data.size() % 2 == 1) {
+        out.back() = data.back();
+    }
+    return {out};
+}
+
+/// @brief Serialization for vectors for signed and unsigned words.
+template <typename Input, std::enable_if_t<std::is_integral<Input>::value && (sizeof(Input) == 2), bool> = true>
+inline types::serial_comm_hub_requests::VectorUint16 serialize(const std::vector<Input>& data) {
+    std::vector<int32_t> out(data.size());
+    std::copy(data.begin(), data.end(), out.begin());
+    return {out};
+}
+
+/// @brief Serialization for vectors of integral types.
+template <typename Input, std::enable_if_t<std::is_integral<Input>::value && (sizeof(Input) > 2), bool> = true>
+types::serial_comm_hub_requests::VectorUint16 serialize(const std::vector<Input>& data) {
+    constexpr size_t factor = sizeof(Input) / sizeof(int16_t);
+    std::vector<int32_t> out(data.size() * factor);
+    auto begin = out.begin();
+    for (const auto& ii : data) {
+        const auto ii_out = serialize(ii);
+        std::move(ii_out.data.begin(), ii_out.data.end(), begin);
+        begin += ii_out.data.size();
+    }
+
+    return {out};
+}
+
+inline types::serial_comm_hub_requests::VectorUint16 serialize(const std::string& data) {
+    std::vector<char> tmp(data.begin(), data.end());
+    return serialize(tmp);
+}
+
+template <typename Clock>
+types::serial_comm_hub_requests::VectorUint16 serialize(const std::chrono::time_point<Clock>& time_point) {
+    // TODO(ddo) this is narrowing from uint to int.
+    const auto seconds =
+        static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(time_point.time_since_epoch()).count());
+    return serialize(seconds);
+}

--- a/modules/GenericPowermeter/serialization.hpp
+++ b/modules/GenericPowermeter/serialization.hpp
@@ -22,6 +22,8 @@
 
 #include <generated/types/serial_comm_hub_requests.hpp>
 
+namespace modbus {
+
 namespace internal {
 
 using Result = types::serial_comm_hub_requests::Result;
@@ -176,3 +178,4 @@ types::serial_comm_hub_requests::VectorUint16 serialize(const std::chrono::time_
         static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::seconds>(time_point.time_since_epoch()).count());
     return serialize(seconds);
 }
+} // namespace modbus

--- a/modules/GenericPowermeter/tests/CMakeLists.txt
+++ b/modules/GenericPowermeter/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_executable(generic_powermeter_tests serialization_test.cpp)
+
+set(INCLUDE_DIR 
+    "${PROJECT_SOURCE_DIR}/modules/GenericPowermeter"
+    "${PROJECT_SOURCE_DIR}/modules/GenericPowermeter/tests")
+
+get_target_property(GENERATED_INCLUDE_DIR generate_cpp_files EVEREST_GENERATED_INCLUDE_DIR)
+
+target_include_directories(generic_powermeter_tests PUBLIC 
+    ${GTEST_INCLUDE_DIRS}
+    ${INCLUDE_DIR}
+    ${GENERATED_INCLUDE_DIR}
+)
+
+find_package(GTest REQUIRED)
+
+target_link_libraries(generic_powermeter_tests PRIVATE
+    ${GTEST_LIBRARIES} 
+    ${GTEST_MAIN_LIBRARIES} 
+    everest::framework
+    everest::log
+    nlohmann_json::nlohmann_json
+)
+
+add_test(generic_powermeter_tests generic_powermeter_tests)

--- a/modules/GenericPowermeter/tests/CMakeLists.txt
+++ b/modules/GenericPowermeter/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(INCLUDE_DIR
     "${PROJECT_SOURCE_DIR}/modules/GenericPowermeter"
     "${PROJECT_SOURCE_DIR}/modules/GenericPowermeter/tests")
 
+add_dependencies(generic_powermeter_tests generate_cpp_files)
 get_target_property(GENERATED_INCLUDE_DIR generate_cpp_files EVEREST_GENERATED_INCLUDE_DIR)
 
 target_include_directories(generic_powermeter_tests PUBLIC 

--- a/modules/GenericPowermeter/tests/serialization_test.cpp
+++ b/modules/GenericPowermeter/tests/serialization_test.cpp
@@ -1,0 +1,93 @@
+#include "../serialization.hpp"
+#include <generated/types/serial_comm_hub_requests.hpp>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+using namespace types::serial_comm_hub_requests;
+using Request = types::serial_comm_hub_requests::Result;
+
+/// @brief Typed test
+template <typename T> struct DeserializationFixture : public testing::Test {
+    using Type = T;
+};
+
+using DeserializationTypes = testing::Types<uint8_t, char, uint16_t, int16_t, uint32_t, int32_t, size_t, std::string>;
+
+TYPED_TEST_SUITE(DeserializationFixture, DeserializationTypes);
+TYPED_TEST(DeserializationFixture, Invalid) {
+    // Empty messages are throwing.
+    ASSERT_ANY_THROW(deserialize<typename TestFixture::Type>({}));
+}
+
+using SmallTypes = testing::Types<uint8_t, uint16_t>;
+template <typename T> using SmallTypesFixture = DeserializationFixture<T>;
+TYPED_TEST_SUITE(SmallTypesFixture, SmallTypes);
+
+TYPED_TEST(SmallTypesFixture, Integral) {
+    using Type = typename TestFixture::Type;
+    Request req{StatusCodeEnum::Success, std::vector<int>{0xdead}};
+    ASSERT_EQ(deserialize<Type>(req), static_cast<Type>(0xdead));
+
+    req.value.value().push_back(1);
+    ASSERT_ANY_THROW(deserialize<Type>(req));
+
+    req.value.value().clear();
+    ASSERT_ANY_THROW(deserialize<Type>(req));
+}
+
+using MediumTypes = testing::Types<uint32_t, float>;
+template <typename T> using MediumTypesFixture = DeserializationFixture<T>;
+TYPED_TEST_SUITE(MediumTypesFixture, MediumTypes);
+
+TYPED_TEST(MediumTypesFixture, MediumTypes) {
+
+    using Type = typename TestFixture::Type;
+    Request req{StatusCodeEnum::Success, std::vector<int>{0xdead, 0xbeef}};
+    ASSERT_EQ(deserialize<Type>(req), static_cast<Type>(0xdeadbeef));
+
+    req.value.value().push_back(1);
+    ASSERT_ANY_THROW(deserialize<Type>(req));
+
+    req.value.value().clear();
+    ASSERT_ANY_THROW(deserialize<Type>(req));
+}
+
+TEST(Serialization, Integral) {
+    ASSERT_EQ(serialize(uint8_t{0xde}).data, std::vector<int32_t>{0xde});
+    ASSERT_EQ(serialize(uint16_t{0xdead}).data, std::vector<int32_t>{0xdead});
+    {
+
+        const std::vector<int32_t> expected{0xdead, 0xbeef};
+        ASSERT_EQ(serialize(uint32_t{0xdeadbeef}).data, expected);
+    }
+
+    {
+        const std::vector<int32_t> expected{0, 0, 0xdead, 0xbeef};
+        ASSERT_EQ(serialize(size_t{0xdeadbeef}).data, expected);
+    }
+}
+
+TEST(Serialization, Vector) {
+    ASSERT_EQ(serialize(std::vector<uint8_t>{0xde}).data, std::vector<int32_t>{0xde});
+    {
+        const std::vector<int32_t> expected{0xdead, 0xbe};
+        ASSERT_EQ(serialize(std::vector<uint8_t>{0xde, 0xad, 0xbe}).data, expected);
+    }
+
+    ASSERT_EQ(serialize(std::vector<uint16_t>{0xdead}).data, std::vector<int32_t>{0xdead});
+    {
+        const std::vector<int32_t> expected{0xdead, 0xbeef};
+        ASSERT_EQ(serialize(std::vector<uint16_t>{0xdead, 0xbeef}).data, expected);
+    }
+
+    {
+        const std::vector<int32_t> expected{0xdead, 0xbeef, 0, 0xacdc};
+        ASSERT_EQ(serialize(std::vector<uint32_t>{0xdeadbeef, 0xacdc}).data, expected);
+    }
+
+    {
+        const std::vector<int32_t> expected{0, 0, 0xdead, 0xbeef};
+        ASSERT_EQ(serialize(std::vector<size_t>{0xdeadbeef}).data, expected);
+    }
+}

--- a/modules/GenericPowermeter/tests/serialization_test.cpp
+++ b/modules/GenericPowermeter/tests/serialization_test.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+using namespace modbus;
 using namespace types::serial_comm_hub_requests;
 using Request = types::serial_comm_hub_requests::Result;
 


### PR DESCRIPTION
This pr adds support for transactions in the generic power meter. 

The mechanics of transactions differ significantly between power meter vendors. Therefore we can't just extend the config in the same way we did for reading power meter values. This pr adds an optional configuration field which will delegate the transaction calls to a "specific" power meter. This allows the user to re-use the work done by the generic power meter and still have transactions. 

