### PR TITLE
Bazel: choose tags or commit, when parsing dependencies.yaml

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,7 +68,7 @@ ext-openv2g:
 # mbedtls
 ext-mbedtls:
   git: https://github.com/EVerest/ext-mbedtls.git
-  git_tag: 8b3f26a
+  git_tag: 8b3f26a5ac38d4fdccbc5c5366229f3e01dafcc0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_MBEDTLS"
   options:
     - ENABLE_PROGRAMS OFF

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,3 +1,6 @@
+# `git_tag` can be either a tag or a commit hash.
+# For the sake of unambiguity the `git_tag` field is treated as a hash
+# only if it is 40 characters long hexadecimal string.
 ---
 everest-framework:
   git: https://github.com/EVerest/everest-framework.git

--- a/third-party/bazel/deps_versions.bzl
+++ b/third-party/bazel/deps_versions.bzl
@@ -6,70 +6,87 @@
 EVEREST_DEPS = struct(
 	# Josev
 	Josev_repo = "https://github.com/EVerest/ext-switchev-iso15118.git",
+	Josev_commit = None,
 	Josev_tag = "2024.2.1",
 
 	# catch2
 	catch2_repo = "https://github.com/catchorg/Catch2.git",
+	catch2_commit = None,
 	catch2_tag = "v3.4.0",
 
 	# everest-framework
 	everest_framework_repo = "https://github.com/EVerest/everest-framework.git",
+	everest_framework_commit = None,
 	everest_framework_tag = "v0.13.0",
 
 	# everest-utils
 	everest_utils_repo = "https://github.com/EVerest/everest-utils.git",
-	everest_utils_tag = "2d7ea3e4742114cb7e3b1e71b3d1e7da566e2146",
+	everest_utils_commit = "2d7ea3e4742114cb7e3b1e71b3d1e7da566e2146",
+	everest_utils_tag = None,
 
 	# ext-mbedtls
 	ext_mbedtls_repo = "https://github.com/EVerest/ext-mbedtls.git",
-	ext_mbedtls_tag = "8b3f26a",
+	ext_mbedtls_commit = "8b3f26a5ac38d4fdccbc5c5366229f3e01dafcc0",
+	ext_mbedtls_tag = None,
 
 	# ext-openv2g
 	ext_openv2g_repo = "https://github.com/EVerest/ext-openv2g.git",
+	ext_openv2g_commit = None,
 	ext_openv2g_tag = "2023.3.0",
 
 	# gtest
 	gtest_repo = "https://github.com/google/googletest.git",
+	gtest_commit = None,
 	gtest_tag = "release-1.12.1",
 
 	# libcurl
 	libcurl_repo = "https://github.com/curl/curl.git",
+	libcurl_commit = None,
 	libcurl_tag = "curl-8_4_0",
 
 	# libevse-security
 	libevse_security_repo = "https://github.com/EVerest/libevse-security.git",
+	libevse_security_commit = None,
 	libevse_security_tag = "v0.6.0",
 
 	# libfsm
 	libfsm_repo = "https://github.com/EVerest/libfsm.git",
+	libfsm_commit = None,
 	libfsm_tag = "v0.2.0",
 
 	# libmodbus
 	libmodbus_repo = "https://github.com/EVerest/libmodbus.git",
+	libmodbus_commit = None,
 	libmodbus_tag = "v0.3.1",
 
 	# libocpp
 	libocpp_repo = "https://github.com/EVerest/libocpp.git",
+	libocpp_commit = None,
 	libocpp_tag = "v0.11.0",
 
 	# libslac
 	libslac_repo = "https://github.com/EVerest/libslac.git",
+	libslac_commit = None,
 	libslac_tag = "v0.3.0",
 
 	# libtimer
 	libtimer_repo = "https://github.com/EVerest/libtimer.git",
+	libtimer_commit = None,
 	libtimer_tag = "v0.1.1",
 
 	# pugixml
 	pugixml_repo = "https://github.com/zeux/pugixml",
+	pugixml_commit = None,
 	pugixml_tag = "v1.12.1",
 
 	# sigslot
 	sigslot_repo = "https://github.com/palacaze/sigslot",
+	sigslot_commit = None,
 	sigslot_tag = "v1.2.0",
 
 	# sqlite_cpp
 	sqlite_cpp_repo = "https://github.com/SRombauts/SQLiteCpp.git",
+	sqlite_cpp_commit = None,
 	sqlite_cpp_tag = "3.3.1",
 
 )

--- a/third-party/bazel/repos.bzl
+++ b/third-party/bazel/repos.bzl
@@ -25,6 +25,7 @@ def everest_core_repos():
         git_repository,
         name = "everest-framework",
         remote = EVEREST_DEPS.everest_framework_repo,
+        commit = EVEREST_DEPS.everest_framework_commit,
         tag = EVEREST_DEPS.everest_framework_tag,
     )
 
@@ -60,6 +61,7 @@ def everest_core_repos():
         git_repository,
         name = "pugixml",
         remote = EVEREST_DEPS.pugixml_repo,
+        commit = EVEREST_DEPS.pugixml_commit,
         tag = EVEREST_DEPS.pugixml_tag,
         build_file_content = """
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
@@ -83,6 +85,7 @@ cmake(
         git_repository,
         name = "libmodbus",
         remote = EVEREST_DEPS.libmodbus_repo,
+        commit = EVEREST_DEPS.libmodbus_commit,
         tag = EVEREST_DEPS.libmodbus_tag,
         build_file_content = """
 cc_library(
@@ -113,6 +116,7 @@ cc_library(
         git_repository,
         name = "sigslot",
         remote = EVEREST_DEPS.sigslot_repo,
+        commit = EVEREST_DEPS.sigslot_commit,
         tag = EVEREST_DEPS.sigslot_tag,
         build_file_content = """
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
@@ -138,6 +142,7 @@ cmake(
         git_repository,
         name = "libtimer",
         remote = EVEREST_DEPS.libtimer_repo,
+        commit = EVEREST_DEPS.libtimer_commit,
         tag = EVEREST_DEPS.libtimer_tag,
         build_file_content = """
 cc_library(
@@ -154,11 +159,7 @@ cc_library(
         git_repository,
         name = "everest-utils",
         remote = EVEREST_DEPS.everest_utils_repo,
-        # Note here, we use the `commit` instead of tag,
-        # because bazel is strict and doesn't allow to use 
-        # something like "revision".
-        # Once we switch to tag in dependencies.yaml, we should
-        # use tag here as well.
-        commit = EVEREST_DEPS.everest_utils_tag,
+        commit = EVEREST_DEPS.everest_utils_commit,
+        tag = EVEREST_DEPS.everest_utils_tag,
     )
 


### PR DESCRIPTION
## Describe your changes

Now bazel dep_tool, Is able to decide if the commit or tag is used as a reference and generate the *.bzl files accordingly.
There is a limitation: commit should we always be a full 40-character string, otherwise it's treated as a tag.


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

