### PR TITLE
OCPP201: Default IdTokenEnum::Local

### DIFF
--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -496,6 +496,8 @@ ocpp::v201::IdToken get_id_token(const types::authorization::ProvidedIdToken& pr
     id_token.idToken = provided_id_token.id_token;
     if (provided_id_token.id_token_type.has_value()) {
         id_token.type = get_id_token_enum(provided_id_token.id_token_type.value());
+    } else {
+        id_token.type = ocpp::v201::IdTokenEnum::Local;
     }
     return id_token;
 }


### PR DESCRIPTION
adding default IdTokenEnum::Local in case id_token_type of ProvidedIdToken is not set.

id_token_type is not required in ProvidedIdToken but is required in OCPP Type IdToken, so we need a default.