### PR TITLE
Fix forced unlocking

### DIFF
--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -415,7 +415,17 @@ void IECStateMachine::connector_unlock() {
 }
 
 void IECStateMachine::connector_force_unlock() {
-    force_unlocked = true;
+    RawCPState cp;
+
+    {
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::IEC_force_unlock);
+        cp = cp_state;
+    }
+
+    if (cp == RawCPState::B or cp == RawCPState::C) {
+        force_unlocked = true;
+        check_connector_lock();
+    }
 }
 
 void IECStateMachine::check_connector_lock() {

--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -203,7 +203,6 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
         [[fallthrough]];
 
     case RawCPState::C:
-        force_unlocked = false;
         connector_lock();
         // Table A.6: Sequence 1.2 Plug-in
         if (last_cp_state == RawCPState::A || last_cp_state == RawCPState::Disabled ||

--- a/modules/EvseManager/IECStateMachine.hpp
+++ b/modules/EvseManager/IECStateMachine.hpp
@@ -87,9 +87,7 @@ public:
 
     void enable(bool en);
 
-    void connector_lock();
-    void connector_unlock();
-    void check_connector_lock();
+    void connector_force_unlock();
 
     // Signal for internal events type
     sigslot::signal<CPEvent> signal_event;
@@ -97,6 +95,9 @@ public:
     sigslot::signal<> signal_unlock;
 
 private:
+    void connector_lock();
+    void connector_unlock();
+    void check_connector_lock();
     const std::unique_ptr<evse_board_supportIntf>& r_bsp;
 
     bool pwm_running{false};
@@ -123,6 +124,7 @@ private:
     std::atomic_bool three_phases{true};
     std::atomic_bool is_locked{false};
     std::atomic_bool should_be_locked{false};
+    std::atomic_bool force_unlocked{false};
 
     std::atomic_bool enabled{false};
     std::atomic_bool relais_on{false};

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -448,7 +448,7 @@ bool evse_managerImpl::handle_external_ready_to_start_charging() {
 }
 
 bool evse_managerImpl::handle_force_unlock(int& connector_id) {
-    mod->bsp->connector_unlock();
+    mod->bsp->connector_force_unlock();
     return true;
 };
 

--- a/modules/EvseManager/scoped_lock_timeout.hpp
+++ b/modules/EvseManager/scoped_lock_timeout.hpp
@@ -57,6 +57,7 @@ enum class MutexDescription {
     IEC_set_pwm_off,
     IEC_set_pwm_F,
     IEC_allow_power_on,
+    IEC_force_unlock,
     EVSE_set_ev_info,
     EVSE_publish_ev_info,
     EVSE_subscribe_DC_EVMaximumLimits,
@@ -171,6 +172,8 @@ static std::string to_string(MutexDescription d) {
         return "IECStateMachine::set_pwm_F";
     case MutexDescription::IEC_allow_power_on:
         return "IECStateMachine::allow_power_on";
+    case MutexDescription::IEC_force_unlock:
+        return "IECStateMachine::force_unlock";
     case MutexDescription::EVSE_set_ev_info:
         return "EvseManager.cpp: set ev_info present_voltage/current";
     case MutexDescription::EVSE_publish_ev_info:


### PR DESCRIPTION
Force unlocking was not working after the bsp refactoring. This PR fixes force unlocking in state B. Force unlocking in state C is not supported.