### PR TITLE
Use correct hashes for libocpp and libevse-security

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -50,13 +50,13 @@ libcurl:
 # and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: 6e702ef5df568c2f9929a3c3b97a09c0cb4c5b21
+  git_tag: 34ced9f4452c2ffe3145f4ff200c42dc83278c47
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 9deeb534c7f38981a422b53a6f0416bdb791b368
+  git_tag: 169573382e4d790103ce008027bb753d5ebd124a
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/third-party/bazel/deps_versions.bzl
+++ b/third-party/bazel/deps_versions.bzl
@@ -46,7 +46,7 @@ EVEREST_DEPS = struct(
 
 	# libevse-security
 	libevse_security_repo = "https://github.com/EVerest/libevse-security.git",
-	libevse_security_commit = "6e702ef5df568c2f9929a3c3b97a09c0cb4c5b21",
+	libevse_security_commit = "34ced9f4452c2ffe3145f4ff200c42dc83278c47",
 	libevse_security_tag = None,
 
 	# libfsm
@@ -61,7 +61,7 @@ EVEREST_DEPS = struct(
 
 	# libocpp
 	libocpp_repo = "https://github.com/EVerest/libocpp.git",
-	libocpp_commit = "9deeb534c7f38981a422b53a6f0416bdb791b368",
+	libocpp_commit = "169573382e4d790103ce008027bb753d5ebd124a",
 	libocpp_tag = None,
 
 	# libslac


### PR DESCRIPTION
When #665 was merged it did not point to git hashes on the main branch but on a now deleted feature branches

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

