### PR TITLE
RsIskraMeter: Remove env_logger dependency

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -28,7 +28,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "env_logger",
  "everestrs",
  "everestrs-build",
  "log",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -41,7 +41,6 @@ name = "RsPaymentTerminal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger",
  "everestrs",
  "everestrs-build",
  "log",

--- a/modules/RsIskraMeter/Cargo.toml
+++ b/modules/RsIskraMeter/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1.0.75"
 chrono = "0.4.31"
 everestrs = { workspace=true }
 log = "0.4.20"
-env_logger = "0.10.0"
 rand = "0.8.5"
 mockall = { version = "0.12.1", optional = true }
 mockall_double = { version = "0.3.1", optional = true}

--- a/modules/RsPaymentTerminal/Cargo.toml
+++ b/modules/RsPaymentTerminal/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1.0.75"
 zvt_feig_terminal = { git="https://github.com/Everest/zvt.git", rev="843ecf44ab592216bd4a483a07543c329d2baee1" }
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "net", "sync"] }
 log = "0.4.20"
-env_logger = "0.10.0"
 mockall = { version = "0.12.1", optional = true }
 mockall_double = { version = "0.3.1", optional = true}
 


### PR DESCRIPTION
Remove the `env_logger` since we can only have one logger (and this is provided by the framework)

