### PR TITLE
libgpio: fix description

### DIFF
--- a/lib/staging/gpio/gpio.hpp
+++ b/lib/staging/gpio/gpio.hpp
@@ -2,10 +2,11 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 
 /*
- This is a simple wrapper around libgpiod C++ wrapper.
- The interface of libgpiod is powerful but somewhat hard to use for simple things,
- this class simplifies its usage in EVerest where usually just setting or
- reading of a single GPIO is required.
+ This is a simple wrapper for accessing GPIOs via the Linux kernel's
+ GPIO Character Device Userspace API (v1). This API was introduced in Linux
+ kernel version 4.8.
+ This wrapper attempts to provide a simple interface to that API, for uses
+ in EVerest where simply setting or reading of a single GPIO is required.
 */
 
 #ifndef GPIO_HPP


### PR DESCRIPTION
## Describe your changes

The internal libgpio's documentation claims its use of libgpiod, which was never the case.

Properly describe the API it uses, including its version. (v1 is deprecated since Linux kernel 5.10, but conditionally using the new v2 API is a different task.)

See also https://lists.lfenergy.org/g/everest/message/921

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

