### PR TITLE
Fix conversion of EVerest to OCPP KeyPair type

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -49,7 +49,7 @@ libcurl:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.9.7
+  git_tag: 496c14b
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/lib/staging/ocpp/evse_security_ocpp.cpp
+++ b/lib/staging/ocpp/evse_security_ocpp.cpp
@@ -248,6 +248,7 @@ ocpp::OCSPRequestData to_ocpp(types::evse_security::OCSPRequestData other) {
 ocpp::KeyPair to_ocpp(types::evse_security::KeyPair other) {
     ocpp::KeyPair lhs;
     lhs.certificate_path = other.certificate;
+    lhs.certificate_single_path = other.certificate_single;
     lhs.key_path = other.key;
     lhs.password = other.password;
     return lhs;


### PR DESCRIPTION
Change required due to: https://github.com/EVerest/libocpp/pull/455

ocpp::KeyPair was extended so that certificate_single_path is added on conversion