### PR TITLE
Provided fix if both payment options are disabled in the EvseManager

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -117,6 +117,10 @@ void EvseManager::ready() {
         if (config.payment_enable_contract) {
             payment_options.push_back(types::iso15118_charger::PaymentOption::Contract);
         }
+        if (config.payment_enable_eim == false and config.payment_enable_contract == false) {
+            EVLOG_warning << "Both payment options are disabled! ExternalPayment is nevertheless enabled in this case.";
+            payment_options.push_back(types::iso15118_charger::PaymentOption::ExternalPayment);
+        }
         r_hlc[0]->call_session_setup(payment_options, config.payment_enable_contract);
 
         r_hlc[0]->subscribe_dlink_error([this] {
@@ -719,6 +723,11 @@ void EvseManager::ready() {
             }
             if (config.payment_enable_contract) {
                 payment_options.push_back(types::iso15118_charger::PaymentOption::Contract);
+            }
+            if (config.payment_enable_eim == false and config.payment_enable_contract == false) {
+                EVLOG_warning
+                    << "Both payment options are disabled! ExternalPayment is nevertheless enabled in this case.";
+                payment_options.push_back(types::iso15118_charger::PaymentOption::ExternalPayment);
             }
             r_hlc[0]->call_session_setup(payment_options, config.payment_enable_contract);
         }


### PR DESCRIPTION
## Describe your changes
If both payment options are disabled, the evse_manager then sends the EIM option to the module as a fallback option.
## Issue ticket number and link
#596 
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

