### PR TITLE
Add SignedMeterValue type powermeter types

### DIFF
--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -86,7 +86,7 @@ LemDCBM400600Controller::stop_transaction(const std::string& transaction_id) {
             [this, transaction_id]() {
                 this->request_device_to_stop_transaction(transaction_id);
                 auto signed_meter_value =
-                    types::powermeter::SignedMeterValue{fetch_ocmf_result(transaction_id), "OCMF", "OCMF"};
+                    types::powermeter::SignedMeterValue{fetch_ocmf_result(transaction_id), "", "OCMF"};
                 return types::powermeter::TransactionStopResponse{types::powermeter::TransactionRequestStatus::OK,
                                                                   signed_meter_value};
             },

--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -85,8 +85,10 @@ LemDCBM400600Controller::stop_transaction(const std::string& transaction_id) {
         return call_with_retry(
             [this, transaction_id]() {
                 this->request_device_to_stop_transaction(transaction_id);
+                auto signed_meter_value =
+                    types::powermeter::SignedMeterValue{fetch_ocmf_result(transaction_id), "OCMF", "OCMF"};
                 return types::powermeter::TransactionStopResponse{types::powermeter::TransactionRequestStatus::OK,
-                                                                  fetch_ocmf_result(transaction_id)};
+                                                                  signed_meter_value};
             },
             this->config.transaction_number_of_http_retries, this->config.transaction_retry_wait_in_milliseconds);
     } catch (DCBMUnexpectedResponseException& error) {

--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -86,7 +86,7 @@ LemDCBM400600Controller::stop_transaction(const std::string& transaction_id) {
             [this, transaction_id]() {
                 this->request_device_to_stop_transaction(transaction_id);
                 auto signed_meter_value =
-                    types::powermeter::SignedMeterValue{fetch_ocmf_result(transaction_id), "", "OCMF"};
+                    types::units_signed::SignedMeterValue{fetch_ocmf_result(transaction_id), "", "OCMF"};
                 return types::powermeter::TransactionStopResponse{types::powermeter::TransactionRequestStatus::OK,
                                                                   signed_meter_value};
             },

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -257,11 +257,13 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received ChargingPausedEV";
         this->charge_point->on_suspend_charging_ev(ocpp_connector_id);
-    } else if (session_event.event == types::evse_manager::SessionEventEnum::ChargingPausedEVSE or session_event.event == types::evse_manager::SessionEventEnum::WaitingForEnergy) {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::ChargingPausedEVSE or
+               session_event.event == types::evse_manager::SessionEventEnum::WaitingForEnergy) {
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received ChargingPausedEVSE";
         this->charge_point->on_suspend_charging_evse(ocpp_connector_id);
-    } else if (session_event.event == types::evse_manager::SessionEventEnum::ChargingStarted || session_event.event == types::evse_manager::SessionEventEnum::ChargingResumed) {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::ChargingStarted ||
+               session_event.event == types::evse_manager::SessionEventEnum::ChargingResumed) {
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received ChargingResumed";
         this->charge_point->on_resume_charging(ocpp_connector_id);

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -247,8 +247,14 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
         if (transaction_started.reservation_id) {
             reservation_id_opt.emplace(transaction_started.reservation_id.value());
         }
+        std::optional<std::string> signed_meter_data;
+        if (signed_meter_value.has_value()) {
+            // there is no specified way of transmitting signing method, encoding method and public key
+            // this has to be negotiated beforehand or done in a custom data transfer
+            signed_meter_data.emplace(signed_meter_value.value().signed_meter_data);
+        }
         this->charge_point->on_transaction_started(ocpp_connector_id, session_event.uuid, id_token, energy_Wh_import,
-                                                   reservation_id_opt, timestamp, signed_meter_value);
+                                                   reservation_id_opt, timestamp, signed_meter_data);
     } else if (event == "ChargingPausedEV") {
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received ChargingPausedEV";
@@ -274,8 +280,14 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
         if (transaction_finished.id_tag.has_value()) {
             id_tag_opt.emplace(ocpp::CiString<20>(transaction_finished.id_tag.value().id_token));
         }
+        std::optional<std::string> signed_meter_data;
+        if (signed_meter_value.has_value()) {
+            // there is no specified way of transmitting signing method, encoding method and public key
+            // this has to be negotiated beforehand or done in a custom data transfer
+            signed_meter_data.emplace(signed_meter_value.value().signed_meter_data);
+        }
         this->charge_point->on_transaction_stopped(ocpp_connector_id, session_event.uuid, reason, timestamp,
-                                                   energy_Wh_import, id_tag_opt, signed_meter_value);
+                                                   energy_Wh_import, id_tag_opt, signed_meter_data);
         // always triggered by libocpp
     } else if (event == "SessionStarted") {
         EVLOG_info << "Connector#" << ocpp_connector_id << ": "

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -222,18 +222,16 @@ void OCPP::publish_charging_schedules(
 }
 
 void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::SessionEvent& session_event) {
-    auto event = types::evse_manager::session_event_enum_to_string(session_event.event);
-
     auto everest_connector_id = session_event.connector_id.value_or(1);
     auto ocpp_connector_id = this->evse_connector_map[evse_id][everest_connector_id];
 
-    if (event == "Enabled") {
+    if (session_event.event == types::evse_manager::SessionEventEnum::Enabled) {
         this->charge_point->on_enabled(evse_id);
-    } else if (event == "Disabled") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::Disabled) {
         EVLOG_debug << "EVSE#" << evse_id << ": "
                     << "Received Disabled";
         this->charge_point->on_disabled(evse_id);
-    } else if (event == "TransactionStarted") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::TransactionStarted) {
         EVLOG_info << "EVSE#" << evse_id << ": "
                    << "Received TransactionStarted";
         const auto transaction_started = session_event.transaction_started.value();
@@ -255,19 +253,19 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
         }
         this->charge_point->on_transaction_started(ocpp_connector_id, session_event.uuid, id_token, energy_Wh_import,
                                                    reservation_id_opt, timestamp, signed_meter_data);
