### PR TITLE
fix: address mutex deadlock in state machine

### DIFF
--- a/modules/EvseManager/EventQueue.hpp
+++ b/modules/EvseManager/EventQueue.hpp
@@ -37,7 +37,7 @@ public:
 
     events_t wait() {
         std::unique_lock<std::mutex> ul(mux);
-        cv.wait(ul);
+        cv.wait(ul, [this]() { return !pending.empty(); });
         events_t active;
         pending.swap(active);
         ul.unlock();

--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -2,17 +2,23 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 
 #include "IECStateMachine.hpp"
+#include "everest/logging.hpp"
 
+#include <cstdint>
 #include <math.h>
 #include <string.h>
 
 namespace module {
 
 // helper type for visitor
-template <class... Ts> struct overloaded : Ts... {
-    using Ts::operator()...;
-};
+template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+enum class TimerControl : std::uint8_t {
+    do_nothing,
+    start,
+    stop,
+};
 
 static std::variant<RawCPState, CPEvent> from_bsp_event(types::board_support_common::Event e) {
     switch (e) {
@@ -132,155 +138,178 @@ void IECStateMachine::feed_state_machine_no_thread() {
 std::queue<CPEvent> IECStateMachine::state_machine() {
 
     std::queue<CPEvent> events;
-    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::IEC_state_machine);
+    auto timer = TimerControl::do_nothing;
 
-    switch (cp_state) {
+    {
+        // mutex protected section
 
-    case RawCPState::Disabled:
-        if (last_cp_state != RawCPState::Disabled) {
-            pwm_running = false;
-            r_bsp->call_pwm_off();
-            ev_simplified_mode = false;
-            timeout_state_c1.stop();
-            call_allow_power_on_bsp(false);
-            connector_unlock();
-        }
-        break;
+        Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::IEC_state_machine);
 
-    case RawCPState::A:
-        if (last_cp_state != RawCPState::A) {
-            pwm_running = false;
-            r_bsp->call_pwm_off();
-            ev_simplified_mode = false;
-            car_plugged_in = false;
-            call_allow_power_on_bsp(false);
-            timeout_state_c1.stop();
-            connector_unlock();
-        }
+        switch (cp_state) {
 
-        // Table A.6: Sequence 2.1 Unplug at state Bx (or any other
-        // state) Table A.6: Sequence 2.2 Unplug at state Cx, Dx
-        if (last_cp_state != RawCPState::A && last_cp_state != RawCPState::Disabled) {
-            events.push(CPEvent::CarUnplugged);
-        }
-        break;
-
-    case RawCPState::B:
-        // Table A.6: Sequence 7 EV stops charging
-        // Table A.6: Sequence 8.2 EV supply equipment
-        // responds to EV opens S2 (w/o PWM)
-        connector_lock();
-
-        if (last_cp_state != RawCPState::A && last_cp_state != RawCPState::B) {
-
-            events.push(CPEvent::CarRequestedStopPower);
-            // Need to switch off according to Table A.6 Sequence 8.1
-            // within 100ms
-            call_allow_power_on_bsp(false);
-            timeout_state_c1.stop();
-        }
-
-        // Table A.6: Sequence 1.1 Plug-in
-        if (last_cp_state == RawCPState::A || last_cp_state == RawCPState::Disabled ||
-            (!car_plugged_in && last_cp_state == RawCPState::F)) {
-            events.push(CPEvent::CarPluggedIn);
-            ev_simplified_mode = false;
-        }
-
-        if (last_cp_state == RawCPState::E || last_cp_state == RawCPState::F) {
-            // Triggers SLAC start
-            events.push(CPEvent::EFtoBCD);
-        }
-        break;
-
-    case RawCPState::D:
-        connector_lock();
-        // If state D is not supported switch off.
-        if (not has_ventilation) {
-            call_allow_power_on_bsp(false);
-            timeout_state_c1.stop();
+        case RawCPState::Disabled:
+            if (last_cp_state != RawCPState::Disabled) {
+                pwm_running = false;
+                r_bsp->call_pwm_off();
+                ev_simplified_mode = false;
+                timer = TimerControl::stop;
+                call_allow_power_on_bsp(false);
+                connector_unlock();
+            }
             break;
-        }
-        // no break, intended fall through: If we support state D it is handled the same way as state C
-        [[fallthrough]];
 
-    case RawCPState::C:
-        connector_lock();
-        // Table A.6: Sequence 1.2 Plug-in
-        if (last_cp_state == RawCPState::A || last_cp_state == RawCPState::Disabled ||
-            (!car_plugged_in && last_cp_state == RawCPState::F)) {
-            events.push(CPEvent::CarPluggedIn);
-            EVLOG_info << "Detected simplified mode.";
-            ev_simplified_mode = true;
-        } else if (last_cp_state == RawCPState::B) {
-            events.push(CPEvent::CarRequestedPower);
-        }
-
-        if (!pwm_running && last_pwm_running) { // X2->C1
-                                                // Table A.6 Sequence 10.2: EV does not stop drawing power
-                                                // even if PWM stops. Stop within 6 seconds (E.g. Kona1!)
-            timeout_state_c1.start(std::chrono::seconds(6));
-        }
-
-        // PWM switches on while in state C
-        if (pwm_running && !last_pwm_running) {
-            // when resuming after a pause before the EV goes to state B, stop the timer.
-            timeout_state_c1.stop();
-
-            // If we resume charging and the EV never left state C during pause we allow non-compliant EVs to switch
-            // on again.
-            if (power_on_allowed) {
-                call_allow_power_on_bsp(true);
-            }
-        }
-
-        if (timeout_state_c1.reached()) {
-            EVLOG_warning << "Timeout of 6 seconds reached, EV did not go back to state B after PWM was switch off. "
-                             "Power off under load.";
-            // We are still in state C, but the 6 seconds timeout has been reached. Now force power off under load.
-            call_allow_power_on_bsp(false);
-        }
-
-        if (pwm_running) { // C2
-            // 1) When we come from state B: switch on if we are allowed to
-            // 2) When we are in C2 for a while now and finally get a delayed power_on_allowed: also switch on
-            if (power_on_allowed && (!last_power_on_allowed || last_cp_state == RawCPState::B)) {
-                // Table A.6: Sequence 4 EV ready to charge.
-                // Must enable power within 3 seconds.
-                call_allow_power_on_bsp(true);
+        case RawCPState::A:
+            if (last_cp_state != RawCPState::A) {
+                pwm_running = false;
+                r_bsp->call_pwm_off();
+                ev_simplified_mode = false;
+                car_plugged_in = false;
+                call_allow_power_on_bsp(false);
+                timer = TimerControl::stop;
+                connector_unlock();
             }
 
-            // Simulate Request power Event here for simplified mode
-            // to ensure that this mode behaves similar for higher
-            // layers. Note this does not work with 5% mode
-            // correctly, but simplified mode does not support HLC
-            // anyway.
-            if (!last_pwm_running && ev_simplified_mode) {
+            // Table A.6: Sequence 2.1 Unplug at state Bx (or any other
+            // state) Table A.6: Sequence 2.2 Unplug at state Cx, Dx
+            if (last_cp_state != RawCPState::A && last_cp_state != RawCPState::Disabled) {
+                events.push(CPEvent::CarUnplugged);
+            }
+            break;
+
+        case RawCPState::B:
+            // Table A.6: Sequence 7 EV stops charging
+            // Table A.6: Sequence 8.2 EV supply equipment
+            // responds to EV opens S2 (w/o PWM)
+            connector_lock();
+
+            if (last_cp_state != RawCPState::A && last_cp_state != RawCPState::B) {
+
+                events.push(CPEvent::CarRequestedStopPower);
+                // Need to switch off according to Table A.6 Sequence 8.1
+                // within 100ms
+                call_allow_power_on_bsp(false);
+                timer = TimerControl::stop;
+            }
+
+            // Table A.6: Sequence 1.1 Plug-in
+            if (last_cp_state == RawCPState::A || last_cp_state == RawCPState::Disabled ||
+                (!car_plugged_in && last_cp_state == RawCPState::F)) {
+                events.push(CPEvent::CarPluggedIn);
+                ev_simplified_mode = false;
+            }
+
+            if (last_cp_state == RawCPState::E || last_cp_state == RawCPState::F) {
+                // Triggers SLAC start
+                events.push(CPEvent::EFtoBCD);
+            }
+            break;
+
+        case RawCPState::D:
+            connector_lock();
+            // If state D is not supported switch off.
+            if (not has_ventilation) {
+                call_allow_power_on_bsp(false);
+                timer = TimerControl::stop;
+                break;
+            }
+            // no break, intended fall through: If we support state D it is handled the same way as state C
+            [[fallthrough]];
+
+        case RawCPState::C:
+            connector_lock();
+            // Table A.6: Sequence 1.2 Plug-in
+            if (last_cp_state == RawCPState::A || last_cp_state == RawCPState::Disabled ||
+                (!car_plugged_in && last_cp_state == RawCPState::F)) {
+                events.push(CPEvent::CarPluggedIn);
+                EVLOG_info << "Detected simplified mode.";
+                ev_simplified_mode = true;
+            } else if (last_cp_state == RawCPState::B) {
                 events.push(CPEvent::CarRequestedPower);
             }
-        }
-        break;
 
-    case RawCPState::E:
-        connector_unlock();
-        if (last_cp_state != RawCPState::E) {
-            timeout_state_c1.stop();
+            if (!pwm_running && last_pwm_running) { // X2->C1
+                                                    // Table A.6 Sequence 10.2: EV does not stop drawing power
+                                                    // even if PWM stops. Stop within 6 seconds (E.g. Kona1!)
+                timer = TimerControl::start;
+            }
+
+            // PWM switches on while in state C
+            if (pwm_running && !last_pwm_running) {
+                // when resuming after a pause before the EV goes to state B, stop the timer.
+                timer = TimerControl::stop;
+
+                // If we resume charging and the EV never left state C during pause we allow non-compliant EVs to switch
+                // on again.
+                if (power_on_allowed) {
+                    call_allow_power_on_bsp(true);
+                }
+            }
+
+            if (timeout_state_c1.reached()) {
+                EVLOG_warning
+                    << "Timeout of 6 seconds reached, EV did not go back to state B after PWM was switch off. "
+                       "Power off under load.";
+                // We are still in state C, but the 6 seconds timeout has been reached. Now force power off under load.
+                call_allow_power_on_bsp(false);
+            }
+
+            if (pwm_running) { // C2
+                // 1) When we come from state B: switch on if we are allowed to
+                // 2) When we are in C2 for a while now and finally get a delayed power_on_allowed: also switch on
+                if (power_on_allowed && (!last_power_on_allowed || last_cp_state == RawCPState::B)) {
+                    // Table A.6: Sequence 4 EV ready to charge.
+                    // Must enable power within 3 seconds.
+                    call_allow_power_on_bsp(true);
+                }
+
+                // Simulate Request power Event here for simplified mode
+                // to ensure that this mode behaves similar for higher
+                // layers. Note this does not work with 5% mode
+                // correctly, but simplified mode does not support HLC
+                // anyway.
+                if (!last_pwm_running && ev_simplified_mode) {
+                    events.push(CPEvent::CarRequestedPower);
+                }
+            }
+            break;
+
+        case RawCPState::E:
+            connector_unlock();
+            if (last_cp_state != RawCPState::E) {
+                timer = TimerControl::stop;
+                call_allow_power_on_bsp(false);
+            }
+            break;
+
+        case RawCPState::F:
+            connector_unlock();
+            timer = TimerControl::stop;
             call_allow_power_on_bsp(false);
+            break;
         }
-        break;
 
-    case RawCPState::F:
-        connector_unlock();
-        timeout_state_c1.stop();
-        call_allow_power_on_bsp(false);
-        break;
+        check_connector_lock();
+
+        last_cp_state = cp_state;
+        last_pwm_running = pwm_running;
+        last_power_on_allowed = power_on_allowed;
+
+        // end of mutex protected section
     }
 
-    check_connector_lock();
-
-    last_cp_state = cp_state;
-    last_pwm_running = pwm_running;
-    last_power_on_allowed = power_on_allowed;
+    // stopping the timer could lead to a deadlock when called from the
+    // mutex protected section
+    switch (timer) {
+    case TimerControl::start:
+        timeout_state_c1.start(std::chrono::seconds(6));
+        break;
+    case TimerControl::stop:
+        timeout_state_c1.stop();
+        break;
+    case TimerControl::do_nothing:
+    default:
+        break;
+    }
 
     return events;
 }

--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -11,7 +11,9 @@
 namespace module {
 
 // helper type for visitor
-template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template <class... Ts> struct overloaded : Ts... {
+    using Ts::operator()...;
+};
 template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
 
 enum class TimerControl : std::uint8_t {

--- a/modules/EvseManager/tests/CMakeLists.txt
+++ b/modules/EvseManager/tests/CMakeLists.txt
@@ -16,6 +16,9 @@ target_sources(${TEST_TARGET_NAME} PRIVATE
     ErrorHandlingTest.cpp
     EventQueueTest.cpp
     ../ErrorHandling.cpp
+    IECStateMachineTest.cpp
+    ../IECStateMachine.cpp
+    ../backtrace.cpp
 )
 
 target_compile_definitions(${TEST_TARGET_NAME} PRIVATE

--- a/modules/EvseManager/tests/EvseManagerStub.hpp
+++ b/modules/EvseManager/tests/EvseManagerStub.hpp
@@ -4,6 +4,7 @@
 #ifndef EVSEMANAGERSTUB_H_
 #define EVSEMANAGERSTUB_H_
 
+#include "ModuleAdapterStub.hpp"
 #include <ErrorHandling.hpp>
 
 //-----------------------------------------------------------------------------
@@ -60,98 +61,6 @@ struct evse_managerImplStub : public evse_managerImplBase {
     }
     virtual bool handle_external_ready_to_start_charging() {
         return true;
-    }
-};
-
-struct ModuleAdapterStub : public Everest::ModuleAdapter {
-
-    ModuleAdapterStub() : Everest::ModuleAdapter() {
-        call = [this](const Requirement& req, const std::string& str, Parameters p) {
-            return this->call_fn(req, str, p);
-        };
-        publish = [this](const std::string& s1, const std::string& s2, Value v) { this->publish_fn(s1, s2, v); };
-        subscribe = [this](const Requirement& req, const std::string& str, ValueCallback cb) {
-            this->subscribe_fn(req, str, cb);
-        };
-        subscribe_error = [this](const Requirement& req, const std::string& str, Everest::error::ErrorCallback cb) {
-            this->subscribe_error_fn(req, str, cb);
-        };
-        subscribe_all_errors = [this](Everest::error::ErrorCallback cb) { this->subscribe_all_errors_fn(cb); };
-        subscribe_error_cleared = [this](const Requirement& req, const std::string& str,
-                                         Everest::error::ErrorCallback cb) {
-            this->subscribe_error_cleared_fn(req, str, cb);
-        };
-        subscribe_all_errors_cleared = [this](Everest::error::ErrorCallback cb) {
-            subscribe_all_errors_cleared_fn(cb);
-        };
-        raise_error = [this](const std::string& s1, const std::string& s2, const std::string& s3,
-                             const Everest::error::Severity& sev) { return this->raise_error_fn(s1, s2, s3, sev); };
-        request_clear_error_uuid = [this](const std::string& str, const Everest::error::ErrorHandle& eh) {
-            return this->request_clear_error_uuid_fn(str, eh);
-        };
-        request_clear_all_errors_of_module = [this](const std::string& str) {
-            return this->request_clear_all_errors_of_module_fn(str);
-        };
-        request_clear_all_errors_of_type_of_module = [this](const std::string& s1, const std::string& s2) {
-            return this->request_clear_all_errors_of_type_of_module_fn(s1, s2);
-        };
-        ext_mqtt_publish = [this](const std::string& s1, const std::string& s2) { this->ext_mqtt_publish_fn(s1, s2); };
-        ext_mqtt_subscribe = [this](const std::string& str, StringHandler sh) {
-            return this->ext_mqtt_subscribe_fn(str, sh);
-        };
-        telemetry_publish = [this](const std::string& s1, const std::string& s2, const std::string& s3,
-                                   const Everest::TelemetryMap& tm) { this->telemetry_publish_fn(s1, s2, s3, tm); };
-    }
-
-    virtual Result call_fn(const Requirement&, const std::string&, Parameters) {
-        std::printf("call_fn\n");
-        return std::nullopt;
-    }
-    virtual void publish_fn(const std::string&, const std::string&, Value) {
-        std::printf("publish_fn\n");
-    }
-    virtual void subscribe_fn(const Requirement&, const std::string&, ValueCallback) {
-        std::printf("subscribe_fn\n");
-    }
-    virtual void subscribe_error_fn(const Requirement&, const std::string&, Everest::error::ErrorCallback) {
-        std::printf("subscribe_error_fn\n");
-    }
-    virtual void subscribe_all_errors_fn(Everest::error::ErrorCallback) {
-        std::printf("subscribe_all_errors_fn\n");
-    }
-    virtual void subscribe_error_cleared_fn(const Requirement&, const std::string&, Everest::error::ErrorCallback) {
-        std::printf("subscribe_error_cleared_fn\n");
-    }
-    virtual void subscribe_all_errors_cleared_fn(Everest::error::ErrorCallback) {
-        std::printf("subscribe_all_errors_cleared_fn\n");
-    }
-    virtual Everest::error::ErrorHandle raise_error_fn(const std::string&, const std::string&, const std::string&,
-                                                       const Everest::error::Severity&) {
-        std::printf("raise_error_fn\n");
-        return Everest::error::ErrorHandle();
-    }
-    virtual Result request_clear_error_uuid_fn(const std::string&, const Everest::error::ErrorHandle&) {
-        std::printf("request_clear_error_uuid_fn\n");
-        return std::nullopt;
-    }
-    virtual Result request_clear_all_errors_of_module_fn(const std::string&) {
-        std::printf("request_clear_all_errors_of_module_fn\n");
-        return std::nullopt;
-    }
-    virtual Result request_clear_all_errors_of_type_of_module_fn(const std::string&, const std::string&) {
-        std::printf("request_clear_all_errors_of_type_of_module_fn\n");
-        return std::nullopt;
-    }
-    virtual void ext_mqtt_publish_fn(const std::string&, const std::string&) {
-        std::printf("ext_mqtt_publish_fn\n");
-    }
-    virtual std::function<void()> ext_mqtt_subscribe_fn(const std::string&, StringHandler) {
-        std::printf("ext_mqtt_subscribe_fn\n");
-        return nullptr;
-    }
-    virtual void telemetry_publish_fn(const std::string&, const std::string&, const std::string&,
-                                      const Everest::TelemetryMap&) {
-        std::printf("telemetry_publish_fn\n");
     }
 };
 

--- a/modules/EvseManager/tests/IECStateMachineTest.cpp
+++ b/modules/EvseManager/tests/IECStateMachineTest.cpp
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "evse_board_supportIntfStub.hpp"
+#include <EventQueue.hpp>
+#include <IECStateMachine.hpp>
+#include <chrono>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace {
+
+using BspEvent = types::board_support_common::BspEvent;
+using Event = types::board_support_common::Event;
+using Reason = types::evse_board_support::Reason;
+
+using namespace std::chrono_literals;
+
+struct BspStub : public module::stub::ModuleAdapterStub {
+    typedef Result (BspStub::*bsp_fn)(Parameters p);
+    ValueCallback event_cb;
+    std::map<std::string, bsp_fn> _bsp;
+
+    BspStub() : module::stub::ModuleAdapterStub() {
+        _bsp["allow_power_on"] = &BspStub::call_allow_power_on;
+        _bsp["enable"] = &BspStub::call_enable;
+        _bsp["pwm_off"] = &BspStub::call_pwm_off;
+        _bsp["pwm_on"] = &BspStub::call_pwm_on;
+    }
+
+    // ------------------------------------------------------------------------
+    // test interface (calls from BSP)
+
+    void raise_event(Event event) {
+        if (event_cb != nullptr) {
+            BspEvent bsp_event;
+            bsp_event.event = event;
+            event_cb(bsp_event);
+        }
+    };
+
+    // ------------------------------------------------------------------------
+    // BSP calls
+
+    virtual Result call_allow_power_on(Parameters p) {
+        std::cout << "call_allow_power_on(" << p << ")" << std::endl;
+        return std::nullopt;
+    }
+
+    virtual Result call_enable(Parameters p) {
+        std::cout << "call_enable(" << p << ")" << std::endl;
+        return std::nullopt;
+    }
+
+    virtual Result call_pwm_off(Parameters p) {
+        std::cout << "call_pwm_off(" << p << ")" << std::endl;
+        return std::nullopt;
+    }
+
+    virtual Result call_pwm_on(Parameters p) {
+        std::cout << "call_pwm_on(" << p << ")" << std::endl;
+        return std::nullopt;
+    }
+
+    // ------------------------------------------------------------------------
+    // internal interface
+    virtual void subscribe_fn(const Requirement&, const std::string& fn, ValueCallback cb) override {
+        std::printf("subscribe_fn(%s)\n", fn.c_str());
+        event_cb = cb;
+    }
+
+    virtual Result call_fn(const Requirement& req, const std::string& fn, Parameters p) override {
+        if (auto itt = _bsp.find(fn); itt == _bsp.end()) {
+            std::cout << "<missing> call_fn(" << fn << "," << p << ")" << std::endl;
+            return std::nullopt;
+        } else {
+            return std::invoke(itt->second, this, p);
+        }
+    }
+};
+
+TEST(IECStateMachine, init) {
+    std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>();
+    module::IECStateMachine state_machine(std::move(bsp_if));
+}
+
+#if 0
+// test to demonstrate the output from backtrace
+
+struct BspStubTimeout : public BspStub {
+    Result call_allow_power_on(Parameters p) {
+        std::cout << "call_allow_power_on(" << p << ")" << std::endl;
+        std::cout << "call_allow_power_on: sleep (" << std::this_thread::get_id() << ")" << std::endl;
+        std::this_thread::sleep_for(200s);
+        std::cout << "call_allow_power_on: finished" << std::endl;
+        return std::nullopt;
+    }
+};
+
+TEST(IECStateMachine, init_subscribe) {
+    Everest::install_backtrace_handler();
+
+    BspStubTimeout bsp;
+    std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
+    module::IECStateMachine state_machine(std::move(bsp_if));
+
+    state_machine.enable(true);
+    state_machine.allow_power_on(true, Reason::FullPowerCharging);
+    bsp.raise_event(Event::A);
+    bsp.raise_event(Event::B);
+    bsp.raise_event(Event::PowerOn);
+    bsp.raise_event(Event::C);
+    std::cout << "main: sleep (" << std::this_thread::get_id() << ")" << std::endl;
+    std::this_thread::sleep_for(300s);
+}
+#endif
+
+struct BspStubDeadlock : public BspStub {
+    std::vector<std::chrono::time_point<std::chrono::steady_clock>> call_pwm_off_times;
+    std::vector<std::chrono::time_point<std::chrono::steady_clock>> call_allow_power_on_times;
+    int count = 0;
+    enum class events_t : std::uint8_t {
+        call_allow_power_on,
+        call_enable,
+        call_pwm_off,
+        call_pwm_on,
+        signal_lock,
+        sleeping,
+    };
+    module::EventQueue<events_t> events;
+
+    std::string to_string(module::EventQueue<events_t>::events_t e) {
+        std::string result;
+        for (const auto& i : e) {
+            result += std::to_string(static_cast<std::uint8_t>(i));
+            result += " ";
+        }
+        return result;
+    }
+
+    bool contains(module::EventQueue<events_t>::events_t e, events_t event) {
+        for (const auto& i : e) {
+            if (i == event) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    auto wait() {
+        return events.wait();
+    }
+
+    virtual Result call_allow_power_on(Parameters p) {
+        std::cout << "call_allow_power_on(" << p << ")" << std::endl;
+        call_allow_power_on_times.push_back(std::chrono::steady_clock::now());
+        events.push(events_t::call_allow_power_on);
+        return std::nullopt;
+    }
+
+    virtual Result call_enable(Parameters p) {
+        std::cout << "call_enable(" << p << ")" << std::endl;
+        events.push(events_t::call_enable);
+        return std::nullopt;
+    }
+
+    virtual Result call_pwm_off(Parameters p) {
+        std::cout << "call_pwm_off(" << p << ")" << std::endl;
+        call_pwm_off_times.push_back(std::chrono::steady_clock::now());
+        if (count == 2) {
+            std::cout << "sleeping ..." << std::endl;
+            events.push(events_t::sleeping);
+            std::this_thread::sleep_for(7s);
+        }
+        count++;
+        events.push(events_t::call_pwm_off);
+        return std::nullopt;
+    }
+
+    virtual Result call_pwm_on(Parameters p) {
+        std::cout << "call_pwm_on(" << p << ")" << std::endl;
+        events.push(events_t::call_pwm_on);
+        return std::nullopt;
+    }
+
+    auto elapsed() const {
+        auto last_call_pwm_off_time = call_pwm_off_times.back();
+        auto last_call_allow_power_on_time = call_allow_power_on_times.back();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(last_call_allow_power_on_time -
+                                                                     last_call_pwm_off_time)
+            .count();
+    }
+};
+
+TEST(IECStateMachine, deadlock_test) {
+    /*
+     * a deadlock was caused by timeout_state_c1 timing out and
+     * trying to raise an event while state_machine() was running
+     * and wanting to stop the timer
+     * 61851-1 state C starts the timer (from x2)
+     *
+     * check the timer runs for 6 seconds
+     */
+    Everest::install_backtrace_handler();
+
+    BspStubDeadlock bsp;
+    std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
+    module::IECStateMachine state_machine(std::move(bsp_if));
+
+    std::uint8_t signal_lock_count = 0;
+
+    state_machine.signal_lock.connect([&signal_lock_count, &bsp]() {
+        signal_lock_count++;
+        std::cout << "signal_lock" << std::endl;
+        // bsp.events.push(BspStubDeadlock::events_t::signal_lock);
+    });
+
+    state_machine.enable(true);
+    auto actions = bsp.wait();
+    ASSERT_EQ(actions.size(), 1);
+    ASSERT_EQ(actions[0], BspStubDeadlock::events_t::call_enable);
+
+    bsp.raise_event(Event::A);
+    actions = bsp.wait();
+    ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::call_pwm_off));
+
+    bsp.raise_event(Event::B);
+    actions = bsp.wait();
+    // std::cout << bsp.to_string(actions) << std::endl;
+    // call_allow_power_on and/or signal_lock
+    // ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::call_allow_power_on));
+
+    state_machine.set_pwm(0.5);
+    actions = bsp.wait();
+    // std::cout << bsp.to_string(actions) << std::endl;
+    ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::call_pwm_on));
+
+    state_machine.allow_power_on(true, types::evse_board_support::Reason::FullPowerCharging);
+    std::this_thread::sleep_for(1s);
+    // actions = bsp.wait();
+    // ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::signal_lock));
+
+    bsp.raise_event(Event::C);
+    actions = bsp.wait();
+    // std::cout << bsp.to_string(actions) << std::endl;
+    ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::call_allow_power_on));
+
+    state_machine.set_pwm_off();
+    // expect state_machine to run once and then again when the
+    // timer expires
+
+    std::this_thread::sleep_for(8s);
+    auto elapsed = bsp.elapsed();
+    std::cout << "Elapsed: " << elapsed << std::endl;
+    EXPECT_GT(elapsed, 6000);
+    EXPECT_LT(elapsed, 6500);
+}
+
+TEST(IECStateMachine, deadlock_fix) {
+    /*
+     * a deadlock was caused by timeout_state_c1 timing out and
+     * trying to raise an event while state_machine() was running
+     * and wanting to stop the timer
+     * 61851-1 state C starts the timer (from X2)
+     */
+    Everest::install_backtrace_handler();
+
+    BspStubDeadlock bsp;
+    std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
+    module::IECStateMachine state_machine(std::move(bsp_if));
+
+    std::uint8_t signal_lock_count = 0;
+
+    state_machine.signal_lock.connect([&signal_lock_count, &bsp]() {
+        signal_lock_count++;
+        std::cout << "signal_lock" << std::endl;
+        // bsp.events.push(BspStubDeadlock::events_t::signal_lock);
+    });
+
+    state_machine.enable(true);
+    auto actions = bsp.wait();
+    ASSERT_EQ(actions.size(), 1);
+    ASSERT_EQ(actions[0], BspStubDeadlock::events_t::call_enable);
+
+    bsp.raise_event(Event::A);
+    actions = bsp.wait();
+    // std::cout << bsp.to_string(actions) << std::endl;
+    ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::call_pwm_off));
+
+    bsp.raise_event(Event::B);
+    actions = bsp.wait();
+    // call_allow_power_on and/or signal_lock
+    // ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::call_allow_power_on));
+
+    state_machine.set_pwm(0.5);
+    actions = bsp.wait();
+    ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::call_pwm_on));
+
+    state_machine.allow_power_on(true, types::evse_board_support::Reason::FullPowerCharging);
+    std::this_thread::sleep_for(1s);
+
+    bsp.raise_event(Event::C);
+    actions = bsp.wait();
+    ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::call_allow_power_on));
+
+    state_machine.set_pwm_off();
+    // expect state_machine to run once and then again when the
+    // timer expires
+
+    actions = bsp.wait();
+    ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::call_pwm_off));
+
+    // this would previously trigger the deadlock
+    bsp.raise_event(Event::A);
+    actions = bsp.wait();
+    // std::cout << bsp.to_string(actions) << std::endl;
+    ASSERT_TRUE(bsp.contains(actions, BspStubDeadlock::events_t::sleeping));
+
+    std::this_thread::sleep_for(10s);
+    // if there is a deadlock the test won't finish
+}
+
+} // namespace

