### PR TITLE
OCPP module: Add sorting to get_variables ocpp_generic interface implementation

### DIFF
--- a/interfaces/ocpp.yaml
+++ b/interfaces/ocpp.yaml
@@ -48,7 +48,7 @@ cmds:
           $ref: /ocpp#/GetVariableRequest
     result:
       description: >-
-        List of GetVariableResult containing the result for every requested value. Does not guarantee preservation of order!
+        List of GetVariableResult containing the result for every requested value. Preserves the order of the input requests.
       type: array
       items:
         type: object


### PR DESCRIPTION
The order in get_variables request in the OCPP interface shall be preserved  to simplify downstream handling of the interface.