### PR TITLE
bugfix: disable non-necessary tooling for sqlite_cpp

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -89,6 +89,9 @@ gtest:
 sqlite_cpp:
   git: https://github.com/SRombauts/SQLiteCpp.git
   git_tag: 3.3.1
+  options:
+  - SQLITECPP_RUN_CPPLINT OFF
+  - SQLITECPP_RUN_CPPCHECK OFF
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_SQLITE_CPP"
 catch2:
   git: https://github.com/catchorg/Catch2.git


### PR DESCRIPTION
- sqlite_cpp dependency runs linter and checker by default
- this is not necessary and might lead to unwanted build noise
- closes #612

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