--- a/modules/EvseManager/tests/IECStateMachineTest.cpp
+++ b/modules/EvseManager/tests/IECStateMachineTest.cpp
@@ -197,6 +197,8 @@ struct BspStubDeadlock : public BspStub {
 };
 
 TEST(IECStateMachine, deadlock_test) {
+    GTEST_SKIP() << "relies on thread timing so occasionally fails";
+
     /*
      * a deadlock was caused by timeout_state_c1 timing out and
      * trying to raise an event while state_machine() was running
@@ -263,6 +265,8 @@ TEST(IECStateMachine, deadlock_test) {
 }
 
 TEST(IECStateMachine, deadlock_fix) {
+    GTEST_SKIP() << "relies on thread timing so occasionally fails";
+
     /*
      * a deadlock was caused by timeout_state_c1 timing out and
      * trying to raise an event while state_machine() was running

--- a/modules/EvseManager/tests/IECStateMachineTest.cpp
+++ b/modules/EvseManager/tests/IECStateMachineTest.cpp
@@ -3,6 +3,7 @@
 #include "evse_board_supportIntfStub.hpp"
 #include <EventQueue.hpp>
 #include <IECStateMachine.hpp>
+#include <backtrace.hpp>
 #include <chrono>
 #include <gtest/gtest.h>
 #include <memory>
@@ -99,7 +100,9 @@ struct BspStubTimeout : public BspStub {
 };
 
 TEST(IECStateMachine, init_subscribe) {
+#ifdef EVEREST_USE_BACKTRACES
     Everest::install_backtrace_handler();
+#endif
 
     BspStubTimeout bsp;
     std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
@@ -202,7 +205,9 @@ TEST(IECStateMachine, deadlock_test) {
      *
      * check the timer runs for 6 seconds
      */
+#ifdef EVEREST_USE_BACKTRACES
     Everest::install_backtrace_handler();
+#endif
 
     BspStubDeadlock bsp;
     std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
@@ -264,7 +269,9 @@ TEST(IECStateMachine, deadlock_fix) {
      * and wanting to stop the timer
      * 61851-1 state C starts the timer (from X2)
      */
+#ifdef EVEREST_USE_BACKTRACES
     Everest::install_backtrace_handler();
+#endif
 
     BspStubDeadlock bsp;
     std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);

--- a/modules/EvseManager/tests/ModuleAdapterStub.hpp
+++ b/modules/EvseManager/tests/ModuleAdapterStub.hpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#ifndef MODULEADAPRERSTUB_H_
+#define MODULEADAPRERSTUB_H_
+
+#include <framework/ModuleAdapter.hpp>
+
+//-----------------------------------------------------------------------------
+namespace module::stub {
+
+struct ModuleAdapterStub : public Everest::ModuleAdapter {
+
+    ModuleAdapterStub() : Everest::ModuleAdapter() {
+        call = [this](const Requirement& req, const std::string& str, Parameters p) {
+            return this->call_fn(req, str, p);
+        };
+        publish = [this](const std::string& s1, const std::string& s2, Value v) { this->publish_fn(s1, s2, v); };
+        subscribe = [this](const Requirement& req, const std::string& str, ValueCallback cb) {
+            this->subscribe_fn(req, str, cb);
+        };
+        subscribe_error = [this](const Requirement& req, const std::string& str, Everest::error::ErrorCallback cb) {
+            this->subscribe_error_fn(req, str, cb);
+        };
+        subscribe_all_errors = [this](Everest::error::ErrorCallback cb) { this->subscribe_all_errors_fn(cb); };
+        subscribe_error_cleared = [this](const Requirement& req, const std::string& str,
+                                         Everest::error::ErrorCallback cb) {
+            this->subscribe_error_cleared_fn(req, str, cb);
+        };
+        subscribe_all_errors_cleared = [this](Everest::error::ErrorCallback cb) {
+            subscribe_all_errors_cleared_fn(cb);
+        };
+        raise_error = [this](const std::string& s1, const std::string& s2, const std::string& s3,
+                             const Everest::error::Severity& sev) { return this->raise_error_fn(s1, s2, s3, sev); };
+        request_clear_error_uuid = [this](const std::string& str, const Everest::error::ErrorHandle& eh) {
+            return this->request_clear_error_uuid_fn(str, eh);
+        };
+        request_clear_all_errors_of_module = [this](const std::string& str) {
+            return this->request_clear_all_errors_of_module_fn(str);
+        };
+        request_clear_all_errors_of_type_of_module = [this](const std::string& s1, const std::string& s2) {
+            return this->request_clear_all_errors_of_type_of_module_fn(s1, s2);
+        };
+        ext_mqtt_publish = [this](const std::string& s1, const std::string& s2) { this->ext_mqtt_publish_fn(s1, s2); };
+        ext_mqtt_subscribe = [this](const std::string& str, StringHandler sh) {
+            return this->ext_mqtt_subscribe_fn(str, sh);
+        };
+        telemetry_publish = [this](const std::string& s1, const std::string& s2, const std::string& s3,
+                                   const Everest::TelemetryMap& tm) { this->telemetry_publish_fn(s1, s2, s3, tm); };
+    }
+
+    virtual Result call_fn(const Requirement&, const std::string&, Parameters) {
+        std::printf("call_fn\n");
+        return std::nullopt;
+    }
+    virtual void publish_fn(const std::string&, const std::string&, Value) {
+        std::printf("publish_fn\n");
+    }
+    virtual void subscribe_fn(const Requirement&, const std::string& fn, ValueCallback) {
+        std::printf("subscribe_fn(%s)\n", fn.c_str());
+    }
+    virtual void subscribe_error_fn(const Requirement&, const std::string&, Everest::error::ErrorCallback) {
+        std::printf("subscribe_error_fn\n");
+    }
+    virtual void subscribe_all_errors_fn(Everest::error::ErrorCallback) {
+        std::printf("subscribe_all_errors_fn\n");
+    }
+    virtual void subscribe_error_cleared_fn(const Requirement&, const std::string&, Everest::error::ErrorCallback) {
+        std::printf("subscribe_error_cleared_fn\n");
+    }
+    virtual void subscribe_all_errors_cleared_fn(Everest::error::ErrorCallback) {
+        std::printf("subscribe_all_errors_cleared_fn\n");
+    }
+    virtual Everest::error::ErrorHandle raise_error_fn(const std::string&, const std::string&, const std::string&,
+                                                       const Everest::error::Severity&) {
+        std::printf("raise_error_fn\n");
+        return Everest::error::ErrorHandle();
+    }
+    virtual Result request_clear_error_uuid_fn(const std::string&, const Everest::error::ErrorHandle&) {
+        std::printf("request_clear_error_uuid_fn\n");
+        return std::nullopt;
+    }
+    virtual Result request_clear_all_errors_of_module_fn(const std::string&) {
+        std::printf("request_clear_all_errors_of_module_fn\n");
+        return std::nullopt;
+    }
+    virtual Result request_clear_all_errors_of_type_of_module_fn(const std::string&, const std::string&) {
+        std::printf("request_clear_all_errors_of_type_of_module_fn\n");
+        return std::nullopt;
+    }
+    virtual void ext_mqtt_publish_fn(const std::string&, const std::string&) {
+        std::printf("ext_mqtt_publish_fn\n");
+    }
+    virtual std::function<void()> ext_mqtt_subscribe_fn(const std::string&, StringHandler) {
+        std::printf("ext_mqtt_subscribe_fn\n");
+        return nullptr;
+    }
+    virtual void telemetry_publish_fn(const std::string&, const std::string&, const std::string&,
+                                      const Everest::TelemetryMap&) {
+        std::printf("telemetry_publish_fn\n");
+    }
+};
+
+} // namespace module::stub
+
+#endif

--- a/modules/EvseManager/tests/evse_board_supportIntfStub.hpp
+++ b/modules/EvseManager/tests/evse_board_supportIntfStub.hpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#ifndef EVSE_BOARD_SUPPORTINTFSTUB_H_
+#define EVSE_BOARD_SUPPORTINTFSTUB_H_
+
+#include "ModuleAdapterStub.hpp"
+#include <generated/interfaces/evse_board_support/Interface.hpp>
+
+//-----------------------------------------------------------------------------
+namespace module::stub {
+
+struct evse_board_supportIntfStub : public evse_board_supportIntf {
+    ModuleAdapterStub module_adapter;
+    Requirement req{"requirement", 1};
+
+    evse_board_supportIntfStub() : evse_board_supportIntf(&module_adapter, req, "EvseManager") {
+    }
+    evse_board_supportIntfStub(ModuleAdapterStub& adapter) : evse_board_supportIntf(&adapter, req, "EvseManager") {
+    }
+};
+
+} // namespace module::stub
+
+#endif


### PR DESCRIPTION
## Describe your changes

There was a deadlock in the IEC state machine when the C1 timer expires whilst the state machine is running and attempting to stop the timer.

The timer raises an event (hence blocks on the mutex) Stopping the timer waits for the thread to finish. Since the state machine is holding the mutex the thread never finishes ...

fix: improvement to EventQueue

Wait on the condition variable now checks the queue size to avoid spurious wakeups.
https://en.cppreference.com/w/cpp/thread/condition_variable

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

