### PR TITLE
OCPP2.0.1: Added master pass conversion to tx-event DEAUTHORIZED

### DIFF
--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -21,6 +21,7 @@ TxEvent get_tx_event(const ocpp::v201::ReasonEnum reason) {
     case ocpp::v201::ReasonEnum::DeAuthorized:
     case ocpp::v201::ReasonEnum::Remote:
     case ocpp::v201::ReasonEnum::Local:
+    case ocpp::v201::ReasonEnum::MasterPass:
         return TxEvent::DEAUTHORIZED;
     case ocpp::v201::ReasonEnum::EVDisconnected:
         return TxEvent::EV_DISCONNECTED;


### PR DESCRIPTION
## Describe your changes
Added master pass conversion to tx-event DEAUTHORIZED. If the reason is `MasterPass` this should convert to a TxEvent::DEAUTHORIZED. 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

