### PR TITLE
Updated libocpp and libevse-security dependencies

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -50,13 +50,13 @@ libcurl:
 # and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: 34ced9f4452c2ffe3145f4ff200c42dc83278c47
+  git_tag: 4330ce2e28e25535dd01558edb2331891c146769
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 169573382e4d790103ce008027bb753d5ebd124a
+  git_tag: 6c2cdead9bdc288f6998ca1a5e6292514f3a41c9
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/third-party/bazel/deps_versions.bzl
+++ b/third-party/bazel/deps_versions.bzl
@@ -46,7 +46,7 @@ EVEREST_DEPS = struct(
 
 	# libevse-security
 	libevse_security_repo = "https://github.com/EVerest/libevse-security.git",
-	libevse_security_commit = "34ced9f4452c2ffe3145f4ff200c42dc83278c47",
+	libevse_security_commit = "4330ce2e28e25535dd01558edb2331891c146769",
 	libevse_security_tag = None,
 
 	# libfsm
@@ -61,7 +61,7 @@ EVEREST_DEPS = struct(
 
 	# libocpp
 	libocpp_repo = "https://github.com/EVerest/libocpp.git",
-	libocpp_commit = "169573382e4d790103ce008027bb753d5ebd124a",
+	libocpp_commit = "6c2cdead9bdc288f6998ca1a5e6292514f3a41c9",
 	libocpp_tag = None,
 
 	# libslac


### PR DESCRIPTION
## Describe your changes

Fixes a issue related to certificate chain retrieval, when the certificate_chain is missing and we only have a 'single' certificate.

## Issue ticket number and link

https://github.com/EVerest/libocpp/pull/620
https://github.com/EVerest/libevse-security/pull/73

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

