### PR TITLE
remove obsolete `rcd_enabled` config variable

### DIFF
--- a/config/config-sil-dc-sae-v2g.yaml
+++ b/config/config-sil-dc-sae-v2g.yaml
@@ -19,7 +19,6 @@ active_modules:
     config_module:
       connector_id: 1
       country_code: DE
-      rcd_enabled: true
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678
       session_logging: true

--- a/config/config-sil-dc-sae-v2h.yaml
+++ b/config/config-sil-dc-sae-v2h.yaml
@@ -19,7 +19,6 @@ active_modules:
     config_module:
       connector_id: 1
       country_code: DE
-      rcd_enabled: true
       evse_id: DE*PNX*E12345*1
       evse_id_din: 49A80737A45678
       session_logging: true

--- a/config/config-sil-ocpp-pnc.yaml
+++ b/config/config-sil-ocpp-pnc.yaml
@@ -23,7 +23,6 @@ active_modules:
       three_phases: true
       has_ventilation: true
       country_code: DE
-      rcd_enabled: true
       evse_id: "DE*PNX*00001"
       session_logging: true
       session_logging_xml: false
@@ -51,7 +50,6 @@ active_modules:
       three_phases: true
       has_ventilation: true
       country_code: DE
-      rcd_enabled: true
       evse_id: "2"
       session_logging: true
       session_logging_xml: false

--- a/modules/simulation/JsYetiSimulator/index.js
+++ b/modules/simulation/JsYetiSimulator/index.js
@@ -464,7 +464,7 @@ function simulation_statemachine(mod) {
 }
 
 function check_error_rcd(mod) {
-  if (mod.rcd_enabled && mod.simulation_data.rcd_current > 5.0) {
+  if (mod.simulation_data.rcd_current > 5.0) {
     if (!mod.rcd_error_reported) {
       mod.provides.rcd.raise.ac_rcd_DC('Simulated fault event', 'High');
       mod.rcd_error_reported = true;
@@ -984,7 +984,6 @@ function clearData(mod) {
   mod.has_ventilation = false;
 
   mod.rcd_current = 0.1;
-  mod.rcd_enabled = true;
   mod.rcd_error = false;
   mod.rcd_error_reported = false;
 


### PR DESCRIPTION
Its implementation and uses were removed in commit e194737f06f7a5a90635046635f399fd4582cd46, but partly forgotten, or came back in with PR #357 in commit da8e936fc0bfb610fb96f22fec1af622ebb35bce.