### PR TITLE
Disable autocharge by default

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -60,7 +60,7 @@ void EvseManager::init() {
     }
 
     // Use SLAC MAC address for Autocharge if configured.
-    if (config.autocharge_use_slac_instead_of_hlc and slac_enabled) {
+    if (config.autocharge_use_slac_instead_of_hlc and slac_enabled and config.enable_autocharge) {
         r_slac[0]->subscribe_ev_mac_address([this](const std::string& token) {
             p_token_provider->publish_provided_token(create_autocharge_token(token, config.connector_id));
         });
@@ -474,7 +474,9 @@ void EvseManager::ready() {
                 r_hlc[0]->call_authorization_response(types::authorization::AuthorizationStatus::Accepted,
                                                       types::authorization::CertificateStatus::NoCertificateAvailable);
             } else {
-                p_token_provider->publish_provided_token(autocharge_token);
+                if (config.enable_autocharge) {
+                    p_token_provider->publish_provided_token(autocharge_token);
+                }
                 Everest::scoped_lock_timeout lock(hlc_mutex, Everest::MutexDescription::EVSE_publish_provided_token);
                 hlc_waiting_for_auth_eim = true;
                 hlc_waiting_for_auth_pnc = false;

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -79,6 +79,7 @@ struct Conf {
     bool hack_pause_imd_during_precharge;
     bool hack_allow_bpt_with_iso2;
     bool autocharge_use_slac_instead_of_hlc;
+    bool enable_autocharge;
     std::string logfile_suffix;
     double soft_over_current_tolerance_percent;
     double soft_over_current_measurement_noise_A;
@@ -204,7 +205,6 @@ public:
         powersupply_capabilities.max_import_current_A = caps.max_import_current_A;
         powersupply_capabilities.max_import_power_W = caps.max_import_power_W;
     }
-
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -146,6 +146,11 @@ config:
     description: Use slac ev mac address for autocharge instead of EVCCID from HLC
     type: boolean
     default: false
+  enable_autocharge:
+    description: >-
+      Enables Autocharge (i.e. Mac address for authorization). Disabled by default as PnC should be used instead.
+    type: boolean
+    default: false
   logfile_suffix:
     description: Use the string given for the log folder name. Special string session_uuid will be replaced with session uuid.
     type: string


### PR DESCRIPTION
## Describe your changes

Autocharge was always enabled. In PnC setups this can be annoying when PnC fails. This PR introduces a config option to enable/disable auto charge and sets it to disabled by default.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

