### PR TITLE
Fix: Allow to link against GCOV

### DIFF
--- a/cmake/everest-generate.cmake
+++ b/cmake/everest-generate.cmake
@@ -134,6 +134,12 @@ if (EVEREST_ENABLE_RS_SUPPORT)
         message(STATUS "Creating rust workspace at ${RUST_WORKSPACE_DIR}")
     endif ()
 
+    if (EVEREST_CORE_BUILD_TESTING)
+        set(EVERESTRS_FEATURE_FLAGS ",features = [\"link_gcov\"]")
+    else()
+        set(EVERESTRS_FEATURE_FLAGS "")
+    endif()
+
     # NOTE (aw): we could also write a small python script, which would do that for us
     add_custom_command(OUTPUT ${RUST_WORKSPACE_CARGO_FILE}
         COMMAND
@@ -149,7 +155,7 @@ if (EVEREST_ENABLE_RS_SUPPORT)
         COMMAND
             echo "[workspace.dependencies]" >> Cargo.toml
         COMMAND
-            echo "everestrs = { path = \"$<TARGET_PROPERTY:everest::everestrs_sys,EVERESTRS_DIR>\" }" >> Cargo.toml
+            echo "everestrs = { path = \"$<TARGET_PROPERTY:everest::everestrs_sys,EVERESTRS_DIR>\" ${EVERESTRS_FEATURE_FLAGS} }" >> Cargo.toml
         COMMAND
             echo "everestrs-build = { path = \"$<TARGET_PROPERTY:everest::everestrs_sys,EVERESTRS_BUILD_DIR>\" }" >> Cargo.toml
         COMMAND

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "everestrs"
 version = "0.1.0"
-source = "git+https://github.com/everest/everest-framework.git?rev=01468678f5b627a96791f749f3139c3d169bf081#01468678f5b627a96791f749f3139c3d169bf081"
+source = "git+https://github.com/everest/everest-framework.git?rev=b9f9b5ddff46856027346a98f5c16d11b16f7436#b9f9b5ddff46856027346a98f5c16d11b16f7436"
 dependencies = [
  "argh",
  "cxx",
@@ -231,7 +231,7 @@ dependencies = [
 [[package]]
 name = "everestrs-build"
 version = "0.1.0"
-source = "git+https://github.com/everest/everest-framework.git?rev=01468678f5b627a96791f749f3139c3d169bf081#01468678f5b627a96791f749f3139c3d169bf081"
+source = "git+https://github.com/everest/everest-framework.git?rev=b9f9b5ddff46856027346a98f5c16d11b16f7436#b9f9b5ddff46856027346a98f5c16d11b16f7436"
 dependencies = [
  "anyhow",
  "argh",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -7,5 +7,5 @@ members = [
 ]
 
 [workspace.dependencies]
-everestrs = { git = "https://github.com/everest/everest-framework.git", rev = "01468678f5b627a96791f749f3139c3d169bf081" }
-everestrs-build = { git = "https://github.com/everest/everest-framework.git", rev = "01468678f5b627a96791f749f3139c3d169bf081" }
+everestrs = { git = "https://github.com/everest/everest-framework.git", rev = "b9f9b5ddff46856027346a98f5c16d11b16f7436" }
+everestrs-build = { git = "https://github.com/everest/everest-framework.git", rev = "b9f9b5ddff46856027346a98f5c16d11b16f7436" }

--- a/third-party/bazel/repos.bzl
+++ b/third-party/bazel/repos.bzl
@@ -13,6 +13,6 @@ def everest_core_repos():
     maybe(
         http_archive,
         name = "everest-framework",
-        url = "https://github.com/everest/everest-framework/archive/01468678f5b627a96791f749f3139c3d169bf081.tar.gz",
-        strip_prefix = "everest-framework-01468678f5b627a96791f749f3139c3d169bf081",
+        url = "https://github.com/everest/everest-framework/archive/b9f9b5ddff46856027346a98f5c16d11b16f7436.tar.gz",
+        strip_prefix = "everest-framework-b9f9b5ddff46856027346a98f5c16d11b16f7436",
     )


### PR DESCRIPTION
When we build with BUILD_TESTING, we're adding the flags for gcov and need to subsequently link against gcov. This commit fixes the behavior for rust

See https://github.com/EVerest/everest-framework/pull/171