### PR TITLE
Fix simplified charging with waiting for energy

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -775,6 +775,8 @@ void Charger::process_cp_events_state(CPEvent cp_event) {
         }
         break;
 
+    case EvseState::WaitingForEnergy:
+        [[fallthrough]];
     case EvseState::WaitingForAuthentication:
         if (cp_event == CPEvent::CarRequestedPower) {
             session_log.car(false, "B->C transition before PWM is enabled at this stage violates IEC61851-1");


### PR DESCRIPTION
## Describe your changes

When waiting for Energy, PWM is switched off. A car should switch to state B when PWM is off. Some cars won't (e.g. if they do simplified charging). In this case, prepare charging after waiting for energy did not work as no B->C transition happens after PWM is enabled again. This PR fixes this issue.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

