### PR TITLE
Codeowners: adjust owners for Cargo.lock and Cargo.toml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,9 @@
 /modules/YetiDriver @corneliusclaussen @hikinggrass
 /modules/simulation/ @SebaLukas @pietfried
 /modules/rust_examples/ @SirVer @golovasteek @dorezyuk
+**/Cargo.toml @SirVer @golovasteek @dorezyuk
+**/Cargo.lock @SirVer @golovasteek @dorezyuk
+
 
 # Rust & Bazel
 *.rs @SirVer @golovasteek @dorezyuk


### PR DESCRIPTION
This should avoid spamming everyone on every Rust/Bazel pr

