### PR TITLE
Support starting transaction in EvseManager

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -96,7 +96,8 @@ void EvseManager::ready() {
 
     hw_capabilities = r_bsp->call_get_hw_capabilities();
 
-    charger = std::unique_ptr<Charger>(new Charger(bsp, error_handling, hw_capabilities.connector_type));
+    charger = std::unique_ptr<Charger>(
+        new Charger(bsp, error_handling, r_powermeter_billing(), hw_capabilities.connector_type, config.evse_id));
 
     if (r_connector_lock.size() > 0) {
         bsp->signal_lock.connect([this]() { r_connector_lock[0]->call_lock(); });

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -275,6 +275,8 @@ void evse_managerImpl::ready() {
                     transaction_finished.meter_value.energy_Wh_export.value().total;
             }
 
+            transaction_finished.start_signed_meter_value = mod->charger->get_start_signed_meter_value();
+            transaction_finished.signed_meter_value = mod->charger->get_stop_signed_meter_value();
             mod->telemetry.publish("session", "events", telemetry_data);
 
             se.transaction_finished.emplace(transaction_finished);

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -50,6 +50,7 @@ void powermeterImpl::ready() {
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
     return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
             {},
+            {},
             "Generic powermeter does not support the stop_transaction command"};
 };
 

--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -56,8 +56,7 @@ LemDCBM400600Controller::start_transaction(const types::powermeter::TransactionR
 
     auto [transaction_min_stop_time, transaction_max_stop_time] = get_transaction_stop_time_bounds();
 
-    return {
-        types::powermeter::TransactionRequestStatus::OK, {}, {}, transaction_min_stop_time, transaction_max_stop_time};
+    return {types::powermeter::TransactionRequestStatus::OK, {}, transaction_min_stop_time, transaction_max_stop_time};
 }
 
 void LemDCBM400600Controller::request_device_to_start_transaction(const types::powermeter::TransactionReq& value) {
@@ -89,6 +88,7 @@ LemDCBM400600Controller::stop_transaction(const std::string& transaction_id) {
                 auto signed_meter_value =
                     types::units_signed::SignedMeterValue{fetch_ocmf_result(transaction_id), "", "OCMF"};
                 return types::powermeter::TransactionStopResponse{types::powermeter::TransactionRequestStatus::OK,
+                                                                  {}, // Empty start_signed_meter_value
                                                                   signed_meter_value};
             },
             this->config.transaction_number_of_http_retries, this->config.transaction_retry_wait_in_milliseconds);
@@ -96,13 +96,13 @@ LemDCBM400600Controller::stop_transaction(const std::string& transaction_id) {
         std::string error_message = fmt::format("Failed to stop transaction {}: {}", transaction_id, error.what());
         EVLOG_error << error_message;
         return types::powermeter::TransactionStopResponse{
-            types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {}, error_message};
+            types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {}, {}, error_message};
     } catch (HttpClientError& error) {
         std::string error_message = fmt::format("Failed to stop transaction {} - connection to device failed: {}",
                                                 transaction_id, error.what());
         EVLOG_error << error_message;
         return types::powermeter::TransactionStopResponse{
-            types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {}, error_message};
+            types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {}, {}, error_message};
     }
 }
 

--- a/modules/LemDCBM400600/tests/test_lem_dcbm_400600_controller.cpp
+++ b/modules/LemDCBM400600/tests/test_lem_dcbm_400600_controller.cpp
@@ -302,8 +302,9 @@ TEST_F(LemDCBM400600ControllerTest, test_stop_transaction) {
     auto res = controller.stop_transaction("mock_transaction_id");
 
     // Verify
-    EXPECT_EQ(transaction_request_status_to_string(res.status), "OK");
-    EXPECT_EQ(res.signed_meter_value.value().signed_meter_data, "mock_ocmf_string");
+    ASSERT_EQ(transaction_request_status_to_string(res.status), "OK");
+    ASSERT_TRUE(res.signed_meter_value.has_value());
+    ASSERT_EQ(res.signed_meter_value.value().signed_meter_data, "mock_ocmf_string");
 }
 
 // \brief Test a failed stop transaction with the DCBM returning an invalid response

