### PR TITLE
Bugfix/fix legacy wakeup sequence

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -414,6 +414,15 @@ void Charger::runStateMachine() {
                 }
             }
 
+            if (!hlc_charging_active && !legacy_wakeup_done && timeInCurrentState > legacy_wakeup_timeout) {
+                session_log.evse(
+                    false, "EV did not transition to state C, trying one legacy wakeup according to IEC61851-1 A.5.3");
+                legacy_wakeup_done = true;
+                t_step_EF_returnState = EvseState::PrepareCharging;
+                t_step_EF_returnPWM = ampereToDutyCycle(getMaxCurrent());
+                currentState = EvseState::T_step_EF;
+            }
+
             // if (charge_mode == ChargeMode::DC) {
             //  DC: wait until car requests power on CP (B->C/D).
             //  Then we close contactor and wait for instructions from HLC.
@@ -455,18 +464,6 @@ void Charger::runStateMachine() {
                     // update PWM if it has changed and 5 seconds have passed since last update
                     if (!hlc_use_5percent_current_session)
                         update_pwm_max_every_5seconds(ampereToDutyCycle(getMaxCurrent()));
-                }
-
-                // If we are in charging for some time now, but relais did not close something is wrong.
-                // Try a T_step_EF to restart charging once (legacy wakeup according to IEC61851-1 A.5.3)
-                if (!hlc_charging_active && !legacy_wakeup_done && timeInCurrentState > legacy_wakeup_timeout &&
-                    !contactors_closed) {
-                    session_log.evse(
-                        false, "Relais not closed after timeout, trying legacy wakeup according to IEC61851-1 A.5.3");
-                    legacy_wakeup_done = true;
-                    t_step_EF_returnState = EvseState::Charging;
-                    t_step_EF_returnPWM = ampereToDutyCycle(getMaxCurrent());
-                    currentState = EvseState::T_step_EF;
                 }
             }
             break;


### PR DESCRIPTION
The previous version was implemented wrong. In AC basic charging, if PWM is enabled in PrepareCharging (CP state B) and the EV does not transition to state C within 30s, a T_step_EF legacy wake up sequence is tried once. We cannot distinguish whether the EV does not want to start charging of it is stuck in a deep sleep mode. So we try to wake it up once and if that does not help we do not try again until the EV is unplugged (we assume it does not want to start charging then)