### PR TITLE
CMakeLists: require C++17 support globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ endif()
 # make own cmake modules available
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+# specify minimum C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 # test whether linking with libatomic is required on some platforms
 include(CheckAtomic)
 if(HAVE_CXX_ATOMICS_WITH_LIB OR HAVE_CXX_ATOMICS64_WITH_LIB)

--- a/lib/staging/can_dpm1000/tests/CMakeLists.txt
+++ b/lib/staging/can_dpm1000/tests/CMakeLists.txt
@@ -9,5 +9,3 @@ target_link_libraries(dpm1000_tester
         can_protocols::dpm1000
         Threads::Threads
 )
-
-target_compile_features(dpm1000_tester PRIVATE cxx_std_17)

--- a/lib/staging/slac/test/CMakeLists.txt
+++ b/lib/staging/slac/test/CMakeLists.txt
@@ -9,7 +9,6 @@ target_link_libraries(evse_slac_test
         slac_fsm_evse
         fmt::fmt
 )
-target_compile_features(evse_slac_test PRIVATE cxx_std_17)
 
 add_executable(evse_vs_ev)
 target_sources(evse_vs_ev
@@ -25,7 +24,6 @@ target_link_libraries(evse_vs_ev
         slac::fsm::ev
         Threads::Threads
 )
-target_compile_features(evse_vs_ev PRIVATE cxx_std_17)
 
 add_executable(bridger)
 target_sources(bridger
@@ -38,4 +36,3 @@ target_link_libraries(bridger
         slac::slac
         fmt::fmt
 )
-target_compile_features(bridger PRIVATE cxx_std_17)

--- a/modules/EvseManager/CMakeLists.txt
+++ b/modules/EvseManager/CMakeLists.txt
@@ -42,9 +42,6 @@ target_link_options(${MODULE_NAME}
 PRIVATE
     "-rdynamic"
 )
-
-# needed for std::filesystem
-target_compile_features(${MODULE_NAME} PUBLIC cxx_std_17)
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 
 target_sources(${MODULE_NAME}

--- a/modules/MicroMegaWattBSP/umwc_comms/CMakeLists.txt
+++ b/modules/MicroMegaWattBSP/umwc_comms/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 project(umwc_comms VERSION 0.1)
-# specify the C++ standard
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/modules/MicroMegaWattBSP/umwc_fwupdate/CMakeLists.txt
+++ b/modules/MicroMegaWattBSP/umwc_fwupdate/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 project(umwc_fwupdate VERSION 0.1)
-# specify the C++ standard
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # add the executable
 add_executable(umwc_fwupdate main.cpp)

--- a/modules/PN532TokenProvider/pn532_serial/CMakeLists.txt
+++ b/modules/PN532TokenProvider/pn532_serial/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 project(pn532_serial VERSION 0.1)
-# specify the C++ standard
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/modules/SerialCommHub/CMakeLists.txt
+++ b/modules/SerialCommHub/CMakeLists.txt
@@ -19,8 +19,6 @@ target_sources(${MODULE_NAME}
     tiny_modbus_rtu.cpp
     crc16.cpp
 )
-
-target_compile_features(${MODULE_NAME} PUBLIC cxx_std_17)
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 
 target_sources(${MODULE_NAME}

--- a/modules/Setup/CMakeLists.txt
+++ b/modules/Setup/CMakeLists.txt
@@ -22,7 +22,6 @@ target_sources(${MODULE_NAME}
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
-target_compile_features(${MODULE_NAME} PRIVATE cxx_std_17)
 if(EVEREST_CORE_BUILD_TESTING)
     include(CTest)
     add_subdirectory(tests)

--- a/modules/System/CMakeLists.txt
+++ b/modules/System/CMakeLists.txt
@@ -29,8 +29,6 @@ target_sources(${MODULE_NAME}
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 # insert other things like install cmds etc here
-target_compile_features(${MODULE_NAME} PRIVATE cxx_std_17)
-
 install(
     PROGRAMS
         constants.env

--- a/modules/YetiDriver/yeti_comms/CMakeLists.txt
+++ b/modules/YetiDriver/yeti_comms/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 project(yeti_comms VERSION 0.1)
-# specify the C++ standard
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # add the executable
 add_library(yeti_comms STATIC)

--- a/modules/YetiDriver/yeti_fwupdate/CMakeLists.txt
+++ b/modules/YetiDriver/yeti_fwupdate/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 project(yeti_fwupdate VERSION 0.1)
-# specify the C++ standard
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # add the executable
 add_executable(yeti_fwupdate main.cpp)

--- a/modules/YetiEvDriver/evyeti_comms/CMakeLists.txt
+++ b/modules/YetiEvDriver/evyeti_comms/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 project(evyeti_comms VERSION 0.1)
-# specify the C++ standard
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
-
 
 configure_file(config.h.in config.h)
 

--- a/modules/simulation/DCSupplySimulator/CMakeLists.txt
+++ b/modules/simulation/DCSupplySimulator/CMakeLists.txt
@@ -9,8 +9,6 @@ ev_setup_cpp_module()
 
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 # insert your custom targets and additional config variables here
-# needed for std::scoped_lock
-target_compile_features(${MODULE_NAME} PUBLIC cxx_std_17)
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 
 target_sources(${MODULE_NAME}


### PR DESCRIPTION
## Describe your changes
Many modules use C++17 features already, either explicitly (requested support via CMake) or implicitly. Make this a global CMake requirement, and drop the local ones.

While the resulting flags also apply to the dependencies when building with EDM, the EVerest dependencies should nevertheless mark their requirements separately, as they can be built and used separately.

Perhaps the docs need a hint as well.
## Issue ticket number and link
As [discussed on Zulip](https://lfenergy.zulipchat.com/#narrow/stream/417678-EVerest.3A-Framework-.26-Tools/topic/Marking.20code.20as.20requiring.20C.2B.2B17/near/435542432)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

