### PR TITLE
Remove left-over references to SunSpec library and modules

### DIFF
--- a/module-dependencies.cmake
+++ b/module-dependencies.cmake
@@ -8,11 +8,7 @@ ev_define_dependency(
 
 ev_define_dependency(
     DEPENDENCY_NAME libmodbus
-    DEPENDENT_MODULES_LIST PowermeterBSM SunspecReader SunspecScanner)
-
-ev_define_dependency(
-    DEPENDENCY_NAME libsunspec
-    DEPENDENT_MODULES_LIST SunspecReader SunspecScanner)
+    DEPENDENT_MODULES_LIST PowermeterBSM)
 
 ev_define_dependency(
     DEPENDENCY_NAME pugixml


### PR DESCRIPTION
## Describe your changes

Seems that these references were forgotten by last cleanup.

## Issue ticket number and link

n/a

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

