### PR TITLE
Fix connector lock unlock too early before relais open

### DIFF
--- a/modules/EvseManager/IECStateMachine.hpp
+++ b/modules/EvseManager/IECStateMachine.hpp
@@ -87,6 +87,7 @@ public:
 
     void connector_lock();
     void connector_unlock();
+    void check_connector_lock();
 
     // Signal for internal events type
     sigslot::signal<CPEvent> signal_event;
@@ -118,9 +119,11 @@ private:
     void call_allow_power_on_bsp(bool value);
 
     std::atomic_bool three_phases{true};
-    std::atomic_bool locked{false};
+    std::atomic_bool is_locked{false};
+    std::atomic_bool should_be_locked{false};
 
     std::atomic_bool enabled{false};
+    std::atomic_bool relais_on{false};
 };
 
 } // namespace module


### PR DESCRIPTION
In the current implementation, the motor lock is controlled merely by the CP state. It should however not open the lock while the output contactors are still closed. This PR changes the behaviour so that the unlock command is only sent if both the CP state is appropriate and the opening of contactors has been confirmed by the BSP.