### PR TITLE
doc: how to activate  `EVLOG_debug` for one module

### DIFF
--- a/cmake/assets/logging.ini
+++ b/cmake/assets/logging.ini
@@ -3,6 +3,12 @@
 
 [Core]
 DisableLogging=false
+
+# To get debug logs of only one module, add the "%Process% contains" filter, e.g.:
+#
+#     "(%Process% contains OCPP201 and %Severity% >= DEBG)"
+#
+# whereas "OCPP201" is the value of the field `active_modules.NAME.module` in the respective /config/config-*.yaml.
 Filter="%Severity% >= INFO"
 
 [Sinks.Console]


### PR DESCRIPTION
Was lingering around locally. Pushing it to not accidentally commit it sometime.

Credits:  @hikinggrass  (see https://lists.lfenergy.org/g/everest/topic/101853426)