-    } else if (event == "ChargingPausedEV") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::ChargingPausedEV) {
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received ChargingPausedEV";
         this->charge_point->on_suspend_charging_ev(ocpp_connector_id);
-    } else if (event == "ChargingPausedEVSE" or event == "WaitingForEnergy") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::ChargingPausedEVSE or session_event.event == types::evse_manager::SessionEventEnum::WaitingForEnergy) {
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received ChargingPausedEVSE";
         this->charge_point->on_suspend_charging_evse(ocpp_connector_id);
-    } else if (event == "ChargingStarted" || event == "ChargingResumed") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::ChargingStarted || session_event.event == types::evse_manager::SessionEventEnum::ChargingResumed) {
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received ChargingResumed";
         this->charge_point->on_resume_charging(ocpp_connector_id);
-    } else if (event == "TransactionFinished") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::TransactionFinished) {
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received TransactionFinished";
         const auto transaction_finished = session_event.transaction_finished.value();
@@ -289,7 +287,7 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
         this->charge_point->on_transaction_stopped(ocpp_connector_id, session_event.uuid, reason, timestamp,
                                                    energy_Wh_import, id_tag_opt, signed_meter_data);
         // always triggered by libocpp
-    } else if (event == "SessionStarted") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::SessionStarted) {
         EVLOG_info << "Connector#" << ocpp_connector_id << ": "
                    << "Received SessionStarted";
         // ev side disconnect
@@ -297,29 +295,28 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
         this->charge_point->on_session_started(ocpp_connector_id, session_event.uuid,
                                                get_session_started_reason(session_started.reason),
                                                session_started.logging_path);
-    } else if (event == "SessionFinished") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::SessionFinished) {
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received SessionFinished";
         // ev side disconnect
         this->charge_point->on_session_stopped(ocpp_connector_id, session_event.uuid);
-    } else if (event == "Error") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::Error) {
         EVLOG_debug << "Connector#" << ocpp_connector_id << ": "
                     << "Received Error";
         const auto error_info = get_error_info(session_event.error);
         this->charge_point->on_error(ocpp_connector_id, error_info.ocpp_error_code, error_info.info,
                                      error_info.vendor_id, error_info.vendor_error_code);
-    } else if (event == "AllErrorsCleared") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::AllErrorsCleared) {
         this->charge_point->on_fault(ocpp_connector_id, ocpp::v16::ChargePointErrorCode::NoError);
-    } else if (event == "PermanentFault") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::PermanentFault) {
         const auto error_info = get_error_info(session_event.error);
         this->charge_point->on_fault(ocpp_connector_id, error_info.ocpp_error_code, error_info.info,
                                      error_info.vendor_id, error_info.vendor_error_code);
-    } else if (event == "ReservationStart") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::ReservationStart) {
         this->charge_point->on_reservation_start(ocpp_connector_id);
-    } else if (event == "ReservationEnd") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::ReservationEnd) {
         this->charge_point->on_reservation_end(ocpp_connector_id);
-    } else if (event == "ReservationAuthtokenMismatch") {
-    } else if (event == "PluginTimeout") {
+    } else if (session_event.event == types::evse_manager::SessionEventEnum::PluginTimeout) {
         this->charge_point->on_plugin_timeout(ocpp_connector_id);
     }
 }

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -140,16 +140,16 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
     meter_value.timestamp = ocpp::DateTime(power_meter.timestamp);
 
     // signed_meter_value is intended for OCMF style blobs of signed meter value reports during transaction start or end
-    // this is added to Energy.Active.Import.Register
-
-    // Energy.Active.Import.Register
+    // This is interpreted as Energy.Active.Import.Register
     ocpp::v201::SampledValue sampled_value = get_sampled_value(
         reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register, "Wh", std::nullopt);
     sampled_value.value = power_meter.energy_Wh_import.total;
     // add signedMeterValue if present
     if (signed_meter_value.has_value()) {
-        const auto& energy_Wh_import_signed = signed_meter_value.value();
-        sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed);
+        sampled_value.signedMeterValue = get_signed_meter_value(signed_meter_value.value());
+    }
+    meter_value.sampledValue.push_back(sampled_value);
+
     // individual signed meter values can be provided by the power_meter itself
 
     // Energy.Active.Import.Register

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -889,7 +889,6 @@ void OCPP201::ready() {
                     get_meter_value(transaction_started.meter_value, ocpp::v201::ReadingContextEnum::Transaction_Begin,
                                     transaction_started.signed_meter_value);
                 const auto session_id = session_event.uuid;
-                const auto signed_meter_value = transaction_started.signed_meter_value;
                 const auto reservation_id = transaction_started.reservation_id;
                 const auto remote_start_id = transaction_started.id_tag.request_id;
 
@@ -989,8 +988,8 @@ void OCPP201::ready() {
         });
 
         evse->subscribe_powermeter([this, evse_id](const types::powermeter::Powermeter& power_meter) {
-            const auto meter_value =
-                get_meter_value(power_meter, ocpp::v201::ReadingContextEnum::Sample_Periodic, std::nullopt);
+            const auto meter_value = get_meter_value(power_meter, ocpp::v201::ReadingContextEnum::Sample_Periodic,
+                                                     power_meter.signed_meter_value);
             this->charge_point->on_meter_value(evse_id, meter_value);
         });
 

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -150,6 +150,14 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
     if (signed_meter_value.has_value()) {
         const auto& energy_Wh_import_signed = signed_meter_value.value();
         sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed);
+    // individual signed meter values can be provided by the power_meter itself
+
+    // Energy.Active.Import.Register
+    if (power_meter.energy_Wh_import_signed.has_value()) {
+        const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
+        if (energy_Wh_import_signed.total.has_value()) {
+            sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.total.value());
+        }
     }
     meter_value.sampledValue.push_back(sampled_value);
 
@@ -157,18 +165,36 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
                                           "Wh", ocpp::v201::PhaseEnum::L1);
         sampled_value.value = power_meter.energy_Wh_import.L1.value();
