### PR TITLE
OCPP2.0.1: Configurable TxStart and TxStop points

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -53,7 +53,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 8ba2086
+  git_tag: 04f87bb
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/API/API.cpp
+++ b/modules/API/API.cpp
@@ -357,11 +357,11 @@ void API::init() {
                 if (session_event.event == types::evse_manager::SessionEventEnum::TransactionStarted) {
                     if (session_event.transaction_started.has_value()) {
                         auto transaction_started = session_event.transaction_started.value();
-                        auto energy_Wh_import = transaction_started.meter_value.energy_Wh_import.total;
+                        auto energy_Wh_import = session_event.meter_value.energy_Wh_import.total;
                         session_info->set_start_energy_import_wh(energy_Wh_import);
 
-                        if (transaction_started.meter_value.energy_Wh_export.has_value()) {
-                            auto energy_Wh_export = transaction_started.meter_value.energy_Wh_export.value().total;
+                        if (session_event.meter_value.energy_Wh_export.has_value()) {
+                            auto energy_Wh_export = session_event.meter_value.energy_Wh_export.value().total;
                             session_info->set_start_energy_export_wh(energy_Wh_export);
                         } else {
                             session_info->start_energy_export_wh_was_set = false;
@@ -370,11 +370,11 @@ void API::init() {
                 } else if (session_event.event == types::evse_manager::SessionEventEnum::TransactionFinished) {
                     if (session_event.transaction_finished.has_value()) {
                         auto transaction_finished = session_event.transaction_finished.value();
-                        auto energy_Wh_import = transaction_finished.meter_value.energy_Wh_import.total;
+                        auto energy_Wh_import = session_event.meter_value.energy_Wh_import.total;
                         session_info->set_end_energy_import_wh(energy_Wh_import);
 
-                        if (transaction_finished.meter_value.energy_Wh_export.has_value()) {
-                            auto energy_Wh_export = transaction_finished.meter_value.energy_Wh_export.value().total;
+                        if (session_event.meter_value.energy_Wh_export.has_value()) {
+                            auto energy_Wh_export = session_event.meter_value.energy_Wh_export.value().total;
                             session_info->set_end_energy_export_wh(energy_Wh_export);
                         } else {
                             session_info->end_energy_export_wh_was_set = false;

--- a/modules/API/API.cpp
+++ b/modules/API/API.cpp
@@ -357,11 +357,11 @@ void API::init() {
                 if (session_event.event == types::evse_manager::SessionEventEnum::TransactionStarted) {
                     if (session_event.transaction_started.has_value()) {
                         auto transaction_started = session_event.transaction_started.value();
-                        auto energy_Wh_import = session_event.meter_value.energy_Wh_import.total;
+                        auto energy_Wh_import = transaction_started.meter_value.energy_Wh_import.total;
                         session_info->set_start_energy_import_wh(energy_Wh_import);
 
-                        if (session_event.meter_value.energy_Wh_export.has_value()) {
-                            auto energy_Wh_export = session_event.meter_value.energy_Wh_export.value().total;
+                        if (transaction_started.meter_value.energy_Wh_export.has_value()) {
+                            auto energy_Wh_export = transaction_started.meter_value.energy_Wh_export.value().total;
                             session_info->set_start_energy_export_wh(energy_Wh_export);
                         } else {
                             session_info->start_energy_export_wh_was_set = false;
@@ -370,11 +370,11 @@ void API::init() {
                 } else if (session_event.event == types::evse_manager::SessionEventEnum::TransactionFinished) {
                     if (session_event.transaction_finished.has_value()) {
                         auto transaction_finished = session_event.transaction_finished.value();
-                        auto energy_Wh_import = session_event.meter_value.energy_Wh_import.total;
+                        auto energy_Wh_import = transaction_finished.meter_value.energy_Wh_import.total;
                         session_info->set_end_energy_import_wh(energy_Wh_import);
 
-                        if (session_event.meter_value.energy_Wh_export.has_value()) {
-                            auto energy_Wh_export = session_event.meter_value.energy_Wh_export.value().total;
+                        if (transaction_finished.meter_value.energy_Wh_export.has_value()) {
+                            auto energy_Wh_export = transaction_finished.meter_value.energy_Wh_export.value().total;
                             session_info->set_end_energy_export_wh(energy_Wh_export);
                         } else {
                             session_info->end_energy_export_wh_was_set = false;

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -49,9 +49,9 @@ static SessionEvent get_transaction_started_event(const ProvidedIdToken provided
     SessionEvent session_event;
     session_event.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event;
-    transaction_event.meter_value.energy_Wh_import.total = 0;
+    session_event.meter_value.energy_Wh_import.total = 0;
     transaction_event.id_tag = provided_token;
-    transaction_event.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
+    session_event.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     session_event.transaction_started = transaction_event;
     return session_event;
 }
@@ -832,9 +832,9 @@ TEST_F(AuthTest, test_complete_event_flow) {
     SessionEvent session_event_5;
     session_event_5.event = SessionEventEnum::TransactionFinished;
     TransactionStarted transaction_finished_event;
-    transaction_finished_event.meter_value.energy_Wh_import.total = 1000;
+    session_event_5.meter_value.energy_Wh_import.total = 1000;
     transaction_finished_event.id_tag = provided_token;
-    transaction_finished_event.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
+    session_event_5.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
 
     SessionEvent session_event_6;
     session_event_6.event = SessionEventEnum::SessionFinished;

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -49,7 +49,7 @@ static SessionEvent get_transaction_started_event(const ProvidedIdToken provided
     SessionEvent session_event;
     session_event.event = SessionEventEnum::TransactionStarted;
     TransactionStarted transaction_event;
-    session_event.meter_value.energy_Wh_import.total = 0;
+    transaction_event.meter_value.energy_Wh_import.total = 0;
     transaction_event.id_tag = provided_token;
     session_event.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     session_event.transaction_started = transaction_event;
@@ -832,7 +832,7 @@ TEST_F(AuthTest, test_complete_event_flow) {
     SessionEvent session_event_5;
     session_event_5.event = SessionEventEnum::TransactionFinished;
     TransactionStarted transaction_finished_event;
-    session_event_5.meter_value.energy_Wh_import.total = 1000;
+    transaction_finished_event.meter_value.energy_Wh_import.total = 1000;
     transaction_finished_event.id_tag = provided_token;
     session_event_5.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
 

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -1217,6 +1217,7 @@ void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& tok
         if (not shared_context.session_active) {
             start_session(true);
         }
+        signal_simple_event(types::evse_manager::SessionEventEnum::Authorized);
         shared_context.authorized = true;
         shared_context.authorized_pnc =
             token.authorization_type == types::authorization::AuthorizationType::PlugAndCharge;
@@ -1234,6 +1235,7 @@ bool Charger::deauthorize() {
 }
 
 bool Charger::deauthorize_internal() {
+    signal_simple_event(types::evse_manager::SessionEventEnum::Deauthorized);
     if (shared_context.session_active) {
         auto s = shared_context.current_state;
 

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -146,7 +146,8 @@ public:
 
     // Signal for EvseEvents
     sigslot::signal<types::evse_manager::SessionEventEnum> signal_simple_event;
-    sigslot::signal<types::evse_manager::StartSessionReason> signal_session_started_event;
+    sigslot::signal<types::evse_manager::StartSessionReason, std::optional<types::authorization::ProvidedIdToken>>
+        signal_session_started_event;
     sigslot::signal<types::authorization::ProvidedIdToken> signal_transaction_started_event;
     sigslot::signal<types::evse_manager::StopTransactionReason, std::optional<types::authorization::ProvidedIdToken>>
         signal_transaction_finished_event;

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -734,18 +734,20 @@ void EvseManager::ready() {
         }
     });
 
-    charger->signal_session_started_event.connect([this](types::evse_manager::StartSessionReason start_reason) {
-        // Reset EV information on Session start and end
-        ev_info = types::evse_manager::EVInfo();
-        p_evse->publish_ev_info(ev_info);
+    charger->signal_session_started_event.connect(
+        [this](types::evse_manager::StartSessionReason start_reason,
+               const std::optional<types::authorization::ProvidedIdToken>& provided_id_token) {
+            // Reset EV information on Session start and end
+            ev_info = types::evse_manager::EVInfo();
+            p_evse->publish_ev_info(ev_info);
 
-        std::vector<types::iso15118_charger::PaymentOption> payment_options;
+            std::vector<types::iso15118_charger::PaymentOption> payment_options;
 
-        if (get_hlc_enabled() and start_reason == types::evse_manager::StartSessionReason::Authorized) {
-            payment_options.push_back(types::iso15118_charger::PaymentOption::ExternalPayment);
-            r_hlc[0]->call_session_setup(payment_options, false);
-        }
-    });
+            if (get_hlc_enabled() and start_reason == types::evse_manager::StartSessionReason::Authorized) {
+                payment_options.push_back(types::iso15118_charger::PaymentOption::ExternalPayment);
+                r_hlc[0]->call_session_setup(payment_options, false);
+            }
+        });
 
     invoke_ready(*p_evse);
     invoke_ready(*p_energy_grid);

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -149,8 +149,7 @@ void evse_managerImpl::ready() {
             this->mod->selected_protocol = "IEC61851-1";
             types::evse_manager::SessionStarted session_started;
 
-            se.timestamp =
-                date::format("%FT%TZ", std::chrono::time_point_cast<std::chrono::milliseconds>(date::utc_clock::now()));
+            se.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
             session_started.meter_value = mod->get_latest_powermeter_data_billing();
 
             if (mod->config.disable_authentication &&
@@ -201,8 +200,7 @@ void evse_managerImpl::ready() {
         types::evse_manager::SessionEvent se;
         se.event = types::evse_manager::SessionEventEnum::TransactionStarted;
         types::evse_manager::TransactionStarted transaction_started;
-        se.timestamp =
-            date::format("%FT%TZ", std::chrono::time_point_cast<std::chrono::milliseconds>(date::utc_clock::now()));
+        se.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
 
         transaction_started.meter_value = mod->get_latest_powermeter_data_billing();
         if (mod->is_reserved()) {
@@ -243,8 +241,7 @@ void evse_managerImpl::ready() {
             this->mod->selected_protocol = "Unknown";
             types::evse_manager::TransactionFinished transaction_finished;
 
-            se.timestamp =
-                date::format("%FT%TZ", std::chrono::time_point_cast<std::chrono::milliseconds>(date::utc_clock::now()));
+            se.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
 
             transaction_finished.meter_value = mod->get_latest_powermeter_data_billing();
 
@@ -283,8 +280,7 @@ void evse_managerImpl::ready() {
         types::evse_manager::SessionEvent se;
 
         se.event = e;
-        se.timestamp =
-            date::format("%FT%TZ", std::chrono::time_point_cast<std::chrono::milliseconds>(date::utc_clock::now()));
+        se.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
 
         const auto session_uuid = this->mod->charger->get_session_id();
         if (e == types::evse_manager::SessionEventEnum::SessionFinished) {

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -306,6 +306,11 @@ void evse_managerImpl::ready() {
             types::evse_manager::ChargingStateChangedEvent charging_state_changed_event;
             charging_state_changed_event.meter_value = mod->get_latest_powermeter_data_billing();
             se.charging_state_changed_event = charging_state_changed_event;
+        } else if (e == types::evse_manager::SessionEventEnum::Authorized or
+                   e == types::evse_manager::SessionEventEnum::Deauthorized) {
+            types::evse_manager::AuthorizationEvent authorization_event;
+            authorization_event.meter_value = mod->get_latest_powermeter_data_billing();
+            se.authorization_event = authorization_event;
         }
 
         se.uuid = session_uuid;

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -142,7 +142,8 @@ void evse_managerImpl::ready() {
     });
 
     mod->charger->signal_session_started_event.connect(
-        [this](const types::evse_manager::StartSessionReason& start_reason) {
+        [this](const types::evse_manager::StartSessionReason& start_reason,
+               const std::optional<types::authorization::ProvidedIdToken>& provided_id_token) {
             types::evse_manager::SessionEvent se;
             se.event = types::evse_manager::SessionEventEnum::SessionStarted;
             this->mod->selected_protocol = "IEC61851-1";
@@ -169,6 +170,12 @@ void evse_managerImpl::ready() {
 
             session_started.reason = start_reason;
             const auto session_uuid = this->mod->charger->get_session_id();
+            session_started.meter_value = mod->get_latest_powermeter_data_billing();
+            session_started.id_tag = provided_id_token;
+            if (mod->is_reserved()) {
+                session_started.reservation_id = mod->get_reservation_id();
+            }
+
             session_started.logging_path = session_log.startSession(
                 mod->config.logfile_suffix == "session_uuid" ? session_uuid : mod->config.logfile_suffix);
 

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -170,7 +170,7 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
         const auto transaction_started = session_event.transaction_started.value();
 
         const auto timestamp = ocpp::DateTime(session_event.timestamp);
-        const auto energy_Wh_import = session_event.meter_value.energy_Wh_import.total;
+        const auto energy_Wh_import = transaction_started.meter_value.energy_Wh_import.total;
         const auto session_id = session_event.uuid;
         const auto id_token = transaction_started.id_tag.id_token.value;
         const auto signed_meter_value = transaction_started.signed_meter_value;
@@ -206,7 +206,7 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
 
         const auto transaction_finished = session_event.transaction_finished.value();
         const auto timestamp = ocpp::DateTime(session_event.timestamp);
-        const auto energy_Wh_import = session_event.meter_value.energy_Wh_import.total;
+        const auto energy_Wh_import = transaction_finished.meter_value.energy_Wh_import.total;
         const auto signed_meter_value = transaction_finished.signed_meter_value;
 
         auto reason = ocpp::v16::Reason::Other;

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -169,8 +169,8 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
                    << "Received TransactionStarted";
         const auto transaction_started = session_event.transaction_started.value();
 
-        const auto timestamp = ocpp::DateTime(transaction_started.timestamp);
-        const auto energy_Wh_import = transaction_started.meter_value.energy_Wh_import.total;
+        const auto timestamp = ocpp::DateTime(session_event.timestamp);
+        const auto energy_Wh_import = session_event.meter_value.energy_Wh_import.total;
         const auto session_id = session_event.uuid;
         const auto id_token = transaction_started.id_tag.id_token.value;
         const auto signed_meter_value = transaction_started.signed_meter_value;
@@ -205,8 +205,8 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
                     << "Received TransactionFinished";
 
         const auto transaction_finished = session_event.transaction_finished.value();
-        const auto timestamp = ocpp::DateTime(transaction_finished.timestamp);
-        const auto energy_Wh_import = transaction_finished.meter_value.energy_Wh_import.total;
+        const auto timestamp = ocpp::DateTime(session_event.timestamp);
+        const auto energy_Wh_import = session_event.meter_value.energy_Wh_import.total;
         const auto signed_meter_value = transaction_finished.signed_meter_value;
 
         auto reason = ocpp::v16::Reason::Other;

--- a/modules/OCPP201/CMakeLists.txt
+++ b/modules/OCPP201/CMakeLists.txt
@@ -27,9 +27,13 @@ target_sources(${MODULE_NAME}
         "auth_provider/auth_token_providerImpl.cpp"
         "data_transfer/ocpp_data_transferImpl.cpp"
         "conversions.cpp"
+        "transaction_handler.cpp"
         "ocpp_generic/ocppImpl.cpp"
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 # insert other things like install cmds etc here
+if(EVEREST_CORE_BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -827,8 +827,6 @@ void OCPP201::process_disabled(const int32_t evse_id, const int32_t connector_id
 void OCPP201::process_authorized(const int32_t evse_id, const int32_t connector_id,
                                  const types::evse_manager::SessionEvent& session_event) {
     // currently handled as part of SessionStarted and TransactionStarted events
-    const auto tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::AUTHORIZED);
-    this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
 }
 
 void OCPP201::process_deauthorized(const int32_t evse_id, const int32_t connector_id,

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -15,23 +15,47 @@ const std::string CERTS_DIR = "certs";
 
 namespace fs = std::filesystem;
 
-TxStartPoint get_tx_start_point(const std::string& tx_start_point_string) {
-    if (tx_start_point_string == "ParkingBayOccupancy") {
-        return TxStartPoint::ParkingBayOccupancy;
-    } else if (tx_start_point_string == "EVConnected") {
-        return TxStartPoint::EVConnected;
-    } else if (tx_start_point_string == "Authorized") {
-        return TxStartPoint::Authorized;
-    } else if (tx_start_point_string == "PowerPathClosed") {
-        return TxStartPoint::PowerPathClosed;
-    } else if (tx_start_point_string == "EnergyTransfer") {
-        return TxStartPoint::EnergyTransfer;
-    } else if (tx_start_point_string == "DataSigned") {
-        return TxStartPoint::DataSigned;
+TxEvent get_tx_event(const ocpp::v201::ReasonEnum reason) {
+    switch (reason) {
+    case ocpp::v201::ReasonEnum::DeAuthorized:
+    case ocpp::v201::ReasonEnum::Remote:
+    case ocpp::v201::ReasonEnum::Local:
+        return TxEvent::DEAUTHORIZED;
+    case ocpp::v201::ReasonEnum::EVDisconnected:
+        return TxEvent::EV_DISCONNECTED;
+    default:
+        return TxEvent::NONE;
+    }
+}
+
+std::set<TxStartStopPoint> get_tx_start_stop_points(const std::string& tx_start_stop_point_csl) {
+    std::set<TxStartStopPoint> tx_start_stop_points;
+    std::vector<std::string> csv;
+    std::string str;
+    std::stringstream ss(tx_start_stop_point_csl);
+    while (std::getline(ss, str, ',')) {
+        csv.push_back(str);
     }
 
-    // default to PowerPathClosed for now
-    return TxStartPoint::PowerPathClosed;
+    for (const auto tx_start_stop_point : csv) {
+        if (tx_start_stop_point == "ParkingBayOccupancy") {
+            tx_start_stop_points.insert(TxStartStopPoint::ParkingBayOccupancy);
+        } else if (tx_start_stop_point == "EVConnected") {
+            tx_start_stop_points.insert(TxStartStopPoint::EVConnected);
+        } else if (tx_start_stop_point == "Authorized") {
+            tx_start_stop_points.insert(TxStartStopPoint::Authorized);
+        } else if (tx_start_stop_point == "PowerPathClosed") {
+            tx_start_stop_points.insert(TxStartStopPoint::PowerPathClosed);
+        } else if (tx_start_stop_point == "EnergyTransfer") {
+            tx_start_stop_points.insert(TxStartStopPoint::EnergyTransfer);
+        } else if (tx_start_stop_point == "DataSigned") {
+            tx_start_stop_points.insert(TxStartStopPoint::DataSigned);
+        } else {
+            // default to PowerPathClosed for now
+            tx_start_stop_points.insert(TxStartStopPoint::PowerPathClosed);
+        }
+    }
+    return tx_start_stop_points;
 }
 
 void OCPP201::init_evse_ready_map() {
@@ -131,8 +155,8 @@ void OCPP201::ready() {
         try {
             return this->r_system->call_is_reset_allowed(types::system::ResetType::NotSpecified);
         } catch (std::out_of_range& e) {
-            EVLOG_warning
-                << "Could not convert OCPP ResetEnum to EVerest ResetType while executing is_reset_allowed_callback.";
+            EVLOG_warning << "Could not convert OCPP ResetEnum to EVerest ResetType while executing "
+                             "is_reset_allowed_callback.";
             return false;
         }
     };
@@ -304,16 +328,35 @@ void OCPP201::ready() {
         this->config.CoreDatabasePath, sql_init_path.string(), this->config.MessageLogPath,
         std::make_shared<EvseSecurity>(*this->r_security), callbacks);
 
+    std::set<TxStartStopPoint> tx_start_points;
+    std::set<TxStartStopPoint> tx_stop_points;
+
     const auto tx_start_point_request_value_response = this->charge_point->request_value<std::string>(
         ocpp::v201::Component{"TxCtrlr"}, ocpp::v201::Variable{"TxStartPoint"}, ocpp::v201::AttributeEnum::Actual);
     if (tx_start_point_request_value_response.status == ocpp::v201::GetVariableStatusEnum::Accepted and
         tx_start_point_request_value_response.value.has_value()) {
-        auto tx_start_point_string = tx_start_point_request_value_response.value.value();
-        this->tx_start_point = get_tx_start_point(tx_start_point_string);
-        EVLOG_info << "TxStartPoint from device model: " << tx_start_point_string;
+        auto tx_start_point_csl =
+            tx_start_point_request_value_response.value.value(); // contains comma seperated list of TxStartPoints
+        tx_start_points = get_tx_start_stop_points(tx_start_point_csl);
+        EVLOG_info << "TxStartPoints from device model: " << tx_start_point_csl;
     } else {
-        this->tx_start_point = TxStartPoint::PowerPathClosed;
+        tx_start_points = {TxStartStopPoint::PowerPathClosed};
     }
+
+    const auto tx_stop_point_request_value_response = this->charge_point->request_value<std::string>(
+        ocpp::v201::Component{"TxCtrlr"}, ocpp::v201::Variable{"TxStopPoint"}, ocpp::v201::AttributeEnum::Actual);
+    if (tx_stop_point_request_value_response.status == ocpp::v201::GetVariableStatusEnum::Accepted and
+        tx_stop_point_request_value_response.value.has_value()) {
+        auto tx_stop_point_csl =
+            tx_stop_point_request_value_response.value.value(); // contains comma seperated list of TxStartPoints
+        tx_stop_points = get_tx_start_stop_points(tx_stop_point_csl);
+        EVLOG_info << "TxStopPoints from device model: " << tx_stop_point_csl;
+    } else {
+        tx_stop_points = {TxStartStopPoint::EVConnected, TxStartStopPoint::Authorized};
+    }
+
+    this->transaction_handler =
+        std::make_unique<TransactionHandler>(this->r_evse_manager.size(), tx_start_points, tx_stop_points);
 
     const auto ev_connection_timeout_request_value_response = this->charge_point->request_value<int32_t>(
         ocpp::v201::Component{"TxCtrlr"}, ocpp::v201::Variable{"EVConnectionTimeOut"},
@@ -346,33 +389,86 @@ void OCPP201::ready() {
         evse->subscribe_session_event([this, evse_id](types::evse_manager::SessionEvent session_event) {
             const auto connector_id = session_event.connector_id.value_or(1);
             const auto evse_connector = std::make_pair(evse_id, connector_id);
+            auto tx_event_effect =
+                TxEventEffect::NONE; // this var controls if a transaction shall be started or stopped
+            bool is_authorized_event = false;
+            ocpp::v201::IdToken authorized_id_token;
             switch (session_event.event) {
             case types::evse_manager::SessionEventEnum::SessionStarted: {
                 if (!session_event.session_started.has_value()) {
-                    this->session_started_reasons[evse_connector] =
-                        types::evse_manager::StartSessionReason::EVConnected;
-                } else {
-                    this->session_started_reasons[evse_connector] = session_event.session_started.value().reason;
+                    throw std::runtime_error("SessionEvent SessionStarted does not contain session_started context");
                 }
 
-                switch (this->tx_start_point) {
-                case TxStartPoint::EVConnected:
-                    [[fallthrough]];
-                case TxStartPoint::Authorized:
-                    [[fallthrough]];
-                case TxStartPoint::PowerPathClosed:
-                    [[fallthrough]];
-                case TxStartPoint::EnergyTransfer:
-                    this->charge_point->on_session_started(evse_id, connector_id);
-                    break;
+                const auto session_started = session_event.session_started.value();
+
+                std::optional<ocpp::v201::IdToken> id_token = std::nullopt;
+                std::optional<ocpp::v201::IdToken> group_id_token = std::nullopt;
+                std::optional<int32_t> remote_start_id = std::nullopt;
+                auto charging_state = ocpp::v201::ChargingStateEnum::Idle;
+                auto trigger_reason = ocpp::v201::TriggerReasonEnum::Authorized;
+                auto tx_event = TxEvent::AUTHORIZED;
+                if (session_started.reason == types::evse_manager::StartSessionReason::EVConnected) {
+                    tx_event = TxEvent::EV_CONNECTED;
+                    trigger_reason = ocpp::v201::TriggerReasonEnum::CablePluggedIn;
+                    charging_state = ocpp::v201::ChargingStateEnum::EVConnected;
+                } else if (!session_started.id_tag.has_value()) {
+                    EVLOG_warning << "Session started with reason Authorized, but no id_tag provided as part of the "
+                                     "session event";
+                } else {
+                    id_token = conversions::to_ocpp_id_token(session_started.id_tag.value().id_token);
+                    authorized_id_token = id_token.value();
+                    is_authorized_event = true;
+                    remote_start_id = session_started.id_tag.value().request_id;
+                    if (session_started.id_tag.value().parent_id_token.has_value()) {
+                        group_id_token =
+                            conversions::to_ocpp_id_token(session_started.id_tag.value().parent_id_token.value());
+                    }
+                    if (session_started.id_tag.value().authorization_type ==
+                        types::authorization::AuthorizationType::OCPP) {
+                        trigger_reason = ocpp::v201::TriggerReasonEnum::RemoteStart;
+                    }
                 }
+                const auto timestamp = ocpp::DateTime(session_started.timestamp);
+                const auto meter_value = conversions::to_ocpp_meter_value(
+                    session_started.meter_value, ocpp::v201::ReadingContextEnum::Transaction_Begin,
+                    session_started.signed_meter_value);
+                const auto reservation_id = session_started.reservation_id;
+
+                auto transaction_data = std::make_shared<TransactionData>(connector_id, session_event.uuid, timestamp,
+                                                                          trigger_reason, meter_value, charging_state);
+                transaction_data->id_token = id_token;
+                transaction_data->group_id_token = group_id_token;
+                transaction_data->remote_start_id = remote_start_id;
+                transaction_data->reservation_id = reservation_id;
+                this->transaction_handler->add_transaction_data(evse_id, transaction_data);
+
+                this->charge_point->on_session_started(evse_id, connector_id);
+                // add transaction data to transaction handler
+                tx_event_effect = this->transaction_handler->submit_event(evse_id, tx_event);
                 break;
             }
             case types::evse_manager::SessionEventEnum::SessionFinished: {
                 this->charge_point->on_session_finished(evse_id, connector_id);
+                auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
+                if (transaction_data != nullptr) {
+                    transaction_data->charging_state = ocpp::v201::ChargingStateEnum::Idle;
+                }
+                tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::EV_DISCONNECTED);
                 break;
             }
             case types::evse_manager::SessionEventEnum::TransactionStarted: {
+                if (!session_event.transaction_started.has_value()) {
+                    throw std::runtime_error(
+                        "SessionEvent TransactionStarted does not contain session_started context");
+                }
+
+                auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
+                if (transaction_data == nullptr) {
+                    throw std::runtime_error(
+                        "Could not update transaction data because no tranasaction data is present");
+                }
+
+                auto tx_event = TxEvent::AUTHORIZED;
                 const auto transaction_started = session_event.transaction_started.value();
                 const auto timestamp = ocpp::DateTime(transaction_started.timestamp);
                 const auto meter_value = conversions::to_ocpp_meter_value(
@@ -382,6 +478,7 @@ void OCPP201::ready() {
                 const auto reservation_id = transaction_started.reservation_id;
                 const auto remote_start_id = transaction_started.id_tag.request_id;
                 const auto id_token = conversions::to_ocpp_id_token(transaction_started.id_tag.id_token);
+                authorized_id_token = id_token;
 
                 std::optional<ocpp::v201::IdToken> group_id_token = std::nullopt;
                 if (transaction_started.id_tag.parent_id_token.has_value()) {
@@ -390,69 +487,71 @@ void OCPP201::ready() {
 
                 // assume cable has been plugged in first and then authorized
                 auto trigger_reason = ocpp::v201::TriggerReasonEnum::Authorized;
+                is_authorized_event = true;
 
                 // if session started reason was Authorized, Transaction is started because of EV plug in event
-                if (this->session_started_reasons[evse_connector] ==
-                    types::evse_manager::StartSessionReason::Authorized) {
+                if (transaction_data->trigger_reason == ocpp::v201::TriggerReasonEnum::Authorized) {
                     trigger_reason = ocpp::v201::TriggerReasonEnum::CablePluggedIn;
+                    tx_event = TxEvent::EV_CONNECTED;
+                    is_authorized_event = false;
                 }
 
                 if (transaction_started.id_tag.authorization_type == types::authorization::AuthorizationType::OCPP) {
                     trigger_reason = ocpp::v201::TriggerReasonEnum::RemoteStart;
                 }
 
-                if (this->tx_start_point == TxStartPoint::EnergyTransfer) {
-                    this->transaction_starts[evse_connector].emplace(TransactionStart{
-                        evse_id, connector_id, session_id, timestamp, trigger_reason, meter_value, id_token,
-                        group_id_token, reservation_id, remote_start_id, ocpp::v201::ChargingStateEnum::Charging});
-                } else {
-                    this->charge_point->on_transaction_started(
-                        evse_id, connector_id, session_id, timestamp, trigger_reason, meter_value, id_token,
-                        group_id_token, reservation_id, remote_start_id,
-                        ocpp::v201::ChargingStateEnum::EVConnected); // FIXME(piet): add proper groupIdToken +
-                                                                     // ChargingStateEnum
-                }
-
+                tx_event_effect = this->transaction_handler->submit_event(evse_id, tx_event);
                 break;
             }
             case types::evse_manager::SessionEventEnum::TransactionFinished: {
+                if (!session_event.transaction_finished.has_value()) {
+                    throw std::runtime_error(
+                        "SessionEvent TransactionFinished does not contain session_started context");
+                }
                 const auto transaction_finished = session_event.transaction_finished.value();
-                const auto timestamp = ocpp::DateTime(transaction_finished.timestamp);
-                const auto signed_meter_value = transaction_finished.signed_meter_value;
-                const auto meter_value = conversions::to_ocpp_meter_value(
-                    transaction_finished.meter_value, ocpp::v201::ReadingContextEnum::Transaction_End,
-                    signed_meter_value);
-                ocpp::v201::ReasonEnum reason = ocpp::v201::ReasonEnum::Other;
+                auto tx_event = TxEvent::NONE;
+                auto reason = ocpp::v201::ReasonEnum::Other;
                 if (transaction_finished.reason.has_value()) {
                     reason = conversions::to_ocpp_reason(transaction_finished.reason.value());
+                    tx_event = get_tx_event(reason);
                 }
+                auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
+                if (transaction_data != nullptr) {
+                    const auto timestamp = ocpp::DateTime(transaction_finished.timestamp);
+                    const auto signed_meter_value = transaction_finished.signed_meter_value;
+                    const auto meter_value = conversions::to_ocpp_meter_value(
+                        transaction_finished.meter_value, ocpp::v201::ReadingContextEnum::Transaction_End,
+                        signed_meter_value);
 
-                std::optional<ocpp::v201::IdToken> id_token = std::nullopt;
-                if (transaction_finished.id_tag.has_value()) {
-                    id_token = conversions::to_ocpp_id_token(transaction_finished.id_tag.value().id_token);
+                    std::optional<ocpp::v201::IdToken> id_token = std::nullopt;
+                    if (transaction_finished.id_tag.has_value()) {
+                        id_token = conversions::to_ocpp_id_token(transaction_finished.id_tag.value().id_token);
+                    }
+
+                    // this is required to report the correct charging_state within a TransactionEvent(Ended) message
+                    auto charging_state = transaction_data->charging_state;
+                    if (reason == ocpp::v201::ReasonEnum::EVDisconnected) {
+                        charging_state = ocpp::v201::ChargingStateEnum::Idle;
+                    } else if (tx_event == TxEvent::DEAUTHORIZED) {
+                        charging_state = ocpp::v201::ChargingStateEnum::EVConnected;
+                    }
+
+                    transaction_data->timestamp = timestamp;
+                    transaction_data->meter_value = meter_value;
+                    transaction_data->stop_reason = reason;
+                    transaction_data->id_token = id_token;
+                    transaction_data->charging_state = charging_state;
                 }
-
-                this->charge_point->on_transaction_finished(evse_id, timestamp, meter_value, reason, id_token, "",
-                                                            ocpp::v201::ChargingStateEnum::EVConnected);
+                tx_event_effect = this->transaction_handler->submit_event(evse_id, tx_event);
                 break;
             }
             case types::evse_manager::SessionEventEnum::ChargingStarted: {
-                if (this->tx_start_point == TxStartPoint::EnergyTransfer) {
-                    if (this->transaction_starts[evse_connector].has_value()) {
-                        auto transaction_start = this->transaction_starts[evse_connector].value();
-                        this->charge_point->on_transaction_started(
-                            transaction_start.evse_id, transaction_start.connector_id, transaction_start.session_id,
-                            transaction_start.timestamp, transaction_start.trigger_reason,
-                            transaction_start.meter_start, transaction_start.id_token, transaction_start.group_id_token,
-                            transaction_start.reservation_id, transaction_start.remote_start_id,
-                            transaction_start.charging_state);
-                        this->transaction_starts[evse_connector].reset();
-                    } else {
-                        EVLOG_error
-                            << "ChargingStarted with TxStartPoint EnergyTransfer but no TransactionStart was available";
-                    }
+                auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
+                if (transaction_data != nullptr) {
+                    transaction_data->charging_state = ocpp::v201::ChargingStateEnum::Charging;
                 }
                 this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::Charging);
+                tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::ENERGY_TRANSFER_STARTED);
                 break;
             }
             case types::evse_manager::SessionEventEnum::ChargingResumed: {
@@ -460,11 +559,21 @@ void OCPP201::ready() {
                 break;
             }
             case types::evse_manager::SessionEventEnum::ChargingPausedEV: {
+                auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
+                if (transaction_data != nullptr) {
+                    transaction_data->charging_state = ocpp::v201::ChargingStateEnum::SuspendedEV;
+                }
                 this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::SuspendedEV);
+                tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::ENERGY_TRANSFER_STOPPED);
                 break;
             }
             case types::evse_manager::SessionEventEnum::ChargingPausedEVSE: {
+                auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
+                if (transaction_data != nullptr) {
+                    transaction_data->charging_state = ocpp::v201::ChargingStateEnum::SuspendedEVSE;
+                }
                 this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::SuspendedEVSE);
+                tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::ENERGY_TRANSFER_STOPPED);
                 break;
             }
             case types::evse_manager::SessionEventEnum::Disabled: {
@@ -476,6 +585,34 @@ void OCPP201::ready() {
                 this->charge_point->on_enabled(evse_id, connector_id);
                 break;
             }
+            }
+
+            // process resulting tx_event_effect
+            if (tx_event_effect == TxEventEffect::START_TRANSACTION) {
+                const auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
+                if (transaction_data == nullptr) {
+                    throw std::runtime_error("Could not start transaction because no tranasaction data is present");
+                }
+                transaction_data->started = true;
+                this->charge_point->on_transaction_started(
+                    evse_id, transaction_data->connector_id, transaction_data->session_id, transaction_data->timestamp,
+                    transaction_data->trigger_reason, transaction_data->meter_value, transaction_data->id_token,
+                    transaction_data->group_id_token, transaction_data->reservation_id,
+                    transaction_data->remote_start_id, transaction_data->charging_state);
+            } else if (tx_event_effect == TxEventEffect::STOP_TRANSACTION) {
+                const auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
+                if (transaction_data == nullptr) {
+                    throw std::runtime_error("Could not stop transaction because no tranasaction data is present");
+                }
+                this->charge_point->on_transaction_finished(
+                    evse_id, transaction_data->timestamp, transaction_data->meter_value, transaction_data->stop_reason,
+                    transaction_data->id_token, std::nullopt, transaction_data->charging_state);
+                this->transaction_handler->reset_transaction_data(evse_id);
+            }
+
+            // process authorized event
+            if (is_authorized_event) {
+                this->charge_point->on_authorized(evse_id, connector_id, authorized_id_token);
             }
         });
 

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -114,7 +114,16 @@ types::powermeter::Powermeter get_meter_value(const types::evse_manager::Session
                event_type == types::evse_manager::SessionEventEnum::ChargingResumed or
                event_type == types::evse_manager::SessionEventEnum::ChargingPausedEV or
                event_type == types::evse_manager::SessionEventEnum::ChargingPausedEVSE) {
+        if (!session_event.charging_state_changed_event.has_value()) {
+            throw std::runtime_error("SessionEvent does not contain charging_state_changed_event context");
+        }
         return session_event.charging_state_changed_event.value().meter_value;
+    } else if (event_type == types::evse_manager::SessionEventEnum::Authorized or
+               event_type == types::evse_manager::SessionEventEnum::Deauthorized) {
+        if (!session_event.authorization_event.has_value()) {
+            throw std::runtime_error("SessionEvent Authorized or Deauthorized does not contain authorization_event context");
+        }
+        return session_event.authorization_event.value().meter_value;
     } else {
         throw std::runtime_error("Could not retrieve meter value from SessionEvent");
     }

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -121,7 +121,8 @@ types::powermeter::Powermeter get_meter_value(const types::evse_manager::Session
     } else if (event_type == types::evse_manager::SessionEventEnum::Authorized or
                event_type == types::evse_manager::SessionEventEnum::Deauthorized) {
         if (!session_event.authorization_event.has_value()) {
-            throw std::runtime_error("SessionEvent Authorized or Deauthorized does not contain authorization_event context");
+            throw std::runtime_error(
+                "SessionEvent Authorized or Deauthorized does not contain authorization_event context");
         }
         return session_event.authorization_event.value().meter_value;
     } else {

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -29,29 +29,8 @@
 #include <tuple>
 
 #include <ocpp/v201/charge_point.hpp>
+#include <transaction_handler.hpp>
 
-enum class TxStartPoint {
-    ParkingBayOccupancy,
-    EVConnected,
-    Authorized,
-    PowerPathClosed,
-    EnergyTransfer,
-    DataSigned
-};
-
-struct TransactionStart {
-    int32_t evse_id;
-    int32_t connector_id;
-    std::string session_id;
-    ocpp::DateTime timestamp;
-    ocpp::v201::TriggerReasonEnum trigger_reason;
-    ocpp::v201::MeterValue meter_start;
-    ocpp::v201::IdToken id_token;
-    std::optional<ocpp::v201::IdToken> group_id_token;
-    std::optional<int32_t> reservation_id;
-    std::optional<int32_t> remote_start_id;
-    ocpp::v201::ChargingStateEnum charging_state;
-};
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {
@@ -119,12 +98,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    // track the session started reasons for every EVSE+Connector combination to be able to report correct trigger
-    // reason in TransactionStarted event
-    std::map<std::pair<int32_t, int32_t>, types::evse_manager::StartSessionReason> session_started_reasons;
-    std::map<std::pair<int32_t, int32_t>, std::optional<TransactionStart>> transaction_starts;
-
-    TxStartPoint tx_start_point;
+    std::unique_ptr<TransactionHandler> transaction_handler;
 
     std::filesystem::path ocpp_share_path;
 
@@ -135,11 +109,6 @@ private:
     void init_evse_ready_map();
     bool all_evse_ready();
     std::map<int32_t, int32_t> get_connector_structure();
-
-    void transaction_start(std::int32_t evseid, std::int32_t connector, const std::string& session_id,
-                           const std::optional<std::string>& transaction_id);
-    void transaction_end(std::int32_t evseid, std::int32_t connector, const std::string& session_id,
-                         const std::optional<std::string>& transaction_id);
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -109,6 +109,33 @@ private:
     void init_evse_ready_map();
     bool all_evse_ready();
     std::map<int32_t, int32_t> get_connector_structure();
+    void process_session_event(const int32_t evse_id, const types::evse_manager::SessionEvent& session_event);
+    void process_tx_event_effect(const int32_t evse_id, const TxEventEffect tx_event_effect,
+                                 const types::evse_manager::SessionEvent& session_event);
+    void process_session_started(const int32_t evse_id, const int32_t connector_id,
+                                 const types::evse_manager::SessionEvent& session_event);
+    void process_session_finished(const int32_t evse_id, const int32_t connector_id,
+                                  const types::evse_manager::SessionEvent& session_event);
+    void process_transaction_started(const int32_t evse_id, const int32_t connector_id,
+                                     const types::evse_manager::SessionEvent& session_event);
+    void process_transaction_finished(const int32_t evse_id, const int32_t connector_id,
+                                      const types::evse_manager::SessionEvent& session_event);
+    void process_charging_started(const int32_t evse_id, const int32_t connector_id,
+                                  const types::evse_manager::SessionEvent& session_event);
+    void process_charging_resumed(const int32_t evse_id, const int32_t connector_id,
+                                  const types::evse_manager::SessionEvent& session_event);
+    void process_charging_paused_ev(const int32_t evse_id, const int32_t connector_id,
+                                    const types::evse_manager::SessionEvent& session_event);
+    void process_charging_paused_evse(const int32_t evse_id, const int32_t connector_id,
+                                      const types::evse_manager::SessionEvent& session_event);
+    void process_enabled(const int32_t evse_id, const int32_t connector_id,
+                         const types::evse_manager::SessionEvent& session_event);
+    void process_disabled(const int32_t evse_id, const int32_t connector_id,
+                          const types::evse_manager::SessionEvent& session_event);
+    void process_authorized(const int32_t evse_id, const int32_t connector_id,
+                            const types::evse_manager::SessionEvent& session_event);
+    void process_deauthorized(const int32_t evse_id, const int32_t connector_id,
+                              const types::evse_manager::SessionEvent& session_event);
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/OCPP201/tests/CMakeLists.txt
+++ b/modules/OCPP201/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(TEST_TARGET_NAME ${PROJECT_NAME}transaction_handler_tests)
+add_executable(${TEST_TARGET_NAME} transaction_handler_tests.cpp)
+
+set(INCLUDE_DIR 
+    "${PROJECT_SOURCE_DIR}/modules/OCPP201")
+
+target_include_directories(${TEST_TARGET_NAME} PUBLIC
+    ${INCLUDE_DIR}
+)
+
+target_link_libraries(${TEST_TARGET_NAME} PRIVATE
+    everest::ocpp
+    GTest::gtest_main
+    )
+
+target_sources(${TEST_TARGET_NAME} PRIVATE "../transaction_handler.cpp")
+
+add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})

--- a/modules/OCPP201/tests/transaction_handler_tests.cpp
+++ b/modules/OCPP201/tests/transaction_handler_tests.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <transaction_handler.hpp>
+
+namespace module {
+
+class TransactionHandlerTest : public ::testing::Test {
+
+protected:
+    void SetUp() override {
+    }
+
+    void TearDown() override {
+    }
+
+    std::shared_ptr<TransactionData> transaction_data() {
+        return std::make_shared<TransactionData>(1, "123", ocpp::DateTime(), ocpp::v201::TriggerReasonEnum::Authorized,
+                                                 ocpp::v201::MeterValue(), ocpp::v201::ChargingStateEnum::Idle);
+    }
+};
+
+TEST_F(TransactionHandlerTest, test_authorized) {
+    TransactionHandler transaction_handler(2, {TxStartStopPoint::Authorized}, {TxStartStopPoint::Authorized});
+
+    transaction_handler.add_transaction_data(1, transaction_data());
+
+    auto res = transaction_handler.submit_event(1, TxEvent::AUTHORIZED);
+    ASSERT_EQ(res, TxEventEffect::START_TRANSACTION);
+    transaction_handler.get_transaction_data(1)->started = true;
+
+    res = transaction_handler.submit_event(1, TxEvent::AUTHORIZED);
+    ASSERT_EQ(res, TxEventEffect::NONE);
+
+    res = transaction_handler.submit_event(1, TxEvent::DEAUTHORIZED);
+    ASSERT_EQ(res, TxEventEffect::STOP_TRANSACTION);
+
+    ASSERT_THROW(transaction_handler.submit_event(2, TxEvent::AUTHORIZED), std::runtime_error);
+}
+
+TEST_F(TransactionHandlerTest, test_power_path_closed) {
+    TransactionHandler transaction_handler(2, {TxStartStopPoint::PowerPathClosed}, {TxStartStopPoint::PowerPathClosed});
+
+    transaction_handler.add_transaction_data(1, transaction_data());
+
+    auto res = transaction_handler.submit_event(1, TxEvent::AUTHORIZED);
+    ASSERT_EQ(res, TxEventEffect::NONE);
+
+    res = transaction_handler.submit_event(1, TxEvent::EV_CONNECTED);
+    ASSERT_EQ(res, TxEventEffect::START_TRANSACTION);
+
+    transaction_handler.get_transaction_data(1)->started = true;
+
+    res = transaction_handler.submit_event(1, TxEvent::PARKING_BAY_UNOCCUPIED);
+    ASSERT_EQ(res, TxEventEffect::NONE);
+
+    res = transaction_handler.submit_event(1, TxEvent::EV_CONNECTED);
+    ASSERT_EQ(res, TxEventEffect::NONE);
+
+    res = transaction_handler.submit_event(1, TxEvent::EV_DISCONNECTED);
+    ASSERT_EQ(res, TxEventEffect::STOP_TRANSACTION);
+}
+
+TEST_F(TransactionHandlerTest, test_ev_connected) {
+    TransactionHandler transaction_handler(2, {TxStartStopPoint::EVConnected}, {TxStartStopPoint::EVConnected});
+
+    transaction_handler.add_transaction_data(1, transaction_data());
+
+    auto res = transaction_handler.submit_event(1, TxEvent::EV_CONNECTED);
+    ASSERT_EQ(res, TxEventEffect::START_TRANSACTION);
+    transaction_handler.get_transaction_data(1)->started = true;
+
+    res = transaction_handler.submit_event(1, TxEvent::DEAUTHORIZED);
+    ASSERT_EQ(res, TxEventEffect::NONE);
+
+    res = transaction_handler.submit_event(1, TxEvent::EV_DISCONNECTED);
+    ASSERT_EQ(res, TxEventEffect::STOP_TRANSACTION);
+}
+
+TEST_F(TransactionHandlerTest, test_parking_bay_occupied) {
+    TransactionHandler transaction_handler(2, {TxStartStopPoint::ParkingBayOccupancy},
+                                           {TxStartStopPoint::ParkingBayOccupancy});
+
+    transaction_handler.add_transaction_data(1, transaction_data());
+
+    auto res = transaction_handler.submit_event(1, TxEvent::PARKING_BAY_OCCUPIED);
+    ASSERT_EQ(res, TxEventEffect::START_TRANSACTION);
+    transaction_handler.get_transaction_data(1)->started = true;
+
+    res = transaction_handler.submit_event(1, TxEvent::EV_DISCONNECTED);
+    ASSERT_EQ(res, TxEventEffect::NONE);
+
+    res = transaction_handler.submit_event(1, TxEvent::PARKING_BAY_UNOCCUPIED);
+    ASSERT_EQ(res, TxEventEffect::STOP_TRANSACTION);
+}
+
+TEST_F(TransactionHandlerTest, test_multiple) {
+    TransactionHandler transaction_handler(2, {TxStartStopPoint::EVConnected, TxStartStopPoint::Authorized},
+                                           {TxStartStopPoint::PowerPathClosed});
+    transaction_handler.add_transaction_data(1, transaction_data());
+
+    auto res = transaction_handler.submit_event(1, TxEvent::EV_CONNECTED);
+    ASSERT_EQ(res, TxEventEffect::START_TRANSACTION);
+    transaction_handler.get_transaction_data(1)->started = true;
+
+    res = transaction_handler.submit_event(1, TxEvent::DEAUTHORIZED);
+    ASSERT_EQ(res, TxEventEffect::STOP_TRANSACTION);
+
+    transaction_handler.reset_transaction_data(1);
+
+    transaction_handler.add_transaction_data(1, transaction_data());
+
+    res = transaction_handler.submit_event(1, TxEvent::AUTHORIZED);
+    ASSERT_EQ(res, TxEventEffect::START_TRANSACTION);
+    transaction_handler.get_transaction_data(1)->started = true;
+
+    res = transaction_handler.submit_event(1, TxEvent::SIGNED_START_DATA_RECEIVED);
+    ASSERT_EQ(res, TxEventEffect::NONE);
+
+    res = transaction_handler.submit_event(1, TxEvent::EV_DISCONNECTED);
+    ASSERT_EQ(res, TxEventEffect::STOP_TRANSACTION);
+}
+
+TEST_F(TransactionHandlerTest, test_invalid_params) {
+    TransactionHandler transaction_handler(2, {TxStartStopPoint::EVConnected, TxStartStopPoint::Authorized},
+                                           {TxStartStopPoint::PowerPathClosed});
+    ASSERT_THROW(transaction_handler.get_transaction_data(1), std::runtime_error);
+    ASSERT_THROW(transaction_handler.reset_transaction_data(2), std::runtime_error);
+    ASSERT_THROW(transaction_handler.add_transaction_data(-1, transaction_data()), std::runtime_error);
+    ASSERT_THROW(transaction_handler.add_transaction_data(3, transaction_data()), std::runtime_error);
+}
+
+} // namespace module

--- a/modules/OCPP201/tests/transaction_handler_tests.cpp
+++ b/modules/OCPP201/tests/transaction_handler_tests.cpp
@@ -18,7 +18,7 @@ protected:
 
     std::shared_ptr<TransactionData> transaction_data() {
         return std::make_shared<TransactionData>(1, "123", ocpp::DateTime(), ocpp::v201::TriggerReasonEnum::Authorized,
-                                                 ocpp::v201::MeterValue(), ocpp::v201::ChargingStateEnum::Idle);
+                                                 ocpp::v201::ChargingStateEnum::Idle);
     }
 };
 
@@ -36,8 +36,6 @@ TEST_F(TransactionHandlerTest, test_authorized) {
 
     res = transaction_handler.submit_event(1, TxEvent::DEAUTHORIZED);
     ASSERT_EQ(res, TxEventEffect::STOP_TRANSACTION);
-
-    ASSERT_THROW(transaction_handler.submit_event(2, TxEvent::AUTHORIZED), std::out_of_range);
 }
 
 TEST_F(TransactionHandlerTest, test_power_path_closed) {
@@ -126,8 +124,8 @@ TEST_F(TransactionHandlerTest, test_multiple) {
 TEST_F(TransactionHandlerTest, test_invalid_params) {
     TransactionHandler transaction_handler(2, {TxStartStopPoint::EVConnected, TxStartStopPoint::Authorized},
                                            {TxStartStopPoint::PowerPathClosed});
-    ASSERT_THROW(transaction_handler.get_transaction_data(1), std::out_of_range);
-    ASSERT_THROW(transaction_handler.reset_transaction_data(2), std::out_of_range);
+    ASSERT_THROW(transaction_handler.get_transaction_data(3), std::out_of_range);
+    ASSERT_THROW(transaction_handler.reset_transaction_data(3), std::out_of_range);
     ASSERT_THROW(transaction_handler.add_transaction_data(-1, transaction_data()), std::out_of_range);
     ASSERT_THROW(transaction_handler.add_transaction_data(3, transaction_data()), std::out_of_range);
 }

--- a/modules/OCPP201/tests/transaction_handler_tests.cpp
+++ b/modules/OCPP201/tests/transaction_handler_tests.cpp
@@ -37,7 +37,7 @@ TEST_F(TransactionHandlerTest, test_authorized) {
     res = transaction_handler.submit_event(1, TxEvent::DEAUTHORIZED);
     ASSERT_EQ(res, TxEventEffect::STOP_TRANSACTION);
 
-    ASSERT_THROW(transaction_handler.submit_event(2, TxEvent::AUTHORIZED), std::runtime_error);
+    ASSERT_THROW(transaction_handler.submit_event(2, TxEvent::AUTHORIZED), std::out_of_range);
 }
 
 TEST_F(TransactionHandlerTest, test_power_path_closed) {
@@ -126,10 +126,10 @@ TEST_F(TransactionHandlerTest, test_multiple) {
 TEST_F(TransactionHandlerTest, test_invalid_params) {
     TransactionHandler transaction_handler(2, {TxStartStopPoint::EVConnected, TxStartStopPoint::Authorized},
                                            {TxStartStopPoint::PowerPathClosed});
-    ASSERT_THROW(transaction_handler.get_transaction_data(1), std::runtime_error);
-    ASSERT_THROW(transaction_handler.reset_transaction_data(2), std::runtime_error);
-    ASSERT_THROW(transaction_handler.add_transaction_data(-1, transaction_data()), std::runtime_error);
-    ASSERT_THROW(transaction_handler.add_transaction_data(3, transaction_data()), std::runtime_error);
+    ASSERT_THROW(transaction_handler.get_transaction_data(1), std::out_of_range);
+    ASSERT_THROW(transaction_handler.reset_transaction_data(2), std::out_of_range);
+    ASSERT_THROW(transaction_handler.add_transaction_data(-1, transaction_data()), std::out_of_range);
+    ASSERT_THROW(transaction_handler.add_transaction_data(3, transaction_data()), std::out_of_range);
 }
 
 } // namespace module

--- a/modules/OCPP201/transaction_handler.cpp
+++ b/modules/OCPP201/transaction_handler.cpp
@@ -15,7 +15,7 @@ TransactionHandler::TransactionHandler(const int32_t nr_of_evses, const std::set
     }
 
     if (nr_of_evses <= 0) {
-        throw std::runtime_error("Cannot construct TransactionHandler with either nr_of_evses <= 0");
+        throw std::runtime_error("Cannot construct TransactionHandler with nr_of_evses <= 0");
     }
 
     for (int32_t evse_id = 1; evse_id <= nr_of_evses; evse_id++) {

--- a/modules/OCPP201/transaction_handler.cpp
+++ b/modules/OCPP201/transaction_handler.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <transaction_handler.hpp>
+
+namespace module {
+
+TransactionHandler::TransactionHandler(const int32_t nr_of_evses, const std::set<TxStartStopPoint>& tx_start_points,
+                                       const std::set<TxStartStopPoint>& tx_stop_points) :
+    tx_start_points(tx_start_points), tx_stop_points(tx_stop_points) {
+
+    if (tx_start_points.empty() or tx_stop_points.empty()) {
+        throw std::runtime_error(
+            "Cannot construct TransactionHandler with either TxStart or TxStop points being empty");
+    }
+
+    if (nr_of_evses <= 0) {
+        throw std::runtime_error(
+            "Cannot construct TransactionHandler with either nr_of_evses <= 0");
+    }
+
+    for (int32_t evse_id = 1; evse_id <= nr_of_evses; evse_id++) {
+        tx_start_stop_conditions[evse_id] = TxStartStopConditions();
+    }
+}
+
+TxEventEffect TransactionHandler::submit_event(const int32_t evse_id, const TxEvent tx_event) {
+    this->tx_start_stop_conditions[evse_id].submit_event(tx_event);
+
+    if (this->should_transaction_start(evse_id)) {
+        return TxEventEffect::START_TRANSACTION;
+    }
+
+    if (this->should_transaction_stop(evse_id)) {
+        return TxEventEffect::STOP_TRANSACTION;
+    }
+
+    return TxEventEffect::NONE;
+}
+
+void TransactionHandler::add_transaction_data(const int32_t evse_id,
+                                              const std::shared_ptr<TransactionData>& transaction_data) {
+    if (evse_id <= 0 or evse_id > this->tx_start_stop_conditions.size()) {
+        throw std::runtime_error("Can not add transaction data for evse_id <= 0 or > nr_of_evses");
+    }
+    this->evse_id_transaction_data_map[evse_id] = transaction_data;
+}
+
+std::shared_ptr<TransactionData> TransactionHandler::get_transaction_data(const int32_t evse_id) {
+    if (!this->evse_id_transaction_data_map.count(evse_id)) {
+        throw std::runtime_error("Attempt to get transaction_data for invalid evse_id");
+    }
+    return this->evse_id_transaction_data_map[evse_id];
+}
+
+void TransactionHandler::reset_transaction_data(const int32_t evse_id) {
+    if (!this->evse_id_transaction_data_map.count(evse_id)) {
+        throw std::runtime_error("Attempt to reset transaction_data for invalid evse_id");
+    }
+    this->evse_id_transaction_data_map[evse_id].reset();
+}
+
+bool TransactionHandler::should_transaction_start(const int32_t evse_id) {
+    if (!this->evse_id_transaction_data_map.count(evse_id)) {
+        throw std::runtime_error("Can not retrieve if transaction should start for invalid evse_id");
+    }
+
+    // check if transaction data is present
+    if (this->evse_id_transaction_data_map[evse_id] == nullptr) {
+        return false;
+    }
+
+    // check if transaction has not yet been started (in OCPP)
+    if (!this->evse_id_transaction_data_map[evse_id]->started) {
+        for (const auto& tx_start_condition : this->tx_start_points) {
+            if (this->tx_start_stop_conditions[evse_id].is_start_condition_fullfilled(tx_start_condition)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool TransactionHandler::should_transaction_stop(const int32_t evse_id) {
+    if (!this->evse_id_transaction_data_map.count(evse_id)) {
+        throw std::runtime_error("Can not retrieve if transaction should stop for invalid evse_id");
+    }
+
+    // check if transaction data is present
+    if (this->evse_id_transaction_data_map[evse_id] == nullptr) {
+        return false;
+    }
+
+    // check if transaction is already started (in OCPP) for this evse
+    if (this->evse_id_transaction_data_map[evse_id]->started) {
+        for (const auto& tx_stop_condition : this->tx_stop_points) {
+            if (this->tx_start_stop_conditions[evse_id].is_stop_condition_fullfilled(tx_stop_condition)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace module

--- a/modules/OCPP201/transaction_handler.cpp
+++ b/modules/OCPP201/transaction_handler.cpp
@@ -20,7 +20,16 @@ TransactionHandler::TransactionHandler(const int32_t nr_of_evses, const std::set
 
     for (int32_t evse_id = 1; evse_id <= nr_of_evses; evse_id++) {
         tx_start_stop_conditions[evse_id] = TxStartStopConditions();
+        evse_id_transaction_data_map[evse_id] = nullptr;
     }
+}
+
+void TransactionHandler::set_tx_start_points(const std::set<TxStartStopPoint>& tx_start_points) {
+    this->tx_start_points = tx_start_points;
+}
+
+void TransactionHandler::set_tx_stop_points(const std::set<TxStartStopPoint>& tx_stop_points) {
+    this->tx_stop_points = tx_stop_points;
 }
 
 TxEventEffect TransactionHandler::submit_event(const int32_t evse_id, const TxEvent tx_event) {

--- a/modules/OCPP201/transaction_handler.cpp
+++ b/modules/OCPP201/transaction_handler.cpp
@@ -15,8 +15,7 @@ TransactionHandler::TransactionHandler(const int32_t nr_of_evses, const std::set
     }
 
     if (nr_of_evses <= 0) {
-        throw std::runtime_error(
-            "Cannot construct TransactionHandler with either nr_of_evses <= 0");
+        throw std::runtime_error("Cannot construct TransactionHandler with either nr_of_evses <= 0");
     }
 
     for (int32_t evse_id = 1; evse_id <= nr_of_evses; evse_id++) {
@@ -41,28 +40,28 @@ TxEventEffect TransactionHandler::submit_event(const int32_t evse_id, const TxEv
 void TransactionHandler::add_transaction_data(const int32_t evse_id,
                                               const std::shared_ptr<TransactionData>& transaction_data) {
     if (evse_id <= 0 or evse_id > this->tx_start_stop_conditions.size()) {
-        throw std::runtime_error("Can not add transaction data for evse_id <= 0 or > nr_of_evses");
+        throw std::out_of_range("Can not add transaction data for evse_id <= 0 or > nr_of_evses");
     }
     this->evse_id_transaction_data_map[evse_id] = transaction_data;
 }
 
 std::shared_ptr<TransactionData> TransactionHandler::get_transaction_data(const int32_t evse_id) {
     if (!this->evse_id_transaction_data_map.count(evse_id)) {
-        throw std::runtime_error("Attempt to get transaction_data for invalid evse_id");
+        throw std::out_of_range("Attempt to get transaction_data for invalid evse_id");
     }
     return this->evse_id_transaction_data_map[evse_id];
 }
 
 void TransactionHandler::reset_transaction_data(const int32_t evse_id) {
     if (!this->evse_id_transaction_data_map.count(evse_id)) {
-        throw std::runtime_error("Attempt to reset transaction_data for invalid evse_id");
+        throw std::out_of_range("Attempt to reset transaction_data for invalid evse_id");
     }
     this->evse_id_transaction_data_map[evse_id].reset();
 }
 
 bool TransactionHandler::should_transaction_start(const int32_t evse_id) {
     if (!this->evse_id_transaction_data_map.count(evse_id)) {
-        throw std::runtime_error("Can not retrieve if transaction should start for invalid evse_id");
+        throw std::out_of_range("Can not retrieve if transaction should start for invalid evse_id");
     }
 
     // check if transaction data is present
@@ -83,7 +82,7 @@ bool TransactionHandler::should_transaction_start(const int32_t evse_id) {
 
 bool TransactionHandler::should_transaction_stop(const int32_t evse_id) {
     if (!this->evse_id_transaction_data_map.count(evse_id)) {
-        throw std::runtime_error("Can not retrieve if transaction should stop for invalid evse_id");
+        throw std::out_of_range("Can not retrieve if transaction should stop for invalid evse_id");
     }
 
     // check if transaction data is present

--- a/modules/OCPP201/transaction_handler.hpp
+++ b/modules/OCPP201/transaction_handler.hpp
@@ -15,8 +15,7 @@
 namespace module {
 
 /// \brief TxStartStopPoint of OCPP2.0.1
-enum class TxStartStopPoint
-{
+enum class TxStartStopPoint {
     ParkingBayOccupancy,
     EVConnected,
     Authorized,
@@ -26,8 +25,7 @@ enum class TxStartStopPoint
 };
 
 /// \brief TxEvents that influence if conditions for TxStartStopPoints are fullfilled
-enum class TxEvent
-{
+enum class TxEvent {
     NONE,
     EV_CONNECTED,
     EV_DISCONNECTED,
@@ -42,8 +40,7 @@ enum class TxEvent
 
 /// \brief Effect to an TxEvent. An effect can either trigger the start of a Transaction, the stop of a transaction or
 /// it can have no effect
-enum class TxEventEffect
-{
+enum class TxEventEffect {
     START_TRANSACTION,
     STOP_TRANSACTION,
     NONE

--- a/modules/OCPP201/transaction_handler.hpp
+++ b/modules/OCPP201/transaction_handler.hpp
@@ -139,7 +139,7 @@ struct TransactionData {
     std::optional<int32_t> reservation_id;
     std::optional<int32_t> remote_start_id;
 
-    TransactionData(const int32_t connector_id, const std::string session_id, const ocpp::DateTime timestamp,
+    TransactionData(const int32_t connector_id, const std::string& session_id, const ocpp::DateTime timestamp,
                     const ocpp::v201::TriggerReasonEnum trigger_reason,
                     const ocpp::v201::ChargingStateEnum charging_state) :
         connector_id(connector_id),

--- a/modules/OCPP201/transaction_handler.hpp
+++ b/modules/OCPP201/transaction_handler.hpp
@@ -140,13 +140,12 @@ struct TransactionData {
     std::optional<int32_t> remote_start_id;
 
     TransactionData(const int32_t connector_id, const std::string session_id, const ocpp::DateTime timestamp,
-                    const ocpp::v201::TriggerReasonEnum trigger_reason, const ocpp::v201::MeterValue meter_value,
+                    const ocpp::v201::TriggerReasonEnum trigger_reason,
                     const ocpp::v201::ChargingStateEnum charging_state) :
         connector_id(connector_id),
         session_id(session_id),
         timestamp(timestamp),
         trigger_reason(trigger_reason),
-        meter_value(meter_value),
         charging_state(charging_state){};
 };
 
@@ -164,6 +163,12 @@ public:
     /// \param tx_event
     /// \return
     TxEventEffect submit_event(const int32_t evse_id, const TxEvent tx_event);
+
+    /// \brief Sets the given \p tx_start_points
+    void set_tx_start_points(const std::set<TxStartStopPoint>& tx_start_points);
+
+    /// \brief Sets the given \p tx_stop_points
+    void set_tx_stop_points(const std::set<TxStartStopPoint>& tx_stop_points);
 
     /// \brief Adds \p transaction_data to \ref evse_id_transaction_data_map for the given \p evse_id
     /// \param evse_id

--- a/modules/OCPP201/transaction_handler.hpp
+++ b/modules/OCPP201/transaction_handler.hpp
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <vector>
+
+#include <ocpp/v201/ocpp_types.hpp>
+
+namespace module {
+
+/// \brief TxStartStopPoint of OCPP2.0.1
+enum class TxStartStopPoint
+{
+    ParkingBayOccupancy,
+    EVConnected,
+    Authorized,
+    PowerPathClosed,
+    EnergyTransfer,
+    DataSigned
+};
+
+/// \brief TxEvents that influence if conditions for TxStartStopPoints are fullfilled
+enum class TxEvent
+{
+    NONE,
+    EV_CONNECTED,
+    EV_DISCONNECTED,
+    AUTHORIZED,
+    DEAUTHORIZED,
+    PARKING_BAY_OCCUPIED,
+    PARKING_BAY_UNOCCUPIED,
+    ENERGY_TRANSFER_STARTED,
+    ENERGY_TRANSFER_STOPPED,
+    SIGNED_START_DATA_RECEIVED
+};
+
+/// \brief Effect to an TxEvent. An effect can either trigger the start of a Transaction, the stop of a transaction or
+/// it can have no effect
+enum class TxEventEffect
+{
+    START_TRANSACTION,
+    STOP_TRANSACTION,
+    NONE
+};
+
+/// \brief Struct that contains boolean conditions from which a TxEventEffect can be derived
+struct TxStartStopConditions {
+    bool is_authorized = false;
+    bool is_ev_connected = false;
+    bool is_parking_bay_occupied = false;
+    bool is_energy_transfered = false;
+    bool is_signed_data_received = false;
+
+    void submit_event(const TxEvent tx_event) {
+
+        switch (tx_event) {
+        case TxEvent::EV_CONNECTED:
+            is_ev_connected = true;
+            break;
+        case TxEvent::EV_DISCONNECTED:
+            is_ev_connected = false;
+            break;
+        case TxEvent::AUTHORIZED:
+            is_authorized = true;
+            break;
+        case TxEvent::DEAUTHORIZED:
+            is_authorized = false;
+            break;
+        case TxEvent::PARKING_BAY_OCCUPIED:
+            is_parking_bay_occupied = true;
+            break;
+        case TxEvent::PARKING_BAY_UNOCCUPIED:
+            is_parking_bay_occupied = false;
+            break;
+        case TxEvent::ENERGY_TRANSFER_STARTED:
+            is_energy_transfered = true;
+            break;
+        case TxEvent::ENERGY_TRANSFER_STOPPED:
+            is_energy_transfered = false;
+            break;
+        case TxEvent::SIGNED_START_DATA_RECEIVED:
+            is_signed_data_received = true;
+            break;
+        }
+    };
+
+    bool is_start_condition_fullfilled(const TxStartStopPoint tx_start_point) {
+        switch (tx_start_point) {
+        case TxStartStopPoint::ParkingBayOccupancy:
+            return is_parking_bay_occupied;
+        case TxStartStopPoint::EVConnected:
+            return is_ev_connected;
+        case TxStartStopPoint::Authorized:
+            return is_authorized;
+        case TxStartStopPoint::PowerPathClosed:
+            return is_authorized and is_ev_connected;
+        case TxStartStopPoint::EnergyTransfer:
+            return is_energy_transfered;
+        case TxStartStopPoint::DataSigned:
+            return is_signed_data_received;
+        default:
+            return false;
+        }
+    };
+
+    bool is_stop_condition_fullfilled(const TxStartStopPoint tx_stop_point) {
+        switch (tx_stop_point) {
+        case TxStartStopPoint::ParkingBayOccupancy:
+            return !is_parking_bay_occupied;
+        case TxStartStopPoint::EVConnected:
+            return !is_ev_connected;
+        case TxStartStopPoint::Authorized:
+            return !is_authorized;
+        case TxStartStopPoint::PowerPathClosed:
+            return !is_authorized or !is_ev_connected;
+        case TxStartStopPoint::EnergyTransfer:
+            return !is_energy_transfered;
+        default:
+            return false;
+        }
+    };
+};
+
+/// \brief Contains information that is required for a TransactionEvent (Started / Stopped) message in OCPP2.0.1.
+struct TransactionData {
+    bool started = false;
+    int32_t connector_id;
+    std::string session_id;
+    ocpp::DateTime timestamp;
+    ocpp::v201::TriggerReasonEnum trigger_reason;
+    ocpp::v201::MeterValue meter_value;
+    ocpp::v201::ChargingStateEnum charging_state;
+    ocpp::v201::ReasonEnum stop_reason = ocpp::v201::ReasonEnum::Other;
+    std::optional<ocpp::v201::IdToken> id_token;
+    std::optional<ocpp::v201::IdToken> group_id_token;
+    std::optional<int32_t> reservation_id;
+    std::optional<int32_t> remote_start_id;
+
+    TransactionData(const int32_t connector_id, const std::string session_id, const ocpp::DateTime timestamp,
+                    const ocpp::v201::TriggerReasonEnum trigger_reason, const ocpp::v201::MeterValue meter_value,
+                    const ocpp::v201::ChargingStateEnum charging_state) :
+        connector_id(connector_id),
+        session_id(session_id),
+        timestamp(timestamp),
+        trigger_reason(trigger_reason),
+        meter_value(meter_value),
+        charging_state(charging_state){};
+};
+
+/// \brief OCPP2.0.1 defines configurable TxStartPoints and TxStopPoints. This class handles TxEvents to determine when
+/// OCPP2.0.1 transactions shall start and stop.
+class TransactionHandler {
+public:
+    TransactionHandler(const int32_t nr_of_evses, const std::set<TxStartStopPoint>& tx_start_points,
+                       const std::set<TxStartStopPoint>& tx_stop_points);
+
+    /// \brief Submits the given \p tx_event at the given \p evse_id . Based on the configured \ref tx_start_points and
+    /// \ref tx_stop_points, this function determines if a Transaction shall start or stop. The effect of the event is
+    /// returned
+    /// \param evse_id
+    /// \param tx_event
+    /// \return
+    TxEventEffect submit_event(const int32_t evse_id, const TxEvent tx_event);
+
+    /// \brief Adds \p transaction_data to \ref evse_id_transaction_data_map for the given \p evse_id
+    /// \param evse_id
+    /// \param transaction_data
+    void add_transaction_data(const int32_t evse_id, const std::shared_ptr<TransactionData>& transaction_data);
+
+    /// \brief Gets transaction_data for the given \p evse_id from the \ref evse_id_transaction_data_map
+    std::shared_ptr<TransactionData> get_transaction_data(const int32_t evse_id);
+
+    /// \brief Resets transaction_data for the given \p evse_id in the \ref evse_id_transaction_data_map. It efectively
+    /// sets the value for the \p evse_id to nullptr
+    void reset_transaction_data(const int32_t evse_id);
+
+private:
+    std::set<TxStartStopPoint> tx_start_points;
+    std::set<TxStartStopPoint> tx_stop_points;
+
+    // map that holds information about states that are relevant in order to determine start and stop of OCPP2.0.1
+    // transactions
+    std::map<int32_t, TxStartStopConditions> tx_start_stop_conditions;
+
+    // map that holds transaction_data for each evse_id . The transaction_data shall be updated based on the present
+    // information available on the charge point
+    std::map<int32_t, std::shared_ptr<TransactionData>> evse_id_transaction_data_map;
+
+    /// \brief Determines if a transaction shall start for the given \p evse_id based on the present \ref
+    /// tx_start_stop_conditions for this \p evse_id
+    bool should_transaction_start(const int32_t evse_id);
+
+    /// \brief Determines if a transaction shall stop for the given \p evse_id based on the present \ref
+    /// tx_start_stop_conditions for this \p evse_id
+    bool should_transaction_stop(const int32_t evse_id);
+};
+
+} // namespace module

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -236,6 +236,17 @@ types:
         description: Exported meter value
         type: object
         $ref: /powermeter#/Powermeter
+  AuthorizationEvent:
+    description: Context for authorization event (Authorized or Deauthorized)
+    type: object
+    additionalProperties: false
+    required:
+      - meter_value
+    properties:
+      meter_value:
+        description: Exported meter value
+        type: object
+        $ref: /powermeter#/Powermeter
   ErrorEnum:
     description: >-
       Note this is only kept for compatibility with the legacy error handling and will be removed soon.
@@ -351,6 +362,12 @@ types:
           ChargingStarted, ChargingResumed, ChargingPausedEV, Charging
         type: object
         $ref: /evse_manager#/ChargingStateChangedEvent
+      authorization_event:
+        description: >-
+          Data for Authorization event. Shall be set for the following SessionEventEnums: 
+          Authorized, Deauthorized
+        type: object
+        $ref: /evse_manager#/AuthorizationEvent
       error:
         description: Details on error type
         type: object

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -144,6 +144,7 @@ types:
     required:
       - timestamp
       - reason
+      - meter_value
     properties:
       timestamp:
         description: Session start time in RFC3339 format
@@ -153,6 +154,21 @@ types:
         description: Reason for session start
         type: string
         $ref: /evse_manager#/StartSessionReason
+      id_tag:
+        description: The id tag assigned to this session
+        type: object
+        $ref: /authorization#/ProvidedIdToken
+      meter_value:
+        description: Session start exported meter value
+        type: object
+        $ref: /powermeter#/Powermeter
+      signed_meter_value:
+        description: The signed meter value report of the started session
+        type: object
+        $ref: /units_signed#/SignedMeterValue
+      reservation_id:
+        description: Id of the reservation
+        type: integer
       logging_path:
         description: >-
           File system path where additional log files are stored, such as

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -147,6 +147,7 @@ types:
     additionalProperties: false
     required:
       - reason
+      - meter_value
     properties:
       reason:
         description: Reason for session start
@@ -156,6 +157,10 @@ types:
         description: The id tag assigned to this session
         type: object
         $ref: /authorization#/ProvidedIdToken
+      meter_value:
+        description: Exported meter value
+        type: object
+        $ref: /powermeter#/Powermeter
       signed_meter_value:
         description: The signed meter value report of the started session
         type: object
@@ -176,11 +181,16 @@ types:
     additionalProperties: false
     required:
       - id_tag
+      - meter_value
     properties:
       id_tag:
         description: The id tag assigned to this transaction
         type: object
         $ref: /authorization#/ProvidedIdToken
+      meter_value:
+        description: Exported meter value
+        type: object
+        $ref: /powermeter#/Powermeter
       signed_meter_value:
         description: The signed meter value report of the started transaction
         type: object
@@ -192,6 +202,8 @@ types:
     description: Data for TransactionFinished event
     type: object
     additionalProperties: false
+    required:
+      - meter_value
     properties:
       meter_value:
         description: Transaction finished meter value
@@ -213,6 +225,17 @@ types:
         description: Id tag that was used to stop the transaction. Only present if transaction was stopped locally.
         type: object
         $ref: /authorization#/ProvidedIdToken
+  ChargingStateChangedEvent:
+    description: Context for ChargingStateChanged event
+    type: object
+    additionalProperties: false
+    required:
+      - meter_value
+    properties:
+      meter_value:
+        description: Exported meter value
+        type: object
+        $ref: /powermeter#/Powermeter
   ErrorEnum:
     description: >-
       Note this is only kept for compatibility with the legacy error handling and will be removed soon.
@@ -287,7 +310,6 @@ types:
       - uuid
       - event
       - timestamp
-      - meter_value
     properties:
       uuid:
         description: >-
@@ -298,10 +320,6 @@ types:
         description: Session start time in RFC3339 format
         type: string
         format: date-time
-      meter_value:
-        description: Session start exported meter value
-        type: object
-        $ref: /powermeter#/Powermeter
       connector_id:
         description: >-
           Id of the connector of this EVSE. 
@@ -327,6 +345,12 @@ types:
           out
         type: object
         $ref: /evse_manager#/TransactionFinished
+      charging_state_changed_event:
+        description: >-
+          Data for ChargingStateChangedEvent. Shall be set for the following SessionEventEnums: 
+          ChargingStarted, ChargingResumed, ChargingPausedEV, Charging
+        type: object
+        $ref: /evse_manager#/ChargingStateChangedEvent
       error:
         description: Details on error type
         type: object

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -88,6 +88,8 @@ types:
   SessionEventEnum:
     description: >-
       Session Event enum
+        Authorized: Signaled when the EVSE is authorized for charging
+        Deauthorized: Signaled when the EVSE is not authorized for charging (anymore)
         Enabled: Signaled when the EVSE is enabled (e.g. after an enable command)
         Disabled: Signaled when the EVSE is disabled (e.g. after a disable command)
         SessionStarted: Signaled when a session has been started. A session has been started either when an EV is plugged in or the user has been authorized to start a transaction (e.g. after an authorize command)
@@ -112,6 +114,8 @@ types:
         PluginTimeout: Signaled when an EV has been Plugged in but no authorization is present within specified ConnectionTimeout
     type: string
     enum:
+      - Authorized
+      - Deauthorized
       - Enabled
       - Disabled
       - SessionStarted
@@ -142,14 +146,8 @@ types:
     type: object
     additionalProperties: false
     required:
-      - timestamp
       - reason
-      - meter_value
     properties:
-      timestamp:
-        description: Session start time in RFC3339 format
-        type: string
-        format: date-time
       reason:
         description: Reason for session start
         type: string
@@ -158,10 +156,6 @@ types:
         description: The id tag assigned to this session
         type: object
         $ref: /authorization#/ProvidedIdToken
-      meter_value:
-        description: Session start exported meter value
-        type: object
-        $ref: /powermeter#/Powermeter
       signed_meter_value:
         description: The signed meter value report of the started session
         type: object
@@ -176,38 +170,17 @@ types:
           Filenames should start with "incomplete-" when they are not finished yet,
           this allows other process to wait for the completion after the SessionFinished event.
         type: string
-  SessionFinished:
-    description: Data for the SessionFinished event
-    type: object
-    additionalProperties: false
-    required:
-      - timestamp
-    properties:
-      timestamp:
-        description: Session start time in RFC3339 format
-        type: string
-        format: date-time
   TransactionStarted:
     description: Data for the TransactionStarted event
     type: object
     additionalProperties: false
     required:
-      - timestamp
-      - meter_value
       - id_tag
     properties:
-      timestamp:
-        description: Transaction start time in RFC3339 format
-        type: string
-        format: date-time
       id_tag:
         description: The id tag assigned to this transaction
         type: object
         $ref: /authorization#/ProvidedIdToken
-      meter_value:
-        description: Transaction start exported meter value
-        type: object
-        $ref: /powermeter#/Powermeter
       signed_meter_value:
         description: The signed meter value report of the started transaction
         type: object
@@ -219,14 +192,7 @@ types:
     description: Data for TransactionFinished event
     type: object
     additionalProperties: false
-    required:
-      - timestamp
-      - meter_value
     properties:
-      timestamp:
-        description: Transaction end time in RFC3339 format
-        type: string
-        format: date-time
       meter_value:
         description: Transaction finished meter value
         type: object
@@ -320,12 +286,22 @@ types:
     required:
       - uuid
       - event
+      - timestamp
+      - meter_value
     properties:
       uuid:
         description: >-
           An EVSE generated UUID for this session, can be used e.g. for
           database storage.
         type: string
+      timestamp:
+        description: Session start time in RFC3339 format
+        type: string
+        format: date-time
+      meter_value:
+        description: Session start exported meter value
+        type: object
+        $ref: /powermeter#/Powermeter
       connector_id:
         description: >-
           Id of the connector of this EVSE. 
@@ -340,11 +316,7 @@ types:
       session_started:
         description: data for SessionStarted event
         type: object
-        $ref: /evse_manager#/SessionStarted
-      session_finished:
-        description: data for the SessionFinished event
-        type: object
-        $ref: /evse_manager#/SessionFinished
+        $ref: /evse_manager#/SessionStarted  
       transaction_started:
         description: data for TransactionStarted event
         type: object


### PR DESCRIPTION
## Describe your changes
This PR includes support for configurable TxStart and TxStop points in OCPP2.0.1
* Added transaction_handler + tests for handling of configurable TxStartPoints and TxStopPoints

To be able to support this within EVerest, the following changes to the EvseManager module and respective interfaces were required:
* Added meter_value and timestamp to to SessionEvent type
* Added id_tag, signed_meter_value and reservation_id to SessionStarted type
* Now using transaction_handler in OCPP201 module to control when TransactionEvents of type Started and Stopped are sent
* Added changes required by changes SessionStarted and SessionEvent type

## Issue ticket number and link
Companion PR in libocpp: https://github.com/EVerest/libocpp/pull/546

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

