### PR TITLE
Added missing cstdint in WifiSetup

### DIFF
--- a/modules/Setup/WiFiSetup.hpp
+++ b/modules/Setup/WiFiSetup.hpp
@@ -3,6 +3,7 @@
 #ifndef WIFISETUP_HPP
 #define WIFISETUP_HPP
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
I could not build the current everest-core release on my Fedora 39 container. The WifiSetup module seems to be missing an include <cstdint>. After including that it builds again.