+        if (power_meter.energy_Wh_import_signed.has_value()) {
+            const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
+            if (energy_Wh_import_signed.L1.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.L1.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
     }
     if (power_meter.energy_Wh_import.L2.has_value()) {
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
                                           "Wh", ocpp::v201::PhaseEnum::L2);
         sampled_value.value = power_meter.energy_Wh_import.L2.value();
+        if (power_meter.energy_Wh_import_signed.has_value()) {
+            const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
+            if (energy_Wh_import_signed.L2.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.L2.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
     }
     if (power_meter.energy_Wh_import.L3.has_value()) {
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
                                           "Wh", ocpp::v201::PhaseEnum::L3);
         sampled_value.value = power_meter.energy_Wh_import.L3.value();
+        if (power_meter.energy_Wh_import_signed.has_value()) {
+            const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
+            if (energy_Wh_import_signed.L3.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.L3.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
     }
 
@@ -177,23 +203,47 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         auto sampled_value = get_sampled_value(
             reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register, "Wh", std::nullopt);
         sampled_value.value = power_meter.energy_Wh_export.value().total;
+        if (power_meter.energy_Wh_export_signed.has_value()) {
+            const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
+            if (energy_Wh_export_signed.total.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.total.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.energy_Wh_export.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_import.L1.value();
+            if (power_meter.energy_Wh_export_signed.has_value()) {
+                const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
+                if (energy_Wh_export_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.energy_Wh_export.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_import.L2.value();
+            if (power_meter.energy_Wh_export_signed.has_value()) {
+                const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
+                if (energy_Wh_export_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.energy_Wh_export.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_import.L3.value();
+            if (power_meter.energy_Wh_export_signed.has_value()) {
+                const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
+                if (energy_Wh_export_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -203,23 +253,47 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         auto sampled_value =
             get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W", std::nullopt);
         sampled_value.value = power_meter.power_W.value().total;
+        if (power_meter.power_W_signed.has_value()) {
+            const auto& power_W_signed = power_meter.power_W_signed.value();
+            if (power_W_signed.total.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.total.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.power_W.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_import.L1.value();
+            if (power_meter.power_W_signed.has_value()) {
+                const auto& power_W_signed = power_meter.power_W_signed.value();
+                if (power_W_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.power_W.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_import.L2.value();
+            if (power_meter.power_W_signed.has_value()) {
+                const auto& power_W_signed = power_meter.power_W_signed.value();
+                if (power_W_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.power_W.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_import.L3.value();
+            if (power_meter.power_W_signed.has_value()) {
+                const auto& power_W_signed = power_meter.power_W_signed.value();
+                if (power_W_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -229,23 +303,47 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         auto sampled_value =
             get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var", std::nullopt);
         sampled_value.value = power_meter.VAR.value().total;
+        if (power_meter.VAR_signed.has_value()) {
+            const auto& VAR_signed = power_meter.VAR_signed.value();
+            if (VAR_signed.total.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.total.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.VAR.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_import.L1.value();
+            if (power_meter.VAR_signed.has_value()) {
+                const auto& VAR_signed = power_meter.VAR_signed.value();
+                if (VAR_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.VAR.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_import.L2.value();
+            if (power_meter.VAR_signed.has_value()) {
+                const auto& VAR_signed = power_meter.VAR_signed.value();
+                if (VAR_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.VAR.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_import.L3.value();
+            if (power_meter.VAR_signed.has_value()) {
+                const auto& VAR_signed = power_meter.VAR_signed.value();
+                if (VAR_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -258,30 +356,60 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.current_A.value().L1.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.current_A.value().L2.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.current_A.value().L3.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().DC.has_value()) {
             sampled_value =
                 get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A", std::nullopt);
             sampled_value.value = power_meter.current_A.value().DC.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.DC.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.DC.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().N.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::N);
             sampled_value.value = power_meter.current_A.value().N.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.N.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.N.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -292,23 +420,47 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
                                               ocpp::v201::PhaseEnum::L1_N);
             sampled_value.value = power_meter.voltage_V.value().L1.value();
+            if (power_meter.voltage_V_signed.has_value()) {
+                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
+                if (voltage_V_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
                                               ocpp::v201::PhaseEnum::L2_N);
             sampled_value.value = power_meter.voltage_V.value().L2.value();
+            if (power_meter.voltage_V_signed.has_value()) {
+                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
+                if (voltage_V_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
                                               ocpp::v201::PhaseEnum::L3_N);
             sampled_value.value = power_meter.voltage_V.value().L3.value();
+            if (power_meter.voltage_V_signed.has_value()) {
+                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
+                if (voltage_V_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().DC.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V", std::nullopt);
             sampled_value.value = power_meter.voltage_V.value().DC.value();
+            if (power_meter.voltage_V_signed.has_value()) {
+                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
+                if (voltage_V_signed.DC.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.DC.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -140,18 +140,16 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
     meter_value.timestamp = ocpp::DateTime(power_meter.timestamp);
 
     // signed_meter_value is intended for OCMF style blobs of signed meter value reports during transaction start or end
-    // individual signed meter values can be provided by the power_meter itself
+    // this is added to Energy.Active.Import.Register
 
     // Energy.Active.Import.Register
     ocpp::v201::SampledValue sampled_value = get_sampled_value(
         reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register, "Wh", std::nullopt);
     sampled_value.value = power_meter.energy_Wh_import.total;
     // add signedMeterValue if present
-    if (power_meter.energy_Wh_import_signed.has_value()) {
-        const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
-        if (energy_Wh_import_signed.total.has_value()) {
-            sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.total.value());
-        }
+    if (signed_meter_value.has_value()) {
+        const auto& energy_Wh_import_signed = signed_meter_value.value();
+        sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed);
     }
     meter_value.sampledValue.push_back(sampled_value);
 
@@ -159,36 +157,18 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
                                           "Wh", ocpp::v201::PhaseEnum::L1);
         sampled_value.value = power_meter.energy_Wh_import.L1.value();
-        if (power_meter.energy_Wh_import_signed.has_value()) {
-            const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
-            if (energy_Wh_import_signed.L1.has_value()) {
-                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.L1.value());
-            }
-        }
         meter_value.sampledValue.push_back(sampled_value);
     }
     if (power_meter.energy_Wh_import.L2.has_value()) {
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
                                           "Wh", ocpp::v201::PhaseEnum::L2);
         sampled_value.value = power_meter.energy_Wh_import.L2.value();
-        if (power_meter.energy_Wh_import_signed.has_value()) {
-            const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
-            if (energy_Wh_import_signed.L2.has_value()) {
-                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.L2.value());
-            }
-        }
         meter_value.sampledValue.push_back(sampled_value);
     }
     if (power_meter.energy_Wh_import.L3.has_value()) {
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
                                           "Wh", ocpp::v201::PhaseEnum::L3);
         sampled_value.value = power_meter.energy_Wh_import.L3.value();
-        if (power_meter.energy_Wh_import_signed.has_value()) {
-            const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
-            if (energy_Wh_import_signed.L3.has_value()) {
-                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.L3.value());
-            }
-        }
         meter_value.sampledValue.push_back(sampled_value);
     }
 
@@ -197,47 +177,23 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         auto sampled_value = get_sampled_value(
             reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register, "Wh", std::nullopt);
         sampled_value.value = power_meter.energy_Wh_export.value().total;
-        if (power_meter.energy_Wh_export_signed.has_value()) {
-            const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
-            if (energy_Wh_export_signed.total.has_value()) {
-                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.total.value());
-            }
-        }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.energy_Wh_export.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_import.L1.value();
-            if (power_meter.energy_Wh_export_signed.has_value()) {
-                const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
-                if (energy_Wh_export_signed.L1.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.L1.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.energy_Wh_export.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_import.L2.value();
-            if (power_meter.energy_Wh_export_signed.has_value()) {
-                const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
-                if (energy_Wh_export_signed.L2.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.L2.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.energy_Wh_export.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_import.L3.value();
-            if (power_meter.energy_Wh_export_signed.has_value()) {
-                const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
-                if (energy_Wh_export_signed.L3.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.L3.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -247,47 +203,23 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         auto sampled_value =
             get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W", std::nullopt);
         sampled_value.value = power_meter.power_W.value().total;
-        if (power_meter.power_W_signed.has_value()) {
-            const auto& power_W_signed = power_meter.power_W_signed.value();
-            if (power_W_signed.total.has_value()) {
-                sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.total.value());
-            }
-        }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.power_W.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_import.L1.value();
-            if (power_meter.power_W_signed.has_value()) {
-                const auto& power_W_signed = power_meter.power_W_signed.value();
-                if (power_W_signed.L1.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.L1.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.power_W.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_import.L2.value();
-            if (power_meter.power_W_signed.has_value()) {
-                const auto& power_W_signed = power_meter.power_W_signed.value();
-                if (power_W_signed.L2.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.L2.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.power_W.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_import.L3.value();
-            if (power_meter.power_W_signed.has_value()) {
-                const auto& power_W_signed = power_meter.power_W_signed.value();
-                if (power_W_signed.L3.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.L3.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -297,47 +229,23 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         auto sampled_value =
             get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var", std::nullopt);
         sampled_value.value = power_meter.VAR.value().total;
-        if (power_meter.VAR_signed.has_value()) {
-            const auto& VAR_signed = power_meter.VAR_signed.value();
-            if (VAR_signed.total.has_value()) {
-                sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.total.value());
-            }
-        }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.VAR.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_import.L1.value();
-            if (power_meter.VAR_signed.has_value()) {
-                const auto& VAR_signed = power_meter.VAR_signed.value();
-                if (VAR_signed.L1.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.L1.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.VAR.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_import.L2.value();
-            if (power_meter.VAR_signed.has_value()) {
-                const auto& VAR_signed = power_meter.VAR_signed.value();
-                if (VAR_signed.L2.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.L2.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.VAR.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_import.L3.value();
-            if (power_meter.VAR_signed.has_value()) {
-                const auto& VAR_signed = power_meter.VAR_signed.value();
-                if (VAR_signed.L3.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.L3.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -350,60 +258,30 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.current_A.value().L1.value();
-            if (power_meter.current_A_signed.has_value()) {
-                const auto& current_A_signed = power_meter.current_A_signed.value();
-                if (current_A_signed.L1.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.L1.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.current_A.value().L2.value();
-            if (power_meter.current_A_signed.has_value()) {
-                const auto& current_A_signed = power_meter.current_A_signed.value();
-                if (current_A_signed.L2.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.L2.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.current_A.value().L3.value();
-            if (power_meter.current_A_signed.has_value()) {
-                const auto& current_A_signed = power_meter.current_A_signed.value();
-                if (current_A_signed.L3.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.L3.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().DC.has_value()) {
             sampled_value =
                 get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A", std::nullopt);
             sampled_value.value = power_meter.current_A.value().DC.value();
-            if (power_meter.current_A_signed.has_value()) {
-                const auto& current_A_signed = power_meter.current_A_signed.value();
-                if (current_A_signed.DC.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.DC.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().N.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::N);
             sampled_value.value = power_meter.current_A.value().N.value();
-            if (power_meter.current_A_signed.has_value()) {
-                const auto& current_A_signed = power_meter.current_A_signed.value();
-                if (current_A_signed.N.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.N.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -414,47 +292,23 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
                                               ocpp::v201::PhaseEnum::L1_N);
             sampled_value.value = power_meter.voltage_V.value().L1.value();
-            if (power_meter.voltage_V_signed.has_value()) {
-                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
-                if (voltage_V_signed.L1.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.L1.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
                                               ocpp::v201::PhaseEnum::L2_N);
             sampled_value.value = power_meter.voltage_V.value().L2.value();
-            if (power_meter.voltage_V_signed.has_value()) {
-                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
-                if (voltage_V_signed.L2.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.L2.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
                                               ocpp::v201::PhaseEnum::L3_N);
             sampled_value.value = power_meter.voltage_V.value().L3.value();
-            if (power_meter.voltage_V_signed.has_value()) {
-                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
-                if (voltage_V_signed.L3.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.L3.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().DC.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V", std::nullopt);
             sampled_value.value = power_meter.voltage_V.value().DC.value();
-            if (power_meter.voltage_V_signed.has_value()) {
-                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
-                if (voltage_V_signed.DC.has_value()) {
-                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.DC.value());
-                }
-            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -139,8 +139,8 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
     ocpp::v201::MeterValue meter_value;
     meter_value.timestamp = ocpp::DateTime(power_meter.timestamp);
 
-    // signed_meter_value is for OCMF style blobs of signed meter value reports during transaction start or end
-    // individual signed meter values are provided by the power_meter itself
+    // signed_meter_value is intended for OCMF style blobs of signed meter value reports during transaction start or end
+    // individual signed meter values can be provided by the power_meter itself
 
     // Energy.Active.Import.Register
     ocpp::v201::SampledValue sampled_value = get_sampled_value(
@@ -150,30 +150,45 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
     if (power_meter.energy_Wh_import_signed.has_value()) {
         const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
         if (energy_Wh_import_signed.total.has_value()) {
-            const auto& energy_Wh_import_signed_total = energy_Wh_import_signed.total.value();
-            sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed_total);
+            sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.total.value());
         }
     }
-
-    // TODO(kai): add all other possible signed meter values
-
     meter_value.sampledValue.push_back(sampled_value);
+
     if (power_meter.energy_Wh_import.L1.has_value()) {
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
                                           "Wh", ocpp::v201::PhaseEnum::L1);
         sampled_value.value = power_meter.energy_Wh_import.L1.value();
+        if (power_meter.energy_Wh_import_signed.has_value()) {
+            const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
+            if (energy_Wh_import_signed.L1.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.L1.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
     }
     if (power_meter.energy_Wh_import.L2.has_value()) {
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
                                           "Wh", ocpp::v201::PhaseEnum::L2);
         sampled_value.value = power_meter.energy_Wh_import.L2.value();
+        if (power_meter.energy_Wh_import_signed.has_value()) {
+            const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
+            if (energy_Wh_import_signed.L2.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.L2.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
     }
     if (power_meter.energy_Wh_import.L3.has_value()) {
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
                                           "Wh", ocpp::v201::PhaseEnum::L3);
         sampled_value.value = power_meter.energy_Wh_import.L3.value();
+        if (power_meter.energy_Wh_import_signed.has_value()) {
+            const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
+            if (energy_Wh_import_signed.L3.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.L3.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
     }
 
@@ -182,23 +197,47 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         auto sampled_value = get_sampled_value(
             reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register, "Wh", std::nullopt);
         sampled_value.value = power_meter.energy_Wh_export.value().total;
+        if (power_meter.energy_Wh_export_signed.has_value()) {
+            const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
+            if (energy_Wh_export_signed.total.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.total.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.energy_Wh_export.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_import.L1.value();
+            if (power_meter.energy_Wh_export_signed.has_value()) {
+                const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
+                if (energy_Wh_export_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.energy_Wh_export.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_import.L2.value();
+            if (power_meter.energy_Wh_export_signed.has_value()) {
+                const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
+                if (energy_Wh_export_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.energy_Wh_export.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_import.L3.value();
+            if (power_meter.energy_Wh_export_signed.has_value()) {
+                const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
+                if (energy_Wh_export_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_export_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -208,23 +247,47 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         auto sampled_value =
             get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W", std::nullopt);
         sampled_value.value = power_meter.power_W.value().total;
+        if (power_meter.power_W_signed.has_value()) {
+            const auto& power_W_signed = power_meter.power_W_signed.value();
+            if (power_W_signed.total.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.total.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.power_W.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_import.L1.value();
+            if (power_meter.power_W_signed.has_value()) {
+                const auto& power_W_signed = power_meter.power_W_signed.value();
+                if (power_W_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.power_W.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_import.L2.value();
+            if (power_meter.power_W_signed.has_value()) {
+                const auto& power_W_signed = power_meter.power_W_signed.value();
+                if (power_W_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.power_W.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_import.L3.value();
+            if (power_meter.power_W_signed.has_value()) {
+                const auto& power_W_signed = power_meter.power_W_signed.value();
+                if (power_W_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(power_W_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -234,23 +297,47 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         auto sampled_value =
             get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var", std::nullopt);
         sampled_value.value = power_meter.VAR.value().total;
+        if (power_meter.VAR_signed.has_value()) {
+            const auto& VAR_signed = power_meter.VAR_signed.value();
+            if (VAR_signed.total.has_value()) {
+                sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.total.value());
+            }
+        }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.VAR.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_import.L1.value();
+            if (power_meter.VAR_signed.has_value()) {
+                const auto& VAR_signed = power_meter.VAR_signed.value();
+                if (VAR_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.VAR.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_import.L2.value();
+            if (power_meter.VAR_signed.has_value()) {
+                const auto& VAR_signed = power_meter.VAR_signed.value();
+                if (VAR_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.VAR.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_import.L3.value();
+            if (power_meter.VAR_signed.has_value()) {
+                const auto& VAR_signed = power_meter.VAR_signed.value();
+                if (VAR_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(VAR_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -263,30 +350,60 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::L1);
             sampled_value.value = power_meter.current_A.value().L1.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::L2);
             sampled_value.value = power_meter.current_A.value().L2.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::L3);
             sampled_value.value = power_meter.current_A.value().L3.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().DC.has_value()) {
             sampled_value =
                 get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A", std::nullopt);
             sampled_value.value = power_meter.current_A.value().DC.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.DC.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.DC.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().N.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
                                               ocpp::v201::PhaseEnum::N);
             sampled_value.value = power_meter.current_A.value().N.value();
+            if (power_meter.current_A_signed.has_value()) {
+                const auto& current_A_signed = power_meter.current_A_signed.value();
+                if (current_A_signed.N.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(current_A_signed.N.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }
@@ -297,23 +414,47 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
                                               ocpp::v201::PhaseEnum::L1_N);
             sampled_value.value = power_meter.voltage_V.value().L1.value();
+            if (power_meter.voltage_V_signed.has_value()) {
+                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
+                if (voltage_V_signed.L1.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.L1.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
                                               ocpp::v201::PhaseEnum::L2_N);
             sampled_value.value = power_meter.voltage_V.value().L2.value();
+            if (power_meter.voltage_V_signed.has_value()) {
+                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
+                if (voltage_V_signed.L2.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.L2.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
                                               ocpp::v201::PhaseEnum::L3_N);
             sampled_value.value = power_meter.voltage_V.value().L3.value();
+            if (power_meter.voltage_V_signed.has_value()) {
+                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
+                if (voltage_V_signed.L3.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.L3.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().DC.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V", std::nullopt);
             sampled_value.value = power_meter.voltage_V.value().DC.value();
+            if (power_meter.voltage_V_signed.has_value()) {
+                const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
+                if (voltage_V_signed.DC.has_value()) {
+                    sampled_value.signedMeterValue = get_signed_meter_value(voltage_V_signed.DC.value());
+                }
+            }
             meter_value.sampledValue.push_back(sampled_value);
         }
     }

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -123,7 +123,7 @@ ocpp::v201::SampledValue get_sampled_value(const ocpp::v201::ReadingContextEnum&
     return sampled_value;
 }
 
-ocpp::v201::SignedMeterValue get_signed_meter_value(const types::powermeter::SignedMeterValue& signed_meter_value) {
+ocpp::v201::SignedMeterValue get_signed_meter_value(const types::units_signed::SignedMeterValue& signed_meter_value) {
     ocpp::v201::SignedMeterValue ocpp_signed_meter_value;
     ocpp_signed_meter_value.signedMeterData = signed_meter_value.signed_meter_data;
     ocpp_signed_meter_value.signingMethod = signed_meter_value.signing_method;
@@ -135,7 +135,7 @@ ocpp::v201::SignedMeterValue get_signed_meter_value(const types::powermeter::Sig
 
 ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& power_meter,
                                        const ocpp::v201::ReadingContextEnum& reading_context,
-                                       const std::optional<types::powermeter::SignedMeterValue> signed_meter_value) {
+                                       const std::optional<types::units_signed::SignedMeterValue> signed_meter_value) {
     ocpp::v201::MeterValue meter_value;
     meter_value.timestamp = ocpp::DateTime(power_meter.timestamp);
 

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -215,7 +215,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.energy_Wh_export.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L1);
-            sampled_value.value = power_meter.energy_Wh_import.L1.value();
+            sampled_value.value = power_meter.energy_Wh_export.L1.value();
             if (power_meter.energy_Wh_export_signed.has_value()) {
                 const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
                 if (energy_Wh_export_signed.L1.has_value()) {
@@ -227,7 +227,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.energy_Wh_export.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L2);
-            sampled_value.value = power_meter.energy_Wh_import.L2.value();
+            sampled_value.value = power_meter.energy_Wh_export.L2.value();
             if (power_meter.energy_Wh_export_signed.has_value()) {
                 const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
                 if (energy_Wh_export_signed.L2.has_value()) {
@@ -239,7 +239,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.energy_Wh_export.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L3);
-            sampled_value.value = power_meter.energy_Wh_import.L3.value();
+            sampled_value.value = power_meter.energy_Wh_export.L3.value();
             if (power_meter.energy_Wh_export_signed.has_value()) {
                 const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
                 if (energy_Wh_export_signed.L3.has_value()) {
@@ -265,7 +265,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.power_W.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L1);
-            sampled_value.value = power_meter.energy_Wh_import.L1.value();
+            sampled_value.value = power_meter.power_W.L1.value();
             if (power_meter.power_W_signed.has_value()) {
                 const auto& power_W_signed = power_meter.power_W_signed.value();
                 if (power_W_signed.L1.has_value()) {
@@ -277,7 +277,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.power_W.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L2);
-            sampled_value.value = power_meter.energy_Wh_import.L2.value();
+            sampled_value.value = power_meter.power_W.L2.value();
             if (power_meter.power_W_signed.has_value()) {
                 const auto& power_W_signed = power_meter.power_W_signed.value();
                 if (power_W_signed.L2.has_value()) {
@@ -289,7 +289,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.power_W.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L3);
-            sampled_value.value = power_meter.energy_Wh_import.L3.value();
+            sampled_value.value = power_meter.power_W.L3.value();
             if (power_meter.power_W_signed.has_value()) {
                 const auto& power_W_signed = power_meter.power_W_signed.value();
                 if (power_W_signed.L3.has_value()) {
@@ -315,7 +315,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.VAR.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L1);
-            sampled_value.value = power_meter.energy_Wh_import.L1.value();
+            sampled_value.value = power_meter.VAR.value().L1.value();
             if (power_meter.VAR_signed.has_value()) {
                 const auto& VAR_signed = power_meter.VAR_signed.value();
                 if (VAR_signed.L1.has_value()) {
@@ -327,7 +327,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.VAR.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L2);
-            sampled_value.value = power_meter.energy_Wh_import.L2.value();
+            sampled_value.value = power_meter.VAR.value().L2.value();
             if (power_meter.VAR_signed.has_value()) {
                 const auto& VAR_signed = power_meter.VAR_signed.value();
                 if (VAR_signed.L2.has_value()) {
@@ -339,7 +339,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.VAR.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import, "var",
                                               ocpp::v201::PhaseEnum::L3);
-            sampled_value.value = power_meter.energy_Wh_import.L3.value();
+            sampled_value.value = power_meter.VAR.value().L3.value();
             if (power_meter.VAR_signed.has_value()) {
                 const auto& VAR_signed = power_meter.VAR_signed.value();
                 if (VAR_signed.L3.has_value()) {

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -154,12 +154,14 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
 
     // Energy.Active.Import.Register
     if (power_meter.energy_Wh_import_signed.has_value()) {
+        sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
+                                          "Wh", std::nullopt);
         const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
         if (energy_Wh_import_signed.total.has_value()) {
             sampled_value.signedMeterValue = get_signed_meter_value(energy_Wh_import_signed.total.value());
         }
+        meter_value.sampledValue.push_back(sampled_value);
     }
-    meter_value.sampledValue.push_back(sampled_value);
 
     if (power_meter.energy_Wh_import.L1.has_value()) {
         sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -215,7 +215,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.energy_Wh_export.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L1);
-            sampled_value.value = power_meter.energy_Wh_export.L1.value();
+            sampled_value.value = power_meter.energy_Wh_export.value().L1.value();
             if (power_meter.energy_Wh_export_signed.has_value()) {
                 const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
                 if (energy_Wh_export_signed.L1.has_value()) {
@@ -227,7 +227,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.energy_Wh_export.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L2);
-            sampled_value.value = power_meter.energy_Wh_export.L2.value();
+            sampled_value.value = power_meter.energy_Wh_export.value().L2.value();
             if (power_meter.energy_Wh_export_signed.has_value()) {
                 const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
                 if (energy_Wh_export_signed.L2.has_value()) {
@@ -239,7 +239,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.energy_Wh_export.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register,
                                               "Wh", ocpp::v201::PhaseEnum::L3);
-            sampled_value.value = power_meter.energy_Wh_export.L3.value();
+            sampled_value.value = power_meter.energy_Wh_export.value().L3.value();
             if (power_meter.energy_Wh_export_signed.has_value()) {
                 const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
                 if (energy_Wh_export_signed.L3.has_value()) {
@@ -265,7 +265,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.power_W.value().L1.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L1);
-            sampled_value.value = power_meter.power_W.L1.value();
+            sampled_value.value = power_meter.power_W.value().L1.value();
             if (power_meter.power_W_signed.has_value()) {
                 const auto& power_W_signed = power_meter.power_W_signed.value();
                 if (power_W_signed.L1.has_value()) {
@@ -277,7 +277,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.power_W.value().L2.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L2);
-            sampled_value.value = power_meter.power_W.L2.value();
+            sampled_value.value = power_meter.power_W.value().L2.value();
             if (power_meter.power_W_signed.has_value()) {
                 const auto& power_W_signed = power_meter.power_W_signed.value();
                 if (power_W_signed.L2.has_value()) {
@@ -289,7 +289,7 @@ ocpp::v201::MeterValue get_meter_value(const types::powermeter::Powermeter& powe
         if (power_meter.power_W.value().L3.has_value()) {
             sampled_value = get_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
                                               ocpp::v201::PhaseEnum::L3);
-            sampled_value.value = power_meter.power_W.L3.value();
+            sampled_value.value = power_meter.power_W.value().L3.value();
             if (power_meter.power_W_signed.has_value()) {
                 const auto& power_W_signed = power_meter.power_W_signed.value();
                 if (power_W_signed.L3.has_value()) {

--- a/modules/PowermeterBSM/main/powermeterImpl.cpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.cpp
@@ -44,8 +44,9 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
         transport::DataVector data = transport->fetch(known_model::BSM_OCMF_CurrentSnapshot);
 
         bsm::SignedOCMFSnapshot signed_snapshot(data);
+        auto signed_meter_value = types::powermeter::SignedMeterValue{signed_snapshot.O(), "OCMF", "OCMF"};
 
-        return {types::powermeter::TransactionRequestStatus::OK, signed_snapshot.O()};
+        return {types::powermeter::TransactionRequestStatus::OK, signed_meter_value};
 
     } catch (const std::runtime_error& e) {
         EVLOG_error << __PRETTY_FUNCTION__ << " Error: " << e.what() << std::endl;

--- a/modules/PowermeterBSM/main/powermeterImpl.cpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.cpp
@@ -44,7 +44,7 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
         transport::DataVector data = transport->fetch(known_model::BSM_OCMF_CurrentSnapshot);
 
         bsm::SignedOCMFSnapshot signed_snapshot(data);
-        auto signed_meter_value = types::powermeter::SignedMeterValue{signed_snapshot.O(), "OCMF", "OCMF"};
+        auto signed_meter_value = types::powermeter::SignedMeterValue{signed_snapshot.O(), "", "OCMF"};
 
         return {types::powermeter::TransactionRequestStatus::OK, signed_meter_value};
 

--- a/modules/PowermeterBSM/main/powermeterImpl.cpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.cpp
@@ -44,7 +44,7 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
         transport::DataVector data = transport->fetch(known_model::BSM_OCMF_CurrentSnapshot);
 
         bsm::SignedOCMFSnapshot signed_snapshot(data);
-        auto signed_meter_value = types::powermeter::SignedMeterValue{signed_snapshot.O(), "", "OCMF"};
+        auto signed_meter_value = types::units_signed::SignedMeterValue{signed_snapshot.O(), "", "OCMF"};
 
         return {types::powermeter::TransactionRequestStatus::OK, signed_meter_value};
 

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -193,7 +193,7 @@ types:
         type: object
         $ref: /powermeter#/Powermeter
       signed_meter_value:
-        description: The signed meter value report of the started transation
+        description: The signed meter value report of the started transaction
         type: object
         $ref: /units_signed#/SignedMeterValue
       reservation_id:
@@ -216,7 +216,7 @@ types:
         type: object
         $ref: /powermeter#/Powermeter
       signed_meter_value:
-        description: The signed meter value report of the stopped transation
+        description: The signed meter value report of the stopped transaction
         type: object
         $ref: /units_signed#/SignedMeterValue
       reason:

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -193,8 +193,9 @@ types:
         type: object
         $ref: /powermeter#/Powermeter
       signed_meter_value:
-        description: Signed meter value
-        type: string
+        description: The signed meter value report of the started transation
+        type: object
+        $ref: /powermeter#/SignedMeterValue
       reservation_id:
         description: Id of the reservation
         type: integer
@@ -215,8 +216,9 @@ types:
         type: object
         $ref: /powermeter#/Powermeter
       signed_meter_value:
-        description: Signed meter value
-        type: string
+        description: The signed meter value report of the stopped transation
+        type: object
+        $ref: /powermeter#/SignedMeterValue
       reason:
         description: Reason for stopping transaction
         type: string

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -195,7 +195,7 @@ types:
       signed_meter_value:
         description: The signed meter value report of the started transation
         type: object
-        $ref: /powermeter#/SignedMeterValue
+        $ref: /units_signed#/SignedMeterValue
       reservation_id:
         description: Id of the reservation
         type: integer
@@ -218,7 +218,7 @@ types:
       signed_meter_value:
         description: The signed meter value report of the stopped transation
         type: object
-        $ref: /powermeter#/SignedMeterValue
+        $ref: /units_signed#/SignedMeterValue
       reason:
         description: Reason for stopping transaction
         type: string

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -1,5 +1,26 @@
 description: Powermeter types
 types:
+  SignedMeterValue:
+    description: Representation of a signed meter value
+    type: object
+    additionalProperties: false
+    required:
+      - signed_meter_data
+      - signing_method
+      - encoding_method
+    properties:
+      signed_meter_data:
+        description: Base64 encoded signed meter data
+        type: string
+      signing_method:
+        description: Method used to create the signature
+        type: string
+      encoding_method:
+        description: Method used to encode the meter values before signing them
+        type: string
+      public_key:
+        description: Base64 encoded public key
+        type: string
   TransactionReq:
     description: Required input parameter for starting an OCMF transaction. These values will be included in the signed OCMF packet.
     type: object
@@ -68,9 +89,10 @@ types:
       status:
         description: Response status that indicates whether the transaction stop request could successfully be performed.
         $ref: /powermeter#/TransactionRequestStatus
-      ocmf:
+      signed_meter_value:
         description: The signed OCMF report of the stopped transaction. Must be provided if status is OK.
-        type: string
+        type: object
+        $ref: /powermeter#/SignedMeterValue
       error:
         description: If status is not OK, a verbose error message.
         type: string
@@ -122,3 +144,7 @@ types:
         description: Grid frequency in Hertz
         type: object
         $ref: /units#/Frequency
+      signed_meter_value:
+        description: Signed instantaneous meter values if supported by the meter
+        type: object
+        $ref: /powermeter#/SignedMeterValue

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -80,7 +80,7 @@ types:
         type: string
         format: date-time
   TransactionStopResponse:
-    description: Report returned when a OCMF transaction is requested to stop. If successful, includes the signed OCMF string. In case of an error, an additional error message can be provided.
+    description: Report returned when a signed transaction is requested to stop. If successful, includes the signed meter value object. In case of an error, an additional error message can be provided.
     type: object
     additionalProperties: false
     required:
@@ -90,7 +90,7 @@ types:
         description: Response status that indicates whether the transaction stop request could successfully be performed.
         $ref: /powermeter#/TransactionRequestStatus
       signed_meter_value:
-        description: The signed OCMF report of the stopped transaction. Must be provided if status is OK.
+        description: The signed meter value report of the stopped transaction. Must be provided if status is OK.
         type: object
         $ref: /powermeter#/SignedMeterValue
       error:

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -123,36 +123,37 @@ types:
         description: Grid frequency in Hertz
         type: object
         $ref: /units#/Frequency
-      energy_Wh_import_signed:
-        description: Imported energy in Wh (from grid)
-        type: object
-        $ref: /units_signed#/Energy
-      energy_Wh_export_signed:
-        description: Exported energy in Wh (to grid)
-        type: object
-        $ref: /units_signed#/Energy
-      power_W_signed:
-        description:
-          Instantaneous power in Watt. Negative values are exported, positive
-          values imported Energy.
-        type: object
-        $ref: /units_signed#/Power
-      voltage_V_signed:
-        description: Voltage in Volts
-        type: object
-        $ref: /units_signed#/Voltage
-      VAR_signed:
-        description: Reactive power VAR
-        type: object
-        $ref: /units_signed#/ReactivePower
-      current_A_signed:
-        description: Current in ampere
-        type: object
-        $ref: /units_signed#/Current
-      frequency_Hz_signed:
-        description: Grid frequency in Hertz
-        type: object
-        $ref: /units_signed#/Frequency
+      # Possible extension for individual signed meter values
+      # energy_Wh_import_signed:
+      #   description: Imported energy in Wh (from grid)
+      #   type: object
+      #   $ref: /units_signed#/Energy
+      # energy_Wh_export_signed:
+      #   description: Exported energy in Wh (to grid)
+      #   type: object
+      #   $ref: /units_signed#/Energy
+      # power_W_signed:
+      #   description:
+      #     Instantaneous power in Watt. Negative values are exported, positive
+      #     values imported Energy.
+      #   type: object
+      #   $ref: /units_signed#/Power
+      # voltage_V_signed:
+      #   description: Voltage in Volts
+      #   type: object
+      #   $ref: /units_signed#/Voltage
+      # VAR_signed:
+      #   description: Reactive power VAR
+      #   type: object
+      #   $ref: /units_signed#/ReactivePower
+      # current_A_signed:
+      #   description: Current in ampere
+      #   type: object
+      #   $ref: /units_signed#/Current
+      # frequency_Hz_signed:
+      #   description: Grid frequency in Hertz
+      #   type: object
+      #   $ref: /units_signed#/Frequency
       signed_meter_value:
         description: >-
           Signed collection of instantaneous meter values if supported by the meter.

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -154,6 +154,8 @@ types:
         type: object
         $ref: /units_signed#/Frequency
       signed_meter_value:
-        description: Signed instantaneous meter values if supported by the meter
+        description: >-
+          Signed collection of instantaneous meter values if supported by the meter.
+          This is intended for meters that only support signing a collection of meter values.
         type: object
         $ref: /units_signed#/SignedMeterValue

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -1,26 +1,5 @@
 description: Powermeter types
 types:
-  SignedMeterValue:
-    description: Representation of a signed meter value
-    type: object
-    additionalProperties: false
-    required:
-      - signed_meter_data
-      - signing_method
-      - encoding_method
-    properties:
-      signed_meter_data:
-        description: Base64 encoded signed meter data
-        type: string
-      signing_method:
-        description: Method used to create the signature
-        type: string
-      encoding_method:
-        description: Method used to encode the meter values before signing them
-        type: string
-      public_key:
-        description: Base64 encoded public key
-        type: string
   TransactionReq:
     description: Required input parameter for starting an OCMF transaction. These values will be included in the signed OCMF packet.
     type: object
@@ -92,7 +71,7 @@ types:
       signed_meter_value:
         description: The signed meter value report of the stopped transaction. Must be provided if status is OK.
         type: object
-        $ref: /powermeter#/SignedMeterValue
+        $ref: /units_signed#/SignedMeterValue
       error:
         description: If status is not OK, a verbose error message.
         type: string
@@ -144,7 +123,37 @@ types:
         description: Grid frequency in Hertz
         type: object
         $ref: /units#/Frequency
+      energy_Wh_import_signed:
+        description: Imported energy in Wh (from grid)
+        type: object
+        $ref: /units_signed#/Energy
+      energy_Wh_export_signed:
+        description: Exported energy in Wh (to grid)
+        type: object
+        $ref: /units_signed#/Energy
+      power_W_signed:
+        description:
+          Instantaneous power in Watt. Negative values are exported, positive
+          values imported Energy.
+        type: object
+        $ref: /units_signed#/Power
+      voltage_V_signed:
+        description: Voltage in Volts
+        type: object
+        $ref: /units_signed#/Voltage
+      VAR_signed:
+        description: Reactive power VAR
+        type: object
+        $ref: /units_signed#/ReactivePower
+      current_A_signed:
+        description: Current in ampere
+        type: object
+        $ref: /units_signed#/Current
+      frequency_Hz_signed:
+        description: Grid frequency in Hertz
+        type: object
+        $ref: /units_signed#/Frequency
       signed_meter_value:
         description: Signed instantaneous meter values if supported by the meter
         type: object
-        $ref: /powermeter#/SignedMeterValue
+        $ref: /units_signed#/SignedMeterValue

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -123,37 +123,37 @@ types:
         description: Grid frequency in Hertz
         type: object
         $ref: /units#/Frequency
-      # Possible extension for individual signed meter values
-      # energy_Wh_import_signed:
-      #   description: Imported energy in Wh (from grid)
-      #   type: object
-      #   $ref: /units_signed#/Energy
-      # energy_Wh_export_signed:
-      #   description: Exported energy in Wh (to grid)
-      #   type: object
-      #   $ref: /units_signed#/Energy
-      # power_W_signed:
-      #   description:
-      #     Instantaneous power in Watt. Negative values are exported, positive
-      #     values imported Energy.
-      #   type: object
-      #   $ref: /units_signed#/Power
-      # voltage_V_signed:
-      #   description: Voltage in Volts
-      #   type: object
-      #   $ref: /units_signed#/Voltage
-      # VAR_signed:
-      #   description: Reactive power VAR
-      #   type: object
-      #   $ref: /units_signed#/ReactivePower
-      # current_A_signed:
-      #   description: Current in ampere
-      #   type: object
-      #   $ref: /units_signed#/Current
-      # frequency_Hz_signed:
-      #   description: Grid frequency in Hertz
-      #   type: object
-      #   $ref: /units_signed#/Frequency
+      # Extension for individual signed meter values
+      energy_Wh_import_signed:
+        description: Imported energy in Wh (from grid)
+        type: object
+        $ref: /units_signed#/Energy
+      energy_Wh_export_signed:
+        description: Exported energy in Wh (to grid)
+        type: object
+        $ref: /units_signed#/Energy
+      power_W_signed:
+        description:
+          Instantaneous power in Watt. Negative values are exported, positive
+          values imported Energy.
+        type: object
+        $ref: /units_signed#/Power
+      voltage_V_signed:
+        description: Voltage in Volts
+        type: object
+        $ref: /units_signed#/Voltage
+      VAR_signed:
+        description: Reactive power VAR
+        type: object
+        $ref: /units_signed#/ReactivePower
+      current_A_signed:
+        description: Current in ampere
+        type: object
+        $ref: /units_signed#/Current
+      frequency_Hz_signed:
+        description: Grid frequency in Hertz
+        type: object
+        $ref: /units_signed#/Frequency
       signed_meter_value:
         description: >-
           Signed collection of instantaneous meter values if supported by the meter.

--- a/types/units_signed.yaml
+++ b/types/units_signed.yaml
@@ -1,0 +1,155 @@
+description: Unit types
+types:
+  SignedMeterValue:
+    description: Representation of a signed meter value
+    type: object
+    additionalProperties: false
+    required:
+      - signed_meter_data
+      - signing_method
+      - encoding_method
+    properties:
+      signed_meter_data:
+        description: Signed meter data (encoded in a string representation with eg. Base64)
+        type: string
+      signing_method:
+        description: Method used to create the signature
+        type: string
+      encoding_method:
+        description: Method used to encode the meter values before signing them
+        type: string
+      public_key:
+        description: Public key (encoded in a string representation with eg. Base64)
+        type: string
+      timestamp:
+        description: Timestamp of measurement
+        type: string
+        format: date-time
+  Current:
+    description: Current in Ampere
+    type: object
+    additionalProperties: false
+    properties:
+      DC:
+        description: DC current
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L1:
+        description: AC L1 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L2:
+        description: AC L2 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L3:
+        description: AC L3 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      N:
+        description: AC Neutral value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+  Voltage:
+    description: Voltage in Volt
+    type: object
+    additionalProperties: false
+    properties:
+      DC:
+        description: DC voltage
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L1:
+        description: AC L1 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L2:
+        description: AC L2 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L3:
+        description: AC L3 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+  Frequency:
+    description: "AC only: Frequency in Hertz"
+    type: object
+    additionalProperties: false
+    properties:
+      L1:
+        description: AC L1 value
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L2:
+        description: AC L2 value
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L3:
+        description: AC L3 value
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+  Power:
+    description:
+      Instantaneous power in Watt. Negative values are exported, positive
+      values imported Energy.
+    type: object
+    additionalProperties: false
+    properties:
+      total:
+        description: DC / AC Sum value
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L1:
+        description: AC L1 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L2:
+        description: AC L2 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L3:
+        description: AC L3 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+  Energy:
+    description: Energy in Wh.
+    type: object
+    additionalProperties: false
+    properties:
+      total:
+        description: DC / AC Sum value (which is relevant for billing)
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L1:
+        description: AC L1 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L2:
+        description: AC L2 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L3:
+        description: AC L3 value only
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+  ReactivePower:
+    description: Reactive power VAR
+    type: object
+    additionalProperties: false
+    properties:
+      total:
+        description: VAR total
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L1:
+        description: VAR phase A
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L2:
+        description: VAR phase B
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      L3:
+        description: VAR phase C
+        type: object
+        $ref: /units_signed#/SignedMeterValue


### PR DESCRIPTION
This allows the encapsulation of additionaly metadata like the signing method, encoding method or the public key next to the signed meter data