### PR TITLE
DummyTokenProvider: Add connector-id config option

### DIFF
--- a/modules/DummyTokenProvider/main/auth_token_providerImpl.cpp
+++ b/modules/DummyTokenProvider/main/auth_token_providerImpl.cpp
@@ -13,6 +13,9 @@ void auth_token_providerImpl::init() {
 
             token.id_token = {config.token, types::authorization::IdTokenType::ISO14443};
             token.authorization_type = types::authorization::string_to_authorization_type(config.type);
+            if (config.connector_id > 0) {
+                token.connectors.emplace({config.connector_id});
+            }
 
             EVLOG_info << "Publishing new dummy token: " << token.id_token << " ("
                        << types::authorization::authorization_type_to_string(token.authorization_type) << ")";

--- a/modules/DummyTokenProvider/main/auth_token_providerImpl.hpp
+++ b/modules/DummyTokenProvider/main/auth_token_providerImpl.hpp
@@ -23,6 +23,7 @@ struct Conf {
     std::string token;
     std::string type;
     double timeout;
+    int connector_id;
 };
 
 class auth_token_providerImpl : public auth_token_providerImplBase {

--- a/modules/DummyTokenProvider/manifest.yaml
+++ b/modules/DummyTokenProvider/manifest.yaml
@@ -23,6 +23,11 @@ provides:
         minimum: 0
         maximum: 120
         default: 10
+      connector_id:
+        description: If >0, the generated token is only valid for this connector_id
+        type: integer
+        minimum: 0
+        default: 0
 requires:
   evse:
     interface: evse_manager


### PR DESCRIPTION
## Describe your changes

In a dual output setup, it makes sense to restrict the DummyTokenProvider to one connector id.
This PR adds a config option for that. If not set, the default behaviour is the same as before, so it does not break any configs.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

