### PR TITLE
Proper shutdown of the TCP connection

### DIFF
--- a/modules/EvseV2G/din_server.cpp
+++ b/modules/EvseV2G/din_server.cpp
@@ -899,9 +899,6 @@ static enum v2g_event handle_din_welding_detection(struct v2g_connection* conn) 
 static enum v2g_event handle_din_session_stop(struct v2g_connection* conn) {
     struct dinSessionStopResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.SessionStopRes;
 
-    /* At first, publish charging session state */
-    conn->ctx->p_charger->publish_dlink_terminate(NULL);
-
     /* Now fill the EVSE response message */
     res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
 

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -2232,7 +2232,6 @@ static enum v2g_event handle_iso_session_stop(struct v2g_connection* conn) {
     switch (req->ChargingSession) {
     case iso1chargingSessionType_Terminate:
         conn->dlink_action = MQTT_DLINK_ACTION_TERMINATE;
-        conn->ctx->p_charger->publish_dlink_terminate(nullptr);
         conn->ctx->hlc_pause_active = false;
         /* Set next expected req msg */
         conn->ctx->state = (int)iso_dc_state_id::WAIT_FOR_TERMINATED_SESSION;
@@ -2244,14 +2243,12 @@ static enum v2g_event handle_iso_session_stop(struct v2g_connection* conn) {
         if (((conn->ctx->last_v2g_msg != V2G_POWER_DELIVERY_MSG) &&
              (conn->ctx->last_v2g_msg != V2G_WELDING_DETECTION_MSG))) {
             conn->dlink_action = MQTT_DLINK_ACTION_TERMINATE;
-            conn->ctx->p_charger->publish_dlink_terminate(nullptr);
             res->ResponseCode = iso1responseCodeType_FAILED;
             conn->ctx->hlc_pause_active = false;
             conn->ctx->state = (int)iso_dc_state_id::WAIT_FOR_TERMINATED_SESSION;
         } else {
             /* Init sleep mode for the EV */
             conn->dlink_action = MQTT_DLINK_ACTION_PAUSE;
-            conn->ctx->p_charger->publish_dlink_pause(nullptr);
             conn->ctx->hlc_pause_active = true;
             conn->ctx->state = (int)iso_dc_state_id::WAIT_FOR_SESSIONSETUP;
         }
@@ -2260,7 +2257,6 @@ static enum v2g_event handle_iso_session_stop(struct v2g_connection* conn) {
     default:
         /* Set next expected req msg */
         conn->dlink_action = MQTT_DLINK_ACTION_TERMINATE;
-        conn->ctx->p_charger->publish_dlink_terminate(nullptr);
         conn->ctx->state = (int)iso_dc_state_id::WAIT_FOR_TERMINATED_SESSION;
     }
 


### PR DESCRIPTION
Currently, `dlink_terminate` is sent to the SLAC module directly after the `SessionStopRes` message is sent. This is too fast. As a result, the EV has no chance to close its TCP/TLS connection. Most EVs have problems with this.

Now the EV is informed that the EVSE intends to close the TCP/TLS server. After waiting 5 seconds, the Charger closes the connection and only then sends `dlink_terminate`.