### PR TITLE
DC Powersupply: allow runtime update of max current/watt caps

### DIFF
--- a/interfaces/power_supply_DC.yaml
+++ b/interfaces/power_supply_DC.yaml
@@ -1,7 +1,9 @@
 description: Interface for power supplies used for DC charging
 cmds:
   getCapabilities:
-    description: Get capabilities of power supply
+    description: >-
+      Get maximum capabilities of power supply. It should report the maximum possible values under best conditions, even if it
+      is e.g. derated at this moment due to high temperature.
     result:
       description: Capabilities
       type: object
@@ -46,3 +48,7 @@ vars:
     description: Fault code. Published when fault happens.
     type: string
     $ref: /power_supply_DC#/FaultCode
+  update_capabilities:
+    description: Update some capability values at run-time. This can be used to e.g. report lower limits due to temperature de-rating of the PSU.
+    type: object
+    $ref: /power_supply_DC#/UpdateCapabilities

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -166,7 +166,6 @@ public:
     void charger_was_authorized();
 
     const std::vector<std::unique_ptr<powermeterIntf>>& r_powermeter_billing();
-    types::power_supply_DC::Capabilities powersupply_capabilities;
 
     // FIXME: this will be removed with proper intergration of BPT on ISO-20
     // on DIN SPEC and -2 we claim a positive charging current on ISO protocol,
@@ -191,6 +190,21 @@ public:
     std::chrono::time_point<date::utc_clock> random_delay_start_time;
     std::atomic<std::chrono::seconds> random_delay_max_duration;
     std::atomic<std::chrono::time_point<std::chrono::steady_clock>> timepoint_ready_for_charging;
+
+    types::power_supply_DC::Capabilities get_powersupply_capabilities() {
+        std::scoped_lock lock(powersupply_capabilities_mutex);
+        return powersupply_capabilities;
+    }
+
+    void update_powersupply_capabilities(types::power_supply_DC::UpdateCapabilities caps) {
+        std::scoped_lock lock(powersupply_capabilities_mutex);
+        powersupply_capabilities.max_export_current_A = caps.max_export_current_A;
+        powersupply_capabilities.max_export_power_W = caps.max_export_power_W;
+
+        powersupply_capabilities.max_import_current_A = caps.max_import_current_A;
+        powersupply_capabilities.max_import_power_W = caps.max_import_power_W;
+    }
+
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:
@@ -205,6 +219,9 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+    std::mutex powersupply_capabilities_mutex;
+    types::power_supply_DC::Capabilities powersupply_capabilities;
+
     Everest::timed_mutex_traceable power_mutex;
     types::powermeter::Powermeter latest_powermeter_data_billing;
 

--- a/types/power_supply_DC.yaml
+++ b/types/power_supply_DC.yaml
@@ -93,6 +93,26 @@ types:
         type: number
         minimum: 0.0
         maximum: 1.0
+  UpdateCapabilities:
+    description: Runtime update of some of the capabilities values. Can be used to e.g. inform about throttling of a power supply due to temperature de-rating.
+    type: object
+    additionalProperties: false
+    required:
+      - max_export_current_A
+      - max_export_power_W
+    properties:
+      max_export_current_A:
+        description: Maximum current that the power supply can output in Ampere
+        type: number
+      max_import_current_A:
+        description: Maximum current that the power supply can output in Ampere
+        type: number
+      max_export_power_W:
+        description: Maximum export power that the power supply can output in Watt
+        type: number
+      max_import_power_W:
+        description: Maximum import power that the power supply can sink in Watt
+        type: number
   FaultCode:
     description: Fault codes
     type: string


### PR DESCRIPTION
## Describe your changes

DC power supplies may need to adjust the initially reported capabilities during run time (e.g. due to thermal throttling or load sharing between ports).
This adds a var to the power_supply_DC interface to allow to pusblish those changes.
Current implementations do not have to be modified if they do not need this new feature.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

