### PR TITLE
Enable DIN70121 by default

### DIFF
--- a/modules/EvseV2G/manifest.yaml
+++ b/modules/EvseV2G/manifest.yaml
@@ -11,7 +11,7 @@ config:
   supported_DIN70121:
     description: The EVSE supports the DIN SPEC
     type: boolean
-    default: false
+    default: true
   supported_ISO15118_2:
     description: The EVSE supports ISO15118-2
     type: boolean


### PR DESCRIPTION
## Describe your changes

Up to now, DIN70121 was disabled by default. If no options are given, I think we should enable all protocols for maximum compatibility.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

