### PR TITLE
Changed type of id_tag of TransactionFinished and StopTransactionRequest types from string to ProvidedIdToken 

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -41,7 +41,7 @@ libcurl:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.9.6
+  git_tag: 8114bce
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -111,7 +111,7 @@ TokenHandlingResult AuthHandler::handle_token(const ProvidedIdToken& provided_to
         if (connector_used_for_transaction != -1) {
             StopTransactionRequest req;
             req.reason = StopTransactionReason::Local;
-            req.id_tag.emplace(provided_token.id_token);
+            req.id_tag.emplace(provided_token);
             this->stop_transaction_callback(this->connectors.at(connector_used_for_transaction)->evse_index, req);
             EVLOG_info << "Transaction was stopped because id_token was used for transaction";
             return TokenHandlingResult::USED_TO_STOP_TRANSACTION;
@@ -154,7 +154,7 @@ TokenHandlingResult AuthHandler::handle_token(const ProvidedIdToken& provided_to
                     } else {
                         StopTransactionRequest req;
                         req.reason = StopTransactionReason::Local;
-                        req.id_tag.emplace(provided_token.id_token);
+                        req.id_tag.emplace(provided_token);
                         this->stop_transaction_callback(this->connectors.at(connector_used_for_transaction)->evse_index,
                                                         req);
                         EVLOG_info << "Transaction was stopped because parent_id_token was used for transaction";

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -924,7 +924,7 @@ bool Charger::cancelTransaction(const types::evse_manager::StopTransactionReques
         transaction_active = false;
         last_stop_transaction_reason = request.reason;
         if (request.id_tag) {
-            stop_transaction_id_tag = request.id_tag.value();
+            stop_transaction_id_token = request.id_tag.value();
         }
         signalEvent(types::evse_manager::SessionEventEnum::ChargingFinished);
         signalEvent(types::evse_manager::SessionEventEnum::TransactionFinished);
@@ -963,7 +963,7 @@ void Charger::stopSession() {
 
 void Charger::startTransaction() {
     std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    stop_transaction_id_tag.clear();
+    stop_transaction_id_token.reset();
     transaction_active = true;
     signalEvent(types::evse_manager::SessionEventEnum::TransactionStarted);
 }
@@ -976,9 +976,9 @@ void Charger::stopTransaction() {
     signalEvent(types::evse_manager::SessionEventEnum::TransactionFinished);
 }
 
-std::string Charger::getStopTransactionIdTag() {
+std::optional<types::authorization::ProvidedIdToken> Charger::getStopTransactionIdToken() {
     std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    return stop_transaction_id_tag;
+    return stop_transaction_id_token;
 }
 
 types::evse_manager::StopTransactionReason Charger::getTransactionFinishedReason() {

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -88,6 +88,7 @@ public:
     void Authorize(bool a, const types::authorization::ProvidedIdToken& token);
     bool DeAuthorize();
     types::authorization::ProvidedIdToken getIdToken();
+    std::optional<types::authorization::ProvidedIdToken> getStopTransactionIdToken();
 
     bool Authorized_PnC();
     bool Authorized_EIM();
@@ -107,7 +108,6 @@ public:
 
     bool cancelTransaction(const types::evse_manager::StopTransactionRequest&
                                request); // cancel transaction ahead of time when car is still plugged
-    std::string getStopTransactionIdTag();
     types::evse_manager::StopTransactionReason getTransactionFinishedReason(); // get reason for last finished event
     types::evse_manager::StartSessionReason getSessionStartedReason(); // get reason for last session start event
 
@@ -214,7 +214,6 @@ private:
     bool transactionActive();
     bool transaction_active;
     bool session_active;
-    std::string stop_transaction_id_tag;
     types::evse_manager::StopTransactionReason last_stop_transaction_reason;
     types::evse_manager::StartSessionReason last_start_session_reason;
 
@@ -270,6 +269,8 @@ private:
     bool authorized_pnc;
 
     types::authorization::ProvidedIdToken id_token;
+    std::optional<types::authorization::ProvidedIdToken>
+        stop_transaction_id_token; // only set in case transaction was stopped locally
 
     // AC or DC
     ChargeMode charge_mode{0};

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -218,12 +218,8 @@ void evse_managerImpl::ready() {
             transaction_finished.meter_value = mod->get_latest_powermeter_data_billing();
 
             auto reason = mod->charger->getTransactionFinishedReason();
-            const auto id_tag = mod->charger->getStopTransactionIdTag();
-
             transaction_finished.reason.emplace(reason);
-            if (!id_tag.empty()) {
-                transaction_finished.id_tag.emplace(id_tag);
-            }
+            transaction_finished.id_tag = mod->charger->getStopTransactionIdToken();
 
             double energy_import = transaction_finished.meter_value.energy_Wh_import.total;
 

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -191,8 +191,8 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
             types::evse_manager::stop_transaction_reason_to_string(transaction_finished.reason.value()));
         const auto signed_meter_value = transaction_finished.signed_meter_value;
         std::optional<ocpp::CiString<20>> id_tag_opt = std::nullopt;
-        if (transaction_finished.id_tag) {
-            id_tag_opt.emplace(ocpp::CiString<20>(transaction_finished.id_tag.value()));
+        if (transaction_finished.id_tag.has_value()) {
+            id_tag_opt.emplace(ocpp::CiString<20>(transaction_finished.id_tag.value().id_token));
         }
         this->charge_point->on_transaction_stopped(ocpp_connector_id, session_event.uuid, reason, timestamp,
                                                    energy_Wh_import, id_tag_opt, signed_meter_value);

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -13,8 +13,9 @@ types:
         type: string
         $ref: /evse_manager#/StopTransactionReason
       id_tag:
-        description: Id tag that was used to stop the transaction.
-        type: string
+        description: Id tag that was used to stop the transaction. Only present if transaction was stopped locally.
+        type: object
+        $ref: /authorization#/ProvidedIdToken
   StopTransactionReason:
     description: >-
       Reason for stopping transaction
@@ -219,8 +220,9 @@ types:
         type: string
         $ref: /evse_manager#/StopTransactionReason
       id_tag:
-        description: Id tag that was used to stop the transaction
-        type: string
+        description: Id tag that was used to stop the transaction. Only present if transaction was stopped locally.
+        type: object
+        $ref: /authorization#/ProvidedIdToken
   ErrorEnum:
     description: >-
       Note this is only kept for compatibility with the legacy error handling and will be removed soon.


### PR DESCRIPTION
Changed type of id_tag of TransactionFinished and StopTransactionRequest types from string to ProvidedIdToken in order to be able to use the additional data in OCPP2.0.1 TransactionEvent(Ended) request.

libocpp companion PR: https://github.com/EVerest/libocpp/pull/388

Requires update to dependency.yaml once libocpp release is present