### PR TITLE
OCPP1.6 module: Now publishing EnhancedChargingSchedules

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -49,7 +49,7 @@ libcurl:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: dfb29de
+  git_tag: c9827c5
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -142,7 +142,7 @@ void create_empty_user_config(const fs::path& user_config_path) {
     }
 }
 
-void OCPP::set_external_limits(const std::map<int32_t, ocpp::v16::ChargingSchedule>& charging_schedules) {
+void OCPP::set_external_limits(const std::map<int32_t, ocpp::v16::EnhancedChargingSchedule>& charging_schedules) {
     const auto start_time = ocpp::DateTime();
 
     // iterate over all schedules reported by the libocpp to create ExternalLimits
@@ -186,7 +186,8 @@ void OCPP::set_external_limits(const std::map<int32_t, ocpp::v16::ChargingSchedu
     }
 }
 
-void OCPP::publish_charging_schedules(const std::map<int32_t, ocpp::v16::ChargingSchedule>& charging_schedules) {
+void OCPP::publish_charging_schedules(
+    const std::map<int32_t, ocpp::v16::EnhancedChargingSchedule>& charging_schedules) {
     // publish the schedule over mqtt
     Object j;
     for (const auto charging_schedule : charging_schedules) {
@@ -702,8 +703,8 @@ void OCPP::ready() {
     }
 
     this->charging_schedules_timer = std::make_unique<Everest::SteadyTimer>([this]() {
-        const auto charging_schedules =
-            this->charge_point->get_all_composite_charging_schedules(this->config.PublishChargingScheduleDurationS);
+        const auto charging_schedules = this->charge_point->get_all_enhanced_composite_charging_schedules(
+            this->config.PublishChargingScheduleDurationS);
         this->set_external_limits(charging_schedules);
         this->publish_charging_schedules(charging_schedules);
     });
@@ -715,8 +716,8 @@ void OCPP::ready() {
         // this is executed when CSMS sends new ChargingProfile that is accepted by
         // the ChargePoint
         EVLOG_info << "Received new Charging Schedules from CSMS";
-        const auto charging_schedules =
-            this->charge_point->get_all_composite_charging_schedules(this->config.PublishChargingScheduleDurationS);
+        const auto charging_schedules = this->charge_point->get_all_enhanced_composite_charging_schedules(
+            this->config.PublishChargingScheduleDurationS);
         this->set_external_limits(charging_schedules);
         this->publish_charging_schedules(charging_schedules);
     });

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -126,8 +126,8 @@ private:
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
     std::filesystem::path ocpp_share_path;
-    void set_external_limits(const std::map<int32_t, ocpp::v16::ChargingSchedule>& charging_schedules);
-    void publish_charging_schedules(const std::map<int32_t, ocpp::v16::ChargingSchedule>& charging_schedules);
+    void set_external_limits(const std::map<int32_t, ocpp::v16::EnhancedChargingSchedule>& charging_schedules);
+    void publish_charging_schedules(const std::map<int32_t, ocpp::v16::EnhancedChargingSchedule>& charging_schedules);
 
     void init_evse_subscriptions(); // initialize subscriptions to all EVSEs provided by r_evse_manager
     void init_evse_connector_map();


### PR DESCRIPTION
OCPP1.6 module: Now publishing EnhancedChargingSchedules instead of ChargingSchedules. EnhancedChargingSchedules contain a stackLevel in their vector of ChargingSchedulePeriod(s)

This PR requires a version bump of libocpp once this is merged: https://github.com/EVerest/libocpp/pull/453