### PR TITLE
EnergyManager: fix memory bug when multiple Nodes are used

### DIFF
--- a/modules/EnergyManager/Market.cpp
+++ b/modules/EnergyManager/Market.cpp
@@ -268,7 +268,7 @@ void Market::get_list_of_evses(std::vector<Market*>& list) {
         list.push_back(this);
     }
 
-    for (auto child : _children) {
+    for (auto& child : _children) {
         child.get_list_of_evses(list);
     }
 }


### PR DESCRIPTION
When multiple energy Nodes were used in the tree, a use after free memory bug was triggered.