### PR TITLE
Switch to CBV2G from OpenV2G for DIN, ISO-2, PnC and SAP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ else()
     find_package(everest-framework REQUIRED)
     find_package(everest-modbus REQUIRED)
     find_package(everest-ocpp REQUIRED)
-    find_package(everest-openv2g REQUIRED)
+    find_package(libcbv2g REQUIRED)
 
     find_package(PalSigslot REQUIRED)
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,11 +67,11 @@ Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
   git_tag: 2024.6.0
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT AND EVEREST_DEPENDENCY_ENABLED_JOSEV"
-# OpenV2G
-ext-openv2g:
-  git: https://github.com/EVerest/ext-openv2g.git
-  git_tag: 2023.3.0
-  cmake_condition: "EVEREST_DEPENDENCY_ENABLED_OPENV2G"
+# libcbv2g
+libcbv2g:
+  git: https://github.com/EVerest/libcbv2g.git
+  git_tag: v0.2.0
+  cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBCBV2G"
 # mbedtls
 ext-mbedtls:
   git: https://github.com/EVerest/ext-mbedtls.git

--- a/module-dependencies.cmake
+++ b/module-dependencies.cmake
@@ -39,8 +39,8 @@ ev_define_dependency(
     DEPENDENT_MODULES_LIST PyJosev PyEvJosev)
 
 ev_define_dependency(
-    DEPENDENCY_NAME ext-openv2g
-    OUTPUT_VARIABLE_SUFFIX OPENV2G
+    DEPENDENCY_NAME libcbv2g
+    OUTPUT_VARIABLE_SUFFIX LIBCBV2G
     DEPENDENT_MODULES_LIST EvseV2G)
 
 ev_define_dependency(

--- a/modules/EvseV2G/CMakeLists.txt
+++ b/modules/EvseV2G/CMakeLists.txt
@@ -30,7 +30,9 @@ target_link_libraries(${MODULE_NAME}
         mbedcrypto
         mbedtls
         mbedx509
-        everest::openv2g
+        cbv2g::din
+        cbv2g::iso2
+        cbv2g::tp
 )
 
 target_sources(${MODULE_NAME}

--- a/modules/EvseV2G/din_server.cpp
+++ b/modules/EvseV2G/din_server.cpp
@@ -2,8 +2,9 @@
 // Copyright (C) 2023 chargebyte GmbH
 // Copyright (C) 2023 Contributors to EVerest
 
+#include <cbv2g/din/din_msgDefDatatypes.h>
+
 #include <inttypes.h>
-#include <openv2g/dinEXIDatatypes.h>
 #include <string.h>
 
 #include "din_server.hpp"
@@ -19,36 +20,36 @@
  * @param phy_value_dest is the destination struct.
  * @param phy_value_source is the source struct.
  */
-void load_din_physical_value(struct dinPhysicalValueType* const phy_value_dest,
-                             struct iso1PhysicalValueType* const phy_value_source) {
+void load_din_physical_value(struct din_PhysicalValueType* const phy_value_dest,
+                             struct iso2_PhysicalValueType* const phy_value_source) {
     phy_value_dest->Multiplier = phy_value_source->Multiplier;
     phy_value_dest->Value = phy_value_source->Value;
     phy_value_dest->Unit_isUsed = 1;
 
     switch (phy_value_source->Unit) {
-    case iso1unitSymbolType_h:
-        phy_value_dest->Unit = dinunitSymbolType_h;
+    case iso2_unitSymbolType_h:
+        phy_value_dest->Unit = din_unitSymbolType_h;
         break;
-    case iso1unitSymbolType_m:
-        phy_value_dest->Unit = dinunitSymbolType_m;
+    case iso2_unitSymbolType_m:
+        phy_value_dest->Unit = din_unitSymbolType_m;
         break;
-    case iso1unitSymbolType_s:
-        phy_value_dest->Unit = dinunitSymbolType_s;
+    case iso2_unitSymbolType_s:
+        phy_value_dest->Unit = din_unitSymbolType_s;
         break;
-    case iso1unitSymbolType_A:
-        phy_value_dest->Unit = dinunitSymbolType_A;
+    case iso2_unitSymbolType_A:
+        phy_value_dest->Unit = din_unitSymbolType_A;
         break;
-    case iso1unitSymbolType_V:
-        phy_value_dest->Unit = dinunitSymbolType_V;
+    case iso2_unitSymbolType_V:
+        phy_value_dest->Unit = din_unitSymbolType_V;
         break;
-    case iso1unitSymbolType_W:
-        phy_value_dest->Unit = dinunitSymbolType_W;
+    case iso2_unitSymbolType_W:
+        phy_value_dest->Unit = din_unitSymbolType_W;
         break;
-    case iso1unitSymbolType_Wh:
-        phy_value_dest->Unit = dinunitSymbolType_Wh;
+    case iso2_unitSymbolType_Wh:
+        phy_value_dest->Unit = din_unitSymbolType_Wh;
         break;
     default:
-        phy_value_dest->Unit = dinunitSymbolType_h;
+        phy_value_dest->Unit = din_unitSymbolType_h;
         break;
     }
 }
@@ -57,15 +58,15 @@ void load_din_physical_value(struct dinPhysicalValueType* const phy_value_dest,
  * \brief din_validate_state This function checks whether the received message is expected and valid at this
  * point in the communication sequence state machine. The current V2G msg type must be set with the current V2G msg
  * state. \param state is the current state of the charging session \param current_v2g_msg is the current handled V2G
- * message \param state of the actual session. \return Returns a dinResponseCode with sequence error if current_v2g_msg
+ * message \param state of the actual session. \return Returns a din_ResponseCode with sequence error if current_v2g_msg
  * is not expected, otherwise OK.
  */
-static dinresponseCodeType din_validate_state(int state, enum V2gMsgTypeId current_v2g_msg) {
+static din_responseCodeType din_validate_state(int state, enum V2gMsgTypeId current_v2g_msg) {
     /* if the request type has enabled (= set) bit in expected_requests, then this
      * message is ok at this stage; otherwise reject it.
      */
-    return (din_states[state].allowed_requests & (1 << current_v2g_msg)) ? dinresponseCodeType_OK
-                                                                         : dinresponseCodeType_FAILED_SequenceError;
+    return (din_states[state].allowed_requests & (1 << current_v2g_msg)) ? din_responseCodeType_OK
+                                                                         : din_responseCodeType_FAILED_SequenceError;
 }
 
 /*!
@@ -74,10 +75,10 @@ static dinresponseCodeType din_validate_state(int state, enum V2gMsgTypeId curre
  * external error has occurred. \param conn the structure with the external error information. \return Returns the next
  * v2g-event.
  */
-static v2g_event din_validate_response_code(dinresponseCodeType* const din_response_code,
+static v2g_event din_validate_response_code(din_responseCodeType* const din_response_code,
                                             struct v2g_connection const* conn) {
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
-    dinresponseCodeType response_code_tmp;
+    din_responseCodeType response_code_tmp;
 
     if (conn->ctx->is_connection_terminated == true) {
         dlog(DLOG_LEVEL_ERROR, "Connection is terminated. Abort charging");
@@ -86,7 +87,7 @@ static v2g_event din_validate_response_code(dinresponseCodeType* const din_respo
 
     /* If MQTT user abort or emergency shutdown has occurred */
     if ((conn->ctx->stop_hlc == true) || (conn->ctx->intl_emergency_shutdown == true)) {
-        *din_response_code = dinresponseCodeType_FAILED;
+        *din_response_code = din_responseCodeType_FAILED;
     }
 
     /* [V2G-DC-390]: at this point we must check whether the given request is valid at this step;
@@ -95,22 +96,22 @@ static v2g_event din_validate_response_code(dinresponseCodeType* const din_respo
      * error path, since it might not be set, yet!
      */
     response_code_tmp = din_validate_state(conn->ctx->state, conn->ctx->current_v2g_msg);
-    *din_response_code = (response_code_tmp >= dinresponseCodeType_FAILED) ? response_code_tmp : *din_response_code;
+    *din_response_code = (response_code_tmp >= din_responseCodeType_FAILED) ? response_code_tmp : *din_response_code;
 
     /* [V2G-DC-391]: check whether the session id matches the expected one of the active session */
     *din_response_code = ((conn->ctx->current_v2g_msg != V2G_SESSION_SETUP_MSG) &&
                           (conn->ctx->evse_v2g_data.session_id != conn->ctx->ev_v2g_data.received_session_id))
-                             ? dinresponseCodeType_FAILED_UnknownSession
+                             ? din_responseCodeType_FAILED_UnknownSession
                              : *din_response_code;
 
     if ((conn->ctx->terminate_connection_on_failed_response == true) &&
-        (*din_response_code >= dinresponseCodeType_FAILED)) {
+        (*din_response_code >= din_responseCodeType_FAILED)) {
         nextEvent = V2G_EVENT_SEND_AND_TERMINATE; // [V2G-DC-665]
     }
 
     /* log failed response code message */
-    if (*din_response_code >= dinresponseCodeType_FAILED &&
-        *din_response_code <= dinresponseCodeType_FAILED_WrongEnergyTransferType) {
+    if (*din_response_code >= din_responseCodeType_FAILED &&
+        *din_response_code <= din_responseCodeType_FAILED_WrongEnergyTransferType) {
         dlog(DLOG_LEVEL_ERROR, "Failed response code detected for message \"%s\", error: %s",
              v2g_msg_type[conn->ctx->current_v2g_msg], dinResponse[*din_response_code]);
     }
@@ -123,7 +124,7 @@ static v2g_event din_validate_response_code(dinresponseCodeType* const din_respo
  * \param ctx is a pointer to the V2G context.
  * \param din_ev_status the structure the holds the EV Status elements.
  */
-static void publish_DIN_DC_EVStatusType(struct v2g_context* ctx, const struct dinDC_EVStatusType& din_ev_status) {
+static void publish_DIN_DC_EVStatusType(struct v2g_context* ctx, const struct din_DC_EVStatusType& din_ev_status) {
     if ((ctx->ev_v2g_data.din_dc_ev_status.EVErrorCode != din_ev_status.EVErrorCode) ||
         (ctx->ev_v2g_data.din_dc_ev_status.EVReady != din_ev_status.EVReady) ||
         (ctx->ev_v2g_data.din_dc_ev_status.EVRESSSOC != din_ev_status.EVRESSSOC)) {
@@ -144,35 +145,35 @@ static void publish_DIN_DC_EVStatusType(struct v2g_context* ctx, const struct di
 //=============================================
 
 /*!
- * \brief publish_din_service_discovery_req This function publishes the dinServiceDiscoveryReqType message to the MQTT
- * interface. \param ctx is the V2G context. \param dinServiceDiscoveryReqType is the request message.
+ * \brief publish_din_service_discovery_req This function publishes the din_ServiceDiscoveryReqType message to the MQTT
+ * interface. \param ctx is the V2G context. \param din_ServiceDiscoveryReqType is the request message.
  */
 static void
 publish_din_service_discovery_req(struct v2g_context* ctx,
-                                  struct dinServiceDiscoveryReqType const* const v2g_service_discovery_req) {
+                                  struct din_ServiceDiscoveryReqType const* const v2g_service_discovery_req) {
     // V2G values that can be published: ServiceCategory, ServiceScope
 }
 
 /*!
- * \brief publish_din_service_payment_selection_req This function publishes the dinServicePaymentSelectionReqType
+ * \brief publish_din_service_payment_selection_req This function publishes the din_ServicePaymentSelectionReqType
  * message to the MQTT interface.
  * \param ctx is the V2G context.
  * \param v2g_payment_service_selection_req is the request message.
  */
 static void publish_din_service_payment_selection_req(
-    struct v2g_context* ctx, struct dinServicePaymentSelectionReqType const* const v2g_payment_service_selection_req) {
+    struct v2g_context* ctx, struct din_ServicePaymentSelectionReqType const* const v2g_payment_service_selection_req) {
     // V2G values that can be published: SelectedPaymentOption, SelectedServiceList
 }
 
 /*!
- * \brief publish_din_charge_parameter_discovery_req This function publishes the dinChargeParameterDiscoveryReqType
+ * \brief publish_din_charge_parameter_discovery_req This function publishes the din_ChargeParameterDiscoveryReqType
  * message to the MQTT interface.
  * \param ctx is the V2G context.
  * \param v2g_charge_parameter_discovery_req is the request message.
  */
 static void publish_din_charge_parameter_discovery_req(
     struct v2g_context* ctx,
-    struct dinChargeParameterDiscoveryReqType const* const v2g_charge_parameter_discovery_req) {
+    struct din_ChargeParameterDiscoveryReqType const* const v2g_charge_parameter_discovery_req) {
     // V2G values that can be published: DC_EVChargeParameter, MaxEntriesSAScheduleTuple
     ctx->p_charger->publish_RequestedEnergyTransferMode(static_cast<types::iso15118_charger::EnergyTransferMode>(
         v2g_charge_parameter_discovery_req->EVRequestedEnergyTransferType));
@@ -212,11 +213,11 @@ static void publish_din_charge_parameter_discovery_req(
 }
 
 /*!
- * \brief publish_din_power_delivery_req This function publishes the dinPowerDeliveryReqType message to the MQTT
+ * \brief publish_din_power_delivery_req This function publishes the din_PowerDeliveryReqType message to the MQTT
  * interface. \param ctx is the V2G context. \param din_power_delivery_req is the request message.
  */
 static void publish_din_power_delivery_req(struct v2g_context* ctx,
-                                           struct dinPowerDeliveryReqType const* const v2g_power_delivery_req) {
+                                           struct din_PowerDeliveryReqType const* const v2g_power_delivery_req) {
     // V2G values that can be published: ReadyToChargeState
     if (v2g_power_delivery_req->DC_EVPowerDeliveryParameter_isUsed == (unsigned int)1) {
         ctx->p_charger->publish_DC_ChargingComplete(
@@ -230,12 +231,12 @@ static void publish_din_power_delivery_req(struct v2g_context* ctx,
 }
 
 /*!
- * \brief publish_din_precharge_req This function publishes the dinPreChargeReqType message to the MQTT interface.
+ * \brief publish_din_precharge_req This function publishes the din_PreChargeReqType message to the MQTT interface.
  * \param ctx is the V2G context.
  * \param v2g_precharge_req is the request message.
  */
 static void publish_din_precharge_req(struct v2g_context* ctx,
-                                      struct dinPreChargeReqType const* const v2g_precharge_req) {
+                                      struct din_PreChargeReqType const* const v2g_precharge_req) {
     publish_DC_EVTargetVoltageCurrent(
         ctx,
         calc_physical_value(v2g_precharge_req->EVTargetVoltage.Value, v2g_precharge_req->EVTargetVoltage.Multiplier),
@@ -244,11 +245,11 @@ static void publish_din_precharge_req(struct v2g_context* ctx,
 }
 
 /*!
- * \brief publish_din_current_demand_req This function publishes the dinCurrentDemandReqType message to the MQTT
+ * \brief publish_din_current_demand_req This function publishes the din_CurrentDemandReqType message to the MQTT
  * interface. \param ctx is the V2G context. \param v2g_current_demand_req is the request message.
  */
 static void publish_din_current_demand_req(struct v2g_context* ctx,
-                                           struct dinCurrentDemandReqType const* const v2g_current_demand_req) {
+                                           struct din_CurrentDemandReqType const* const v2g_current_demand_req) {
     if ((v2g_current_demand_req->BulkChargingComplete_isUsed == (unsigned int)1) &&
         (ctx->ev_v2g_data.bulk_charging_complete != v2g_current_demand_req->BulkChargingComplete)) {
         ctx->p_charger->publish_DC_BulkChargingComplete(v2g_current_demand_req->BulkChargingComplete);
@@ -301,10 +302,10 @@ static void publish_din_current_demand_req(struct v2g_context* ctx,
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
-    struct dinSessionSetupReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.SessionSetupReq;
-    struct dinSessionSetupResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.SessionSetupRes;
+    struct din_SessionSetupReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.SessionSetupReq;
+    struct din_SessionSetupResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.SessionSetupRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
-    char buffer[dinSessionSetupReqType_EVCCID_BYTES_SIZE * 2 + dinSessionSetupReqType_EVCCID_BYTES_SIZE - 1 +
+    char buffer[din_evccIDType_BYTES_SIZE * 2 + din_evccIDType_BYTES_SIZE - 1 +
                 1]; /* format: (%02x:) * n - 1x ':' + 1x NUL */
     int idx;
 
@@ -326,7 +327,7 @@ static enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
     dlog(DLOG_LEVEL_INFO, "SessionSetupReq.EVCCID: %s", std::string(buffer).size() ? buffer : "(zero length provided)");
 
     /* Now fill the evse response message */
-    res->ResponseCode = dinresponseCodeType_OK_NewSessionEstablished; // [V2G-DC-393]
+    res->ResponseCode = din_responseCodeType_OK_NewSessionEstablished; // [V2G-DC-393]
 
     /* Check and init session id */
     /* If the customer doesen't select a session id, generate one */
@@ -339,8 +340,7 @@ static enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
 
     dlog(DLOG_LEVEL_INFO, "Created new session with id 0x%08" PRIu64, conn->ctx->evse_v2g_data.session_id);
 
-    res->EVSEID.bytesLen =
-        std::min((int)conn->ctx->evse_v2g_data.evse_id.bytesLen, dinSessionSetupResType_EVSEID_BYTES_SIZE);
+    res->EVSEID.bytesLen = std::min((int)conn->ctx->evse_v2g_data.evse_id.bytesLen, iso2_EVSEID_CHARACTER_SIZE);
     memcpy(res->EVSEID.bytes, conn->ctx->evse_v2g_data.evse_id.bytes, res->EVSEID.bytesLen);
 
     res->DateTimeNow_isUsed = conn->ctx->evse_v2g_data.date_time_now_is_used;
@@ -363,22 +363,22 @@ static enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_service_discovery(struct v2g_connection* conn) {
-    struct dinServiceDiscoveryReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.ServiceDiscoveryReq;
-    struct dinServiceDiscoveryResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.ServiceDiscoveryRes;
+    struct din_ServiceDiscoveryReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.ServiceDiscoveryReq;
+    struct din_ServiceDiscoveryResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.ServiceDiscoveryRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
     /* At first, publish the received EV request message to the MQTT interface */
     publish_din_service_discovery_req(conn->ctx, req);
 
     /* Now fill the evse response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
 
     if ((conn->ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.array[0] !=
-         iso1EnergyTransferModeType_DC_core) &&
+         iso2_EnergyTransferModeType_DC_core) &&
         (conn->ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.array[0]) !=
-            iso1EnergyTransferModeType_DC_extended) {
+            iso2_EnergyTransferModeType_DC_extended) {
         conn->ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.array[0] =
-            iso1EnergyTransferModeType_DC_extended;
+            iso2_EnergyTransferModeType_DC_extended;
         dlog(DLOG_LEVEL_WARNING, "Selected EnergyTransferType is not supported in DIN 70121. Correcting value of field "
                                  "SupportedEnergyTransferType0 to 'DC_extended'");
     }
@@ -387,16 +387,16 @@ static enum v2g_event handle_din_service_discovery(struct v2g_connection* conn) 
         conn->ctx->evse_v2g_data.charge_service.ServiceID;               // ID of the charge service
     res->ChargeService.ServiceTag.ServiceName_isUsed = (unsigned int)0;  // [V2G-DC-628] Shall not be used in DIN 70121
     res->ChargeService.ServiceTag.ServiceScope_isUsed = (unsigned int)0; // [V2G-DC-629] Shall not be used in DIN 70121
-    res->ChargeService.ServiceTag.ServiceCategory = dinserviceCategoryType_EVCharging; // Is fixed
+    res->ChargeService.ServiceTag.ServiceCategory = din_serviceCategoryType_EVCharging; // Is fixed
     res->ChargeService.FreeService = conn->ctx->evse_v2g_data.charge_service.FreeService;
     res->ChargeService.EnergyTransferType =
-        (dinEVSESupportedEnergyTransferType)
+        (din_EVSESupportedEnergyTransferType)
             conn->ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.array[0];
 
     res->ServiceList_isUsed = 0; // Shall not be used in DIN 70121
 
     // In the scope of DIN 70121 only ExternalPayment shall be used.
-    res->PaymentOptions.PaymentOption.array[0] = dinpaymentOptionType_ExternalPayment;
+    res->PaymentOptions.PaymentOption.array[0] = din_paymentOptionType_ExternalPayment;
     res->PaymentOptions.PaymentOption.arrayLen = 1;
 
     /* Check the current response code and check if no external error has occurred */
@@ -416,9 +416,9 @@ static enum v2g_event handle_din_service_discovery(struct v2g_connection* conn) 
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_service_payment_selection(struct v2g_connection* conn) {
-    struct dinServicePaymentSelectionReqType* req =
+    struct din_ServicePaymentSelectionReqType* req =
         &conn->exi_in.dinEXIDocument->V2G_Message.Body.ServicePaymentSelectionReq;
-    struct dinServicePaymentSelectionResType* res =
+    struct din_ServicePaymentSelectionResType* res =
         &conn->exi_out.dinEXIDocument->V2G_Message.Body.ServicePaymentSelectionRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
@@ -426,18 +426,18 @@ static enum v2g_event handle_din_service_payment_selection(struct v2g_connection
     publish_din_service_payment_selection_req(conn->ctx, req);
 
     /* Now fill the evse response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
 
-    res->ResponseCode = (req->SelectedPaymentOption != dinpaymentOptionType_ExternalPayment)
-                            ? dinresponseCodeType_FAILED_PaymentSelectionInvalid
+    res->ResponseCode = (req->SelectedPaymentOption != din_paymentOptionType_ExternalPayment)
+                            ? din_responseCodeType_FAILED_PaymentSelectionInvalid
                             : res->ResponseCode; // [V2G-DC-395]
 
     res->ResponseCode = (req->SelectedServiceList.SelectedService.arrayLen == (uint16_t)1 &&
                          (req->SelectedServiceList.SelectedService.array[0].ServiceID ==
                           conn->ctx->evse_v2g_data.charge_service.ServiceID))
                             ? res->ResponseCode
-                            : dinresponseCodeType_FAILED_ServiceSelectionInvalid; // [V2G-DC-396] [V2G-DC-635] (List
-                                                                                  // shall be limited to 1)
+                            : din_responseCodeType_FAILED_ServiceSelectionInvalid; // [V2G-DC-396] [V2G-DC-635] (List
+                                                                                   // shall be limited to 1)
 
     /* Check the current response code and check if no external error has occurred */
     nextEvent = din_validate_response_code(&res->ResponseCode, conn);
@@ -456,21 +456,21 @@ static enum v2g_event handle_din_service_payment_selection(struct v2g_connection
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_contract_authentication(struct v2g_connection* conn) {
-    struct dinContractAuthenticationResType* res =
+    struct din_ContractAuthenticationResType* res =
         &conn->exi_out.dinEXIDocument->V2G_Message.Body.ContractAuthenticationRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
     /* Fill the EVSE response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
     res->EVSEProcessing = (conn->ctx->evse_v2g_data.evse_processing[PHASE_AUTH] == (uint8_t)0)
-                              ? dinEVSEProcessingType_Finished
-                              : dinEVSEProcessingType_Ongoing;
+                              ? din_EVSEProcessingType_Finished
+                              : din_EVSEProcessingType_Ongoing;
 
     /* Check the current response code and check if no external error has occurred */
     nextEvent = din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
-    conn->ctx->state = (res->EVSEProcessing == dinEVSEProcessingType_Ongoing)
+    conn->ctx->state = (res->EVSEProcessing == din_EVSEProcessingType_Ongoing)
                            ? WAIT_FOR_AUTHORIZATION
                            : WAIT_FOR_CHARGEPARAMETERDISCOVERY; // [V2G-DC-444], [V2G-DC-497]
 
@@ -485,9 +485,9 @@ static enum v2g_event handle_din_contract_authentication(struct v2g_connection* 
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
-    struct dinChargeParameterDiscoveryReqType* req =
+    struct din_ChargeParameterDiscoveryReqType* req =
         &conn->exi_in.dinEXIDocument->V2G_Message.Body.ChargeParameterDiscoveryReq;
-    struct dinChargeParameterDiscoveryResType* res =
+    struct din_ChargeParameterDiscoveryResType* res =
         &conn->exi_out.dinEXIDocument->V2G_Message.Body.ChargeParameterDiscoveryRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
@@ -495,35 +495,35 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
     publish_din_charge_parameter_discovery_req(conn->ctx, req);
 
     /* Now fill the EVSE response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
     res->AC_EVSEChargeParameter_isUsed = 0u;
 
-    if (((req->EVRequestedEnergyTransferType != dinEVRequestedEnergyTransferType_DC_core) &&
-         (req->EVRequestedEnergyTransferType != dinEVRequestedEnergyTransferType_DC_extended)) ||
+    if (((req->EVRequestedEnergyTransferType != din_EVRequestedEnergyTransferType_DC_core) &&
+         (req->EVRequestedEnergyTransferType != din_EVRequestedEnergyTransferType_DC_extended)) ||
         conn->ctx->evse_v2g_data.charge_service.SupportedEnergyTransferMode.EnergyTransferMode.array[0] !=
-            (iso1EnergyTransferModeType)req->EVRequestedEnergyTransferType) {
-        res->ResponseCode = dinresponseCodeType_FAILED_WrongEnergyTransferType; // [V2G-DC-397] Failed reponse code is
-                                                                                // logged at the end of the function
+            (iso2_EnergyTransferModeType)req->EVRequestedEnergyTransferType) {
+        res->ResponseCode = din_responseCodeType_FAILED_WrongEnergyTransferType; // [V2G-DC-397] Failed reponse code is
+                                                                                 // logged at the end of the function
     } else {
         log_selected_energy_transfer_type((int)req->EVRequestedEnergyTransferType);
     }
 
     res->ResponseCode = (req->AC_EVChargeParameter_isUsed == (unsigned int)1)
-                            ? dinresponseCodeType_FAILED_WrongChargeParameter
+                            ? din_responseCodeType_FAILED_WrongChargeParameter
                             : res->ResponseCode; // [V2G-DC-398]
 
     /* DC_EVSEChargeParameter */
     res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEIsolationStatus =
-        (dinisolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
+        (din_isolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
     res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEIsolationStatus_isUsed =
         conn->ctx->evse_v2g_data.evse_isolation_status_is_used;
 
     res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSENotification =
-        (dinEVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
+        (din_EVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
     res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEStatusCode =
         (true == conn->ctx->intl_emergency_shutdown)
-            ? dinDC_EVSEStatusCodeType_EVSE_EmergencyShutdown
-            : (dinDC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_PARAMETER];
+            ? din_DC_EVSEStatusCodeType_EVSE_EmergencyShutdown
+            : (din_DC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_PARAMETER];
     res->DC_EVSEChargeParameter.DC_EVSEStatus.NotificationMaxDelay = conn->ctx->evse_v2g_data.notification_max_delay;
 
     if (conn->ctx->evse_v2g_data.evse_current_regulation_tolerance_is_used) {
@@ -563,8 +563,8 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
     // res->EVSEChargeParameter.noContent
     res->EVSEChargeParameter_isUsed = (unsigned int)0;
     res->EVSEProcessing = ((uint8_t)0 == conn->ctx->evse_v2g_data.evse_processing[PHASE_PARAMETER])
-                              ? dinEVSEProcessingType_Finished
-                              : dinEVSEProcessingType_Ongoing;
+                              ? din_EVSEProcessingType_Finished
+                              : din_EVSEProcessingType_Ongoing;
 
     if ((unsigned int)1 == res->DC_EVSEChargeParameter.EVSEMaximumPowerLimit_isUsed) {
         res->SAScheduleList.SAScheduleTuple.array[0].PMaxSchedule.PMaxScheduleEntry.array[0].PMax =
@@ -602,8 +602,8 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
     nextEvent = din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
-    if (res->EVSEProcessing == dinEVSEProcessingType_Finished) {
-        if (res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEStatusCode != dinDC_EVSEStatusCodeType_EVSE_Ready) {
+    if (res->EVSEProcessing == din_EVSEProcessingType_Finished) {
+        if (res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEStatusCode != din_DC_EVSEStatusCodeType_EVSE_Ready) {
             dlog(DLOG_LEVEL_WARNING,
                  "EVSE wants to finish charge parameter phase, but status code is not set to 'ready' (1)");
         }
@@ -623,8 +623,8 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
-    struct dinPowerDeliveryReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.PowerDeliveryReq;
-    struct dinPowerDeliveryResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.PowerDeliveryRes;
+    struct din_PowerDeliveryReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.PowerDeliveryReq;
+    struct din_PowerDeliveryResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.PowerDeliveryRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
     /* At first, publish the received EV request message to the MQTT interface */
@@ -639,17 +639,17 @@ static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
     }
 
     /* Now fill the evse response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
 
     res->AC_EVSEStatus_isUsed = (unsigned int)0;
-    res->DC_EVSEStatus.EVSEIsolationStatus = (dinisolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
+    res->DC_EVSEStatus.EVSEIsolationStatus = (din_isolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
     res->DC_EVSEStatus.EVSEIsolationStatus_isUsed = conn->ctx->evse_v2g_data.evse_isolation_status_is_used;
-    res->DC_EVSEStatus.EVSENotification = (dinEVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
+    res->DC_EVSEStatus.EVSENotification = (din_EVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
     res->DC_EVSEStatus.NotificationMaxDelay = conn->ctx->evse_v2g_data.notification_max_delay;
     res->DC_EVSEStatus.EVSEStatusCode =
         (conn->ctx->intl_emergency_shutdown == true)
-            ? dinDC_EVSEStatusCodeType_EVSE_EmergencyShutdown
-            : (dinDC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE];
+            ? din_DC_EVSEStatusCodeType_EVSE_EmergencyShutdown
+            : (din_DC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE];
     res->DC_EVSEStatus_isUsed = (unsigned int)1;
     res->EVSEStatus_isUsed = (unsigned int)0;
     // res->EVSEStatus.noContent
@@ -658,7 +658,7 @@ static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
     if (req->ChargingProfile_isUsed == (unsigned int)1) {
         /* Check the selected SAScheduleTupleID */
         res->ResponseCode = (req->ChargingProfile.SAScheduleTupleID != (int16_t)SASCHEDULETUPLEID)
-                                ? dinresponseCodeType_FAILED_TariffSelectionInvalid
+                                ? din_responseCodeType_FAILED_TariffSelectionInvalid
                                 : res->ResponseCode; // [V2G-DC-400]
 
         for (uint16_t idx = 0; idx < req->ChargingProfile.ProfileEntry.arrayLen; idx++) {
@@ -668,7 +668,7 @@ static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
             if ((entry_found == false) || (req->ChargingProfile.ProfileEntry.array[idx].ChargingProfileEntryMaxPower >
                                            (conn->ctx->evse_v2g_data.evse_maximum_power_limit.Value *
                                             pow(10, conn->ctx->evse_v2g_data.evse_maximum_power_limit.Multiplier)))) {
-                // res->ResponseCode = dinresponseCodeType_FAILED_ChargingProfileInvalid; //[V2G-DC-399]. Currently
+                // res->ResponseCode = din_responseCodeType_FAILED_ChargingProfileInvalid; //[V2G-DC-399]. Currently
                 // commented to increase compatibility with EV'S
                 dlog(DLOG_LEVEL_WARNING, "EV's charging profile is invalid (ChargingProfileEntryMaxPower %d too high)!",
                      req->ChargingProfile.ProfileEntry.array[idx].ChargingProfileEntryMaxPower);
@@ -678,8 +678,8 @@ static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
     }
 
     res->ResponseCode = ((req->ReadyToChargeState == (int)1) &&
-                         (res->DC_EVSEStatus.EVSEStatusCode != dinDC_EVSEStatusCodeType_EVSE_Ready))
-                            ? dinresponseCodeType_FAILED_PowerDeliveryNotApplied
+                         (res->DC_EVSEStatus.EVSEStatusCode != din_DC_EVSEStatusCodeType_EVSE_Ready))
+                            ? din_responseCodeType_FAILED_PowerDeliveryNotApplied
                             : res->ResponseCode; // [V2G-DC-401]
 
     /* Check the current response code and check if no external error has occurred */
@@ -691,7 +691,7 @@ static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
     } else {
         /* abort charging session if EV is ready to charge after current demand phase */
         if (req->ReadyToChargeState == (int)1) {
-            res->ResponseCode = dinresponseCodeType_FAILED;
+            res->ResponseCode = din_responseCodeType_FAILED;
             nextEvent = V2G_EVENT_SEND_AND_TERMINATE;
         }
         conn->ctx->state = WAIT_FOR_WELDINGDETECTION_SESSIONSTOP; // [V2G-DC-459]
@@ -708,8 +708,8 @@ static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_cable_check(struct v2g_connection* conn) {
-    struct dinCableCheckReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.CableCheckReq;
-    struct dinCableCheckResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.CableCheckRes;
+    struct din_CableCheckReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.CableCheckReq;
+    struct din_CableCheckResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.CableCheckRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
     /* At first, publish the received EV request message to the MQTT interface */
@@ -718,40 +718,41 @@ static enum v2g_event handle_din_cable_check(struct v2g_connection* conn) {
     // TODO: Wait for CP state C [V2G-DC-547]
 
     /* Now fill the evse response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
 
-    res->DC_EVSEStatus.EVSEIsolationStatus = (dinisolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
+    res->DC_EVSEStatus.EVSEIsolationStatus = (din_isolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
     res->DC_EVSEStatus.EVSEIsolationStatus_isUsed = conn->ctx->evse_v2g_data.evse_isolation_status_is_used;
-    res->DC_EVSEStatus.EVSENotification = (dinEVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
-    res->DC_EVSEStatus.NotificationMaxDelay = (uint32_t)conn->ctx->evse_v2g_data.notification_max_delay;
+    res->DC_EVSEStatus.EVSENotification =
+        static_cast<din_EVSENotificationType>(conn->ctx->evse_v2g_data.evse_notification);
+    res->DC_EVSEStatus.NotificationMaxDelay = static_cast<uint32_t>(conn->ctx->evse_v2g_data.notification_max_delay);
     res->EVSEProcessing = (conn->ctx->evse_v2g_data.evse_processing[PHASE_ISOLATION] == (uint8_t)0)
-                              ? dinEVSEProcessingType_Finished
-                              : dinEVSEProcessingType_Ongoing;
+                              ? din_EVSEProcessingType_Finished
+                              : din_EVSEProcessingType_Ongoing;
 
     if (conn->ctx->intl_emergency_shutdown == true) {
-        res->DC_EVSEStatus.EVSEStatusCode = dinDC_EVSEStatusCodeType_EVSE_EmergencyShutdown;
-    } else if (res->EVSEProcessing == dinEVSEProcessingType_Finished) {
-        res->DC_EVSEStatus.EVSEStatusCode = dinDC_EVSEStatusCodeType_EVSE_Ready;
+        res->DC_EVSEStatus.EVSEStatusCode = din_DC_EVSEStatusCodeType_EVSE_EmergencyShutdown;
+    } else if (res->EVSEProcessing == din_EVSEProcessingType_Finished) {
+        res->DC_EVSEStatus.EVSEStatusCode = din_DC_EVSEStatusCodeType_EVSE_Ready;
     } else {
         res->DC_EVSEStatus.EVSEStatusCode =
-            static_cast<dinDC_EVSEStatusCodeType>(conn->ctx->evse_v2g_data.evse_status_code[PHASE_ISOLATION]);
+            static_cast<din_DC_EVSEStatusCodeType>(conn->ctx->evse_v2g_data.evse_status_code[PHASE_ISOLATION]);
     }
 
     /* Check the current response code and check if no external error has occurred */
     nextEvent = din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
-    if ((res->EVSEProcessing == dinEVSEProcessingType_Finished) &&
+    if ((res->EVSEProcessing == din_EVSEProcessingType_Finished) &&
         (res->DC_EVSEStatus.EVSEIsolationStatus_isUsed == (unsigned int)1) &&
-        ((res->DC_EVSEStatus.EVSEIsolationStatus == dinisolationLevelType_Valid) ||
-         (res->DC_EVSEStatus.EVSEIsolationStatus == dinisolationLevelType_Warning)) &&
-        (res->DC_EVSEStatus.EVSEStatusCode == dinDC_EVSEStatusCodeType_EVSE_Ready)) {
+        ((res->DC_EVSEStatus.EVSEIsolationStatus == din_isolationLevelType_Valid) ||
+         (res->DC_EVSEStatus.EVSEIsolationStatus == din_isolationLevelType_Warning)) &&
+        (res->DC_EVSEStatus.EVSEStatusCode == din_DC_EVSEStatusCodeType_EVSE_Ready)) {
         conn->ctx->state = WAIT_FOR_PRECHARGE; // [V2G-DC-499]
     } else {
-        if ((res->EVSEProcessing == dinEVSEProcessingType_Finished) &&
+        if ((res->EVSEProcessing == din_EVSEProcessingType_Finished) &&
             ((res->DC_EVSEStatus.EVSEIsolationStatus_isUsed == (unsigned int)0) ||
-             ((res->DC_EVSEStatus.EVSEIsolationStatus != dinisolationLevelType_Valid) &&
-              (dinisolationLevelType_Warning != res->DC_EVSEStatus.EVSEIsolationStatus)))) {
+             ((res->DC_EVSEStatus.EVSEIsolationStatus != din_isolationLevelType_Valid) &&
+              (din_isolationLevelType_Warning != res->DC_EVSEStatus.EVSEIsolationStatus)))) {
             dlog(DLOG_LEVEL_WARNING, "EVSE wants to finish cable check phase, but either status code is not set to "
                                      "'ready' (1) or isolation status is not valid");
         }
@@ -770,23 +771,23 @@ static enum v2g_event handle_din_cable_check(struct v2g_connection* conn) {
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_pre_charge(struct v2g_connection* conn) {
-    struct dinPreChargeReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.PreChargeReq;
-    struct dinPreChargeResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.PreChargeRes;
+    struct din_PreChargeReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.PreChargeReq;
+    struct din_PreChargeResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.PreChargeRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
     /* At first, publish the received EV request message to the customer MQTT interface */
     publish_din_precharge_req(conn->ctx, req);
 
     /* Now fill the EVSE response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
 
-    res->DC_EVSEStatus.EVSEIsolationStatus = (dinisolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
+    res->DC_EVSEStatus.EVSEIsolationStatus = (din_isolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
     res->DC_EVSEStatus.EVSEIsolationStatus_isUsed = conn->ctx->evse_v2g_data.evse_isolation_status_is_used;
-    res->DC_EVSEStatus.EVSENotification = (dinEVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
+    res->DC_EVSEStatus.EVSENotification = (din_EVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
     res->DC_EVSEStatus.EVSEStatusCode =
         (conn->ctx->intl_emergency_shutdown == true)
-            ? dinDC_EVSEStatusCodeType_EVSE_EmergencyShutdown
-            : (dinDC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_PRECHARGE];
+            ? din_DC_EVSEStatusCodeType_EVSE_EmergencyShutdown
+            : (din_DC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_PRECHARGE];
     res->DC_EVSEStatus.NotificationMaxDelay = conn->ctx->evse_v2g_data.notification_max_delay;
 
     load_din_physical_value(&res->EVSEPresentVoltage, &conn->ctx->evse_v2g_data.evse_present_voltage);
@@ -808,23 +809,23 @@ static enum v2g_event handle_din_pre_charge(struct v2g_connection* conn) {
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_current_demand(struct v2g_connection* conn) {
-    struct dinCurrentDemandReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.CurrentDemandReq;
-    struct dinCurrentDemandResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.CurrentDemandRes;
+    struct din_CurrentDemandReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.CurrentDemandReq;
+    struct din_CurrentDemandResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.CurrentDemandRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
     /* At first, publish the received EV request message to the MQTT interface */
     publish_din_current_demand_req(conn->ctx, req);
 
     /* Now fill the evse response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
 
-    res->DC_EVSEStatus.EVSEIsolationStatus = (dinisolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
+    res->DC_EVSEStatus.EVSEIsolationStatus = (din_isolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
     res->DC_EVSEStatus.EVSEIsolationStatus_isUsed = conn->ctx->evse_v2g_data.evse_isolation_status_is_used;
-    res->DC_EVSEStatus.EVSENotification = (dinEVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
+    res->DC_EVSEStatus.EVSENotification = (din_EVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
     res->DC_EVSEStatus.EVSEStatusCode =
         (conn->ctx->intl_emergency_shutdown == true)
-            ? dinDC_EVSEStatusCodeType_EVSE_EmergencyShutdown
-            : (dinDC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE];
+            ? din_DC_EVSEStatusCodeType_EVSE_EmergencyShutdown
+            : (din_DC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE];
     res->DC_EVSEStatus.NotificationMaxDelay = (uint32_t)conn->ctx->evse_v2g_data.notification_max_delay;
 
     res->EVSECurrentLimitAchieved = conn->ctx->evse_v2g_data.evse_current_limit_achieved;
@@ -862,8 +863,8 @@ static enum v2g_event handle_din_current_demand(struct v2g_connection* conn) {
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_welding_detection(struct v2g_connection* conn) {
-    struct dinWeldingDetectionReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.WeldingDetectionReq;
-    struct dinWeldingDetectionResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.WeldingDetectionRes;
+    struct din_WeldingDetectionReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.WeldingDetectionReq;
+    struct din_WeldingDetectionResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.WeldingDetectionRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
     /* At first, publish the received EV request message to the MQTT interface */
@@ -872,15 +873,15 @@ static enum v2g_event handle_din_welding_detection(struct v2g_connection* conn) 
     /* TODO: Waiting for CP-State B [V2G-DC-556]. */
 
     /* Now fill the evse response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
 
-    res->DC_EVSEStatus.EVSEIsolationStatus = (dinisolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
+    res->DC_EVSEStatus.EVSEIsolationStatus = (din_isolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
     res->DC_EVSEStatus.EVSEIsolationStatus_isUsed = conn->ctx->evse_v2g_data.evse_isolation_status_is_used;
-    res->DC_EVSEStatus.EVSENotification = (dinEVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
+    res->DC_EVSEStatus.EVSENotification = (din_EVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
     res->DC_EVSEStatus.EVSEStatusCode =
         (conn->ctx->intl_emergency_shutdown == true)
-            ? dinDC_EVSEStatusCodeType_EVSE_EmergencyShutdown
-            : (dinDC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_WELDING];
+            ? din_DC_EVSEStatusCodeType_EVSE_EmergencyShutdown
+            : (din_DC_EVSEStatusCodeType)conn->ctx->evse_v2g_data.evse_status_code[PHASE_WELDING];
     res->DC_EVSEStatus.NotificationMaxDelay = (uint32_t)conn->ctx->evse_v2g_data.notification_max_delay;
 
     load_din_physical_value(&res->EVSEPresentVoltage, &conn->ctx->evse_v2g_data.evse_present_voltage);
@@ -902,10 +903,10 @@ static enum v2g_event handle_din_welding_detection(struct v2g_connection* conn) 
  * \return Returns the next V2G-event.
  */
 static enum v2g_event handle_din_session_stop(struct v2g_connection* conn) {
-    struct dinSessionStopResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.SessionStopRes;
+    struct din_SessionStopResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.SessionStopRes;
 
     /* Now fill the EVSE response message */
-    res->ResponseCode = dinresponseCodeType_OK; // [V2G-DC-388]
+    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
 
     /* Check the current response code and check if no external error has occurred */
     din_validate_response_code(&res->ResponseCode, conn);
@@ -921,27 +922,19 @@ static enum v2g_event handle_din_session_stop(struct v2g_connection* conn) {
 }
 
 enum v2g_event din_handle_request(v2g_connection* conn) {
-    struct dinEXIDocument* exi_in = conn->exi_in.dinEXIDocument;
-    struct dinEXIDocument* exi_out = conn->exi_out.dinEXIDocument;
+    struct din_exiDocument* exi_in = conn->exi_in.dinEXIDocument;
+    struct din_exiDocument* exi_out = conn->exi_out.dinEXIDocument;
     enum v2g_event next_v2g_event = V2G_EVENT_TERMINATE_CONNECTION; // ERROR_UNEXPECTED_REQUEST_MESSAGE;
-
-    /* check whether we have a valid EXI document embedded within a V2G message */
-    if (!exi_in->V2G_Message_isUsed) {
-        dlog(DLOG_LEVEL_ERROR, "V2G Message not used. Ignoring msg");
-        return V2G_EVENT_IGNORE_MSG;
-    }
 
     /* extract session id */
     conn->ctx->ev_v2g_data.received_session_id = v2g_session_id_from_exi(false, exi_in);
 
     /* init V2G structure (document, header, body) */
-    init_dinEXIDocument(exi_out);
-    exi_out->V2G_Message_isUsed = 1u;
-    init_dinMessageHeaderType(&exi_out->V2G_Message.Header);
+    init_din_exiDocument(exi_out);
+    init_din_MessageHeaderType(&exi_out->V2G_Message.Header);
 
     exi_out->V2G_Message.Header.SessionID.bytesLen = 8;
-    init_dinBodyType(&exi_out->V2G_Message.Body);
-    exi_out->V2G_Message_isUsed = 1u;
+    init_din_BodyType(&exi_out->V2G_Message.Body);
 
     // === Start request handling ===
     if (exi_in->V2G_Message.Body.CurrentDemandReq_isUsed) {
@@ -952,26 +945,26 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
         }
         conn->ctx->current_v2g_msg = V2G_CURRENT_DEMAND_MSG;
         exi_out->V2G_Message.Body.CurrentDemandRes_isUsed = 1u;
-        init_dinCurrentDemandResType(&exi_out->V2G_Message.Body.CurrentDemandRes);
+        init_din_CurrentDemandResType(&exi_out->V2G_Message.Body.CurrentDemandRes);
         next_v2g_event = handle_din_current_demand(conn);
     } else if (exi_in->V2G_Message.Body.SessionSetupReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "Handling SessionSetupReq");
         conn->ctx->current_v2g_msg = V2G_SESSION_SETUP_MSG;
         exi_out->V2G_Message.Body.SessionSetupRes_isUsed = 1u;
-        init_dinSessionSetupResType(&exi_out->V2G_Message.Body.SessionSetupRes);
+        init_din_SessionSetupResType(&exi_out->V2G_Message.Body.SessionSetupRes);
         /* Handle v2g msg */
         next_v2g_event = handle_din_session_setup(conn);
     } else if (exi_in->V2G_Message.Body.ServiceDiscoveryReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "Handling ServiceDiscoveryReq");
         conn->ctx->current_v2g_msg = V2G_SERVICE_DISCOVERY_MSG;
         exi_out->V2G_Message.Body.ServiceDiscoveryRes_isUsed = 1u;
-        init_dinServiceDiscoveryResType(&exi_out->V2G_Message.Body.ServiceDiscoveryRes);
+        init_din_ServiceDiscoveryResType(&exi_out->V2G_Message.Body.ServiceDiscoveryRes);
         next_v2g_event = handle_din_service_discovery(conn);
     } else if (exi_in->V2G_Message.Body.ServicePaymentSelectionReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "Handling PaymentServiceSelectionReq");
         conn->ctx->current_v2g_msg = V2G_PAYMENT_SERVICE_SELECTION_MSG;
         exi_out->V2G_Message.Body.ServicePaymentSelectionRes_isUsed = 1u;
-        init_dinServicePaymentSelectionResType(&exi_out->V2G_Message.Body.ServicePaymentSelectionRes);
+        init_din_ServicePaymentSelectionResType(&exi_out->V2G_Message.Body.ServicePaymentSelectionRes);
         next_v2g_event = handle_din_service_payment_selection(conn);
     } else if (exi_in->V2G_Message.Body.ContractAuthenticationReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "Handling ContractAuthenticationReq");
@@ -981,7 +974,7 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
             conn->ctx->p_charger->publish_Require_Auth_EIM(nullptr);
         }
         exi_out->V2G_Message.Body.ContractAuthenticationRes_isUsed = 1u;
-        init_dinContractAuthenticationResType(&exi_out->V2G_Message.Body.ContractAuthenticationRes);
+        init_din_ContractAuthenticationResType(&exi_out->V2G_Message.Body.ContractAuthenticationRes);
         next_v2g_event = handle_din_contract_authentication(conn);
     } else if (exi_in->V2G_Message.Body.PaymentDetailsReq_isUsed) {
         dlog(DLOG_LEVEL_ERROR, "PaymentDetails request is not supported in DIN 70121");
@@ -998,7 +991,7 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
             dlog(DLOG_LEVEL_INFO, "Parameter-phase started");
         }
         exi_out->V2G_Message.Body.ChargeParameterDiscoveryRes_isUsed = 1u;
-        init_dinChargeParameterDiscoveryResType(&exi_out->V2G_Message.Body.ChargeParameterDiscoveryRes);
+        init_din_ChargeParameterDiscoveryResType(&exi_out->V2G_Message.Body.ChargeParameterDiscoveryRes);
         next_v2g_event = handle_din_charge_parameter(conn);
     } else if (exi_in->V2G_Message.Body.CableCheckReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "Handling CableCheckReq");
@@ -1008,7 +1001,7 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
             dlog(DLOG_LEVEL_INFO, "Isolation-phase started");
         }
         exi_out->V2G_Message.Body.CableCheckRes_isUsed = 1u;
-        init_dinCableCheckResType(&exi_out->V2G_Message.Body.CableCheckRes);
+        init_din_CableCheckResType(&exi_out->V2G_Message.Body.CableCheckRes);
         next_v2g_event = handle_din_cable_check(conn);
     } else if (exi_in->V2G_Message.Body.PreChargeReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "Handling PreChargeReq");
@@ -1017,7 +1010,7 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
             dlog(DLOG_LEVEL_INFO, "Precharge-phase started");
         }
         exi_out->V2G_Message.Body.PreChargeRes_isUsed = 1u;
-        init_dinPreChargeResType(&exi_out->V2G_Message.Body.PreChargeRes);
+        init_din_PreChargeResType(&exi_out->V2G_Message.Body.PreChargeRes);
         next_v2g_event = handle_din_pre_charge(conn);
     } else if (exi_in->V2G_Message.Body.PowerDeliveryReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "Handling PowerDeliveryReq");
@@ -1026,19 +1019,19 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
             dlog(DLOG_LEVEL_INFO, "Charge-phase started");
         }
         exi_out->V2G_Message.Body.PowerDeliveryRes_isUsed = 1u;
-        init_dinPowerDeliveryResType(&exi_out->V2G_Message.Body.PowerDeliveryRes);
+        init_din_PowerDeliveryResType(&exi_out->V2G_Message.Body.PowerDeliveryRes);
         next_v2g_event = handle_din_power_delivery(conn);
     } else if (exi_in->V2G_Message.Body.ChargingStatusReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "ChargingStatus request is not supported in DIN 70121");
         conn->ctx->current_v2g_msg = V2G_UNKNOWN_MSG;
         exi_out->V2G_Message.Body.ChargingStatusRes_isUsed = 0u;
-        init_dinChargingStatusResType(&exi_out->V2G_Message.Body.ChargingStatusRes);
+        init_din_ChargingStatusResType(&exi_out->V2G_Message.Body.ChargingStatusRes);
         next_v2g_event = V2G_EVENT_IGNORE_MSG;
     } else if (exi_in->V2G_Message.Body.MeteringReceiptReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "MeteringReceipt request is not supported in DIN 70121");
         conn->ctx->current_v2g_msg = V2G_UNKNOWN_MSG;
         exi_out->V2G_Message.Body.MeteringReceiptRes_isUsed = 0u;
-        init_dinMeteringReceiptResType(&exi_out->V2G_Message.Body.MeteringReceiptRes);
+        init_din_MeteringReceiptResType(&exi_out->V2G_Message.Body.MeteringReceiptRes);
         next_v2g_event = V2G_EVENT_IGNORE_MSG;
     } else if (exi_in->V2G_Message.Body.CertificateUpdateReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "CertificateUpdate request is not supported in DIN 70121");
@@ -1055,14 +1048,14 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
             dlog(DLOG_LEVEL_INFO, "Welding-phase started");
         }
         exi_out->V2G_Message.Body.WeldingDetectionRes_isUsed = 1u;
-        init_dinWeldingDetectionResType(&exi_out->V2G_Message.Body.WeldingDetectionRes);
+        init_din_WeldingDetectionResType(&exi_out->V2G_Message.Body.WeldingDetectionRes);
         next_v2g_event = handle_din_welding_detection(conn);
     } else if (exi_in->V2G_Message.Body.SessionStopReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "Handling SessionStopReq");
         conn->ctx->current_v2g_msg = V2G_SESSION_STOP_MSG;
 
         exi_out->V2G_Message.Body.SessionStopRes_isUsed = 1u;
-        init_dinSessionStopResType(&exi_out->V2G_Message.Body.SessionStopRes);
+        init_din_SessionStopResType(&exi_out->V2G_Message.Body.SessionStopRes);
         next_v2g_event = handle_din_session_stop(conn);
     } else {
         dlog(DLOG_LEVEL_ERROR, "Create_response_message: request type not found");
@@ -1074,7 +1067,7 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
         memcpy(exi_out->V2G_Message.Header.SessionID.bytes, &conn->ctx->evse_v2g_data.session_id, sizeof(uint64_t));
 
         // TODO: Set byteLen
-        exi_out->V2G_Message.Header.SessionID.bytesLen = dinMessageHeaderType_SessionID_BYTES_SIZE;
+        exi_out->V2G_Message.Header.SessionID.bytesLen = din_sessionIDType_BYTES_SIZE;
 
         dlog(DLOG_LEVEL_TRACE, "Current state: %s", din_states[conn->ctx->state].description);
         conn->ctx->last_v2g_msg = conn->ctx->current_v2g_msg;

--- a/modules/EvseV2G/v2g_ctx.hpp
+++ b/modules/EvseV2G/v2g_ctx.hpp
@@ -31,28 +31,28 @@ void v2g_ctx_init_charging_session(struct v2g_context* const ctx, bool is_connec
  * \param physicalValue is the struct of the physical value.
  * \param unit is the unit of the physical value.
  */
-void init_physical_value(struct iso1PhysicalValueType* const physicalValue, iso1unitSymbolType unit);
+void init_physical_value(struct iso2_PhysicalValueType* const physicalValue, iso2_unitSymbolType unit);
 
 /*!
- * \brief populate_physical_value This function fills all elements of a \c iso1PhysicalValueType struct regarding the
+ * \brief populate_physical_value This function fills all elements of a \c iso2_PhysicalValueType struct regarding the
  * parameter value and unit.
  * \param pv is pointer to the physical value struct
  * \param value is the physical value
  * \param unit is the unit of the physical value
  * \return Returns \c true if the convertion was succesfull, otherwise \c false.
  */
-bool populate_physical_value(struct iso1PhysicalValueType* pv, long long int value, iso1unitSymbolType unit);
+bool populate_physical_value(struct iso2_PhysicalValueType* pv, long long int value, iso2_unitSymbolType unit);
 
 /*!
- * \brief populate_physical_value_float This function fills all elements of a \c iso1PhysicalValueType struct from a
+ * \brief populate_physical_value_float This function fills all elements of a \c iso2_PhysicalValueType struct from a
  * json object.
  * \param pv is pointer to the physical value struct
  * \param value is the physical value
  * \param decimal_places is to determine the precision
  * \param unit is the unit of the physical value
  */
-void populate_physical_value_float(struct iso1PhysicalValueType* pv, float value, uint8_t decimal_places,
-                                   iso1unitSymbolType unit);
+void populate_physical_value_float(struct iso2_PhysicalValueType* pv, float value, uint8_t decimal_places,
+                                   iso2_unitSymbolType unit);
 
 /*!
  * \brief setMinPhysicalValue This function sets the minimum value of ASrcPhyValue and ADstPhyValue in ADstPhyValue.
@@ -61,7 +61,7 @@ void populate_physical_value_float(struct iso1PhysicalValueType* pv, float value
  * \param AIsUsed If AIsUsed is \c 0 ASrcPhyValue will be used to initialize ADstPhyValue and AIsUsed will be set to
  * \c 1. Can be set to \c NULL
  */
-void setMinPhysicalValue(struct iso1PhysicalValueType* ADstPhyValue, const struct iso1PhysicalValueType* ASrcPhyValue,
+void setMinPhysicalValue(struct iso2_PhysicalValueType* ADstPhyValue, const struct iso2_PhysicalValueType* ASrcPhyValue,
                          unsigned int* AIsUsed);
 
 /*!
@@ -122,15 +122,15 @@ void publish_DC_EVTargetVoltageCurrent(struct v2g_context* ctx, const float& v2g
 /*!
  * \brief publish_DC_EVRemainingTime This function publishes the DC_EVRemainingTime
  * \param ctx is a pointer of type \c v2g_context
- * \param iso1_dc_ev_remaining_time_to_full_soc is the EV remaining time to full soc
- * \param iso1_dc_ev_remaining_time_to_full_soc_is_used is set to \c true if used, otherwise \c false
- * \param iso1_dc_ev_remaining_time_to_bulk_soc is the EV remaining time to bulk soc
- * \param iso1_dc_ev_remaining_time_to_bulk_soc_is_used is set to \c true if used, otherwise \c false
+ * \param iso2_dc_ev_remaining_time_to_full_soc is the EV remaining time to full soc
+ * \param iso2_dc_ev_remaining_time_to_full_soc_is_used is set to \c true if used, otherwise \c false
+ * \param iso2_dc_ev_remaining_time_to_bulk_soc is the EV remaining time to bulk soc
+ * \param iso2_dc_ev_remaining_time_to_bulk_soc_is_used is set to \c true if used, otherwise \c false
  */
-void publish_DC_EVRemainingTime(struct v2g_context* ctx, const float& iso1_dc_ev_remaining_time_to_full_soc,
-                                const unsigned int& iso1_dc_ev_remaining_time_to_full_soc_is_used,
-                                const float& iso1_dc_ev_remaining_time_to_bulk_soc,
-                                const unsigned int& iso1_dc_ev_remaining_time_to_bulk_soc_is_used);
+void publish_DC_EVRemainingTime(struct v2g_context* ctx, const float& iso2_dc_ev_remaining_time_to_full_soc,
+                                const unsigned int& iso2_dc_ev_remaining_time_to_full_soc_is_used,
+                                const float& iso2_dc_ev_remaining_time_to_bulk_soc,
+                                const unsigned int& iso2_dc_ev_remaining_time_to_bulk_soc_is_used);
 
 /*!
  * \brief log_selected_energy_transfer_type This function logs the selected_energy_transfer_mode
@@ -145,7 +145,7 @@ void log_selected_energy_transfer_type(int selected_energy_transfer_mode);
  * \param parameter_set_id_len is the array length of parameter_set_id
  * \return Returns \c true if it was successful, otherwise \c false.
  */
-bool add_service_to_service_list(struct v2g_context* v2g_ctx, const struct iso1ServiceType& evse_service,
+bool add_service_to_service_list(struct v2g_context* v2g_ctx, const struct iso2_ServiceType& evse_service,
                                  const int16_t* parameter_set_id = NULL, uint8_t parameter_set_id_len = 0);
 
 /*!
@@ -154,7 +154,7 @@ bool add_service_to_service_list(struct v2g_context* v2g_ctx, const struct iso1S
  * \param parameterSetId is the parameter-set-ID which belongs to the service ID.
  * \param serviceId is the service ID. Currently only service ID 2 ("Certificate") supported.
  */
-void configure_parameter_set(struct iso1ServiceParameterListType* parameterSetList, int16_t parameterSetId,
+void configure_parameter_set(struct iso2_ServiceParameterListType* parameterSetList, int16_t parameterSetId,
                              uint16_t serviceId);
 
 #endif /* V2G_CTX_H */

--- a/modules/EvseV2G/v2g_server.cpp
+++ b/modules/EvseV2G/v2g_server.cpp
@@ -12,15 +12,14 @@
 
 #include <mbedtls/base64.h>
 
-#include <openv2g/appHandEXIDatatypesDecoder.h>
-#include <openv2g/appHandEXIDatatypesEncoder.h>
-#include <openv2g/dinEXIDatatypes.h>
-#include <openv2g/dinEXIDatatypesDecoder.h>
-#include <openv2g/dinEXIDatatypesEncoder.h>
-#include <openv2g/iso1EXIDatatypes.h>
-#include <openv2g/iso1EXIDatatypesDecoder.h>
-#include <openv2g/iso1EXIDatatypesEncoder.h>
-#include <openv2g/v2gtp.h>
+#include <cbv2g/app_handshake/appHand_Decoder.h>
+#include <cbv2g/app_handshake/appHand_Encoder.h>
+#include <cbv2g/common/exi_basetypes.h>
+#include <cbv2g/din/din_msgDefDecoder.h>
+#include <cbv2g/din/din_msgDefEncoder.h>
+#include <cbv2g/exi_v2gtp.h>
+#include <cbv2g/iso_2/iso2_msgDefDecoder.h>
+#include <cbv2g/iso_2/iso2_msgDefEncoder.h>
 
 #include "connection.hpp"
 #include "din_server.hpp"
@@ -160,7 +159,7 @@ static int v2g_incoming_v2gtp(struct v2g_connection* conn) {
         return -1;
     }
 
-    rv = read_v2gtpHeader(conn->buffer, &conn->payload_len);
+    rv = V2GTP_ReadHeader(conn->buffer, &conn->payload_len);
     if (rv == -1) {
         dlog(DLOG_LEVEL_ERROR, "Invalid v2gtp header");
         return -1;
@@ -194,8 +193,8 @@ static int v2g_incoming_v2gtp(struct v2g_connection* conn) {
         return -1;
     }
     /* adjust buffer pos to decode request */
-    conn->buffer_pos = V2GTP_HEADER_LENGTH;
-    conn->stream.size = conn->payload_len + V2GTP_HEADER_LENGTH;
+    conn->stream.byte_pos = V2GTP_HEADER_LENGTH;
+    conn->stream.data_size = conn->payload_len + V2GTP_HEADER_LENGTH;
 
     return 0;
 }
@@ -207,12 +206,11 @@ static int v2g_incoming_v2gtp(struct v2g_connection* conn) {
  */
 int v2g_outgoing_v2gtp(struct v2g_connection* conn) {
     /* fixup/create header */
-    if (write_v2gtpHeader(conn->buffer, conn->buffer_pos - V2GTP_HEADER_LENGTH, V2GTP_EXI_TYPE) != 0) {
-        dlog(DLOG_LEVEL_ERROR, "write_v2gtpHeader() failed");
-        return -1;
-    }
+    const auto len = exi_bitstream_get_length(&conn->stream);
 
-    if (connection_write(conn, conn->buffer, conn->buffer_pos) == -1) {
+    V2GTP_WriteHeader(conn->buffer, len - V2GTP_HEADER_LENGTH);
+
+    if (connection_write(conn, conn->buffer, len) == -1) {
         dlog(DLOG_LEVEL_ERROR, "connection_write(header) failed: %s", strerror(errno));
         return -1;
     }
@@ -232,15 +230,15 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
     uint8_t ev_app_priority = 20; // lowest priority
 
     /* validate handshake request and create response */
-    init_appHandEXIDocument(&conn->handshake_resp);
+    init_appHand_exiDocument(&conn->handshake_resp);
     conn->handshake_resp.supportedAppProtocolRes_isUsed = 1;
     conn->handshake_resp.supportedAppProtocolRes.ResponseCode =
-        appHandresponseCodeType_Failed_NoNegotiation; // [V2G2-172]
+        appHand_responseCodeType_Failed_NoNegotiation; // [V2G2-172]
 
     dlog(DLOG_LEVEL_INFO, "Handling SupportedAppProtocolReq");
     conn->ctx->current_v2g_msg = V2G_SUPPORTED_APP_PROTOCOL_MSG;
 
-    if (decode_appHandExiDocument(&conn->stream, &conn->handshake_req) != 0) {
+    if (decode_appHand_exiDocument(&conn->stream, &conn->handshake_req) != 0) {
         dlog(DLOG_LEVEL_ERROR, "decode_appHandExiDocument() failed");
         return V2G_EVENT_TERMINATE_CONNECTION; // If the mesage can't be decoded we have to terminate the tcp-connection
                                                // (e.g. after an unexpected message)
@@ -249,7 +247,7 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
     json appProtocolArray = json::array(); // to publish supported app protocol array
 
     for (i = 0; i < conn->handshake_req.supportedAppProtocolReq.AppProtocol.arrayLen; i++) {
-        struct appHandAppProtocolType* app_proto = &conn->handshake_req.supportedAppProtocolReq.AppProtocol.array[i];
+        struct appHand_AppProtocolType* app_proto = &conn->handshake_req.supportedAppProtocolReq.AppProtocol.array[i];
         char* proto_ns = strndup(static_cast<const char*>(app_proto->ProtocolNamespace.characters),
                                  app_proto->ProtocolNamespace.charactersLen);
 
@@ -267,7 +265,7 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
             (strcmp(proto_ns, DIN_70121_MSG_DEF) == 0) && (app_proto->VersionNumberMajor == DIN_70121_MAJOR) &&
             (ev_app_priority >= app_proto->Priority)) {
             conn->handshake_resp.supportedAppProtocolRes.ResponseCode =
-                appHandresponseCodeType_OK_SuccessfulNegotiation;
+                appHand_responseCodeType_OK_SuccessfulNegotiation;
             ev_app_priority = app_proto->Priority;
             conn->handshake_resp.supportedAppProtocolRes.SchemaID = app_proto->SchemaID;
             conn->ctx->selected_protocol = V2G_PROTO_DIN70121;
@@ -277,7 +275,7 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
                    (ev_app_priority >= app_proto->Priority)) {
 
             conn->handshake_resp.supportedAppProtocolRes.ResponseCode =
-                appHandresponseCodeType_OK_SuccessfulNegotiation;
+                appHand_responseCodeType_OK_SuccessfulNegotiation;
             ev_app_priority = app_proto->Priority;
             conn->handshake_resp.supportedAppProtocolRes.SchemaID = app_proto->SchemaID;
             conn->ctx->selected_protocol = V2G_PROTO_ISO15118_2013;
@@ -305,7 +303,8 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
     }
 
     std::string selected_protocol_str;
-    if (conn->handshake_resp.supportedAppProtocolRes.ResponseCode == appHandresponseCodeType_OK_SuccessfulNegotiation) {
+    if (conn->handshake_resp.supportedAppProtocolRes.ResponseCode ==
+        appHand_responseCodeType_OK_SuccessfulNegotiation) {
         conn->handshake_resp.supportedAppProtocolRes.SchemaID_isUsed = (unsigned int)1;
         if (V2G_PROTO_DIN70121 == conn->ctx->selected_protocol) {
             dlog(DLOG_LEVEL_INFO, "Protocol negotiation was successful. Selected protocol is DIN70121");
@@ -335,7 +334,7 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
     /* Validate response code */
     if ((conn->ctx->intl_emergency_shutdown == true) || (conn->ctx->stop_hlc == true) ||
         (V2G_EVENT_SEND_AND_TERMINATE == next_event)) {
-        conn->handshake_resp.supportedAppProtocolRes.ResponseCode = appHandresponseCodeType_Failed_NoNegotiation;
+        conn->handshake_resp.supportedAppProtocolRes.ResponseCode = appHand_responseCodeType_Failed_NoNegotiation;
         dlog(DLOG_LEVEL_ERROR, "Abort charging session");
 
         if (conn->ctx->terminate_connection_on_failed_response == true) {
@@ -344,11 +343,10 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
     }
 
     /* encode response at the right buffer location */
-    *(conn->stream.pos) = V2GTP_HEADER_LENGTH;
-    conn->stream.capacity = 8; // as it should be for send
-    conn->stream.buffer = 0;
+    conn->stream.byte_pos = V2GTP_HEADER_LENGTH;
+    conn->stream.bit_count = 0;
 
-    if (encode_appHandExiDocument(&conn->stream, &conn->handshake_resp) != 0) {
+    if (encode_appHand_exiDocument(&conn->stream, &conn->handshake_resp) != 0) {
         dlog(DLOG_LEVEL_ERROR, "Encoding of the protocol handshake message failed");
         next_event = V2G_EVENT_SEND_AND_TERMINATE;
     }
@@ -370,7 +368,6 @@ int v2g_handle_connection(struct v2g_connection* conn) {
 
     /* static setup */
     conn->stream.data = conn->buffer;
-    conn->stream.pos = &conn->buffer_pos;
 
     /* Here is a good point to wait until the customer is ready for a resumed session,
      * because we are waiting for the incoming message of the ev */
@@ -380,10 +377,9 @@ int v2g_handle_connection(struct v2g_connection* conn) {
 
     do {
         /* setup for receive */
-        conn->stream.buffer = 0;
-        conn->stream.capacity = 0; // Set to 8 for send and 0 for recv
-        conn->buffer_pos = 0;
+        conn->stream.data[0] = 0;
         conn->payload_len = 0;
+        exi_bitstream_init(&conn->stream, conn->buffer, 0, 0, nullptr);
 
         /* next call return -1 on error, 1 when peer closed connection, 0 on success */
         rv = v2g_incoming_v2gtp(conn);
@@ -435,25 +431,27 @@ int v2g_handle_connection(struct v2g_connection* conn) {
     switch (selected_protocol) {
     case V2G_PROTO_DIN70121:
     case V2G_PROTO_ISO15118_2010:
-        conn->exi_in.dinEXIDocument = static_cast<struct dinEXIDocument*>(calloc(1, sizeof(struct dinEXIDocument)));
+        conn->exi_in.dinEXIDocument = static_cast<struct din_exiDocument*>(calloc(1, sizeof(struct din_exiDocument)));
         if (conn->exi_in.dinEXIDocument == NULL) {
             dlog(DLOG_LEVEL_ERROR, "out-of-memory");
             goto error_out;
         }
-        conn->exi_out.dinEXIDocument = static_cast<struct dinEXIDocument*>(calloc(1, sizeof(struct dinEXIDocument)));
+        conn->exi_out.dinEXIDocument = static_cast<struct din_exiDocument*>(calloc(1, sizeof(struct din_exiDocument)));
         if (conn->exi_out.dinEXIDocument == NULL) {
             dlog(DLOG_LEVEL_ERROR, "out-of-memory");
             goto error_out;
         }
         break;
     case V2G_PROTO_ISO15118_2013:
-        conn->exi_in.iso1EXIDocument = static_cast<struct iso1EXIDocument*>(calloc(1, sizeof(struct iso1EXIDocument)));
-        if (conn->exi_in.iso1EXIDocument == NULL) {
+        conn->exi_in.iso2EXIDocument =
+            static_cast<struct iso2_exiDocument*>(calloc(1, sizeof(struct iso2_exiDocument)));
+        if (conn->exi_in.iso2EXIDocument == NULL) {
             dlog(DLOG_LEVEL_ERROR, "out-of-memory");
             goto error_out;
         }
-        conn->exi_out.iso1EXIDocument = static_cast<struct iso1EXIDocument*>(calloc(1, sizeof(struct iso1EXIDocument)));
-        if (conn->exi_out.iso1EXIDocument == NULL) {
+        conn->exi_out.iso2EXIDocument =
+            static_cast<struct iso2_exiDocument*>(calloc(1, sizeof(struct iso2_exiDocument)));
+        if (conn->exi_out.iso2EXIDocument == NULL) {
             dlog(DLOG_LEVEL_ERROR, "out-of-memory");
             goto error_out;
         }
@@ -464,9 +462,9 @@ int v2g_handle_connection(struct v2g_connection* conn) {
 
     do {
         /* setup for receive */
-        conn->stream.buffer = 0;
-        conn->stream.capacity = 0; // Set to 8 for send and 0 for recv
-        conn->buffer_pos = 0;
+        conn->stream.data[0] = 0;
+        conn->stream.bit_count = 0;
+        conn->stream.byte_pos = 0;
         conn->payload_len = 0;
 
         /* next call return -1 on error, 1 when peer closed connection, 0 on success */
@@ -488,8 +486,8 @@ int v2g_handle_connection(struct v2g_connection* conn) {
         switch (selected_protocol) {
         case V2G_PROTO_DIN70121:
         case V2G_PROTO_ISO15118_2010:
-            memset(conn->exi_in.dinEXIDocument, 0, sizeof(struct dinEXIDocument));
-            rv = decode_dinExiDocument(&conn->stream, conn->exi_in.dinEXIDocument);
+            memset(conn->exi_in.dinEXIDocument, 0, sizeof(struct din_exiDocument));
+            rv = decode_din_exiDocument(&conn->stream, conn->exi_in.dinEXIDocument);
             if (rv != 0) {
                 dlog(DLOG_LEVEL_ERROR, "decode_dinExiDocument() (previous message \"%s\") failed: %d",
                      v2g_msg_type[conn->ctx->last_v2g_msg], rv);
@@ -499,26 +497,24 @@ int v2g_handle_connection(struct v2g_connection* conn) {
                 break;
             }
 
-            memset(conn->exi_out.dinEXIDocument, 0, sizeof(struct dinEXIDocument));
-            conn->exi_out.dinEXIDocument->V2G_Message_isUsed = 1;
+            memset(conn->exi_out.dinEXIDocument, 0, sizeof(struct din_exiDocument));
 
             v2gEvent = din_handle_request(conn);
             break;
 
         case V2G_PROTO_ISO15118_2013:
-            memset(conn->exi_in.iso1EXIDocument, 0, sizeof(struct iso1EXIDocument));
-            rv = decode_iso1ExiDocument(&conn->stream, conn->exi_in.iso1EXIDocument);
+            memset(conn->exi_in.iso2EXIDocument, 0, sizeof(struct iso2_exiDocument));
+            rv = decode_iso2_exiDocument(&conn->stream, conn->exi_in.iso2EXIDocument);
             if (rv != 0) {
-                dlog(DLOG_LEVEL_ERROR, "decode_iso1EXIDocument() (previous message \"%s\") failed: %d",
+                dlog(DLOG_LEVEL_ERROR, "decode_iso2_exiDocument() (previous message \"%s\") failed: %d",
                      v2g_msg_type[conn->ctx->last_v2g_msg], rv);
                 /* we must ignore packet which we cannot decode, so reset rv to zero to stay in loop */
                 rv = 0;
                 v2gEvent = V2G_EVENT_IGNORE_MSG;
                 break;
             }
-            conn->buffer_pos = 0; // Reset buffer pos for the case if exi msg will be configured over mqtt
-            memset(conn->exi_out.iso1EXIDocument, 0, sizeof(struct iso1EXIDocument));
-            conn->exi_out.iso1EXIDocument->V2G_Message_isUsed = 1;
+            conn->stream.byte_pos = 0; // Reset pos for the case if exi msg will be configured over mqtt
+            memset(conn->exi_out.iso2EXIDocument, 0, sizeof(struct iso2_exiDocument));
 
             v2gEvent = iso_handle_request(conn);
 
@@ -537,23 +533,23 @@ int v2g_handle_connection(struct v2g_connection* conn) {
             stop_receiving_loop = true;
         case V2G_EVENT_NO_EVENT: { // fall-through intended
             /* Reset v2g-buffer */
-            conn->stream.buffer = 0;
-            conn->stream.capacity = 8; // Set to 8 for send and 0 for recv
-            conn->buffer_pos = V2GTP_HEADER_LENGTH;
-            conn->stream.size = DEFAULT_BUFFER_SIZE;
+            conn->stream.data[0] = 0;
+            conn->stream.bit_count = 0;
+            conn->stream.byte_pos = V2GTP_HEADER_LENGTH;
+            conn->stream.data_size = DEFAULT_BUFFER_SIZE;
 
             /* Configure msg and send */
             switch (selected_protocol) {
             case V2G_PROTO_DIN70121:
             case V2G_PROTO_ISO15118_2010:
-                if ((rv = encode_dinExiDocument(&conn->stream, conn->exi_out.dinEXIDocument)) != 0) {
+                if ((rv = encode_din_exiDocument(&conn->stream, conn->exi_out.dinEXIDocument)) != 0) {
                     dlog(DLOG_LEVEL_ERROR, "encode_dinExiDocument() (message \"%s\") failed: %d",
                          v2g_msg_type[conn->ctx->current_v2g_msg], rv);
                 }
                 break;
             case V2G_PROTO_ISO15118_2013:
-                if ((rv = encode_iso1ExiDocument(&conn->stream, conn->exi_out.iso1EXIDocument)) != 0) {
-                    dlog(DLOG_LEVEL_ERROR, "encode_iso1ExiDocument() (message \"%s\") failed: %d",
+                if ((rv = encode_iso2_exiDocument(&conn->stream, conn->exi_out.iso2EXIDocument)) != 0) {
+                    dlog(DLOG_LEVEL_ERROR, "encode_iso2_exiDocument() (message \"%s\") failed: %d",
                          v2g_msg_type[conn->ctx->current_v2g_msg], rv);
                 }
                 break;
@@ -608,10 +604,10 @@ error_out:
             free(conn->exi_out.dinEXIDocument);
         break;
     case V2G_PROTO_ISO15118_2013:
-        if (conn->exi_in.iso1EXIDocument != NULL)
-            free(conn->exi_in.iso1EXIDocument);
-        if (conn->exi_out.iso1EXIDocument != NULL)
-            free(conn->exi_out.iso1EXIDocument);
+        if (conn->exi_in.iso2EXIDocument != NULL)
+            free(conn->exi_in.iso2EXIDocument);
+        if (conn->exi_out.iso2EXIDocument != NULL)
+            free(conn->exi_out.iso2EXIDocument);
         break;
     default:
         break;
@@ -630,8 +626,8 @@ uint64_t v2g_session_id_from_exi(bool is_iso, void* exi_in) {
     uint64_t session_id = 0;
 
     if (is_iso) {
-        struct iso1EXIDocument* req = static_cast<struct iso1EXIDocument*>(exi_in);
-        struct iso1MessageHeaderType* hdr = &req->V2G_Message.Header;
+        struct iso2_exiDocument* req = static_cast<struct iso2_exiDocument*>(exi_in);
+        struct iso2_MessageHeaderType* hdr = &req->V2G_Message.Header;
 
         /* the provided session id could be smaller (error) in case that the peer did not
          * send our full session id back to us; this is why we init the id with 0 above
@@ -639,8 +635,8 @@ uint64_t v2g_session_id_from_exi(bool is_iso, void* exi_in) {
          */
         memcpy(&session_id, &hdr->SessionID.bytes, std::min((int)sizeof(session_id), (int)hdr->SessionID.bytesLen));
     } else {
-        struct dinEXIDocument* req = static_cast<struct dinEXIDocument*>(exi_in);
-        struct dinMessageHeaderType* hdr = &req->V2G_Message.Header;
+        struct din_exiDocument* req = static_cast<struct din_exiDocument*>(exi_in);
+        struct din_MessageHeaderType* hdr = &req->V2G_Message.Header;
 
         /* see comment above */
         memcpy(&session_id, &hdr->SessionID.bytes, std::min((int)sizeof(session_id), (int)hdr->SessionID.bytesLen));

--- a/third-party/bazel/deps_versions.bzl
+++ b/third-party/bazel/deps_versions.bzl
@@ -29,10 +29,10 @@ EVEREST_DEPS = struct(
 	ext_mbedtls_commit = "8b3f26a5ac38d4fdccbc5c5366229f3e01dafcc0",
 	ext_mbedtls_tag = None,
 
-	# ext-openv2g
-	ext_openv2g_repo = "https://github.com/EVerest/ext-openv2g.git",
-	ext_openv2g_commit = None,
-	ext_openv2g_tag = "2023.3.0",
+	# libcbv2g
+	ext_libcbv2g_repo = "https://github.com/EVerest/libcbv2g.git",
+	ext_libcbv2g_commit = None,
+	ext_libcbv2g_tag = "v0.2.0",
 
 	# gtest
 	gtest_repo = "https://github.com/google/googletest.git",


### PR DESCRIPTION
This is the initial work to switch from OpenV2G to CBV2G in the EvseV2g module.

Currently The following is done:

- [x] add cbv2g as a dependency
- [x] link cbv2g to EvseV2G module
- [x] switch SAP
- [x] switch DIN
- [x] switch ISO -2
- [x] switch xmldsig fragment encoding
- [x] Remove OpenV2G
- [x] Test din
- [x] Test iso2
- [x] Test PnC