### PR TITLE
EvseV2G: always assign GenChallenge and EVSETimeStamp in PaymentDetailsRes

### DIFF
--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -1251,6 +1251,10 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
                 } else {
                     res->ResponseCode = iso1responseCodeType_FAILED_CertChainError;
                 }
+                // EVSETimeStamp and GenChallenge are mandatory, GenChallenge has fixed size
+                res->EVSETimeStamp = time(NULL);
+                memset(res->GenChallenge.bytes, 0, GEN_CHALLENGE_SIZE);
+                res->GenChallenge.bytesLen = GEN_CHALLENGE_SIZE;
                 goto error_out;
             }
 


### PR DESCRIPTION
When responding in PaymentDetailsRes with a FAILED ResponseCode, EVSETimeStamp and GenChallenge need to be assigned, even if unused. Especially GenChallenge needs to conform to the fixed size mandated by the schema.

Previously, GenChallenge was sent with size 0 in this case, which could lead to message validation errors on the receiving EV side.

Signed-off-by: Moritz Barsnick <moritz.barsnick@chargebyte.com>