### PR TITLE
EvseManager Charger: simply locking

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -1061,9 +1061,9 @@ void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& tok
     std::scoped_lock lock(state_machine_mutex);
     if (a) {
         // First user interaction was auth? Then start session already here and not at plug in
-        if (not session_active)
+        if (not session_active) {
             start_session(true);
-
+        }
         authorized = true;
         authorized_pnc = token.authorization_type == types::authorization::AuthorizationType::PlugAndCharge;
         id_token = token;

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -249,7 +249,7 @@ void Charger::run_state_machine() {
                     start_transaction();
                 }
 
-                const EvseState targetState(EvseState::PrepareCharging);
+                const EvseState target_state(EvseState::PrepareCharging);
 
                 // EIM done and matching process not started -> we need to go through t_step_EF and fall back to nominal
                 // PWM. This is a complete waste of 4 precious seconds.
@@ -261,7 +261,7 @@ void Charger::run_state_machine() {
                                 false, "AC mode, HLC enabled(ac_enforce_hlc), keeping 5 percent on until a dlink error "
                                        "is signalled.");
                             hlc_use_5percent_current_session = true;
-                            current_state = targetState;
+                            current_state = target_state;
                         } else {
                             if (not get_matching_started()) {
                                 // SLAC matching was not started when EIM arrived
@@ -275,7 +275,7 @@ void Charger::run_state_machine() {
 
                                 // Figure 3 of ISO15118-3: 5 percent start, PnC and EIM
                                 // Figure 4 of ISO15118-3: X1 start, PnC and EIM
-                                t_step_EF_return_state = targetState;
+                                t_step_EF_return_state = target_state;
                                 t_step_EF_return_pwm = 0.;
                                 // fall back to nominal PWM after the t_step_EF break. Note that
                                 // ac_hlc_enabled_current_session remains untouched as HLC can still start later in
@@ -290,7 +290,7 @@ void Charger::run_state_machine() {
                                     session_log.evse(
                                         false, "AC mode, HLC enabled(5percent), matching already started. Go through "
                                                "t_step_X1 and disable 5 percent.");
-                                    t_step_X1_return_state = targetState;
+                                    t_step_X1_return_state = target_state;
                                     t_step_X1_return_pwm = 0.;
                                     hlc_use_5percent_current_session = false;
                                     current_state = EvseState::T_step_X1;
@@ -302,7 +302,7 @@ void Charger::run_state_machine() {
                                         false,
                                         "AC mode, HLC enabled(X1), matching already started. We are in X1 so we can "
                                         "go directly to nominal PWM.");
-                                    current_state = targetState;
+                                    current_state = target_state;
                                 }
                             }
                         }
@@ -313,14 +313,14 @@ void Charger::run_state_machine() {
                         // wants to.
                         session_log.evse(false, "AC mode, HLC disabled. We are in X1 so we can "
                                                 "go directly to nominal PWM.");
-                        current_state = targetState;
+                        current_state = target_state;
                     }
                 } else if (charge_mode == ChargeMode::DC) {
                     // Figure 8 of ISO15118-3: DC with EIM before or after plugin or PnC
                     // simple here as we always stay within 5 percent mode anyway.
                     session_log.evse(false,
                                      "DC mode. We are in 5percent mode so we can continue without further action.");
-                    current_state = targetState;
+                    current_state = target_state;
                 } else {
                     // unsupported charging mode, give up here.
                     error_handling->raise_internal_error("Unsupported charging mode.");
@@ -329,7 +329,7 @@ void Charger::run_state_machine() {
 
                 start_transaction();
 
-                const EvseState targetState(EvseState::PrepareCharging);
+                const EvseState target_state(EvseState::PrepareCharging);
 
                 // We got authorization by Plug and Charge
                 session_log.evse(false, "PnC Authorization received");
@@ -341,14 +341,14 @@ void Charger::run_state_machine() {
                         false, "AC mode, HLC enabled, PnC auth received. We will continue with 5percent independent on "
                                "how we started.");
                     hlc_use_5percent_current_session = true;
-                    current_state = targetState;
+                    current_state = target_state;
 
                 } else if (charge_mode == ChargeMode::DC) {
                     // Figure 8 of ISO15118-3: DC with EIM before or after plugin or PnC
                     // simple here as we always stay within 5 percent mode anyway.
                     session_log.evse(false,
                                      "DC mode. We are in 5percent mode so we can continue without further action.");
-                    current_state = targetState;
+                    current_state = target_state;
                 } else {
                     // unsupported charging mode, give up here.
                     error_handling->raise_internal_error("Unsupported charging mode.");

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -20,10 +20,10 @@ namespace module {
 Charger::Charger(const std::unique_ptr<IECStateMachine>& bsp, const std::unique_ptr<ErrorHandling>& error_handling,
                  const types::evse_board_support::Connector_type& connector_type) :
     bsp(bsp), error_handling(error_handling), connector_type(connector_type) {
-    connectorEnabled = true;
-    maxCurrent = 6.0;
+    connector_enabled = true;
+    max_current = 6.0;
     if (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket) {
-        maxCurrentCable = bsp->read_pp_ampacity();
+        max_current_cable = bsp->read_pp_ampacity();
     }
     authorized = false;
 
@@ -32,12 +32,12 @@ Charger::Charger(const std::unique_ptr<IECStateMachine>& bsp, const std::unique_
     currentState = EvseState::Idle;
     last_state = EvseState::Disabled;
 
-    currentDrawnByVehicle[0] = 0.;
-    currentDrawnByVehicle[1] = 0.;
-    currentDrawnByVehicle[2] = 0.;
+    current_drawn_by_vehicle[0] = 0.;
+    current_drawn_by_vehicle[1] = 0.;
+    current_drawn_by_vehicle[2] = 0.;
 
-    t_step_EF_returnState = EvseState::Idle;
-    t_step_X1_returnState = EvseState::Idle;
+    t_step_EF_return_state = EvseState::Idle;
+    t_step_X1_return_state = EvseState::Idle;
 
     matching_started = false;
 
@@ -48,17 +48,19 @@ Charger::Charger(const std::unique_ptr<IECStateMachine>& bsp, const std::unique_
 
     // Register callbacks for errors/error clearings
     error_handling->signal_error.connect([this](const types::evse_manager::Error e, const bool prevent_charging) {
-        std::scoped_lock lock(stateMutex);
         if (prevent_charging) {
+            std::scoped_lock lock(state_machine_mutex);
             error_prevent_charging_flag = true;
         }
     });
 
     error_handling->signal_all_errors_cleared.connect([this]() {
         EVLOG_info << "All errors cleared";
-        signalEvent(types::evse_manager::SessionEventEnum::AllErrorsCleared);
-        std::scoped_lock lock(stateMutex);
-        error_prevent_charging_flag = false;
+        signal_event(types::evse_manager::SessionEventEnum::AllErrorsCleared);
+        {
+            std::scoped_lock lock(state_machine_mutex);
+            error_prevent_charging_flag = false;
+        }
     });
 }
 
@@ -66,44 +68,44 @@ Charger::~Charger() {
     pwm_F();
 }
 
-void Charger::mainThread() {
+void Charger::main_thread() {
     // Enable CP output
     bsp->enable(true);
 
     // publish initial values
-    signalMaxCurrent(getMaxCurrent());
-    signalState(currentState);
+    signal_max_current(get_max_current_internal());
+    signal_state(currentState);
 
     while (true) {
-        if (mainThreadHandle.shouldExit()) {
+        if (main_thread_handle.shouldExit()) {
             break;
         }
 
         std::this_thread::sleep_for(MAINLOOP_UPDATE_RATE);
 
         {
-            std::scoped_lock lock(stateMutex);
+            std::scoped_lock lock(state_machine_mutex);
             // update power limits
-            powerAvailable();
+            power_available();
             // Run our own state machine update (i.e. run everything that needs
             // to be done on regular intervals independent from events)
-            runStateMachine();
+            run_state_machine();
         }
     }
 }
 
-void Charger::runStateMachine() {
+void Charger::run_state_machine() {
 
     // run over state machine loop until currentState does not change anymore
     do {
         // If a state change happened or an error recovered during a state we reinitialize the state
-        bool initialize_state = (last_state_detect_state_change != currentState) ||
-                                (last_error_prevent_charging_flag != error_prevent_charging_flag);
+        bool initialize_state = (last_state_detect_state_change not_eq currentState) or
+                                (last_error_prevent_charging_flag not_eq error_prevent_charging_flag);
 
         if (initialize_state) {
             session_log.evse(false,
-                             fmt::format("Charger state: {}->{}", evseStateToString(last_state_detect_state_change),
-                                         evseStateToString(currentState)));
+                             fmt::format("Charger state: {}->{}", evse_state_to_string(last_state_detect_state_change),
+                                         evse_state_to_string(currentState)));
         }
 
         last_state = last_state_detect_state_change;
@@ -112,35 +114,36 @@ void Charger::runStateMachine() {
 
         auto now = std::chrono::system_clock::now();
 
-        if (ac_with_soc_timeout && (ac_with_soc_timer -= 50) < 0) {
+        if (ac_with_soc_timeout and (ac_with_soc_timer -= 50) < 0) {
             ac_with_soc_timeout = false;
             ac_with_soc_timer = 3600000;
-            signalACWithSoCTimeout();
+            signal_ac_with_soc_timeout();
             return;
         }
 
         if (initialize_state) {
-            currentStateStarted = now;
-            signalState(currentState);
+            current_state_started = now;
+            signal_state(currentState);
         }
 
         auto timeInCurrentState =
-            std::chrono::duration_cast<std::chrono::milliseconds>(now - currentStateStarted).count();
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - current_state_started).count();
 
         switch (currentState) {
         case EvseState::Disabled:
             if (initialize_state) {
-                signalEvent(types::evse_manager::SessionEventEnum::Disabled);
+                signal_event(types::evse_manager::SessionEventEnum::Disabled);
                 pwm_F();
             }
             break;
 
         case EvseState::Replug:
             if (initialize_state) {
-                signalEvent(types::evse_manager::SessionEventEnum::ReplugStarted);
+                signal_event(types::evse_manager::SessionEventEnum::ReplugStarted);
                 // start timer in case we need to
-                if (ac_with_soc_timeout)
+                if (ac_with_soc_timeout) {
                     ac_with_soc_timer = 120000;
+                }
             }
             // simply wait here until BSP informs us that replugging was finished
             break;
@@ -152,10 +155,10 @@ void Charger::runStateMachine() {
                 iec_allow_close_contactor = false;
                 hlc_charging_active = false;
                 hlc_allow_close_contactor = false;
-                maxCurrentCable = 0;
+                max_current_cable = 0;
                 hlc_charging_terminate_pause = HlcTerminatePause::Unknown;
                 pwm_off();
-                DeAuthorize();
+                deauthorize_internal();
                 transaction_active = false;
                 clear_errors_on_unplug();
             }
@@ -170,13 +173,14 @@ void Charger::runStateMachine() {
                 bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
 
                 if (last_state == EvseState::Replug) {
-                    signalEvent(types::evse_manager::SessionEventEnum::ReplugFinished);
+                    signal_event(types::evse_manager::SessionEventEnum::ReplugFinished);
                 } else {
                     // First user interaction was plug in of car? Start session here.
-                    if (!sessionActive())
-                        startSession(false);
+                    if (not session_active) {
+                        start_session(false);
+                    }
                     // External signal on MQTT
-                    signalEvent(types::evse_manager::SessionEventEnum::AuthRequired);
+                    signal_event(types::evse_manager::SessionEventEnum::AuthRequired);
                 }
                 hlc_use_5percent_current_session = false;
 
@@ -202,19 +206,19 @@ void Charger::runStateMachine() {
             }
 
             // Read PP value in case of AC socket
-            if (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket &&
-                maxCurrentCable == 0) {
-                maxCurrentCable = bsp->read_pp_ampacity();
+            if (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket and
+                max_current_cable == 0) {
+                max_current_cable = bsp->read_pp_ampacity();
                 // retry if the value is not yet available. Some BSPs may take some time to measure the PP.
-                if (maxCurrentCable == 0) {
+                if (max_current_cable == 0) {
                     break;
                 }
             }
 
             // Wait for Energy Manager to supply some power, otherwise wait here.
             // If we have zero power, some cars will not like the ChargingParameter message.
-            if (charge_mode == ChargeMode::DC &&
-                !(currentEvseMaxLimits.EVSEMaximumCurrentLimit > 0 && currentEvseMaxLimits.EVSEMaximumPowerLimit > 0)) {
+            if (charge_mode == ChargeMode::DC and !(current_evse_max_limits.EVSEMaximumCurrentLimit > 0 and
+                                                    current_evse_max_limits.EVSEMaximumPowerLimit > 0)) {
                 break;
             }
 
@@ -237,12 +241,12 @@ void Charger::runStateMachine() {
             // in AC mode: go back to non HLC nominal PWM mode
             // in DC mode: go to error_slac for this session
 
-            if (AuthorizedEIM()) {
+            if (authorized and not authorized_pnc) {
                 session_log.evse(false, "EIM Authorization received");
 
                 // If we are restarting, the transaction may already be active
-                if (!transactionActive()) {
-                    startTransaction();
+                if (not transaction_active) {
+                    start_transaction();
                 }
 
                 const EvseState targetState(EvseState::PrepareCharging);
@@ -259,7 +263,7 @@ void Charger::runStateMachine() {
                             hlc_use_5percent_current_session = true;
                             currentState = targetState;
                         } else {
-                            if (!getMatchingStarted()) {
+                            if (!get_matching_started()) {
                                 // SLAC matching was not started when EIM arrived
 
                                 session_log.evse(
@@ -271,8 +275,8 @@ void Charger::runStateMachine() {
 
                                 // Figure 3 of ISO15118-3: 5 percent start, PnC and EIM
                                 // Figure 4 of ISO15118-3: X1 start, PnC and EIM
-                                t_step_EF_returnState = targetState;
-                                t_step_EF_returnPWM = 0.;
+                                t_step_EF_return_state = targetState;
+                                t_step_EF_return_pwm = 0.;
                                 // fall back to nominal PWM after the t_step_EF break. Note that
                                 // ac_hlc_enabled_current_session remains untouched as HLC can still start later in
                                 // nominal PWM mode
@@ -286,8 +290,8 @@ void Charger::runStateMachine() {
                                     session_log.evse(
                                         false, "AC mode, HLC enabled(5percent), matching already started. Go through "
                                                "t_step_X1 and disable 5 percent.");
-                                    t_step_X1_returnState = targetState;
-                                    t_step_X1_returnPWM = 0.;
+                                    t_step_X1_return_state = targetState;
+                                    t_step_X1_return_pwm = 0.;
                                     hlc_use_5percent_current_session = false;
                                     currentState = EvseState::T_step_X1;
                                 } else {
@@ -321,9 +325,9 @@ void Charger::runStateMachine() {
                     // unsupported charging mode, give up here.
                     error_handling->raise_internal_error("Unsupported charging mode.");
                 }
-            } else if (AuthorizedPnC()) {
+            } else if (authorized and authorized_pnc) {
 
-                startTransaction();
+                start_transaction();
 
                 const EvseState targetState(EvseState::PrepareCharging);
 
@@ -360,11 +364,12 @@ void Charger::runStateMachine() {
             }
             if (timeInCurrentState >= t_step_EF) {
                 session_log.evse(false, "Exit T_step_EF");
-                if (t_step_EF_returnPWM == 0.)
+                if (t_step_EF_return_pwm == 0.) {
                     pwm_off();
-                else
-                    update_pwm_now(t_step_EF_returnPWM);
-                currentState = t_step_EF_returnState;
+                } else {
+                    update_pwm_now(t_step_EF_return_pwm);
+                }
+                currentState = t_step_EF_return_state;
             }
             break;
 
@@ -375,35 +380,36 @@ void Charger::runStateMachine() {
             }
             if (timeInCurrentState >= t_step_X1) {
                 session_log.evse(false, "Exit T_step_X1");
-                if (t_step_X1_returnPWM == 0.)
+                if (t_step_X1_return_pwm == 0.) {
                     pwm_off();
-                else
-                    update_pwm_now(t_step_X1_returnPWM);
-                currentState = t_step_X1_returnState;
+                } else {
+                    update_pwm_now(t_step_X1_return_pwm);
+                }
+                currentState = t_step_X1_return_state;
             }
             break;
 
         case EvseState::PrepareCharging:
 
             if (initialize_state) {
-                signalEvent(types::evse_manager::SessionEventEnum::PrepareCharging);
+                signal_event(types::evse_manager::SessionEventEnum::PrepareCharging);
                 bcb_toggle_reset();
             }
 
             if (charge_mode == ChargeMode::DC) {
-                if (hlc_allow_close_contactor && iec_allow_close_contactor) {
+                if (hlc_allow_close_contactor and iec_allow_close_contactor) {
                     bsp->allow_power_on(true, types::evse_board_support::Reason::DCCableCheck);
                 }
             }
 
             // Wait here until all errors are cleared
-            if (errors_prevent_charging()) {
+            if (errors_prevent_charging_internal()) {
                 break;
             }
 
             // make sure we are enabling PWM
             if (!hlc_use_5percent_current_session) {
-                update_pwm_now_if_changed(ampereToDutyCycle(getMaxCurrent()));
+                update_pwm_now_if_changed(ampere_to_duty_cycle(get_max_current_internal()));
             } else {
                 update_pwm_now_if_changed(PWM_5_PERCENT);
             }
@@ -412,26 +418,26 @@ void Charger::runStateMachine() {
                 // In AC mode BASIC, iec_allow is sufficient.  The same is true for HLC mode when nominal PWM is used as
                 // the car can do BASIC and HLC charging any time. In AC HLC with 5 percent mode, we need to wait for
                 // both iec_allow and hlc_allow.
-                if ((iec_allow_close_contactor && !hlc_use_5percent_current_session) ||
-                    (iec_allow_close_contactor && hlc_allow_close_contactor && hlc_use_5percent_current_session)) {
+                if ((iec_allow_close_contactor and !hlc_use_5percent_current_session) or
+                    (iec_allow_close_contactor and hlc_allow_close_contactor and hlc_use_5percent_current_session)) {
 
-                    signalEvent(types::evse_manager::SessionEventEnum::ChargingStarted);
+                    signal_event(types::evse_manager::SessionEventEnum::ChargingStarted);
 
-                    if (powerAvailable()) {
+                    if (power_available()) {
                         currentState = EvseState::Charging;
                     } else {
                         currentState = EvseState::Charging;
-                        pauseChargingWaitForPower();
+                        pause_charging_wait_for_power_internal();
                     }
                 }
 
-                if (!hlc_charging_active && !legacy_wakeup_done && timeInCurrentState > legacy_wakeup_timeout) {
+                if (!hlc_charging_active and !legacy_wakeup_done and timeInCurrentState > legacy_wakeup_timeout) {
                     session_log.evse(
                         false,
                         "EV did not transition to state C, trying one legacy wakeup according to IEC61851-1 A.5.3");
                     legacy_wakeup_done = true;
-                    t_step_EF_returnState = EvseState::PrepareCharging;
-                    t_step_EF_returnPWM = ampereToDutyCycle(getMaxCurrent());
+                    t_step_EF_return_state = EvseState::PrepareCharging;
+                    t_step_EF_return_pwm = ampere_to_duty_cycle(get_max_current_internal());
                     currentState = EvseState::T_step_EF;
                 }
             }
@@ -452,7 +458,7 @@ void Charger::runStateMachine() {
             }
 
             // Wait here until all errors are cleared
-            if (errors_prevent_charging()) {
+            if (errors_prevent_charging_internal()) {
                 break;
             }
 
@@ -460,16 +466,16 @@ void Charger::runStateMachine() {
                 // FIXME: handle DC pause/resume here
                 // FIXME: handle DC no power available from Energy management
             } else {
-                checkSoftOverCurrent();
+                check_soft_over_current();
 
-                if (!powerAvailable()) {
-                    pauseChargingWaitForPower();
+                if (!power_available()) {
+                    pause_charging_wait_for_power_internal();
                     break;
                 }
 
                 if (initialize_state) {
-                    if (last_state != EvseState::PrepareCharging) {
-                        signalEvent(types::evse_manager::SessionEventEnum::ChargingResumed);
+                    if (last_state not_eq EvseState::PrepareCharging) {
+                        signal_event(types::evse_manager::SessionEventEnum::ChargingResumed);
                     }
 
                     // Allow another wake-up sequence
@@ -477,14 +483,16 @@ void Charger::runStateMachine() {
 
                     bsp->allow_power_on(true, types::evse_board_support::Reason::FullPowerCharging);
                     // make sure we are enabling PWM
-                    if (hlc_use_5percent_current_session)
+                    if (hlc_use_5percent_current_session) {
                         update_pwm_now_if_changed(PWM_5_PERCENT);
-                    else
-                        update_pwm_now_if_changed(ampereToDutyCycle(getMaxCurrent()));
+                    } else {
+                        update_pwm_now_if_changed(ampere_to_duty_cycle(get_max_current_internal()));
+                    }
                 } else {
                     // update PWM if it has changed and 5 seconds have passed since last update
-                    if (!hlc_use_5percent_current_session)
-                        update_pwm_max_every_5seconds(ampereToDutyCycle(getMaxCurrent()));
+                    if (!hlc_use_5percent_current_session) {
+                        update_pwm_max_every_5seconds(ampere_to_duty_cycle(get_max_current_internal()));
+                    }
                 }
             }
             break;
@@ -492,7 +500,7 @@ void Charger::runStateMachine() {
         case EvseState::ChargingPausedEV:
 
             if (charge_mode == ChargeMode::AC) {
-                checkSoftOverCurrent();
+                check_soft_over_current();
             }
 
             // A pause issued by the EV needs to be handled differently for the different charging modes
@@ -511,9 +519,9 @@ void Charger::runStateMachine() {
                     bcb_toggle_reset();
                     bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
                     if (charge_mode == ChargeMode::DC) {
-                        signal_DC_supply_off();
+                        signal_dc_supply_off();
                     }
-                    signalEvent(types::evse_manager::SessionEventEnum::ChargingPausedEV);
+                    signal_event(types::evse_manager::SessionEventEnum::ChargingPausedEV);
                 }
 
                 if (bcb_toggle_detected()) {
@@ -527,12 +535,14 @@ void Charger::runStateMachine() {
                 if (hlc_charging_terminate_pause == HlcTerminatePause::Terminate) {
                     // EV wants to terminate session
                     currentState = EvseState::StoppingCharging;
-                    if (pwm_running)
+                    if (pwm_running) {
                         pwm_off();
+                    }
                 } else if (hlc_charging_terminate_pause == HlcTerminatePause::Pause) {
                     // EV wants an actual pause
-                    if (pwm_running)
+                    if (pwm_running) {
                         pwm_off();
+                    }
                 }
 
             } else {
@@ -540,17 +550,17 @@ void Charger::runStateMachine() {
 
                 // Normally power should be available, since we request a minimum power also during EV pause.
                 // In case the energy manager gives us no energy, we effectivly switch to a pause by EVSE here.
-                if (!powerAvailable()) {
-                    pauseChargingWaitForPower();
+                if (!power_available()) {
+                    pause_charging_wait_for_power_internal();
                     break;
                 }
 
                 if (initialize_state) {
-                    signalEvent(types::evse_manager::SessionEventEnum::ChargingPausedEV);
+                    signal_event(types::evse_manager::SessionEventEnum::ChargingPausedEV);
                 } else {
                     // update PWM if it has changed and 5 seconds have passed since last update
-                    if (!errors_prevent_charging()) {
-                        update_pwm_max_every_5seconds(ampereToDutyCycle(getMaxCurrent()));
+                    if (!errors_prevent_charging_internal()) {
+                        update_pwm_max_every_5seconds(ampere_to_duty_cycle(get_max_current_internal()));
                     }
                 }
             }
@@ -558,7 +568,7 @@ void Charger::runStateMachine() {
 
         case EvseState::ChargingPausedEVSE:
             if (initialize_state) {
-                signalEvent(types::evse_manager::SessionEventEnum::ChargingPausedEVSE);
+                signal_event(types::evse_manager::SessionEventEnum::ChargingPausedEVSE);
                 if (hlc_charging_active) {
                     // currentState = EvseState::StoppingCharging;
                     last_stop_transaction_reason = types::evse_manager::StopTransactionReason::Local;
@@ -573,24 +583,25 @@ void Charger::runStateMachine() {
 
         case EvseState::WaitingForEnergy:
             if (initialize_state) {
-                signalEvent(types::evse_manager::SessionEventEnum::WaitingForEnergy);
-                if (!hlc_use_5percent_current_session)
+                signal_event(types::evse_manager::SessionEventEnum::WaitingForEnergy);
+                if (!hlc_use_5percent_current_session) {
                     pwm_off();
+                }
             }
             break;
 
         case EvseState::StoppingCharging:
             if (initialize_state) {
                 bcb_toggle_reset();
-                if (transactionActive() || sessionActive()) {
-                    signalEvent(types::evse_manager::SessionEventEnum::StoppingCharging);
+                if (transaction_active or session_active) {
+                    signal_event(types::evse_manager::SessionEventEnum::StoppingCharging);
                 }
 
                 if (hlc_charging_active) {
                     if (charge_mode == ChargeMode::DC) {
                         // DC supply off - actually this is after relais switched off
                         // this is a backup switch off, normally it should be switched off earlier by ISO protocol.
-                        signal_DC_supply_off();
+                        signal_dc_supply_off();
                     }
                     // Car is maybe not unplugged yet, so for HLC(AC/DC) wait in this state. We will go to Finished once
                     // car is unplugged.
@@ -603,13 +614,13 @@ void Charger::runStateMachine() {
 
             // Allow session restart after SessionStop.terminate (full restart including new SLAC).
             // Only allow that if the transaction is still running. If it was cancelled externally with
-            // cancelTransaction(), we do not allow restart. If OCPP cancels a transaction it assumes it cannot be
+            // cancel_transaction(), we do not allow restart. If OCPP cancels a transaction it assumes it cannot be
             // restarted. In all other cases, e.g. the EV stopping the transaction it may resume with a BCB toggle.
-            if (hlc_charging_active && bcb_toggle_detected()) {
+            if (hlc_charging_active and bcb_toggle_detected()) {
                 if (transaction_active) {
                     currentState = EvseState::PrepareCharging;
                     // wake up SLAC as well
-                    signal_SLAC_start();
+                    signal_slac_start();
                 } else {
                     session_log.car(false, "Car requested restarting with BCB toggle. Ignored, since we were cancelled "
                                            "externally before.");
@@ -622,25 +633,26 @@ void Charger::runStateMachine() {
             if (initialize_state) {
                 // Transaction may already be stopped when it was cancelled earlier.
                 // In that case, do not sent a second transactionFinished event.
-                if (transactionActive())
-                    stopTransaction();
+                if (transaction_active) {
+                    stop_transaction();
+                }
                 // We may come here from an error state, so a session was maybe not active.
-                if (sessionActive()) {
-                    stopSession();
+                if (session_active) {
+                    stop_session();
                 }
 
                 if (charge_mode == ChargeMode::DC) {
-                    signal_DC_supply_off();
+                    signal_dc_supply_off();
                 }
             }
 
-            restart();
+            currentState = EvseState::Idle;
             break;
         }
-    } while (last_state_detect_state_change != currentState);
+    } while (last_state_detect_state_change not_eq currentState);
 }
 
-void Charger::processEvent(CPEvent cp_event) {
+void Charger::process_event(CPEvent cp_event) {
     switch (cp_event) {
     case CPEvent::CarPluggedIn:
     case CPEvent::CarRequestedPower:
@@ -655,7 +667,7 @@ void Charger::processEvent(CPEvent cp_event) {
         break;
     }
 
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+    std::scoped_lock lock(state_machine_mutex);
 
     if (cp_event == CPEvent::PowerOn) {
         contactors_closed = true;
@@ -663,20 +675,20 @@ void Charger::processEvent(CPEvent cp_event) {
         contactors_closed = false;
     }
 
-    runStateMachine();
+    run_state_machine();
 
     // Process all event actions that are independent of the current state
-    processCPEventsIndependent(cp_event);
+    process_cp_events_independent(cp_event);
 
-    runStateMachine();
+    run_state_machine();
 
     // Process all events that depend on the current state
-    processCPEventsState(cp_event);
+    process_cp_events_state(cp_event);
 
-    runStateMachine();
+    run_state_machine();
 }
 
-void Charger::processCPEventsState(CPEvent cp_event) {
+void Charger::process_cp_events_state(CPEvent cp_event) {
     switch (currentState) {
 
     case EvseState::Idle:
@@ -715,21 +727,21 @@ void Charger::processCPEventsState(CPEvent cp_event) {
         if (cp_event == CPEvent::CarRequestedPower) {
             iec_allow_close_contactor = true;
             // For BASIC charging we can simply switch back to Charging
-            if (charge_mode == ChargeMode::AC && !hlc_charging_active) {
+            if (charge_mode == ChargeMode::AC and !hlc_charging_active) {
                 currentState = EvseState::Charging;
             } else if (!pwm_running) {
                 bcb_toggle_detect_start_pulse();
             }
         }
 
-        if (cp_event == CPEvent::CarRequestedStopPower && !pwm_running && hlc_charging_active) {
+        if (cp_event == CPEvent::CarRequestedStopPower and !pwm_running and hlc_charging_active) {
             bcb_toggle_detect_stop_pulse();
         }
         break;
 
     case EvseState::StoppingCharging:
         // Allow session restart from EV after SessionStop.terminate with BCB toggle
-        if (hlc_charging_active && !pwm_running) {
+        if (hlc_charging_active and !pwm_running) {
             if (cp_event == CPEvent::CarRequestedPower) {
                 bcb_toggle_detect_start_pulse();
             } else if (cp_event == CPEvent::CarRequestedStopPower) {
@@ -743,7 +755,7 @@ void Charger::processCPEventsState(CPEvent cp_event) {
     }
 }
 
-void Charger::processCPEventsIndependent(CPEvent cp_event) {
+void Charger::process_cp_events_independent(CPEvent cp_event) {
     switch (cp_event) {
     case CPEvent::EvseReplugStarted:
         currentState = EvseState::Replug;
@@ -764,9 +776,9 @@ void Charger::processCPEventsIndependent(CPEvent cp_event) {
 }
 
 void Charger::update_pwm_max_every_5seconds(float dc) {
-    if (dc != update_pwm_last_dc) {
+    if (dc not_eq update_pwm_last_dc) {
         auto now = date::utc_clock::now();
-        auto timeSinceLastUpdate = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastPwmUpdate).count();
+        auto timeSinceLastUpdate = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_pwm_update).count();
         if (timeSinceLastUpdate >= 5000) {
             update_pwm_now(dc);
         }
@@ -783,11 +795,11 @@ void Charger::update_pwm_now(float dc) {
         false,
         fmt::format("Set PWM On ({}%) took {} ms", dc * 100.,
                     (std::chrono::duration_cast<std::chrono::milliseconds>(date::utc_clock::now() - start)).count()));
-    lastPwmUpdate = date::utc_clock::now();
+    last_pwm_update = date::utc_clock::now();
 }
 
 void Charger::update_pwm_now_if_changed(float dc) {
-    if (update_pwm_last_dc != dc) {
+    if (update_pwm_last_dc not_eq dc) {
         update_pwm_now(dc);
     }
 }
@@ -808,10 +820,10 @@ void Charger::pwm_F() {
 
 void Charger::run() {
     // spawn new thread and return
-    mainThreadHandle = std::thread(&Charger::mainThread, this);
+    main_thread_handle = std::thread(&Charger::main_thread, this);
 }
 
-float Charger::ampereToDutyCycle(float ampere) {
+float Charger::ampere_to_duty_cycle(float ampere) {
     float dc = 0;
 
     // calculate max current
@@ -836,15 +848,18 @@ float Charger::ampereToDutyCycle(float ampere) {
     return dc;
 }
 
-bool Charger::setMaxCurrent(float c, std::chrono::time_point<date::utc_clock> validUntil) {
-    if (c >= 0.0 && c <= CHARGER_ABSOLUTE_MAX_CURRENT) {
-        std::lock_guard<std::recursive_mutex> lock(configMutex);
+bool Charger::set_max_current(float c, std::chrono::time_point<date::utc_clock> validUntil) {
+    if (c >= 0.0 and c <= CHARGER_ABSOLUTE_MAX_CURRENT) {
+
         // is it still valid?
         if (validUntil > date::utc_clock::now()) {
-            maxCurrent = c;
-            maxCurrentValidUntil = validUntil;
+            {
+                std::lock_guard lock(state_machine_mutex);
+                max_current = c;
+                max_current_valid_until = validUntil;
+            }
             bsp->set_overcurrent_limit(c);
-            signalMaxCurrent(c);
+            signal_max_current(c);
             return true;
         }
     }
@@ -852,8 +867,8 @@ bool Charger::setMaxCurrent(float c, std::chrono::time_point<date::utc_clock> va
 }
 
 // pause if currently charging, else do nothing.
-bool Charger::pauseCharging() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+bool Charger::pause_charging() {
+    std::scoped_lock lock(state_machine_mutex);
     if (currentState == EvseState::Charging) {
         legacy_wakeup_done = false;
         currentState = EvseState::ChargingPausedEVSE;
@@ -862,15 +877,15 @@ bool Charger::pauseCharging() {
     return false;
 }
 
-bool Charger::resumeCharging() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+bool Charger::resume_charging() {
+    std::scoped_lock lock(state_machine_mutex);
 
-    if (hlc_charging_active && transaction_active && currentState == EvseState::ChargingPausedEVSE) {
+    if (hlc_charging_active and transaction_active and currentState == EvseState::ChargingPausedEVSE) {
         currentState = EvseState::PrepareCharging;
         // wake up SLAC as well
-        signal_SLAC_start();
+        signal_slac_start();
         return true;
-    } else if (transactionActive() && currentState == EvseState::ChargingPausedEVSE) {
+    } else if (transaction_active and currentState == EvseState::ChargingPausedEVSE) {
         currentState = EvseState::WaitingForEnergy;
         return true;
     }
@@ -879,8 +894,13 @@ bool Charger::resumeCharging() {
 }
 
 // pause charging since no power is available at the moment
-bool Charger::pauseChargingWaitForPower() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+bool Charger::pause_charging_wait_for_power() {
+    std::scoped_lock lock(state_machine_mutex);
+    return pause_charging_wait_for_power_internal();
+}
+
+// pause charging since no power is available at the moment
+bool Charger::pause_charging_wait_for_power_internal() {
     if (currentState == EvseState::Charging) {
         currentState = EvseState::WaitingForEnergy;
         return true;
@@ -889,10 +909,10 @@ bool Charger::pauseChargingWaitForPower() {
 }
 
 // resume charging since power became available. Does not resume if user paused charging.
-bool Charger::resumeChargingPowerAvailable() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+bool Charger::resume_charging_power_available() {
+    std::scoped_lock lock(state_machine_mutex);
 
-    if (transactionActive() && currentState == EvseState::WaitingForEnergy && powerAvailable()) {
+    if (transaction_active and currentState == EvseState::WaitingForEnergy and power_available()) {
         currentState = EvseState::Charging;
         return true;
     }
@@ -900,21 +920,21 @@ bool Charger::resumeChargingPowerAvailable() {
 }
 
 // pause charging since we run through replug sequence
-bool Charger::evseReplug() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+bool Charger::evse_replug() {
     // call BSP to start the replug sequence. It BSP actually does it,
     // it will emit a EvseReplugStarted event which will then modify our state.
     // If BSP never executes the replug, we also never change state and nothing happens.
     // After replugging finishes, BSP will emit EvseReplugFinished event and we will go back to WaitingForAuth
-    EVLOG_info << fmt::format("Calling evse_replug({})...", t_replug_ms);
-    bsp->evse_replug(t_replug_ms);
+    EVLOG_info << fmt::format("Calling evse_replug({})...", T_REPLUG_MS);
+    bsp->evse_replug(T_REPLUG_MS);
     return true;
 }
 
 // Cancel transaction/charging from external EvseManager interface (e.g. via OCPP)
-bool Charger::cancelTransaction(const types::evse_manager::StopTransactionRequest& request) {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    if (transactionActive()) {
+bool Charger::cancel_transaction(const types::evse_manager::StopTransactionRequest& request) {
+    std::scoped_lock lock(state_machine_mutex);
+
+    if (transaction_active) {
         if (hlc_charging_active) {
             currentState = EvseState::StoppingCharging;
             signal_hlc_stop_charging();
@@ -927,72 +947,58 @@ bool Charger::cancelTransaction(const types::evse_manager::StopTransactionReques
         if (request.id_tag) {
             stop_transaction_id_token = request.id_tag.value();
         }
-        signalEvent(types::evse_manager::SessionEventEnum::ChargingFinished);
-        signalEvent(types::evse_manager::SessionEventEnum::TransactionFinished);
+        signal_event(types::evse_manager::SessionEventEnum::ChargingFinished);
+        signal_event(types::evse_manager::SessionEventEnum::TransactionFinished);
         return true;
     }
     return false;
 }
 
-bool Charger::transactionActive() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    return transaction_active;
-}
-
-bool Charger::sessionActive() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    return session_active;
-}
-
-void Charger::startSession(bool authfirst) {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+void Charger::start_session(bool authfirst) {
     session_active = true;
     authorized = false;
     if (authfirst)
         last_start_session_reason = types::evse_manager::StartSessionReason::Authorized;
     else
         last_start_session_reason = types::evse_manager::StartSessionReason::EVConnected;
-    signalEvent(types::evse_manager::SessionEventEnum::SessionStarted);
+    signal_event(types::evse_manager::SessionEventEnum::SessionStarted);
 }
 
-void Charger::stopSession() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+void Charger::stop_session() {
     session_active = false;
     authorized = false;
-    signalEvent(types::evse_manager::SessionEventEnum::SessionFinished);
+    signal_event(types::evse_manager::SessionEventEnum::SessionFinished);
 }
 
-void Charger::startTransaction() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+void Charger::start_transaction() {
     stop_transaction_id_token.reset();
     transaction_active = true;
-    signalEvent(types::evse_manager::SessionEventEnum::TransactionStarted);
+    signal_event(types::evse_manager::SessionEventEnum::TransactionStarted);
 }
 
-void Charger::stopTransaction() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+void Charger::stop_transaction() {
     transaction_active = false;
     last_stop_transaction_reason = types::evse_manager::StopTransactionReason::EVDisconnected;
-    signalEvent(types::evse_manager::SessionEventEnum::ChargingFinished);
-    signalEvent(types::evse_manager::SessionEventEnum::TransactionFinished);
+    signal_event(types::evse_manager::SessionEventEnum::ChargingFinished);
+    signal_event(types::evse_manager::SessionEventEnum::TransactionFinished);
 }
 
-std::optional<types::authorization::ProvidedIdToken> Charger::getStopTransactionIdToken() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+std::optional<types::authorization::ProvidedIdToken> Charger::get_stop_transaction_id_token() {
+    std::lock_guard lock(state_machine_mutex);
     return stop_transaction_id_token;
 }
 
-types::evse_manager::StopTransactionReason Charger::getTransactionFinishedReason() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+types::evse_manager::StopTransactionReason Charger::get_transaction_finished_reason() {
+    std::scoped_lock lock(state_machine_mutex);
     return last_stop_transaction_reason;
 }
 
-types::evse_manager::StartSessionReason Charger::getSessionStartedReason() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+types::evse_manager::StartSessionReason Charger::get_session_started_reason() {
+    std::scoped_lock lock(state_machine_mutex);
     return last_start_session_reason;
 }
 
-bool Charger::switchThreePhasesWhileCharging(bool n) {
+bool Charger::switch_three_phases_while_charging(bool n) {
     bsp->switch_three_phases_while_charging(n);
     return false; // FIXME: implement real return value when protobuf has sync calls
 }
@@ -1001,10 +1007,10 @@ void Charger::setup(bool three_phases, bool has_ventilation, const std::string& 
                     const ChargeMode _charge_mode, bool _ac_hlc_enabled, bool _ac_hlc_use_5percent,
                     bool _ac_enforce_hlc, bool _ac_with_soc_timeout, float _soft_over_current_tolerance_percent,
                     float _soft_over_current_measurement_noise_A) {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
     // set up board support package
     bsp->setup(three_phases, has_ventilation, country_code);
 
+    std::scoped_lock lock(state_machine_mutex);
     // cache our config variables
     charge_mode = _charge_mode;
     ac_hlc_enabled_current_session = ac_hlc_enabled = _ac_hlc_enabled;
@@ -1014,100 +1020,84 @@ void Charger::setup(bool three_phases, bool has_ventilation, const std::string& 
     ac_with_soc_timer = 3600000;
     soft_over_current_tolerance_percent = _soft_over_current_tolerance_percent;
     soft_over_current_measurement_noise_A = _soft_over_current_measurement_noise_A;
-    if (charge_mode == ChargeMode::AC && ac_hlc_enabled)
+    if (charge_mode == ChargeMode::AC and ac_hlc_enabled)
         EVLOG_info << "AC HLC mode enabled.";
 }
 
-Charger::EvseState Charger::getCurrentState() {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
+Charger::EvseState Charger::get_current_state() {
+    std::scoped_lock lock(state_machine_mutex);
     return currentState;
 }
 
-bool Charger::Authorized_PnC() {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
-    return (authorized && authorized_pnc);
+bool Charger::get_authorized_pnc() {
+    std::scoped_lock lock(state_machine_mutex);
+    return (authorized and authorized_pnc);
 }
 
-bool Charger::Authorized_EIM() {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
-    return (authorized && !authorized_pnc);
+bool Charger::get_authorized_eim() {
+    std::scoped_lock lock(state_machine_mutex);
+    return (authorized and !authorized_pnc);
 }
 
-bool Charger::Authorized_PnC_ready_for_HLC() {
+bool Charger::get_authorized_pnc_ready_for_hlc() {
     bool auth = false, ready = false;
-    {
-        std::lock_guard<std::recursive_mutex> lock(configMutex);
-        auth = (authorized && authorized_pnc);
-    }
-    {
-        std::lock_guard<std::recursive_mutex> lock(stateMutex);
-        ready = (currentState == EvseState::ChargingPausedEV) || (currentState == EvseState::ChargingPausedEVSE) ||
-                (currentState == EvseState::Charging) || (currentState == EvseState::WaitingForEnergy);
-    }
-    return (auth && ready);
+    std::scoped_lock lock(state_machine_mutex);
+    auth = (authorized and authorized_pnc);
+    ready = (currentState == EvseState::ChargingPausedEV) or (currentState == EvseState::ChargingPausedEVSE) or
+            (currentState == EvseState::Charging) or (currentState == EvseState::WaitingForEnergy);
+    return (auth and ready);
 }
 
-bool Charger::Authorized_EIM_ready_for_HLC() {
+bool Charger::get_authorized_eim_ready_for_hlc() {
     bool auth = false, ready = false;
-    {
-        std::lock_guard<std::recursive_mutex> lock(configMutex);
-        auth = (authorized && !authorized_pnc);
-    }
-    {
-        std::lock_guard<std::recursive_mutex> lock(stateMutex);
-        ready = (currentState == EvseState::ChargingPausedEV) || (currentState == EvseState::ChargingPausedEVSE) ||
-                (currentState == EvseState::Charging) || (currentState == EvseState::WaitingForEnergy);
-    }
-    return (auth && ready);
+    std::scoped_lock lock(state_machine_mutex);
+    auth = (authorized and !authorized_pnc);
+    ready = (currentState == EvseState::ChargingPausedEV) or (currentState == EvseState::ChargingPausedEVSE) or
+            (currentState == EvseState::Charging) or (currentState == EvseState::WaitingForEnergy);
+    return (auth and ready);
 }
 
-void Charger::Authorize(bool a, const types::authorization::ProvidedIdToken& token) {
+void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& token) {
+    std::scoped_lock lock(state_machine_mutex);
     if (a) {
         // First user interaction was auth? Then start session already here and not at plug in
-        if (!sessionActive())
-            startSession(true);
-        std::lock_guard<std::recursive_mutex> lock(configMutex);
+        if (not session_active)
+            start_session(true);
+
         authorized = true;
         authorized_pnc = token.authorization_type == types::authorization::AuthorizationType::PlugAndCharge;
         id_token = token;
     } else {
-        if (sessionActive()) {
-            stopSession();
+        if (session_active) {
+            stop_session();
         }
-        std::lock_guard<std::recursive_mutex> lock(configMutex);
         authorized = false;
     }
 }
 
-types::authorization::ProvidedIdToken Charger::getIdToken() {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
+types::authorization::ProvidedIdToken Charger::get_id_token() {
+    std::scoped_lock lock(state_machine_mutex);
     return id_token;
 }
 
-bool Charger::AuthorizedEIM() {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
-    return (authorized && !authorized_pnc);
+bool Charger::deauthorize() {
+    std::scoped_lock lock(state_machine_mutex);
+    return deauthorize_internal();
 }
 
-bool Charger::AuthorizedPnC() {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
-    return (authorized && authorized_pnc);
-}
+bool Charger::deauthorize_internal() {
+    if (session_active) {
+        auto s = currentState;
 
-bool Charger::DeAuthorize() {
-    if (sessionActive()) {
-        auto s = getCurrentState();
-
-        if (s == EvseState::Disabled || s == EvseState::Idle || s == EvseState::WaitingForAuthentication) {
+        if (s == EvseState::Disabled or s == EvseState::Idle or s == EvseState::WaitingForAuthentication) {
 
             // We can safely remove auth as it is not in use right now
-            std::lock_guard<std::recursive_mutex> lock(configMutex);
             if (!authorized) {
-                signalEvent(types::evse_manager::SessionEventEnum::PluginTimeout);
+                signal_event(types::evse_manager::SessionEventEnum::PluginTimeout);
                 return false;
             }
             authorized = false;
-            stopSession();
+            stop_session();
             return true;
         }
     }
@@ -1115,24 +1105,25 @@ bool Charger::DeAuthorize() {
 }
 
 bool Charger::disable(int connector_id) {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    if (connector_id != 0) {
-        connectorEnabled = false;
+    std::scoped_lock lock(state_machine_mutex);
+    if (connector_id not_eq 0) {
+        connector_enabled = false;
     }
     currentState = EvseState::Disabled;
-    signalEvent(types::evse_manager::SessionEventEnum::Disabled);
+    signal_event(types::evse_manager::SessionEventEnum::Disabled);
     return true;
 }
 
 bool Charger::enable(int connector_id) {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    if (connector_id != 0) {
-        connectorEnabled = true;
+    std::scoped_lock lock(state_machine_mutex);
+
+    if (connector_id not_eq 0) {
+        connector_enabled = true;
     }
 
-    signalEvent(types::evse_manager::SessionEventEnum::Enabled);
+    signal_event(types::evse_manager::SessionEventEnum::Enabled);
     if (currentState == EvseState::Disabled) {
-        if (connectorEnabled) {
+        if (connector_enabled) {
             currentState = EvseState::Idle;
         }
         return true;
@@ -1141,21 +1132,11 @@ bool Charger::enable(int connector_id) {
 }
 
 void Charger::set_faulted() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+    std::scoped_lock lock(state_machine_mutex);
     error_prevent_charging_flag = true;
 }
 
-bool Charger::restart() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
-
-    if (currentState == EvseState::Finished) {
-        currentState = EvseState::Idle;
-        return true;
-    }
-    return false;
-}
-
-std::string Charger::evseStateToString(EvseState s) {
+std::string Charger::evse_state_to_string(EvseState s) {
     switch (s) {
     case EvseState::Disabled:
         return ("Disabled");
@@ -1200,49 +1181,55 @@ std::string Charger::evseStateToString(EvseState s) {
     return "Invalid";
 }
 
-float Charger::getMaxCurrent() {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
-    auto maxc = maxCurrent;
+float Charger::get_max_current() {
+    std::scoped_lock lock(state_machine_mutex);
+    return get_max_current_internal();
+}
 
-    if (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket && maxCurrentCable < maxc &&
-        currentState != EvseState::Idle) {
-        maxc = maxCurrentCable;
+float Charger::get_max_current_internal() {
+    auto maxc = max_current;
+
+    if (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket and
+        max_current_cable < maxc and currentState not_eq EvseState::Idle) {
+        maxc = max_current_cable;
     }
 
     return maxc;
 }
 
-void Charger::setCurrentDrawnByVehicle(float l1, float l2, float l3) {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
-    currentDrawnByVehicle[0] = l1;
-    currentDrawnByVehicle[1] = l2;
-    currentDrawnByVehicle[2] = l3;
+void Charger::set_current_drawn_by_vehicle(float l1, float l2, float l3) {
+    std::scoped_lock lock(state_machine_mutex);
+    current_drawn_by_vehicle[0] = l1;
+    current_drawn_by_vehicle[1] = l2;
+    current_drawn_by_vehicle[2] = l3;
 }
 
-void Charger::checkSoftOverCurrent() {
+void Charger::check_soft_over_current() {
     // Allow some tolerance
-    float limit =
-        (getMaxCurrent() + soft_over_current_measurement_noise_A) * (1. + soft_over_current_tolerance_percent / 100.);
+    float limit = (get_max_current_internal() + soft_over_current_measurement_noise_A) *
+                  (1. + soft_over_current_tolerance_percent / 100.);
 
-    if (currentDrawnByVehicle[0] > limit || currentDrawnByVehicle[1] > limit || currentDrawnByVehicle[2] > limit) {
-        if (!overCurrent) {
-            overCurrent = true;
+    if (current_drawn_by_vehicle[0] > limit or current_drawn_by_vehicle[1] > limit or
+        current_drawn_by_vehicle[2] > limit) {
+        if (!over_current) {
+            over_current = true;
             // timestamp when over current happend first
-            lastOverCurrentEvent = date::utc_clock::now();
+            last_over_current_event = date::utc_clock::now();
             session_log.evse(false,
                              fmt::format("Soft overcurrent event (L1:{}, L2:{}, L3:{}, limit {}), starting timer.",
-                                         currentDrawnByVehicle[0], currentDrawnByVehicle[1], currentDrawnByVehicle[2],
-                                         limit));
+                                         current_drawn_by_vehicle[0], current_drawn_by_vehicle[1],
+                                         current_drawn_by_vehicle[2], limit));
         }
     } else {
-        overCurrent = false;
+        over_current = false;
     }
     auto now = date::utc_clock::now();
     auto timeSinceOverCurrentStarted =
-        std::chrono::duration_cast<std::chrono::milliseconds>(now - lastOverCurrentEvent).count();
-    if (overCurrent && timeSinceOverCurrentStarted >= softOverCurrentTimeout) {
-        auto errstr = fmt::format("Soft overcurrent event (L1:{}, L2:{}, L3:{}, limit {}) triggered",
-                                  currentDrawnByVehicle[0], currentDrawnByVehicle[1], currentDrawnByVehicle[2], limit);
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - last_over_current_event).count();
+    if (over_current and timeSinceOverCurrentStarted >= soft_over_current_timeout) {
+        auto errstr =
+            fmt::format("Soft overcurrent event (L1:{}, L2:{}, L3:{}, limit {}) triggered", current_drawn_by_vehicle[0],
+                        current_drawn_by_vehicle[1], current_drawn_by_vehicle[2], limit);
         session_log.evse(false, errstr);
         // raise the OC error
         error_handling->raise_overcurrent_error(errstr);
@@ -1250,62 +1237,62 @@ void Charger::checkSoftOverCurrent() {
 }
 
 // returns whether power is actually available from EnergyManager
-// i.e. maxCurrent is in valid range
-bool Charger::powerAvailable() {
-    if (maxCurrentValidUntil < date::utc_clock::now()) {
+// i.e. max_current is in valid range
+bool Charger::power_available() {
+    if (max_current_valid_until < date::utc_clock::now()) {
         EVLOG_warning << "Power budget expired, falling back to 0.";
-        maxCurrent = 0.;
-        signalMaxCurrent(maxCurrent);
+        max_current = 0.;
+        signal_max_current(max_current);
     }
-    return (getMaxCurrent() > 5.9);
+    return (get_max_current_internal() > 5.9);
 }
 
-void Charger::requestErrorSequence() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    if (currentState == EvseState::WaitingForAuthentication || currentState == EvseState::PrepareCharging) {
-        t_step_EF_returnState = currentState;
+void Charger::request_error_sequence() {
+    std::scoped_lock lock(state_machine_mutex);
+    if (currentState == EvseState::WaitingForAuthentication or currentState == EvseState::PrepareCharging) {
+        t_step_EF_return_state = currentState;
         currentState = EvseState::T_step_EF;
-        signal_SLAC_reset();
+        signal_slac_reset();
         if (hlc_use_5percent_current_session) {
-            t_step_EF_returnPWM = PWM_5_PERCENT;
+            t_step_EF_return_pwm = PWM_5_PERCENT;
         } else {
-            t_step_EF_returnPWM = 0.;
+            t_step_EF_return_pwm = 0.;
         }
     }
 }
 
-void Charger::setMatchingStarted(bool m) {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
+void Charger::set_matching_started(bool m) {
+    std::scoped_lock lock(state_machine_mutex);
     matching_started = m;
 }
 
-bool Charger::getMatchingStarted() {
-    std::lock_guard<std::recursive_mutex> lock(configMutex);
+bool Charger::get_matching_started() {
+    std::scoped_lock lock(state_machine_mutex);
     return matching_started;
 }
 
-void Charger::notifyCurrentDemandStarted() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+void Charger::notify_currentdemand_started() {
+    std::scoped_lock lock(state_machine_mutex);
     if (currentState == EvseState::PrepareCharging) {
-        signalEvent(types::evse_manager::SessionEventEnum::ChargingStarted);
+        signal_event(types::evse_manager::SessionEventEnum::ChargingStarted);
         currentState = EvseState::Charging;
     }
 }
 
 void Charger::inform_new_evse_max_hlc_limits(
     const types::iso15118_charger::DC_EVSEMaximumLimits& _currentEvseMaxLimits) {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    currentEvseMaxLimits = _currentEvseMaxLimits;
+    std::scoped_lock lock(state_machine_mutex);
+    current_evse_max_limits = _currentEvseMaxLimits;
 }
 
 types::iso15118_charger::DC_EVSEMaximumLimits Charger::get_evse_max_hlc_limits() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
-    return currentEvseMaxLimits;
+    std::scoped_lock lock(state_machine_mutex);
+    return current_evse_max_limits;
 }
 
 // HLC stack signalled a pause request for the lower layers.
 void Charger::dlink_pause() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+    std::scoped_lock lock(state_machine_mutex);
     hlc_allow_close_contactor = false;
     pwm_off();
     hlc_charging_terminate_pause = HlcTerminatePause::Pause;
@@ -1313,14 +1300,14 @@ void Charger::dlink_pause() {
 
 // HLC requested end of charging session, so we can stop the 5% PWM
 void Charger::dlink_terminate() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+    std::scoped_lock lock(state_machine_mutex);
     hlc_allow_close_contactor = false;
     pwm_off();
     hlc_charging_terminate_pause = HlcTerminatePause::Terminate;
 }
 
 void Charger::dlink_error() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+    std::scoped_lock lock(state_machine_mutex);
 
     hlc_allow_close_contactor = false;
 
@@ -1344,18 +1331,18 @@ void Charger::dlink_error() {
             // Do t_step_X1 with a t_step_EF afterwards
             // [V2G3-M07-08] The state E/F shall be applied at least T_step_EF: This is already handled in the
             // t_step_EF state.
-            t_step_X1_returnState = EvseState::T_step_EF;
-            t_step_X1_returnPWM = 0.;
+            t_step_X1_return_state = EvseState::T_step_EF;
+            t_step_X1_return_pwm = 0.;
             currentState = EvseState::T_step_X1;
 
             // After returning from T_step_EF, go to Waiting for Auth (We are restarting the session)
-            t_step_EF_returnState = EvseState::WaitingForAuthentication;
+            t_step_EF_return_state = EvseState::WaitingForAuthentication;
             // [V2G3-M07-09] After applying state E/F, the EVSE shall switch to contol pilot state X1 or X2 as soon
             // as the EVSE is ready control for pilot incoming duty matching cycle requests: This is already handled
             // in the Auth step.
 
             // [V2G3-M07-05] says we need to go through X1 at the end of the sequence
-            t_step_EF_returnPWM = 0.;
+            t_step_EF_return_pwm = 0.;
         }
         // else {
         // [V2G3-M07-10] Gives us two options for nominal PWM mode and HLC in case of error: We choose [V2G3-M07-12]
@@ -1366,17 +1353,17 @@ void Charger::dlink_error() {
 }
 
 void Charger::set_hlc_charging_active() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+    std::scoped_lock lock(state_machine_mutex);
     hlc_charging_active = true;
 }
 
 void Charger::set_hlc_allow_close_contactor(bool on) {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+    std::scoped_lock lock(state_machine_mutex);
     hlc_allow_close_contactor = on;
 }
 
 void Charger::set_hlc_error() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+    std::scoped_lock lock(state_machine_mutex);
     error_prevent_charging_flag = true;
 }
 
@@ -1407,7 +1394,7 @@ void Charger::bcb_toggle_detect_stop_pulse() {
     // This is probably and end of BCB toggle, verify it was not too long or too short
     auto pulse_length = std::chrono::steady_clock::now() - hlc_ev_pause_start_of_bcb;
 
-    if (pulse_length > TP_EV_VALD_STATE_DURATION_MIN && pulse_length < TP_EV_VALD_STATE_DURATION_MAX) {
+    if (pulse_length > TP_EV_VALD_STATE_DURATION_MIN and pulse_length < TP_EV_VALD_STATE_DURATION_MAX) {
 
         // enable PWM again. ISO stack should have been ready for the whole time.
         // FIXME where do we go from here? Auth?
@@ -1428,7 +1415,7 @@ void Charger::bcb_toggle_detect_stop_pulse() {
 // etc
 bool Charger::bcb_toggle_detected() {
     auto sequence_length = std::chrono::steady_clock::now() - hlc_ev_pause_start_of_bcb_sequence;
-    if (hlc_bcb_sequence_started && (sequence_length > TT_EVSE_VALD_TOGGLE || hlc_ev_pause_bcb_count >= 3)) {
+    if (hlc_bcb_sequence_started and (sequence_length > TT_EVSE_VALD_TOGGLE or hlc_ev_pause_bcb_count >= 3)) {
         // no need to wait for further BCB toggles
         hlc_ev_pause_bcb_count = 0;
         return true;
@@ -1437,11 +1424,16 @@ bool Charger::bcb_toggle_detected() {
 }
 
 void Charger::set_rcd_error() {
-    std::lock_guard<std::recursive_mutex> lock(stateMutex);
+    std::scoped_lock lock(state_machine_mutex);
     error_prevent_charging_flag = true;
 }
 
 bool Charger::errors_prevent_charging() {
+    std::scoped_lock lock(state_machine_mutex);
+    return errors_prevent_charging_internal();
+}
+
+bool Charger::errors_prevent_charging_internal() {
     if (error_prevent_charging_flag) {
         graceful_stop_charging();
         return true;
@@ -1457,7 +1449,7 @@ void Charger::graceful_stop_charging() {
 
     // Shutdown DC power supplies
     if (charge_mode == ChargeMode::DC) {
-        signal_DC_supply_off();
+        signal_dc_supply_off();
     }
 
     // open contactors

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -50,97 +50,10 @@ public:
             const types::evse_board_support::Connector_type& connector_type);
     ~Charger();
 
-    // Public interface to configure Charger
-    //
-    // Call anytime also during charging, but call setters in this block at
-    // least initially once.
-    //
-
-    // external input to charger: update max_current and new validUntil
-    bool setMaxCurrent(float ampere, std::chrono::time_point<date::utc_clock> validUntil);
-
-    float getMaxCurrent();
-    sigslot::signal<float> signalMaxCurrent;
-
     enum class ChargeMode {
         AC,
         DC
     };
-
-    void setup(bool three_phases, bool has_ventilation, const std::string& country_code, const ChargeMode charge_mode,
-               bool ac_hlc_enabled, bool ac_hlc_use_5percent, bool ac_enforce_hlc, bool ac_with_soc_timeout,
-               float soft_over_current_tolerance_percent, float soft_over_current_measurement_noise_A);
-
-    bool enable(int connector_id);
-    bool disable(int connector_id);
-    void set_faulted();
-    void set_hlc_error();
-    void set_rcd_error();
-    // switch to next charging session after Finished
-    bool restart();
-
-    // Public interface during charging
-    //
-    // Call anytime, but mostly used during charging session
-    //
-
-    // call when in state WaitingForAuthentication
-    void Authorize(bool a, const types::authorization::ProvidedIdToken& token);
-    bool DeAuthorize();
-    types::authorization::ProvidedIdToken getIdToken();
-    std::optional<types::authorization::ProvidedIdToken> getStopTransactionIdToken();
-
-    bool Authorized_PnC();
-    bool Authorized_EIM();
-
-    // this indicates the charger is done with all of its t_step_XX routines and HLC can now also start charging
-    bool Authorized_EIM_ready_for_HLC();
-    bool Authorized_PnC_ready_for_HLC();
-
-    // trigger replug sequence while charging to switch number of phases
-    bool switchThreePhasesWhileCharging(bool n);
-
-    bool pauseCharging();
-    bool pauseChargingWaitForPower();
-    bool resumeCharging();
-    bool resumeChargingPowerAvailable();
-    bool getPausedByEVSE();
-
-    bool cancelTransaction(const types::evse_manager::StopTransactionRequest&
-                               request); // cancel transaction ahead of time when car is still plugged
-    types::evse_manager::StopTransactionReason getTransactionFinishedReason(); // get reason for last finished event
-    types::evse_manager::StartSessionReason getSessionStartedReason(); // get reason for last session start event
-
-    // execute a virtual replug sequence. Does NOT generate a Car plugged in event etc,
-    // since the session is not restarted. It can be used to e.g. restart the ISO session
-    // and switch between AC and DC mode within a session.
-    bool evseReplug();
-
-    void setCurrentDrawnByVehicle(float l1, float l2, float l3);
-
-    bool forceUnlock();
-
-    // Signal for EvseEvents
-    sigslot::signal<types::evse_manager::SessionEventEnum> signalEvent;
-
-    sigslot::signal<> signalACWithSoCTimeout;
-
-    sigslot::signal<> signal_DC_supply_off;
-    sigslot::signal<> signal_SLAC_reset;
-    sigslot::signal<> signal_SLAC_start;
-
-    sigslot::signal<> signal_hlc_stop_charging;
-
-    void processEvent(CPEvent event);
-
-    void run();
-
-    void requestErrorSequence();
-
-    void setMatchingStarted(bool m);
-    bool getMatchingStarted();
-
-    void notifyCurrentDemandStarted();
 
     enum class EvseState {
         Disabled,
@@ -164,10 +77,92 @@ public:
         Pause
     };
 
-    std::string evseStateToString(EvseState s);
+    // Public interface to configure Charger
+    //
+    // Call anytime also during charging, but call setters in this block at
+    // least initially once.
+    //
 
-    EvseState getCurrentState();
-    sigslot::signal<EvseState> signalState;
+    // external input to charger: update max_current and new validUntil
+    bool set_max_current(float ampere, std::chrono::time_point<date::utc_clock> validUntil);
+    float get_max_current();
+    sigslot::signal<float> signal_max_current;
+
+    void setup(bool three_phases, bool has_ventilation, const std::string& country_code, const ChargeMode charge_mode,
+               bool ac_hlc_enabled, bool ac_hlc_use_5percent, bool ac_enforce_hlc, bool ac_with_soc_timeout,
+               float soft_over_current_tolerance_percent, float soft_over_current_measurement_noise_A);
+
+    bool enable(int connector_id);
+    bool disable(int connector_id);
+
+    void set_faulted();
+    void set_hlc_error();
+    void set_rcd_error();
+
+    // Public interface during charging
+    //
+    // Call anytime, but mostly used during charging session
+    //
+
+    // call when in state WaitingForAuthentication
+    void authorize(bool a, const types::authorization::ProvidedIdToken& token);
+    bool deauthorize();
+    types::authorization::ProvidedIdToken get_id_token();
+    std::optional<types::authorization::ProvidedIdToken> get_stop_transaction_id_token();
+
+    bool get_authorized_pnc();
+    bool get_authorized_eim();
+
+    // this indicates the charger is done with all of its t_step_XX routines and HLC can now also start charging
+    bool get_authorized_eim_ready_for_hlc();
+    bool get_authorized_pnc_ready_for_hlc();
+
+    // trigger replug sequence while charging to switch number of phases
+    bool switch_three_phases_while_charging(bool n);
+
+    bool pause_charging();
+    bool pause_charging_wait_for_power();
+    bool resume_charging();
+    bool resume_charging_power_available();
+
+    bool cancel_transaction(const types::evse_manager::StopTransactionRequest&
+                                request); // cancel transaction ahead of time when car is still plugged
+    types::evse_manager::StopTransactionReason get_transaction_finished_reason(); // get reason for last finished event
+    types::evse_manager::StartSessionReason get_session_started_reason(); // get reason for last session start event
+
+    // execute a virtual replug sequence. Does NOT generate a Car plugged in event etc,
+    // since the session is not restarted. It can be used to e.g. restart the ISO session
+    // and switch between AC and DC mode within a session.
+    bool evse_replug();
+
+    void set_current_drawn_by_vehicle(float l1, float l2, float l3);
+
+    // Signal for EvseEvents
+    sigslot::signal<types::evse_manager::SessionEventEnum> signal_event;
+
+    sigslot::signal<> signal_ac_with_soc_timeout;
+
+    sigslot::signal<> signal_dc_supply_off;
+    sigslot::signal<> signal_slac_reset;
+    sigslot::signal<> signal_slac_start;
+
+    sigslot::signal<> signal_hlc_stop_charging;
+
+    void process_event(CPEvent event);
+
+    void run();
+
+    void request_error_sequence();
+
+    void set_matching_started(bool m);
+    bool get_matching_started();
+
+    void notify_currentdemand_started();
+
+    std::string evse_state_to_string(EvseState s);
+
+    EvseState get_current_state();
+    sigslot::signal<EvseState> signal_state;
 
     void inform_new_evse_max_hlc_limits(const types::iso15118_charger::DC_EVSEMaximumLimits& l);
     types::iso15118_charger::DC_EVSEMaximumLimits get_evse_max_hlc_limits();
@@ -182,86 +177,83 @@ public:
     bool errors_prevent_charging();
 
 private:
+    bool errors_prevent_charging_internal();
+    float get_max_current_internal();
+    bool deauthorize_internal();
+    bool pause_charging_wait_for_power_internal();
+
     void bcb_toggle_reset();
     void bcb_toggle_detect_start_pulse();
     void bcb_toggle_detect_stop_pulse();
     bool bcb_toggle_detected();
 
     // main Charger thread
-    Everest::Thread mainThreadHandle;
+    Everest::Thread main_thread_handle;
 
     const std::unique_ptr<IECStateMachine>& bsp;
     const std::unique_ptr<ErrorHandling>& error_handling;
     const types::evse_board_support::Connector_type& connector_type;
 
-    void mainThread();
+    void main_thread();
 
-    float maxCurrent;
-    std::chrono::time_point<date::utc_clock> maxCurrentValidUntil;
-    float maxCurrentCable{0.};
+    float max_current;
+    std::chrono::time_point<date::utc_clock> max_current_valid_until;
+    float max_current_cable{0.};
 
-    bool powerAvailable();
+    bool power_available();
 
-    bool AuthorizedEIM();
-    bool AuthorizedPnC();
+    void start_session(bool authfirst);
+    void stop_session();
 
-    void startSession(bool authfirst);
-    void stopSession();
-    bool sessionActive();
+    void start_transaction();
+    void stop_transaction();
 
-    void startTransaction();
-    void stopTransaction();
-    bool transactionActive();
     bool transaction_active;
     bool session_active;
     types::evse_manager::StopTransactionReason last_stop_transaction_reason;
     types::evse_manager::StartSessionReason last_start_session_reason;
 
-    // This mutex locks all config type members
-    std::recursive_mutex configMutex;
-
-    // This mutex locks all state type members
-    std::recursive_mutex stateMutex;
+    // This mutex locks all variables related to the state machine
+    std::mutex state_machine_mutex;
 
     EvseState currentState;
     EvseState last_state;
     EvseState last_state_detect_state_change;
 
-    std::chrono::system_clock::time_point currentStateStarted;
+    std::chrono::system_clock::time_point current_state_started;
 
-    bool connectorEnabled;
+    bool connector_enabled;
 
     bool error_prevent_charging_flag{false};
     bool last_error_prevent_charging_flag{false};
     void graceful_stop_charging();
 
-    float ampereToDutyCycle(float ampere);
+    float ampere_to_duty_cycle(float ampere);
 
-    void checkSoftOverCurrent();
-    float currentDrawnByVehicle[3];
-    bool overCurrent;
-    std::chrono::time_point<date::utc_clock> lastOverCurrentEvent;
-    const int softOverCurrentTimeout = 7000;
+    void check_soft_over_current();
+    float current_drawn_by_vehicle[3];
+    bool over_current;
+    std::chrono::time_point<date::utc_clock> last_over_current_event;
+    const int soft_over_current_timeout = 7000;
 
     // 4 seconds according to table 3 of ISO15118-3
     const int t_step_EF = 4000;
-    EvseState t_step_EF_returnState;
-    float t_step_EF_returnPWM;
+    EvseState t_step_EF_return_state;
+    float t_step_EF_return_pwm;
 
     // 3 seconds according to IEC61851-1
     const int t_step_X1 = 3000;
-    EvseState t_step_X1_returnState;
-    float t_step_X1_returnPWM;
+    EvseState t_step_X1_return_state;
+    float t_step_X1_return_pwm;
 
-    const float PWM_5_PERCENT = 0.05;
-
-    const int t_replug_ms = 4000;
+    static constexpr float PWM_5_PERCENT = 0.05;
+    static constexpr int T_REPLUG_MS = 4000;
 
     bool matching_started;
 
-    void processCPEventsIndependent(CPEvent cp_event);
-    void processCPEventsState(CPEvent cp_event);
-    void runStateMachine();
+    void process_cp_events_independent(CPEvent cp_event);
+    void process_cp_events_state(CPEvent cp_event);
+    void run_state_machine();
 
     bool authorized;
     // set to true if auth is from PnC, otherwise to false (EIM)
@@ -287,7 +279,7 @@ private:
     bool ac_with_soc_timeout;
     int ac_with_soc_timer;
 
-    std::chrono::time_point<date::utc_clock> lastPwmUpdate;
+    std::chrono::time_point<date::utc_clock> last_pwm_update;
 
     float update_pwm_last_dc;
     void update_pwm_now(float dc);
@@ -297,7 +289,7 @@ private:
     void pwm_F();
     bool pwm_running{false};
 
-    types::iso15118_charger::DC_EVSEMaximumLimits currentEvseMaxLimits;
+    types::iso15118_charger::DC_EVSEMaximumLimits current_evse_max_limits;
 
     static constexpr auto SLEEP_BEFORE_ENABLING_PWM_HLC_MODE = std::chrono::seconds(1);
     static constexpr auto MAINLOOP_UPDATE_RATE = std::chrono::milliseconds(100);
@@ -332,9 +324,9 @@ private:
     constexpr static int legacy_wakeup_timeout{30000};
 
     void clear_errors_on_unplug();
-};
 
-#define CHARGER_ABSOLUTE_MAX_CURRENT double(80.0F)
+    static constexpr float CHARGER_ABSOLUTE_MAX_CURRENT{80.};
+};
 
 } // namespace module
 

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -216,7 +216,7 @@ private:
     // This mutex locks all variables related to the state machine
     std::mutex state_machine_mutex;
 
-    EvseState currentState;
+    EvseState current_state;
     EvseState last_state;
     EvseState last_state_detect_state_change;
 

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -214,7 +214,7 @@ private:
     types::evse_manager::StartSessionReason last_start_session_reason;
 
     // This mutex locks all variables related to the state machine
-    std::mutex state_machine_mutex;
+    std::recursive_mutex state_machine_mutex;
 
     EvseState current_state;
     EvseState last_state;

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -44,30 +44,30 @@ void EvseManager::init() {
     invoke_init(*p_token_provider);
 
     // check if a slac module is connected to the optional requirement
-    slac_enabled = !r_slac.empty();
+    slac_enabled = not r_slac.empty();
 
     // if hlc is disabled in config, disable slac even if requirement is connected
-    if (!(config.ac_hlc_enabled || config.ac_with_soc || config.charge_mode == "DC")) {
+    if (not(config.ac_hlc_enabled or config.ac_with_soc or config.charge_mode == "DC")) {
         slac_enabled = false;
     }
 
     // Use SLAC MAC address for Autocharge if configured.
-    if (config.autocharge_use_slac_instead_of_hlc && slac_enabled) {
+    if (config.autocharge_use_slac_instead_of_hlc and slac_enabled) {
         r_slac[0]->subscribe_ev_mac_address([this](const std::string& token) {
             p_token_provider->publish_provided_token(create_autocharge_token(token, config.connector_id));
         });
     }
 
-    hlc_enabled = !r_hlc.empty();
-    if (!slac_enabled)
+    hlc_enabled = not r_hlc.empty();
+    if (not slac_enabled)
         hlc_enabled = false;
 
-    if (config.charge_mode == "DC" && (!hlc_enabled || !slac_enabled || r_powersupply_DC.empty())) {
+    if (config.charge_mode == "DC" and (not hlc_enabled or not slac_enabled or r_powersupply_DC.empty())) {
         EVLOG_error << "DC mode requires slac, HLC and powersupply DCDC to be connected";
         exit(255);
     }
 
-    if (config.charge_mode == "DC" && r_imd.empty()) {
+    if (config.charge_mode == "DC" and r_imd.empty()) {
         EVLOG_warning << "DC mode without isolation monitoring configured, please check your national regulations.";
     }
 
@@ -212,7 +212,7 @@ void EvseManager::ready() {
             });
 
             // Isolation monitoring for DC charging handler
-            if (!r_imd.empty()) {
+            if (not r_imd.empty()) {
 
                 imd_stop();
 
@@ -224,7 +224,7 @@ void EvseManager::ready() {
             }
 
             // Get voltage/current from DC power supply
-            if (!r_powersupply_DC.empty()) {
+            if (not r_powersupply_DC.empty()) {
                 r_powersupply_DC[0]->subscribe_voltage_current([this](types::power_supply_DC::VoltageCurrent m) {
                     powersupply_measurement = m;
                     types::iso15118_charger::DC_EVSEPresentVoltage_Current present_values;
@@ -240,7 +240,7 @@ void EvseManager::ready() {
                             present_values.EVSEPresentCurrent.value() + config.hack_present_current_offset;
                     }
 
-                    if (config.hack_pause_imd_during_precharge && m.voltage_V * m.current_A > 1000) {
+                    if (config.hack_pause_imd_during_precharge and m.voltage_V * m.current_A > 1000) {
                         // Start IMD again as it was stopped after CableCheck
                         imd_start();
                         EVLOG_info << "Hack: Restarting Isolation Measurement at " << m.voltage_V << " " << m.current_A;
@@ -264,10 +264,11 @@ void EvseManager::ready() {
                 bool target_changed = false;
 
                 // Hack for Skoda Enyaq that should be fixed in a different way
-                if (config.hack_skoda_enyaq && (v.DC_EVTargetVoltage < 300 || v.DC_EVTargetCurrent < 0))
+                if (config.hack_skoda_enyaq and (v.DC_EVTargetVoltage < 300 or v.DC_EVTargetCurrent < 0))
                     return;
 
-                if (v.DC_EVTargetVoltage != latest_target_voltage || v.DC_EVTargetCurrent != latest_target_current) {
+                if (v.DC_EVTargetVoltage not_eq latest_target_voltage or
+                    v.DC_EVTargetCurrent not_eq latest_target_current) {
                     latest_target_voltage = v.DC_EVTargetVoltage;
                     latest_target_current = v.DC_EVTargetCurrent;
                     target_changed = true;
@@ -275,7 +276,7 @@ void EvseManager::ready() {
 
                 if (target_changed) {
                     apply_new_target_voltage_current();
-                    if (!contactor_open) {
+                    if (not contactor_open) {
                         powersupply_DC_on();
                     }
 
@@ -436,8 +437,8 @@ void EvseManager::ready() {
         // implement Auth handlers
         r_hlc[0]->subscribe_Require_Auth_EIM([this]() {
             //  Do we have auth already (i.e. delayed HLC after charging already running)?
-            if ((config.dbg_hlc_auth_after_tstep && charger->get_authorized_eim_ready_for_hlc()) ||
-                (!config.dbg_hlc_auth_after_tstep && charger->get_authorized_eim())) {
+            if ((config.dbg_hlc_auth_after_tstep and charger->get_authorized_eim_ready_for_hlc()) or
+                (not config.dbg_hlc_auth_after_tstep and charger->get_authorized_eim())) {
                 {
                     std::scoped_lock lock(hlc_mutex);
                     hlc_waiting_for_auth_eim = false;
@@ -453,7 +454,7 @@ void EvseManager::ready() {
             }
         });
 
-        if (!config.autocharge_use_slac_instead_of_hlc) {
+        if (not config.autocharge_use_slac_instead_of_hlc) {
             r_hlc[0]->subscribe_EVCCIDD([this](const std::string& token) {
                 autocharge_token = create_autocharge_token(token, config.connector_id);
                 car_manufacturer = get_manufacturer_from_mac(token);
@@ -533,7 +534,7 @@ void EvseManager::ready() {
     }
 
     // Maybe limit to single phase by user setting if possible with HW
-    if (!config.three_phases && hw_capabilities.min_phase_count_import == 1) {
+    if (not config.three_phases and hw_capabilities.min_phase_count_import == 1) {
         hw_capabilities.max_phase_count_import = 1;
         local_three_phases = false;
     } else if (hw_capabilities.max_phase_count_import == 3) {
@@ -614,7 +615,7 @@ void EvseManager::ready() {
     if (r_powermeter_billing().size() > 0) {
         r_powermeter_billing()[0]->subscribe_powermeter([this](types::powermeter::Powermeter p) {
             // Inform charger about current charging current. This is used for slow OC detection.
-            if (p.current_A && p.current_A.value().L1 && p.current_A.value().L2 && p.current_A.value().L3) {
+            if (p.current_A and p.current_A.value().L1 and p.current_A.value().L2 and p.current_A.value().L3) {
                 charger->set_current_drawn_by_vehicle(p.current_A.value().L1.value(), p.current_A.value().L2.value(),
                                                       p.current_A.value().L3.value());
             }
@@ -686,11 +687,11 @@ void EvseManager::ready() {
 
     charger->signal_event.connect([this](types::evse_manager::SessionEventEnum s) {
         // Cancel reservations if charger is disabled or faulted
-        if (s == types::evse_manager::SessionEventEnum::Disabled ||
+        if (s == types::evse_manager::SessionEventEnum::Disabled or
             s == types::evse_manager::SessionEventEnum::PermanentFault) {
             cancel_reservation(true);
         }
-        if (s == types::evse_manager::SessionEventEnum::SessionStarted ||
+        if (s == types::evse_manager::SessionEventEnum::SessionStarted or
             s == types::evse_manager::SessionEventEnum::SessionFinished) {
             // Reset EV information on Session start and end
             ev_info = types::evse_manager::EVInfo();
@@ -699,13 +700,13 @@ void EvseManager::ready() {
 
         std::vector<types::iso15118_charger::PaymentOption> payment_options;
 
-        if (get_hlc_enabled() && s == types::evse_manager::SessionEventEnum::SessionStarted &&
+        if (get_hlc_enabled() and s == types::evse_manager::SessionEventEnum::SessionStarted and
             charger->get_session_started_reason() == types::evse_manager::StartSessionReason::Authorized) {
 
             payment_options.push_back(types::iso15118_charger::PaymentOption::ExternalPayment);
             r_hlc[0]->call_session_setup(payment_options, false);
 
-        } else if (get_hlc_enabled() && s == types::evse_manager::SessionEventEnum::SessionFinished) {
+        } else if (get_hlc_enabled() and s == types::evse_manager::SessionEventEnum::SessionFinished) {
             if (config.payment_enable_eim) {
                 payment_options.push_back(types::iso15118_charger::PaymentOption::ExternalPayment);
             }
@@ -729,7 +730,7 @@ void EvseManager::ready() {
     }
 
     telemetryThreadHandle = std::thread([this]() {
-        while (!telemetryThreadHandle.shouldExit()) {
+        while (not telemetryThreadHandle.shouldExit()) {
             sleep(10);
             auto p = get_latest_powermeter_data_billing();
             Everest::TelemetryMap telemetry_data{{"timestamp", p.timestamp},
@@ -750,75 +751,75 @@ void EvseManager::ready() {
             if (p.energy_Wh_export) {
                 telemetry_data["energy_export_total_Wh"] = p.energy_Wh_export.value().total;
             }
-            if (p.energy_Wh_export && p.energy_Wh_export.value().L1) {
+            if (p.energy_Wh_export and p.energy_Wh_export.value().L1) {
                 telemetry_data["energy_export_L1_Wh"] = p.energy_Wh_export.value().L1.value();
             }
-            if (p.energy_Wh_export && p.energy_Wh_export.value().L2) {
+            if (p.energy_Wh_export and p.energy_Wh_export.value().L2) {
                 telemetry_data["energy_export_L2_Wh"] = p.energy_Wh_export.value().L2.value();
             }
-            if (p.energy_Wh_export && p.energy_Wh_export.value().L3) {
+            if (p.energy_Wh_export and p.energy_Wh_export.value().L3) {
                 telemetry_data["energy_export_L3_Wh"] = p.energy_Wh_export.value().L3.value();
             }
 
             if (p.power_W) {
                 telemetry_data["power_total_W"] = p.power_W.value().total;
             }
-            if (p.power_W && p.power_W.value().L1) {
+            if (p.power_W and p.power_W.value().L1) {
                 telemetry_data["power_L1_W"] = p.power_W.value().L1.value();
             }
-            if (p.power_W && p.power_W.value().L2) {
+            if (p.power_W and p.power_W.value().L2) {
                 telemetry_data["power_L3_W"] = p.power_W.value().L2.value();
             }
-            if (p.power_W && p.power_W.value().L3) {
+            if (p.power_W and p.power_W.value().L3) {
                 telemetry_data["power_L3_W"] = p.power_W.value().L3.value();
             }
 
             if (p.VAR) {
                 telemetry_data["var_total"] = p.VAR.value().total;
             }
-            if (p.VAR && p.VAR.value().L1) {
+            if (p.VAR and p.VAR.value().L1) {
                 telemetry_data["var_L1"] = p.VAR.value().L1.value();
             }
-            if (p.VAR && p.VAR.value().L2) {
+            if (p.VAR and p.VAR.value().L2) {
                 telemetry_data["var_L1"] = p.VAR.value().L2.value();
             }
-            if (p.VAR && p.VAR.value().L3) {
+            if (p.VAR and p.VAR.value().L3) {
                 telemetry_data["var_L1"] = p.VAR.value().L3.value();
             }
 
-            if (p.voltage_V && p.voltage_V.value().L1) {
+            if (p.voltage_V and p.voltage_V.value().L1) {
                 telemetry_data["voltage_L1_V"] = p.voltage_V.value().L1.value();
             }
-            if (p.voltage_V && p.voltage_V.value().L2) {
+            if (p.voltage_V and p.voltage_V.value().L2) {
                 telemetry_data["voltage_L2_V"] = p.voltage_V.value().L2.value();
             }
-            if (p.voltage_V && p.voltage_V.value().L3) {
+            if (p.voltage_V and p.voltage_V.value().L3) {
                 telemetry_data["voltage_L3_V"] = p.voltage_V.value().L3.value();
             }
-            if (p.voltage_V && p.voltage_V.value().DC) {
+            if (p.voltage_V and p.voltage_V.value().DC) {
                 telemetry_data["voltage_DC_V"] = p.voltage_V.value().DC.value();
             }
 
-            if (p.current_A && p.current_A.value().L1) {
+            if (p.current_A and p.current_A.value().L1) {
                 telemetry_data["current_L1_A"] = p.current_A.value().L1.value();
             }
-            if (p.current_A && p.current_A.value().L2) {
+            if (p.current_A and p.current_A.value().L2) {
                 telemetry_data["current_L2_A"] = p.current_A.value().L2.value();
             }
-            if (p.current_A && p.current_A.value().L3) {
+            if (p.current_A and p.current_A.value().L3) {
                 telemetry_data["current_L3_A"] = p.current_A.value().L3.value();
             }
-            if (p.current_A && p.current_A.value().DC) {
+            if (p.current_A and p.current_A.value().DC) {
                 telemetry_data["current_DC_A"] = p.current_A.value().DC.value();
             }
 
             if (p.frequency_Hz) {
                 telemetry_data["frequency_L1_Hz"] = p.frequency_Hz.value().L1;
             }
-            if (p.frequency_Hz && p.frequency_Hz.value().L2) {
+            if (p.frequency_Hz and p.frequency_Hz.value().L2) {
                 telemetry_data["frequency_L2_Hz"] = p.frequency_Hz.value().L2.value();
             }
-            if (p.frequency_Hz && p.frequency_Hz.value().L3) {
+            if (p.frequency_Hz and p.frequency_Hz.value().L3) {
                 telemetry_data["frequency_L3_Hz"] = p.frequency_Hz.value().L3.value();
             }
 
@@ -835,7 +836,7 @@ void EvseManager::ready() {
     //  caps.
     charger->set_max_current(0.0F, date::utc_clock::now() + std::chrono::seconds(10));
     this->p_evse->publish_waiting_for_external_ready(config.external_ready_to_start_charging);
-    if (!config.external_ready_to_start_charging) {
+    if (not config.external_ready_to_start_charging) {
         // immediately ready, otherwise delay until we get the external signal
         this->ready_to_start_charging();
     }
@@ -949,8 +950,8 @@ void EvseManager::setup_v2h_mode() {
     types::iso15118_charger::DC_EVSEMaximumLimits evseMaxLimits;
     types::iso15118_charger::DC_EVSEMinimumLimits evseMinLimits;
 
-    if (powersupply_capabilities.max_import_current_A.has_value() &&
-        powersupply_capabilities.max_import_power_W.has_value() &&
+    if (powersupply_capabilities.max_import_current_A.has_value() and
+        powersupply_capabilities.max_import_power_W.has_value() and
         powersupply_capabilities.max_import_voltage_V.has_value()) {
         evseMaxLimits.EVSEMaximumCurrentLimit = -powersupply_capabilities.max_import_current_A.value();
         evseMaxLimits.EVSEMaximumPowerLimit = -powersupply_capabilities.max_import_power_W.value();
@@ -962,7 +963,7 @@ void EvseManager::setup_v2h_mode() {
         return;
     }
 
-    if (powersupply_capabilities.min_import_current_A.has_value() &&
+    if (powersupply_capabilities.min_import_current_A.has_value() and
         powersupply_capabilities.min_import_voltage_V.has_value()) {
         evseMinLimits.EVSEMinimumCurrentLimit = -powersupply_capabilities.min_import_current_A.value();
         evseMinLimits.EVSEMinimumVoltageLimit = powersupply_capabilities.min_import_voltage_V.value();
@@ -991,7 +992,7 @@ void EvseManager::setup_v2h_mode() {
 bool EvseManager::updateLocalEnergyLimit(types::energy::ExternalLimits l) {
 
     // received empty limits, fall back to hardware limits
-    if (!l.schedule_import.has_value() && !l.schedule_export.has_value()) {
+    if (not l.schedule_import.has_value() and not l.schedule_export.has_value()) {
         EVLOG_info << "External limits are empty, defaulting to hardware limits";
         if (config.charge_mode == "AC") {
             // by default we import energy
@@ -1031,8 +1032,9 @@ bool EvseManager::updateLocalMaxWattLimit(float max_watt) {
 // Note: deprecated, use updateLocalEnergyLimit. Only kept for node red compat.
 // This overwrites all other schedules set before.
 bool EvseManager::updateLocalMaxCurrentLimit(float max_current) {
-    if (config.charge_mode == "DC")
+    if (config.charge_mode == "DC") {
         return false;
+    }
 
     types::energy::ScheduleReqEntry e;
     e.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
@@ -1065,13 +1067,13 @@ bool EvseManager::reserve(int32_t id) {
     }
 
     // is the connector currently ready to accept a new car?
-    if (charger->get_current_state() != Charger::EvseState::Idle) {
+    if (charger->get_current_state() not_eq Charger::EvseState::Idle) {
         return false;
     }
 
     std::lock_guard<std::mutex> lock(reservation_mutex);
 
-    if (!reserved) {
+    if (not reserved) {
         reserved = true;
         reservation_id = id;
 
@@ -1126,7 +1128,7 @@ void EvseManager::log_v2g_message(Object m) {
 
     std::string xml = "";
     std::string json_str = "";
-    if (m["V2G_Message_XML"].is_null() && m["V2G_Message_JSON"].is_string()) {
+    if (m["V2G_Message_XML"].is_null() and m["V2G_Message_JSON"].is_string()) {
         json_str = m["V2G_Message_JSON"];
     } else if (m["V2G_Message_XML"].is_string()) {
         xml = m["V2G_Message_XML"];
@@ -1145,14 +1147,14 @@ void EvseManager::log_v2g_message(Object m) {
 void EvseManager::charger_was_authorized() {
 
     std::scoped_lock lock(hlc_mutex);
-    if (hlc_waiting_for_auth_pnc && charger->get_authorized_pnc()) {
+    if (hlc_waiting_for_auth_pnc and charger->get_authorized_pnc()) {
         r_hlc[0]->call_authorization_response(types::authorization::AuthorizationStatus::Accepted,
                                               types::authorization::CertificateStatus::Accepted);
         hlc_waiting_for_auth_eim = false;
         hlc_waiting_for_auth_pnc = false;
     }
 
-    if (hlc_waiting_for_auth_eim && charger->get_authorized_eim()) {
+    if (hlc_waiting_for_auth_eim and charger->get_authorized_eim()) {
         r_hlc[0]->call_authorization_response(types::authorization::AuthorizationStatus::Accepted,
                                               types::authorization::CertificateStatus::NoCertificateAvailable);
         hlc_waiting_for_auth_eim = false;
@@ -1184,20 +1186,21 @@ void EvseManager::cable_check() {
         Timeout timeout;
         timeout.start(CABLECHECK_CONTACTORS_CLOSE_TIMEOUT);
 
-        while (!timeout.reached()) {
-            if (!contactor_open)
+        while (not timeout.reached()) {
+            if (not contactor_open) {
                 break;
+            }
             std::this_thread::sleep_for(100ms);
         }
 
         // verify the relais are really switched on and set 500V output
-        if (!contactor_open) {
+        if (not contactor_open) {
             if (powersupply_DC_set(config.dc_isolation_voltage_V, 2)) {
                 powersupply_DC_on();
                 imd_start();
 
                 // wait until the voltage has rised to the target value
-                if (!wait_powersupply_DC_voltage_reached(config.dc_isolation_voltage_V)) {
+                if (not wait_powersupply_DC_voltage_reached(config.dc_isolation_voltage_V)) {
                     EVLOG_info << "Voltage did not rise to 500V within timeout";
                     powersupply_DC_off();
                     fail_session();
@@ -1207,7 +1210,7 @@ void EvseManager::cable_check() {
                     // read out one new isolation resistance
                     isolation_measurement.clear();
                     types::isolation_monitor::IsolationMeasurement m;
-                    if (!isolation_measurement.wait_for(m, 10s)) {
+                    if (not isolation_measurement.wait_for(m, 10s)) {
                         EVLOG_info << "Did not receive isolation measurement from IMD within 10 seconds.";
                         powersupply_DC_off();
                         ok = false;
@@ -1224,7 +1227,7 @@ void EvseManager::cable_check() {
                         }
                         powersupply_DC_set(minvoltage, 2);
 
-                        if (!wait_powersupply_DC_below_voltage(minvoltage + 20)) {
+                        if (not wait_powersupply_DC_below_voltage(minvoltage + 20)) {
                             EVLOG_info << "Voltage did not go back to minimal voltage within timeout.";
                             ok = false;
                             fail_session();
@@ -1284,7 +1287,7 @@ void EvseManager::cable_check() {
 }
 
 void EvseManager::powersupply_DC_on() {
-    if (!powersupply_dc_is_on) {
+    if (not powersupply_dc_is_on) {
         session_log.evse(false, "DC power supply: switch ON called");
         r_powersupply_DC[0]->call_setMode(types::power_supply_DC::Mode::Export);
         powersupply_dc_is_on = true;
@@ -1312,9 +1315,9 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
         current = std::abs(current);
     }
 
-    if ((config.hack_allow_bpt_with_iso2 || config.sae_j2847_2_bpt_enabled) && current_demand_active &&
+    if ((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and current_demand_active and
         is_actually_exporting_to_grid) {
-        if (!last_is_actually_exporting_to_grid) {
+        if (not last_is_actually_exporting_to_grid) {
             // switching from import from grid to export to grid
             session_log.evse(false, "DC power supply: switch ON in import mode");
             r_powersupply_DC[0]->call_setMode(types::power_supply_DC::Mode::Import);
@@ -1322,15 +1325,15 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
         last_is_actually_exporting_to_grid = is_actually_exporting_to_grid;
         // Hack: we are exporting to grid but are in ISO-2 mode
         // check limits of supply
-        if (powersupply_capabilities.min_import_voltage_V.has_value() &&
-            voltage >= powersupply_capabilities.min_import_voltage_V.value() &&
+        if (powersupply_capabilities.min_import_voltage_V.has_value() and
+            voltage >= powersupply_capabilities.min_import_voltage_V.value() and
             voltage <= powersupply_capabilities.max_import_voltage_V.value()) {
 
-            if (powersupply_capabilities.max_import_current_A.has_value() &&
+            if (powersupply_capabilities.max_import_current_A.has_value() and
                 current > powersupply_capabilities.max_import_current_A.value())
                 current = powersupply_capabilities.max_import_current_A.value();
 
-            if (powersupply_capabilities.min_import_current_A.has_value() &&
+            if (powersupply_capabilities.min_import_current_A.has_value() and
                 current < powersupply_capabilities.min_import_current_A.value())
                 current = powersupply_capabilities.min_import_current_A.value();
 
@@ -1351,7 +1354,7 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
 
     } else {
 
-        if ((config.hack_allow_bpt_with_iso2 || config.sae_j2847_2_bpt_enabled) && current_demand_active &&
+        if ((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and current_demand_active and
             last_is_actually_exporting_to_grid) {
             // switching from export to grid to import from grid
             session_log.evse(false, "DC power supply: switch ON in export mode");
@@ -1360,7 +1363,7 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
         }
 
         // check limits of supply
-        if (voltage >= powersupply_capabilities.min_export_voltage_V &&
+        if (voltage >= powersupply_capabilities.min_export_voltage_V and
             voltage <= powersupply_capabilities.max_export_voltage_V) {
 
             if (current > powersupply_capabilities.max_export_current_A)
@@ -1399,7 +1402,7 @@ bool EvseManager::wait_powersupply_DC_voltage_reached(double target_voltage) {
     Timeout timeout;
     timeout.start(30s);
     bool voltage_ok = false;
-    while (!timeout.reached()) {
+    while (not timeout.reached()) {
         types::power_supply_DC::VoltageCurrent m;
         if (powersupply_measurement.wait_for(m, 2000ms)) {
             if (fabs(m.voltage_V - target_voltage) < 10) {
@@ -1420,7 +1423,7 @@ bool EvseManager::wait_powersupply_DC_below_voltage(double target_voltage) {
     Timeout timeout;
     timeout.start(30s);
     bool voltage_ok = false;
-    while (!timeout.reached()) {
+    while (not timeout.reached()) {
         types::power_supply_DC::VoltageCurrent m;
         if (powersupply_measurement.wait_for(m, 2000ms)) {
             if (m.voltage_V < target_voltage) {
@@ -1445,13 +1448,13 @@ const std::vector<std::unique_ptr<powermeterIntf>>& EvseManager::r_powermeter_bi
 }
 
 void EvseManager::imd_stop() {
-    if (!r_imd.empty()) {
+    if (not r_imd.empty()) {
         r_imd[0]->call_stop();
     }
 }
 
 void EvseManager::imd_start() {
-    if (!r_imd.empty()) {
+    if (not r_imd.empty()) {
         r_imd[0]->call_start();
     }
 }


### PR DESCRIPTION
The Charger class in EvseManager had a quite complicated locking concept with two (recusive) mutexes. This PR simplies locking with a single mutex using only scoped locking. A few cases where locking was not neccessary were removed. 