### PR TITLE
OCPP Module / Generic OCPP  interface: Add command for internal availability change request

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -41,7 +41,7 @@ libcurl:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: "7865283"
+  git_tag: "a6cd837"
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git

--- a/interfaces/ocpp.yaml
+++ b/interfaces/ocpp.yaml
@@ -73,6 +73,21 @@ cmds:
       items:
         type: object
         $ref: /ocpp#/SetVariableResult
+  change_availability:
+    description: >-
+      Allows to send a ChangeAvailabilityRequest internally (as can be done by the CSMS).
+    arguments:
+      request:
+        description: >-
+          The ChangeAvailabilityRequest as specified in OCPP2.0.1.
+          For OCPP 1.6:
+        type: object
+        $ref: /ocpp#/ChangeAvailabilityRequest
+    result:
+      description: >-
+        Response to ChangeAvailabilityRequest as specified in OCPP 2.0.1
+      type: object
+      $ref: /ocpp#/ChangeAvailabilityResponse
   monitor_variables:
     description: >-
       Command to start monitoring the given ComponentVariable(s). Any of the provided

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -747,4 +747,8 @@ void OCPP::ready() {
     }
 }
 
+int32_t OCPP::get_ocpp_connector_id(int32_t evse_id, int32_t connector_id) {
+    return this->evse_connector_map.at(evse_id).at(connector_id);
+}
+
 } // namespace module

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -134,7 +134,7 @@ private:
     void init_evse_ready_map();
     EvseConnectorMap evse_connector_map; // provides access to OCPP connector id by using EVerests evse and connector id
     std::map<int32_t, int32_t>
-        connector_evse_index_map; // provides access to r_evse_manager index by using OCPP connector id
+        connector_evse_index_map;        // provides access to r_evse_manager index by using OCPP connector id
     std::map<int32_t, bool> evse_ready_map;
     std::mutex evse_ready_mutex;
     std::condition_variable evse_ready_cv;

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -108,6 +108,9 @@ public:
     std::unique_ptr<ocpp::v16::ChargePoint> charge_point;
     std::unique_ptr<Everest::SteadyTimer> charging_schedules_timer;
     bool ocpp_stopped = false;
+
+    // Return the OCPP connector id from a pair of EVerest EVSE id and connector id
+    int32_t get_ocpp_connector_id(int32_t evse_id, int32_t connector_id);
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -131,7 +131,7 @@ private:
     void init_evse_ready_map();
     EvseConnectorMap evse_connector_map; // provides access to OCPP connector id by using EVerests evse and connector id
     std::map<int32_t, int32_t>
-        connector_evse_index_map;        // provides access to r_evse_manager index by using OCPP connector id
+        connector_evse_index_map; // provides access to r_evse_manager index by using OCPP connector id
     std::map<int32_t, bool> evse_ready_map;
     std::mutex evse_ready_mutex;
     std::condition_variable evse_ready_cv;

