### PR TITLE
Fix OCPP compile warning, Setup ev-cli bug

### DIFF
--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -114,6 +114,8 @@ static ErrorInfo get_error_info(const std::optional<types::evse_manager::Error> 
     case types::evse_manager::ErrorEnum::PowermeterTransactionStartFailed:
         return {ocpp::v16::ChargePointErrorCode::InternalError, types::evse_manager::error_enum_to_string(error_code)};
     }
+
+    return {ocpp::v16::ChargePointErrorCode::InternalError};
 }
 
 ocpp::SessionStartedReason get_session_started_reason(const types::evse_manager::StartSessionReason reason) {

--- a/modules/Setup/CMakeLists.txt
+++ b/modules/Setup/CMakeLists.txt
@@ -13,7 +13,8 @@ target_sources(${MODULE_NAME}
     PRIVATE
         "RunApplication.cpp"
         "WiFiSetup.cpp"
-)# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+)
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 
 target_sources(${MODULE_NAME}
     PRIVATE

--- a/modules/Setup/Setup.hpp
+++ b/modules/Setup/Setup.hpp
@@ -22,6 +22,7 @@
 #include <regex>
 
 namespace module {
+namespace fs = std::filesystem;
 
 struct WifiCredentials {
     std::string interface;
@@ -101,8 +102,6 @@ void to_json(json& j, const ApplicationInfo& k);
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {
-
-namespace fs = std::filesystem;
 
 struct Conf {
     bool setup_wifi;


### PR DESCRIPTION
- Fixed OCPP warning for missing return value
- Setup module did not compile after ev-cli update