### PR TITLE
Setup module to support WPA3 Wi-Fi networks

### DIFF
--- a/modules/Setup/CMakeLists.txt
+++ b/modules/Setup/CMakeLists.txt
@@ -23,4 +23,9 @@ target_sources(${MODULE_NAME}
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 target_compile_features(${MODULE_NAME} PRIVATE cxx_std_17)
+if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TESTING) AND BUILD_TESTING)
+    include(CTest)
+    add_subdirectory(tests)
+    set(CMAKE_BUILD_TYPE Debug)
+endif()
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/Setup/Setup.cpp
+++ b/modules/Setup/Setup.cpp
@@ -514,17 +514,24 @@ bool Setup::rfkill_block(std::string rfkill_id) {
 
 void Setup::publish_configured_networks() {
     auto network_devices = this->get_network_devices();
+
+    WpaCliSetup::WifiNetworkStatusList all_wifi_networks;
+
     for (auto device : network_devices) {
         if (!device.wireless) {
             continue;
         }
         WifiConfigureClass wifi;
         auto network_list = wifi.list_networks_status(device.interface);
-        std::string network_list_var = this->var_base + "configured_networks";
-        json configured_networks_json = json::array();
-        configured_networks_json = network_list;
-        this->mqtt.publish(network_list_var, configured_networks_json.dump());
+        for (auto& i : network_list) {
+            all_wifi_networks.push_back(std::move(i));
+        }
     }
+
+    std::string network_list_var = this->var_base + "configured_networks";
+    json configured_networks_json = json::array();
+    configured_networks_json = all_wifi_networks;
+    this->mqtt.publish(network_list_var, configured_networks_json.dump());
 }
 
 bool Setup::add_and_enable_network(const std::string& interface, const std::string& ssid, const std::string& psk,

--- a/modules/Setup/Setup.cpp
+++ b/modules/Setup/Setup.cpp
@@ -100,13 +100,10 @@ void Setup::ready() {
 
     this->discover_network_thread = std::thread([this]() {
         while (true) {
-            if (wifi_scan_enabled) {
+            if ((this->config.setup_wifi) && (wifi_scan_enabled)) {
                 this->discover_network();
             }
             this->publish_hostname();
-            if (this->config.setup_wifi) {
-                this->publish_configured_networks();
-            }
             std::this_thread::sleep_for(std::chrono::seconds(5));
         }
     });

--- a/modules/Setup/WiFiSetup.hpp
+++ b/modules/Setup/WiFiSetup.hpp
@@ -11,34 +11,41 @@ namespace module {
 
 class WpaCliSetup {
 public:
-    typedef std::vector<std::string> flags_t;
+    using flags_t = std::vector<std::string>;
+
+    enum class network_security_t : std::uint8_t {
+        none,
+        wpa2_only,
+        wpa3_only,
+        wpa2_and_wpa3,
+    };
 
     struct WifiScan {
         std::string bssid;
         std::string ssid;
+        flags_t flags;
         int frequency;
         int signal_level;
-        flags_t flags;
     };
-    typedef std::vector<WifiScan> WifiScanList;
+    using WifiScanList = std::vector<WifiScan>;
 
     struct WifiNetworkStatus {
         std::string interface;
-        int network_id;
         std::string ssid;
-        bool connected;
+        int network_id;
         int signal_level;
+        bool connected;
     };
-    typedef std::vector<WifiNetworkStatus> WifiNetworkStatusList;
+    using WifiNetworkStatusList = std::vector<WifiNetworkStatus>;
 
     struct WifiNetwork {
-        int network_id;
         std::string ssid;
+        int network_id;
     };
-    typedef std::vector<WifiNetwork> WifiNetworkList;
+    using WifiNetworkList = std::vector<WifiNetwork>;
 
-    typedef std::map<std::string, std::string> Status;
-    typedef std::map<std::string, std::string> Poll;
+    using Status = std::map<std::string, std::string>;
+    using Poll = std::map<std::string, std::string>;
 
 protected:
     virtual bool do_scan(const std::string& interface);
@@ -48,11 +55,14 @@ protected:
     virtual flags_t parse_flags(const std::string& flags);
 
 public:
-    virtual ~WpaCliSetup() {
-    }
+    virtual ~WpaCliSetup() = default;
     virtual int add_network(const std::string& interface);
     virtual bool set_network(const std::string& interface, int network_id, const std::string& ssid,
-                             const std::string& psk, bool hidden = false);
+                             const std::string& psk, network_security_t mode, bool hidden);
+    virtual bool set_network(const std::string& interface, int network_id, const std::string& ssid,
+                             const std::string& psk, bool hidden) {
+        return set_network(interface, network_id, ssid, psk, network_security_t::wpa2_and_wpa3, hidden);
+    }
     virtual bool enable_network(const std::string& interface, int network_id);
     virtual bool disable_network(const std::string& interface, int network_id);
     virtual bool select_network(const std::string& interface, int network_id);

--- a/modules/Setup/tests/CMakeLists.txt
+++ b/modules/Setup/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(TEST_TARGET_NAME ${PROJECT_NAME}_tests)
+add_executable(${TEST_TARGET_NAME})
+
+target_include_directories(${TEST_TARGET_NAME} PUBLIC ${GTEST_INCLUDE_DIRS} . ..)
+
+target_sources(${TEST_TARGET_NAME} PRIVATE
+    RunApplicationStub.cpp
+    WiFiSetupTest.cpp
+    ../WiFiSetup.cpp
+)
+
+find_package(GTest REQUIRED)
+
+target_link_libraries(${TEST_TARGET_NAME} PRIVATE
+    ${GTEST_LIBRARIES}
+    ${GTEST_MAIN_LIBRARIES}
+)
+
+add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})

--- a/modules/Setup/tests/RunApplicationStub.cpp
+++ b/modules/Setup/tests/RunApplicationStub.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
-#include <RunApplicationStub.hpp>
+#include "RunApplicationStub.hpp"
 #include <gtest/gtest.h>
 
 #include <utility>
@@ -47,8 +47,10 @@ RunApplication::RunApplication() :
     }),
     signal_poll_called(false),
     psk_called(false),
+    sae_password_called(false),
     key_mgmt_called(false),
-    scan_ssid_called(false) {
+    scan_ssid_called(false),
+    key_mgmt_value() {
     active_p = this;
 }
 
@@ -65,8 +67,11 @@ module::CmdOutput RunApplication::run_application(const std::string& name, std::
     } else if (args[2] == "set_network") {
         if (args[4] == "psk") {
             psk_called = true;
+        } else if (args[4] == "sae_password") {
+            sae_password_called = true;
         } else if (args[4] == "key_mgmt") {
             key_mgmt_called = true;
+            key_mgmt_value = args[5];
         } else if (args[4] == "scan_ssid") {
             scan_ssid_called = true;
         }

--- a/modules/Setup/tests/RunApplicationStub.cpp
+++ b/modules/Setup/tests/RunApplicationStub.cpp
@@ -50,7 +50,9 @@ RunApplication::RunApplication() :
     sae_password_called(false),
     key_mgmt_called(false),
     scan_ssid_called(false),
-    key_mgmt_value() {
+    ieee80211w_called(false),
+    key_mgmt_value(),
+    ieee80211w_value() {
     active_p = this;
 }
 
@@ -72,6 +74,9 @@ module::CmdOutput RunApplication::run_application(const std::string& name, std::
         } else if (args[4] == "key_mgmt") {
             key_mgmt_called = true;
             key_mgmt_value = args[5];
+        } else if (args[4] == "ieee80211w") {
+            ieee80211w_called = true;
+            ieee80211w_value = args[5];
         } else if (args[4] == "scan_ssid") {
             scan_ssid_called = true;
         }

--- a/modules/Setup/tests/RunApplicationStub.hpp
+++ b/modules/Setup/tests/RunApplicationStub.hpp
@@ -17,8 +17,10 @@ public:
     std::map<std::string, module::CmdOutput> results;
     bool signal_poll_called;
     bool psk_called;
+    bool sae_password_called;
     bool key_mgmt_called;
     bool scan_ssid_called;
+    std::string key_mgmt_value;
 
     RunApplication();
     virtual ~RunApplication();

--- a/modules/Setup/tests/RunApplicationStub.hpp
+++ b/modules/Setup/tests/RunApplicationStub.hpp
@@ -20,7 +20,9 @@ public:
     bool sae_password_called;
     bool key_mgmt_called;
     bool scan_ssid_called;
+    bool ieee80211w_called;
     std::string key_mgmt_value;
+    std::string ieee80211w_value;
 
     RunApplication();
     virtual ~RunApplication();

--- a/modules/Setup/tests/WiFiSetupTest.cpp
+++ b/modules/Setup/tests/WiFiSetupTest.cpp
@@ -51,6 +51,7 @@ TEST(set_network, none_no_psk) {
     ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", "", WpaCliSetup::network_security_t::none, false));
     ASSERT_FALSE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_FALSE(ra.ieee80211w_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "NONE");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -63,6 +64,7 @@ TEST(set_network, none_psk) {
         obj.set_network("wlan0", 0, "PlusnetWireless", example_psk, WpaCliSetup::network_security_t::none, false));
     ASSERT_FALSE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_FALSE(ra.ieee80211w_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "NONE");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -75,6 +77,7 @@ TEST(set_network, none_password) {
         obj.set_network("wlan0", 0, "PlusnetWireless", example_password, WpaCliSetup::network_security_t::none, false));
     ASSERT_FALSE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_FALSE(ra.ieee80211w_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "NONE");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -86,6 +89,7 @@ TEST(set_network, wpa2_no_psk) {
     ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", "", WpaCliSetup::network_security_t::wpa2_only, false));
     ASSERT_FALSE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_FALSE(ra.ieee80211w_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "NONE");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -98,6 +102,7 @@ TEST(set_network, wpa2_psk) {
         obj.set_network("wlan0", 0, "PlusnetWireless", example_psk, WpaCliSetup::network_security_t::wpa2_only, false));
     ASSERT_TRUE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_FALSE(ra.ieee80211w_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "WPA-PSK");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -110,6 +115,7 @@ TEST(set_network, wpa2_password) {
                                 WpaCliSetup::network_security_t::wpa2_only, false));
     ASSERT_TRUE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_FALSE(ra.ieee80211w_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "WPA-PSK");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -121,6 +127,7 @@ TEST(set_network, wpa3_no_psk) {
     ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", "", WpaCliSetup::network_security_t::wpa3_only, false));
     ASSERT_FALSE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_FALSE(ra.ieee80211w_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "NONE");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -133,6 +140,8 @@ TEST(set_network, wpa3_psk) {
         obj.set_network("wlan0", 0, "PlusnetWireless", example_psk, WpaCliSetup::network_security_t::wpa3_only, false));
     ASSERT_FALSE(ra.psk_called);
     ASSERT_TRUE(ra.sae_password_called);
+    ASSERT_TRUE(ra.ieee80211w_called);
+    ASSERT_EQ(ra.ieee80211w_value, "2");
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "SAE");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -146,6 +155,8 @@ TEST(set_network, wpa3_password) {
     ASSERT_FALSE(ra.psk_called);
     ASSERT_TRUE(ra.sae_password_called);
     ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_TRUE(ra.ieee80211w_called);
+    ASSERT_EQ(ra.ieee80211w_value, "2");
     ASSERT_EQ(ra.key_mgmt_value, "SAE");
     ASSERT_FALSE(ra.scan_ssid_called);
 }
@@ -157,6 +168,7 @@ TEST(set_network, wpa2_and_wpa3_no_psk) {
         obj.set_network("wlan0", 0, "PlusnetWireless", "", WpaCliSetup::network_security_t::wpa2_and_wpa3, false));
     ASSERT_FALSE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_FALSE(ra.ieee80211w_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "NONE");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -170,6 +182,7 @@ TEST(set_network, wpa2_and_wpa3_psk) {
                                 WpaCliSetup::network_security_t::wpa2_and_wpa3, false));
     ASSERT_TRUE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_FALSE(ra.ieee80211w_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "WPA-PSK");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -183,6 +196,8 @@ TEST(set_network, wpa2_and_wpa3_password) {
                                 WpaCliSetup::network_security_t::wpa2_and_wpa3, false));
     ASSERT_TRUE(ra.psk_called);
     ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.ieee80211w_called);
+    ASSERT_EQ(ra.ieee80211w_value, "1");
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "WPA-PSK WPA-PSK-SHA256 SAE");
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -196,6 +211,8 @@ TEST(set_network, wpa2_and_wpa3_password_long) {
                                 WpaCliSetup::network_security_t::wpa2_and_wpa3, false));
     ASSERT_FALSE(ra.psk_called);
     ASSERT_TRUE(ra.sae_password_called);
