### PR TITLE
Move step install everest-testing to github workflow

### DIFF
--- a/.ci/build-kit/test_and_install.sh
+++ b/.ci/build-kit/test_and_install.sh
@@ -3,8 +3,8 @@
 # ninja -j$(nproc) -C build tests
 ninja -j$(nproc) -C build install
 
-# install everestpy via cmake target from everest-framework
-ninja -C build everestpy_pip_install_dist
+# install everest testing by cmake target to make sure using the version defined in dependencies.yaml
+ninja -C build install_everest_testing
 
 rsync -a "$EXT_MOUNT/source/tests" ./
 

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Build, Lint and Test
 on:
   pull_request: {}
   workflow_dispatch:
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build, Lint and Test
     runs-on: ${{ inputs.runner || 'ubuntu-22.04' }}
     steps:
       - name: Format branch name for cache key
@@ -45,7 +45,7 @@ jobs:
         run: |
           mkdir scripts
           rsync -a source/.ci/build-kit/ scripts
-      - name: Pull docker container
+      - name: Pull build-kit image
         run: |
           docker pull --quiet ghcr.io/everest/build-kit-alpine:latest
           docker image tag ghcr.io/everest/build-kit-alpine:latest build-kit
@@ -55,15 +55,15 @@ jobs:
           --volume "$(pwd):/ext" \
           --name compile-container \
           build-kit run-script compile
-      - name: Unit tests and install
+      - name: Create integration-image
         run: |
           docker commit compile-container build-image
           docker run \
           --volume "$(pwd):/ext" \
           --name test-container \
           build-image run-script test_and_install
+          docker commit test-container integration-image
       - name: Run integration tests
         run: |
-          docker commit test-container integration-image
           pushd source/.ci/e2e
           docker-compose run e2e-test-server run-script tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ add_custom_target(install_everest_testing
              ${PYTHON_EXECUTABLE} -m pip install "${CPM_PACKAGE_everest-utils_SOURCE_DIR}/everest-testing" \;
         fi\;
     DEPENDS
-        everestpy_pip_install_dist iso15118_pip_install_dist iso15118_requirements_pip_install_dist
+        everestpy_pip_install_dist
     COMMENT
         "Installing dependencies for testing EVerest"
 )


### PR DESCRIPTION
* Remove dependency to iso15118_pip_install_dist, since it isn't needed in most cases
* Refactor name fields of github workflow
* Use `install_everest_testing` instead of `everestpy_pip_install_dist` to make sure using the corresponding everest-testing version in ci