### PR TITLE
API: Do not publish charger information at all when it is "null"

### DIFF
--- a/modules/API/API.cpp
+++ b/modules/API/API.cpp
@@ -540,7 +540,9 @@ void API::init() {
             while (this->running) {
                 json connectors_array = connectors;
                 this->mqtt.publish(var_connectors, connectors_array.dump());
-                this->mqtt.publish(var_info, this->charger_information.dump());
+                if (not this->charger_information.is_null()) {
+                    this->mqtt.publish(var_info, this->charger_information.dump());
+                }
                 {
                     std::scoped_lock lock(ocpp_data_mutex);
                     this->mqtt.publish(var_ocpp_connection_status, this->ocpp_connection_status);


### PR DESCRIPTION
This could happen when the charger information file is not configured or invalid

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

