### PR TITLE
Fix Price type in money.yaml file

### DIFF
--- a/types/money.yaml
+++ b/types/money.yaml
@@ -507,4 +507,4 @@ types:
         description: >-
           Value in the minor units of the currency.
         type: object
-        $ref: /money#/Value
+        $ref: /money#/MoneyAmount


### PR DESCRIPTION
The money::Price type has an invalid ref to money::Value that was replaced by money::MoneyAmount