### PR TITLE
Add powermeter transaction error type, clear on unplug

### DIFF
--- a/errors/evse_manager.yaml
+++ b/errors/evse_manager.yaml
@@ -9,3 +9,5 @@ errors:
     description: Internal error of the state machine
   - name: MREC4OverCurrentFailure
     description: Over current event
+  - name: PowermeterTransactionStartFailed
+    description: Transaction could not be started at the powermeter

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -156,6 +156,7 @@ void Charger::runStateMachine() {
                 pwm_off();
                 DeAuthorize();
                 transaction_active = false;
+                clear_errors_on_unplug();
             }
             break;
 
@@ -1461,6 +1462,12 @@ void Charger::graceful_stop_charging() {
     if (contactors_closed) {
         bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
     }
+}
+
+void Charger::clear_errors_on_unplug() {
+    error_handling->clear_overcurrent_error();
+    error_handling->clear_internal_error();
+    error_handling->clear_powermeter_transaction_start_failed_error();
 }
 
 } // namespace module

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -330,6 +330,8 @@ private:
     // As per IEC61851-1 A.5.3
     bool legacy_wakeup_done{false};
     constexpr static int legacy_wakeup_timeout{30000};
+
+    void clear_errors_on_unplug();
 };
 
 #define CHARGER_ABSOLUTE_MAX_CURRENT double(80.0F)

--- a/modules/EvseManager/ErrorHandling.hpp
+++ b/modules/EvseManager/ErrorHandling.hpp
@@ -64,6 +64,7 @@ struct ActiveErrors {
     struct evse_manager_errors {
         std::atomic_bool MREC4OverCurrentFailure{false};
         std::atomic_bool Internal{false};
+        std::atomic_bool PowermeterTransactionStartFailed{false};
     } evse_manager;
 
     struct ac_rcd_errors {
@@ -92,11 +93,11 @@ struct ActiveErrors {
                    bsp.MREC17EVSEContactorFault or bsp.MREC19CableOverTempStop or bsp.MREC20PartialInsertion or
                    bsp.MREC23ProximityFault or bsp.MREC24ConnectorVoltageHigh or bsp.MREC25BrokenLatch or
                    bsp.MREC26CutCable or evse_manager.MREC4OverCurrentFailure or evse_manager.Internal or
-                   ac_rcd.MREC2GroundFailure or ac_rcd.VendorError or ac_rcd.Selftest or ac_rcd.AC or ac_rcd.DC or
-                   connector_lock.ConnectorLockCapNotCharged or connector_lock.ConnectorLockUnexpectedOpen or
-                   connector_lock.ConnectorLockUnexpectedClose or connector_lock.ConnectorLockFailedLock or
-                   connector_lock.ConnectorLockFailedUnlock or connector_lock.MREC1ConnectorLockFailure or
-                   connector_lock.VendorError);
+                   evse_manager.PowermeterTransactionStartFailed or ac_rcd.MREC2GroundFailure or ac_rcd.VendorError or
+                   ac_rcd.Selftest or ac_rcd.AC or ac_rcd.DC or connector_lock.ConnectorLockCapNotCharged or
+                   connector_lock.ConnectorLockUnexpectedOpen or connector_lock.ConnectorLockUnexpectedClose or
+                   connector_lock.ConnectorLockFailedLock or connector_lock.ConnectorLockFailedUnlock or
+                   connector_lock.MREC1ConnectorLockFailure or connector_lock.VendorError);
     }
 };
 
@@ -118,6 +119,9 @@ public:
 
     void raise_internal_error(const std::string& description);
     void clear_internal_error();
+
+    void raise_powermeter_transaction_start_failed_error(const std::string& description);
+    void clear_powermeter_transaction_start_failed_error();
 
 private:
     const std::unique_ptr<evse_board_supportIntf>& r_bsp;


### PR DESCRIPTION
- Clears internal Charger errors on unplug
- Creates new error type that can be used by PR440 for powermeter start transaction errors