### PR TITLE
EvseManager: Fix bug where HLC is not stopped on unexpected CP state

### DIFF
--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -280,6 +280,12 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
             if (last_cp_state != RawCPState::E) {
                 timer = TimerControl::stop;
                 call_allow_power_on_bsp(false);
+                pwm_running = false;
+                r_bsp->call_pwm_off();
+                if (last_cp_state == RawCPState::B || last_cp_state == RawCPState::C ||
+                    last_cp_state == RawCPState::D) {
+                    events.push(CPEvent::BCDtoEF);
+                }
             }
             break;
 
@@ -287,6 +293,11 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
             connector_unlock();
             timer = TimerControl::stop;
             call_allow_power_on_bsp(false);
+            pwm_running = false;
+            r_bsp->call_pwm_off();
+            if (last_cp_state == RawCPState::B || last_cp_state == RawCPState::C || last_cp_state == RawCPState::D) {
+                events.push(CPEvent::BCDtoEF);
+            }
             break;
         }
 


### PR DESCRIPTION
Before the HLC session was not stopped by the EvseManager module in case of an unexpected CP state transition while charging. Now the HLC session is stopped in case of a CP state transition C/D -> B/E/F.

## Describe your changes

Implemented CPEvent::BCDtoEF event. Stop HLC session in case of CP state transition C/D -> B/E/F.

## Issue ticket number and link

https://github.com/EVerest/everest-core/issues/668

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements