### PR TITLE
Charger: Fix relay welding handling

### DIFF
--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -248,6 +248,7 @@ private:
         int ac_with_soc_timer;
         // non standard compliant option: time out after a while and switch back to DC to get SoC update
         bool ac_with_soc_timeout;
+        bool contactor_welded{false};
     } shared_context;
 
     struct ConfigContext {


### PR DESCRIPTION
If the relais are welded, the BSP will not report a PowerOff event back. The Charger will continue to send allow_power_on(false) to the BSP at every mainloop run. This PR fixes this, if the relays are welded no further allow_power_on(false) is being sent.