### PR TITLE
Bazel: Allow users to consume Rust crates

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -16,34 +16,6 @@ rust_register_toolchains(
     versions = ["1.74.0"],
 )
 
-load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
-
-crate_universe_dependencies()
-
-load("@rules_rust//crate_universe:defs.bzl", "crates_repository", "crate")
-
-crates_repository(
-    name = "crate_index",
-    cargo_lockfile = "//modules:Cargo.lock",
-    isolated = False,
-    manifests = [
-        "//modules:Cargo.toml",
-        "//modules/RsIskraMeter:Cargo.toml",
-        "//modules/RsPaymentTerminal:Cargo.toml",
-        "//modules/rust_examples/RsExample:Cargo.toml",
-        "//modules/rust_examples/RsExampleUser:Cargo.toml",
-    ],
-    annotations = {
-        "everestrs": [crate.annotation(
-            crate_features = ["build_bazel"],
-        )],
-    },
-)
-
-load("@crate_index//:defs.bzl", "crate_repositories")
-
-crate_repositories()
-
 load("//third-party/bazel:repos.bzl", "everest_core_repos")
 
 everest_core_repos()

--- a/modules/RsIskraMeter/BUILD.bazel
+++ b/modules/RsIskraMeter/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
-load("@crate_index//:defs.bzl", "all_crate_deps")
+load("@everest_core_crate_index//:defs.bzl", "all_crate_deps")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 cargo_build_script(

--- a/modules/RsPaymentTerminal/BUILD.bazel
+++ b/modules/RsPaymentTerminal/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
-load("@crate_index//:defs.bzl", "all_crate_deps")
+load("@everest_core_crate_index//:defs.bzl", "all_crate_deps")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
 
 cargo_build_script(

--- a/modules/rust_examples/RsExample/BUILD.bazel
+++ b/modules/rust_examples/RsExample/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("@crate_index//:defs.bzl", "all_crate_deps")
+load("@everest_core_crate_index//:defs.bzl", "all_crate_deps")
 
 cargo_build_script(
     name = "build_script",

--- a/modules/rust_examples/RsExampleUser/BUILD.bazel
+++ b/modules/rust_examples/RsExampleUser/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("@crate_index//:defs.bzl", "all_crate_deps")
+load("@everest_core_crate_index//:defs.bzl", "all_crate_deps")
 
 cargo_build_script(
     name = "build_script",

--- a/third-party/bazel/defs.bzl
+++ b/third-party/bazel/defs.bzl
@@ -1,4 +1,7 @@
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
+load("@everest_core_crate_index//:defs.bzl", "crate_repositories")
+
 
 def everest_core_defs():
     boost_deps()
+    crate_repositories()

--- a/third-party/bazel/repos.bzl
+++ b/third-party/bazel/repos.bzl
@@ -1,5 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@rules_rust//crate_universe:defs.bzl", "crates_repository", "crate")
+load("@rules_rust//crate_universe:repositories.bzl", "crate_universe_dependencies")
 
 def everest_core_repos():
     maybe(
@@ -16,3 +18,21 @@ def everest_core_repos():
         url = "https://github.com/everest/everest-framework/archive/b9f9b5ddff46856027346a98f5c16d11b16f7436.tar.gz",
         strip_prefix = "everest-framework-b9f9b5ddff46856027346a98f5c16d11b16f7436",
     )
+    crates_repository(
+        name = "everest_core_crate_index",
+        cargo_lockfile = "@everest-core//modules:Cargo.lock",
+        isolated = False,
+        manifests = [
+            "@everest-core//modules:Cargo.toml",
+            "@everest-core//modules/RsIskraMeter:Cargo.toml",
+            "@everest-core//modules/RsPaymentTerminal:Cargo.toml",
+            "@everest-core//modules/rust_examples/RsExample:Cargo.toml",
+            "@everest-core//modules/rust_examples/RsExampleUser:Cargo.toml",
+        ],
+        annotations = {
+            "everestrs": [crate.annotation(
+                crate_features = ["build_bazel"],
+            )],
+        },
+    )
+    crate_universe_dependencies()


### PR DESCRIPTION
Allows users to consume Rust crates in their code

Users can 

```starlack
git_repository(
    name = "everest-core",
    remote = <the remote>,
    commit = <the commit>,

git_repository(
    name = "everest-framework",
    remote = <the remote>,
    commit = <the commit>,
)

load("@everest-framework//third-party/bazel:repos.bzl", "everest_framework_repos")
everest_framework_repos()

load("@everest-framework//third-party/bazel:defs.bzl", "everest_framework_deps")
everest_framework_deps()

load("@everest-core//third-party/bazel:repos.bzl", "everest_core_repos")
everest_core_repos()

load("@everest-core//third-party/bazel:defs.bzl", "everest_core_defs")
everest_core_defs()
```

after which they can run e.x.

```sh
bazel build @everest-core//modules/RsIskraMeter
```
to build the desired module.

When adding new modules  we need to extend the third-party/bazel/BUILD.bazel manifest section
