### PR TITLE
Charger Auth state: Add some more warning logging

### DIFF
--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -323,6 +323,9 @@ private:
         std::chrono::system_clock::time_point current_state_started;
         EvseState last_state_detect_state_change;
         EvseState last_state;
+
+        bool pp_warning_printed{false};
+        bool no_energy_warning_printed{false};
     } internal_context;
 
     // main Charger thread


### PR DESCRIPTION
## Describe your changes

Charger can get stuck in WaitingForAuth state if e.g. PP signal reading fails or no energy is available for DC mode. This PR adds warning log output to see the reason in the log file.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

