### PR TITLE
Adding EnergyTransferMode to iso15118_ev interface & fixing two carsim node red cmds

### DIFF
--- a/config/nodered/config-sil-dc-bpt-flow.json
+++ b/config/nodered/config-sil-dc-bpt-flow.json
@@ -1672,7 +1672,7 @@
         "height": 0,
         "passthru": true,
         "decouple": "false",
-        "topic": "everest_external/nodered/carsim/#/cmd/enable",
+        "topic": "everest_external/nodered/#/carsim/cmd/enable",
         "topicType": "str",
         "style": "",
         "onvalue": "true",
@@ -1789,7 +1789,7 @@
         "options": [
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000;",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
                 "type": "str"
             }
         ],
@@ -1859,7 +1859,7 @@
         "once": true,
         "onceDelay": "1",
         "topic": "sim_commands",
-        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000;",
+        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
         "payloadType": "str",
         "x": 150,
         "y": 1180,

--- a/config/nodered/config-sil-dc-flow.json
+++ b/config/nodered/config-sil-dc-flow.json
@@ -1672,7 +1672,7 @@
         "height": 0,
         "passthru": true,
         "decouple": "false",
-        "topic": "everest_external/nodered/carsim/#/cmd/enable",
+        "topic": "everest_external/nodered/#/carsim/cmd/enable",
         "topicType": "str",
         "style": "",
         "onvalue": "true",
@@ -1789,7 +1789,7 @@
         "options": [
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000;",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
                 "type": "str"
             }
         ],
@@ -1859,7 +1859,7 @@
         "once": true,
         "onceDelay": "1",
         "topic": "sim_commands",
-        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000;",
+        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
         "payloadType": "str",
         "x": 150,
         "y": 1180,

--- a/config/nodered/config-sil-energy-management-flow.json
+++ b/config/nodered/config-sil-energy-management-flow.json
@@ -1676,7 +1676,7 @@
         "height": 0,
         "passthru": true,
         "decouple": "false",
-        "topic": "everest_external/nodered/carsim/#/cmd/enable",
+        "topic": "everest_external/nodered/#/carsim/cmd/enable",
         "topicType": "str",
         "style": "",
         "onvalue": "true",
@@ -1792,12 +1792,12 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
                 "type": "str"
             },
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC_extended;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
                 "type": "str"
             }
         ],
@@ -2565,7 +2565,7 @@
         "height": 0,
         "passthru": true,
         "decouple": "false",
-        "topic": "everest_external/nodered/carsim/#/cmd/enable",
+        "topic": "everest_external/nodered/#/carsim/cmd/enable",
         "topicType": "str",
         "style": "",
         "onvalue": "true",

--- a/config/nodered/config-sil-flow.json
+++ b/config/nodered/config-sil-flow.json
@@ -1711,7 +1711,7 @@
         "height": 0,
         "passthru": true,
         "decouple": "false",
-        "topic": "everest_external/nodered/carsim/#/cmd/enable",
+        "topic": "everest_external/nodered/#/carsim/cmd/enable",
         "topicType": "str",
         "style": "",
         "onvalue": "true",
@@ -1853,7 +1853,7 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             }
         ],

--- a/config/nodered/config-sil-two-evse-flow.json
+++ b/config/nodered/config-sil-two-evse-flow.json
@@ -1994,7 +1994,7 @@
         "height": 0,
         "passthru": true,
         "decouple": "false",
-        "topic": "everest_external/nodered/carsim/#/cmd/enable",
+        "topic": "everest_external/nodered/#/carsim/cmd/enable",
         "topicType": "str",
         "style": "",
         "onvalue": "true",
@@ -2136,12 +2136,12 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC_three_phase_core;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             },
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toogle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000;",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
                 "type": "str"
             }
         ],
@@ -2837,7 +2837,7 @@
         "height": 0,
         "passthru": true,
         "decouple": "false",
-        "topic": "everest_external/nodered/carsim/#/cmd/enable",
+        "topic": "everest_external/nodered/#/carsim/cmd/enable",
         "topicType": "str",
         "style": "",
         "onvalue": "true",

--- a/interfaces/ISO15118_ev.yaml
+++ b/interfaces/ISO15118_ev.yaml
@@ -8,13 +8,7 @@ cmds:
           Selected energy transfer mode for charging that is requested
           by the EVCC
         type: string
-        enum:
-          - AC_single_phase_core
-          - AC_three_phase_core
-          - DC_core
-          - DC_extended
-          - DC_combo_core
-          - DC_unique
+        $ref: /iso15118_ev#/EnergyTransferMode
     result:
       description: Returns true if the evcc simulation started
       type: boolean

--- a/modules/simulation/JsEvManager/index.js
+++ b/modules/simulation/JsEvManager/index.js
@@ -364,12 +364,11 @@ function registerAllCmds(mod) {
   if (mod.uses_list.ev.length > 0) {
     registerCmd(mod, 'iso_start_v2g_session', 1, (mod, c) => {
       switch (c.args[0]) {
-        case 'ac_single_phase_core': mod.energymode = 'AC_single_phase_core'; break;
-        case 'ac_three_phase_core': mod.energymode = 'AC_three_phase_core'; break;
-        case 'dc_core': mod.energymode = 'DC_core'; break;
-        case 'dc_extended': mod.energymode = 'DC_extended'; break;
-        case 'dc_combo_core': mod.energymode = 'DC_combo_core'; break;
-        case 'dc_unique': mod.energymode = 'DC_unique'; break;
+        case 'ac':
+          if (mod.config.module.three_phases !== true) mod.energymode = 'AC_single_phase_core';
+          else mod.energymode = 'AC_three_phase_core';
+          break;
+        case 'dc': mod.energymode = 'DC_extended'; break;
         default: return false;
       }
 
@@ -450,7 +449,7 @@ function registerAllCmds(mod) {
 
     registerCmd(mod, 'iso_wait_for_resume', 0, () => false);
 
-    registerCmd(mod, 'iso_start_bcb_toogle', 1, (mod, c) => {
+    registerCmd(mod, 'iso_start_bcb_toggle', 1, (mod, c) => {
       mod.state = 'bcb_toggle';
       if (mod.bcb_toggles >= c.args[0] || mod.bcb_toggles === 3) {
         mod.bcb_toggles = 0;

--- a/types/iso15118_ev.yaml
+++ b/types/iso15118_ev.yaml
@@ -1,5 +1,15 @@
 description: ISO15118 ev types
 types:
+  EnergyTransferMode:
+    description: Possible energy transfer modes
+    type: string
+    enum:
+      - AC_single_phase_core
+      - AC_three_phase_core
+      - DC_core
+      - DC_extended
+      - DC_combo_core
+      - DC_unique
   DC_EVParameters:
     description: Target settings for dc charging
     type: object


### PR DESCRIPTION
## Describe your changes
- Adding EnergyTransferMode type to iso15118_ev. When starting an ISO SIL, you only need to specify AC or DC in the external cmd. No longer the correct energy_transfer_mode.
- Fix: toogle becomes toggle
- Fix: changed `#` to the correct position in the carsim external cmd

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