--- a/modules/MicroMegaWattBSP/powermeter/powermeterImpl.cpp
+++ b/modules/MicroMegaWattBSP/powermeter/powermeterImpl.cpp
@@ -39,6 +39,7 @@ void powermeterImpl::ready() {
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
     return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
             {},
+            {},
             "MicroMegaWattBSP powermeter does not support the stop_transaction command"};
 };
 

--- a/modules/PowermeterBSM/main/powermeterImpl.cpp
+++ b/modules/PowermeterBSM/main/powermeterImpl.cpp
@@ -50,7 +50,7 @@ types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transacti
 
     } catch (const std::runtime_error& e) {
         EVLOG_error << __PRETTY_FUNCTION__ << " Error: " << e.what() << std::endl;
-        return {types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {}, "get_signed_meter_value_error"};
+        return {types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {}, {}, "get_signed_meter_value_error"};
     }
 };
 

--- a/modules/RsIskraMeter/src/main.rs
+++ b/modules/RsIskraMeter/src/main.rs
@@ -210,7 +210,6 @@ impl TransactionStartResponse {
     {
         Self {
             error: Some(format!("{error:?}")),
-            signed_meter_value: None,
             status: TransactionRequestStatus::UNEXPECTED_ERROR,
             transaction_max_stop_time: None,
             transaction_min_stop_time: None,
@@ -228,6 +227,7 @@ impl TransactionStopResponse {
     {
         Self {
             error: Some(format!("{error:?}")),
+            start_signed_meter_value: None,
             signed_meter_value: None,
             status: TransactionRequestStatus::UNEXPECTED_ERROR,
         }
@@ -728,17 +728,8 @@ impl ReadyState {
         )?;
 
         self.check_signature_status()?;
-        let signature = self.read_signature()?;
-        let signed_meter_values = self.read_signed_meter_values()?;
         Ok(TransactionStartResponse {
             error: Option::None,
-            signed_meter_value: Some(SignedMeterValue {
-                signed_meter_data: create_ocmf(signed_meter_values, signature),
-                signing_method: String::new(),
-                encoding_method: "OCMF".to_string(),
-                public_key: self.read_public_key().ok(),
-                timestamp: None,
-            }),
             transaction_min_stop_time: Option::None,
             status: TransactionRequestStatus::OK,
             transaction_max_stop_time: Option::None,
@@ -781,6 +772,9 @@ impl ReadyState {
         let signed_meter_values = self.read_signed_meter_values()?;
         Ok(TransactionStopResponse {
             error: Option::None,
+            // Iskra meter has both start and stop snapshot in one 
+            // OCMF dataset. So we don't need to send the start snapshot.
+            start_signed_meter_value: None,
             signed_meter_value: Some(SignedMeterValue {
                 signed_meter_data: create_ocmf(signed_meter_values, signature),
                 signing_method: String::new(),

--- a/modules/YetiDriver/powermeter/powermeterImpl.cpp
+++ b/modules/YetiDriver/powermeter/powermeterImpl.cpp
@@ -57,6 +57,7 @@ void powermeterImpl::ready() {
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
     return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED,
             {},
+            {},
             "YetiDriver powermeter does not support the stop_transaction command"};
 };
 

--- a/modules/simulation/JsYetiSimulator/index.js
+++ b/modules/simulation/JsYetiSimulator/index.js
@@ -93,7 +93,7 @@ boot_module(async ({
   });
 
   setup.provides.powermeter.register.stop_transaction((mod, args) => ({
-    status: 'NOT_IMPLEMENTED',
+    status: 'NOT_SUPPORTED',
     error: 'YetiDriver does not support stop transaction request.',
   }));
   setup.provides.powermeter.register.start_transaction((mod, args) => ({ status: 'OK' }));

--- a/tests/core_tests/startup_tests.py
+++ b/tests/core_tests/startup_tests.py
@@ -46,7 +46,9 @@ class ProbeModule:
     def test(self, timeout: float) -> bool:
         end_of_time = time.time() + timeout
 
+        logging.info("Wating for ready event...")
         if not self._ready_event.wait(timeout):
+            logging.error("Ready event not received. Timeout.")
             return False
 
         # fetch fulfillment
@@ -61,15 +63,20 @@ class ProbeModule:
 
         expected_events = ['TransactionStarted', 'TransactionFinished']
 
+        logging.info("Waiting for expected events...")
         while len(expected_events) > 0:
             time_left = end_of_time - time.time()
 
             if time_left < 0:
+                logging.error("Timeout waiting for expected events")
                 return False
 
             try:
+                logging.info("Waiting for event: %s", expected_events[0])
                 event = self._msg_queue.get(timeout=time_left)
+                logging.info("Received event: %s", event)
                 if expected_events[0] == event:
+                    logging.info("Event was expected, removing from list.")
                     expected_events.pop(0)
             except queue.Empty:
                 return False

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -215,6 +215,10 @@ types:
         description: Transaction finished meter value
         type: object
         $ref: /powermeter#/Powermeter
+      start_signed_meter_value:
+        description: The starting signed meter value report of the stopped transaction. If not included in the `signed_meter_value` object, it must be included here.
+        type: object
+        $ref: /units_signed#/SignedMeterValue
       signed_meter_value:
         description: The signed meter value report of the stopped transaction
         type: object
@@ -324,7 +328,7 @@ types:
       session_finished:
         description: data for the SessionFinished event
         type: object
-        $ref: /evse_manager#/SessionFinished  
+        $ref: /evse_manager#/SessionFinished
       transaction_started:
         description: data for TransactionStarted event
         type: object

--- a/types/powermeter.yaml
+++ b/types/powermeter.yaml
@@ -51,10 +51,6 @@ types:
       error:
         description: If status is not OK, a verbose error message.
         type: string
-      signed_meter_value:
-        description: The signed meter value report of the started transaction. Must be provided if status is OK.
-        type: object
-        $ref: /units_signed#/SignedMeterValue
       transaction_min_stop_time:
         description: Earliest point in time the started transaction can be stopped again (if a minimum duration is required by the meter); yields a RFC3339 timestamp.
         type: string
@@ -74,6 +70,10 @@ types:
         type: object
         description: Response status that indicates whether the transaction stop request could successfully be performed.
         $ref: /powermeter#/TransactionRequestStatus
+      start_signed_meter_value:
+        description: The signed meter value report for start of transaction. Needs to be filled if meter provides separate values for start and stop.
+        type: object
+        $ref: /units_signed#/SignedMeterValue
       signed_meter_value:
         description: The signed meter value report of the stopped transaction. Must be provided if status is OK.
         type: object

--- a/types/units_signed.yaml
+++ b/types/units_signed.yaml
@@ -153,3 +153,4 @@ types:
         description: VAR phase C
         type: object
         $ref: /units_signed#/SignedMeterValue
+  


### PR DESCRIPTION
resolves https://github.com/EVerest/everest-core/issues/572

The solution presented here is suitable for basic use-case under German Measurement law.

Prior to starting charging on BSP, the EvseManager will request meter to start transaction.
Starting the transaction on the power meter is expected to return quicly (by either spawning some process in the meter driver, or initiating the transaction on the meter hardware).

The signed meter values for start transaction are not expected to be reported by the meter when transaction is requested.

There are different meter models, and signed meter values for transaction start, may be a separate "SignedMeterValue" object. in this case the `start_signed_meter_value` of "StopTransactionResponse" can be used. And the `signed_meter_value` would contain data for the session finish.
 
 In many cases the meter only issue one signed dataset for session, that contains multiple snapshots encoded, in this case only `signed_meter_value` is used.
 
 
 What is not covered by this PR: 
   * OCPP module as well as libOCPP need to be adjusted, to use "start_signed_meter_value" from `TransactionFinished` event
   * the meter values for the transaction are only transferred at the end of the session, there is no support for asynchronous sending of meter values introduced. Which needs to be designed spearately, once we have better requiremetns from the OCPP of different versions.