### PR TITLE
EvseV2G: Sending the TLS session key over a UDP message

### DIFF
--- a/modules/EvseV2G/connection.hpp
+++ b/modules/EvseV2G/connection.hpp
@@ -12,6 +12,7 @@
 
 int connection_init(struct v2g_context* ctx);
 int connection_start_servers(struct v2g_context* ctx);
+int create_udp_socket(const uint16_t udp_port, const char* interface_name);
 
 /*!
  * \brief connection_read This abstracts a read from the connection socket, so that higher level functions

--- a/modules/EvseV2G/v2g.hpp
+++ b/modules/EvseV2G/v2g.hpp
@@ -166,6 +166,8 @@ typedef struct keylogDebugCtx {
     bool inClientRandom;
     bool inMasterSecret;
     uint8_t hexdumpLinesToProcess;
+    int udp_socket;
+    std::string udp_buffer;
 } keylogDebugCtx;
 
 struct SAE_Bidi_Data {
@@ -203,6 +205,10 @@ struct v2g_context {
 
     int sdp_socket;
     int tcp_socket;
+
+    int udp_port;
+    int udp_socket;
+
     pthread_t tcp_thread;
 
     mbedtls_ssl_config ssl_config;


### PR DESCRIPTION
## Describe your changes

* adds a udp socket to the EvseV2G module that sends the TLS secrets for debugging

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