+    ASSERT_TRUE(ra.ieee80211w_called);
+    ASSERT_EQ(ra.ieee80211w_value, "2");
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_EQ(ra.key_mgmt_value, "SAE");
     ASSERT_FALSE(ra.scan_ssid_called);

--- a/modules/Setup/tests/WiFiSetupTest.cpp
+++ b/modules/Setup/tests/WiFiSetupTest.cpp
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
-#include <RunApplicationStub.hpp>
+#include "RunApplicationStub.hpp"
 #include <WiFiSetup.hpp>
 #include <gtest/gtest.h>
 
 namespace {
+using namespace module;
+constexpr const char* example_psk = "e3003974af901976485f3e655b455791dcc20a5380f42a7839de3bfdc9d70d71";
+constexpr const char* example_password = "LetMeIn2";
+constexpr const char* example_long_password = "e3003974af901976485f3e655b455791dcc20a5380f42a7839de3bfdc9d70d71X";
 
-class WpaCliSetupTest : public module::WpaCliSetup {
+class WpaCliSetupTest : public WpaCliSetup {
 public:
     // override to support testing
     virtual bool is_wifi_interface(const std::string& interface) override {
@@ -41,19 +45,175 @@ TEST(add_network, access_point) {
 
 //-----------------------------------------------------------------------------
 // set_network()
+TEST(set_network, none_no_psk) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", "", WpaCliSetup::network_security_t::none, false));
+    ASSERT_FALSE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "NONE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, none_psk) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(
+        obj.set_network("wlan0", 0, "PlusnetWireless", example_psk, WpaCliSetup::network_security_t::none, false));
+    ASSERT_FALSE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "NONE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, none_password) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(
+        obj.set_network("wlan0", 0, "PlusnetWireless", example_password, WpaCliSetup::network_security_t::none, false));
+    ASSERT_FALSE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "NONE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa2_no_psk) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", "", WpaCliSetup::network_security_t::wpa2_only, false));
+    ASSERT_FALSE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "NONE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa2_psk) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(
+        obj.set_network("wlan0", 0, "PlusnetWireless", example_psk, WpaCliSetup::network_security_t::wpa2_only, false));
+    ASSERT_TRUE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "WPA-PSK");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa2_password) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", example_password,
+                                WpaCliSetup::network_security_t::wpa2_only, false));
+    ASSERT_TRUE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "WPA-PSK");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa3_no_psk) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", "", WpaCliSetup::network_security_t::wpa3_only, false));
+    ASSERT_FALSE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "NONE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa3_psk) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(
+        obj.set_network("wlan0", 0, "PlusnetWireless", example_psk, WpaCliSetup::network_security_t::wpa3_only, false));
+    ASSERT_FALSE(ra.psk_called);
+    ASSERT_TRUE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "SAE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa3_password) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", example_password,
+                                WpaCliSetup::network_security_t::wpa3_only, false));
+    ASSERT_FALSE(ra.psk_called);
+    ASSERT_TRUE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "SAE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa2_and_wpa3_no_psk) {
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(
+        obj.set_network("wlan0", 0, "PlusnetWireless", "", WpaCliSetup::network_security_t::wpa2_and_wpa3, false));
+    ASSERT_FALSE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "NONE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa2_and_wpa3_psk) {
+    // with a PSK result is same as wpa2_only
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", example_psk,
+                                WpaCliSetup::network_security_t::wpa2_and_wpa3, false));
+    ASSERT_TRUE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "WPA-PSK");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa2_and_wpa3_password) {
+    // configure for both
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", example_password,
+                                WpaCliSetup::network_security_t::wpa2_and_wpa3, false));
+    ASSERT_TRUE(ra.psk_called);
+    ASSERT_FALSE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "WPA-PSK WPA-PSK-SHA256 SAE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
+TEST(set_network, wpa2_and_wpa3_password_long) {
+    // configure for WPA3 only
+    stub::RunApplication ra;
+    WpaCliSetupTest obj;
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", example_long_password,
+                                WpaCliSetup::network_security_t::wpa2_and_wpa3, false));
+    ASSERT_FALSE(ra.psk_called);
+    ASSERT_TRUE(ra.sae_password_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
+    ASSERT_EQ(ra.key_mgmt_value, "SAE");
+    ASSERT_FALSE(ra.scan_ssid_called);
+}
+
 TEST(set_network, wpa2) {
     stub::RunApplication ra;
     WpaCliSetupTest obj;
-    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", "LetMeIn2"));
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "PlusnetWireless", "LetMeIn2", false));
     ASSERT_TRUE(ra.psk_called);
