### PR TITLE
EnergyManager: fix high CPU load in some scenarios

### DIFF
--- a/modules/EnergyManager/Market.cpp
+++ b/modules/EnergyManager/Market.cpp
@@ -42,6 +42,7 @@ void globals_t::init(date::utc_clock::time_point start_time, int _interval_durat
 void globals_t::create_timestamps(const date::utc_clock::time_point& start_time,
                                   const types::energy::EnergyFlowRequest& energy_flow_request) {
 
+    timestamps.clear();
     timestamps.reserve(schedule_length);
 
     auto minutes_overflow = start_time.time_since_epoch() % interval_duration;


### PR DESCRIPTION
## Describe your changes

If schedules with changing timestamps were used (e.g. pushed through OCPP smart charging) the internal timestamps array could grow indefinetly leading to high CPU load during calculation and increasing memory usage.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

