### PR TITLE
Adding an infinite auto execution option to the JsEvManager

### DIFF
--- a/modules/simulation/JsEvManager/index.js
+++ b/modules/simulation/JsEvManager/index.js
@@ -120,11 +120,9 @@ function car_statemachine(mod) {
 
         // Wait for physical plugin (ev BSP sees state A on CP and not Disconnected)
 
-        // If we have auto_exec configured, restart simulation when it was unplugged
         evlog.info('Unplug detected, restarting simulation.');
         mod.slac_state = 'UNMATCHED';
         mod.uses_list.ev[0].call.stop_charging();
-        if (globalconf.module.auto_exec) execute_charging_session(mod, { value: globalconf.module.auto_exec_commands });
       }
       break;
     case 'pluggedin':
@@ -203,8 +201,10 @@ function simulation_loop(mod) {
         evlog.debug('Finished simulation.');
         simdata_reset_defaults(mod);
         mod.executionActive = false;
-        // If we have auto_exec configured, restart simulation when it is done
-        if (globalconf.module.auto_exec) execute_charging_session(mod, { value: globalconf.module.auto_exec_commands });
+        // If we have auto_exec_infinite configured, restart simulation when it is done
+        if (globalconf.module.auto_exec === true && globalconf.module.auto_exec_infinite === true) {
+          execute_charging_session(mod, { value: globalconf.module.auto_exec_commands });
+        }
         break;
       }
     } else break; // command blocked, wait for timer to run this function again

--- a/modules/simulation/JsEvManager/manifest.yaml
+++ b/modules/simulation/JsEvManager/manifest.yaml
@@ -14,6 +14,11 @@ config:
       Enable automatic execution of simulation commands at startup from auto_exec_commands config option.
     type: boolean
     default: false
+  auto_exec_infinite:
+    description: >-
+      If enabled the simulation commands executes infinitely.
+    type: boolean
+    default: false
   auto_exec_commands:
     description: >-
       Simulation commands, e.g. sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug


### PR DESCRIPTION
## Describe your changes
Adding auto_exec_infinite config. Now you can choose whether the cmds should run once or infinitely.
This option is mainly used for "real" HW.

## Issue ticket number and link
If auto_exec was active for the JsEvManager, the cmds were executed infinitely. With the auto_exec option, however, the cmds should only run once.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