--- a/modules/OCPP/ocpp_generic/ocppImpl.cpp
+++ b/modules/OCPP/ocpp_generic/ocppImpl.cpp
@@ -228,7 +228,7 @@ void ocppImpl::handle_monitor_variables(std::vector<types::ocpp::ComponentVariab
             [this, cv](const ocpp::v16::KeyValue key_value) {
                 types::ocpp::EventData event_data;
                 event_data.component_variable = cv;
-                event_data.event_id = 0; // irrelevant for OCPP1.6
+                event_data.event_id = 0;                                      // irrelevant for OCPP1.6
                 event_data.timestamp = ocpp::DateTime();
                 event_data.trigger = types::ocpp::EventTriggerEnum::Alerting; // default for OCPP1.6
                 event_data.actual_value = key_value.value.value_or("");

--- a/modules/OCPP/ocpp_generic/ocppImpl.hpp
+++ b/modules/OCPP/ocpp_generic/ocppImpl.hpp
@@ -15,20 +15,6 @@
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
 
-namespace module::ocpp_generic {
-class InputParsingException : public std::exception {
-public:
-    const char* what() {
-        return this->reason.c_str();
-    }
-
-    explicit InputParsingException(std::string reason) : reason(std::move(reason)) {
-    }
-
-private:
-    std::string reason;
-};
-} // namespace module::ocpp_generic
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {

--- a/modules/OCPP/ocpp_generic/ocppImpl.hpp
+++ b/modules/OCPP/ocpp_generic/ocppImpl.hpp
@@ -14,6 +14,21 @@
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
+
+namespace module::ocpp_generic {
+class InputParsingException : public std::exception {
+public:
+    const char* what() {
+        return this->reason.c_str();
+    }
+
+    explicit InputParsingException(std::string reason) : reason(std::move(reason)) {
+    }
+
+private:
+    std::string reason;
+};
+} // namespace module::ocpp_generic
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {
@@ -40,6 +55,8 @@ protected:
     handle_get_variables(std::vector<types::ocpp::GetVariableRequest>& requests) override;
     virtual std::vector<types::ocpp::SetVariableResult>
     handle_set_variables(std::vector<types::ocpp::SetVariableRequest>& requests) override;
+    virtual types::ocpp::ChangeAvailabilityResponse
+    handle_change_availability(types::ocpp::ChangeAvailabilityRequest& request) override;
     virtual void handle_monitor_variables(std::vector<types::ocpp::ComponentVariable>& component_variables) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1

--- a/types/ocpp.yaml
+++ b/types/ocpp.yaml
@@ -411,3 +411,65 @@ types:
       variable_monitoring_id:
         description: Identifies the VariableMonitoring which triggered the event
         type: integer
+  OperationalStatusEnumType:
+    description: >-
+      Operational status of Charging Station /EVSE / Connector
+    type: string
+    enum:
+      - Inoperative
+      - Operative
+  ChangeAvailabilityRequest:
+    description: Request type to change the availability of the Charging Station/ an EVSE / a Connector.
+    type: object
+    required:
+      - operationalStatus
+    properties:
+      operationalStatus:
+        description: Type of availability change that the Charging Station should perform.
+        type: string
+        $ref: /ocpp#/OperationalStatusEnumType
+      evse:
+        description: >-
+          Specify EVSE/Connector whose status is changed. When omitted, the
+          message refers to the Charging Station as a whole.
+        type: object
+        $ref: /ocpp#/EVSE
+  ChangeAvailabilityStatusEnumType:
+    description: >-
+      Status returned in response to ChangeAvailabilityRequest.
+    type: string
+    enum:
+      - Accepted
+      - Rejected
+      - Scheduled
+  StatusInfoType:
+    description: >-
+      Element providing more information about the status.
+    type: object
+    required:
+      - reasonCode
+    properties:
+      reasonCode:
+        description: >-
+          A predefined code for the reason why the status is returned in this response. 
+          The string is case-insensitive.
+        type: string
+      additionalInfo:
+        description: >-
+          Additional text to provide detailed information
+        type: string
+  ChangeAvailabilityResponse:
+    description: Response type to request to change the availability of the Charging Station/ an EVSE / a Connector.
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        description: Indicates whether the Charging Station is able to perform the availability change.
+        type: string
+        $ref: /ocpp#/ChangeAvailabilityStatusEnumType
+      statusInfo:
+        description: Detailed status information.
+        type: object
+        $ref: /ocpp#/StatusInfoType
+

--- a/types/ocpp.yaml
+++ b/types/ocpp.yaml
@@ -422,9 +422,9 @@ types:
     description: Request type to change the availability of the Charging Station/ an EVSE / a Connector.
     type: object
     required:
-      - operationalStatus
+      - operational_status
     properties:
-      operationalStatus:
+      operational_status:
         description: Type of availability change that the Charging Station should perform.
         type: string
         $ref: /ocpp#/OperationalStatusEnumType
@@ -447,14 +447,14 @@ types:
       Element providing more information about the status.
     type: object
     required:
-      - reasonCode
+      - reason_code
     properties:
-      reasonCode:
+      reason_code:
         description: >-
           A predefined code for the reason why the status is returned in this response. 
           The string is case-insensitive.
         type: string
-      additionalInfo:
+      additional_info:
         description: >-
           Additional text to provide detailed information
         type: string
@@ -468,7 +468,7 @@ types:
         description: Indicates whether the Charging Station is able to perform the availability change.
         type: string
         $ref: /ocpp#/ChangeAvailabilityStatusEnumType
-      statusInfo:
+      status_info:
         description: Detailed status information.
         type: object
         $ref: /ocpp#/StatusInfoType


### PR DESCRIPTION

Adds a `change_availability` command to the generic OCPP interface; adds the implementation to the OCPP 1.6 module.

Requires changes in libocpp: https://github.com/EVerest/libocpp/pull/358 (until then marked as draft)