-    ASSERT_FALSE(ra.key_mgmt_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_FALSE(ra.scan_ssid_called);
 }
 
 TEST(set_network, open) {
     stub::RunApplication ra;
     WpaCliSetupTest obj;
-    ASSERT_TRUE(obj.set_network("wlan0", 0, "OpenNet", ""));
+    ASSERT_TRUE(obj.set_network("wlan0", 0, "OpenNet", "", false));
     ASSERT_FALSE(ra.psk_called);
     ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_FALSE(ra.scan_ssid_called);
@@ -64,7 +224,7 @@ TEST(set_network, hidden_wpa2) {
     WpaCliSetupTest obj;
     ASSERT_TRUE(obj.set_network("wlan0", 0, "Hidden", "LetMeIn3", true));
     ASSERT_TRUE(ra.psk_called);
-    ASSERT_FALSE(ra.key_mgmt_called);
+    ASSERT_TRUE(ra.key_mgmt_called);
     ASSERT_TRUE(ra.scan_ssid_called);
 }
 


### PR DESCRIPTION
# background
`wpa_cli` supports the configuration of WPA2 and WPA3 networks. However WPA3 doesn't support a pre-shared key (the output from the wpa_passphrase command), it always requires the plain text passphrase.

By default the update will try and configure dual support for WPA2 and WPA3 based on the "psk": "" MQTT parameter
i.e.

psk|key_mgmt|configuration
---|-------|---------
""|NONE|open network
"&lt;length == 64&gt;"|WPA-PSK|WPA2 only with pre-shared key
"\"MyPassphrase\""|WPA-PSK WPA-PSK-SHA256 SAE|WPA2 and WPA3
"&lt;length &gt; 64&gt;"|SAE|WPA3 only

## additional
- unit tests now part of cmake build
- an additional MQTT parameter could be added to explicitly set the mode (WPA2, WPA3, both, none)<br>it is common for WiFi configuration to require the security being applied. Adding an additional parameter would allow EVerest to fully configure the network (and perhaps support more options: WEP, WPA2 Enterprise mode ...)

The WpaCliSetup has been updated to support network configuration with an additional parameter to indicate the network security to apply. This should make it easier to support new modes alongside an MQTT interface update.