### PR TITLE
Move third-party/bazel/deps_versions.bzl entry to bottom of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,6 @@
 # .github
 /.github/ @pietfried @corneliusclaussen
 
-# third-party/bazel
-/third-party/bazel/deps_versions.bzl @pietfried @hikinggrass @corneliusclaussen @SebaLukas @a-w50 @SirVer @golovasteek @dorezyuk
-
 # cmake
 /cmake/ @hikinggrass @a-w50
 
@@ -42,3 +39,6 @@
 *.rs @SirVer @golovasteek @dorezyuk
 *.bazel @SirVer @golovasteek @dorezyuk
 *.bzl @SirVer @golovasteek @dorezyuk
+
+# third-party/bazel
+/third-party/bazel/deps_versions.bzl @pietfried @hikinggrass @corneliusclaussen @SebaLukas @a-w50 @SirVer @golovasteek @dorezyuk


### PR DESCRIPTION
This way it's not overwritten by the catch-all *.bzl rule

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

