### PR TITLE
connector inoperative overridden

### DIFF
--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -8,29 +8,21 @@ cmds:
       description: Object that contains information of the EVSE including its connectors
       type: object
       $ref: /evse_manager#/Evse
-  enable:
-    description: Enables the evse. EVSE is available for charging after this operation
+  enable_disable:
+    description: Enables or disables the evse
     arguments:
       connector_id:
         description: Specifies the ID of the connector to enable. If 0, the whole EVSE should be enabled
         type: integer
+      cmd_source:
+        description: Source of the enable command
+        type: object
+        $ref: /evse_manager#/EnableDisableSource
     result:
       description: >-
-        Returns true if evse was enabled (or was enabled before), returns
-        false if enable failed e.g. due to permanent fault.
-      type: boolean
-  disable:
-    description: >-
-      Disables the evse. EVSE is not available for charging after this
-      operation
-    arguments:
-      connector_id:
-        description: Specifies the ID of the connector. If 0, the whole EVSE should be disabled
-        type: integer
-    result:
-      description: >-
-        Returns true if evse was disabled (or was disabled before), returns
-        false if it could not be disabled (i.e. due to communication error with hardware)
+        Returns true if evse is enabled after the command, false if it is disabled.
+        This may not be the same value as the request, since there may be a higher priority request
+        from another source that is actually deciding whether it is enabled or disabled.
       type: boolean
   authorize_response:
     description: >-

--- a/modules/API/API.hpp
+++ b/modules/API/API.hpp
@@ -59,6 +59,8 @@ public:
     void set_latest_energy_export_wh(int32_t latest_export_energy_wh);
     void set_latest_total_w(double latest_total_w);
     void set_uk_random_delay_remaining(const types::uk_random_delay::CountDown& c);
+    void set_enable_disable_source(const std::string& active_source, const std::string& active_state,
+                                   const int active_priority);
 
     /// \brief Converts this struct into a serialized json object
     operator std::string();
@@ -95,6 +97,10 @@ private:
     bool is_state_charging(const SessionInfo::State current_state);
 
     std::string state_to_string(State s);
+
+    std::string active_enable_disable_source{"Unspecified"};
+    std::string active_enable_disable_state{"Enabled"};
+    int active_enable_disable_priority{0};
 };
 } // namespace module
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1

--- a/modules/API/README.md
+++ b/modules/API/README.md
@@ -37,22 +37,28 @@ This variable is published every second and contains the hardware capabilities i
 ### everest_api/evse_manager/var/session_info
 This variable is published every second and contains a json object with information relating to the current charging session in the following format:
 ```json
-    {
-        "charged_energy_wh": 0,
-        "charging_duration_s": 84,
-        "datetime": "2022-10-11T16:48:35.747Z",
-        "discharged_energy_wh": 0,
-        "latest_total_w": 0.0,
-        "state": "Unplugged",
-        "active_permanent_faults": [],
-        "active_errors": [],
-        "uk_random_delay": {
-            "remaining_s": 34,
-            "current_limit_after_delay_A": 16.0,
-            "current_limit_during_delay_A": 0.0,
-            "start_time": "2024-02-28T14:11:11.129Z"
-        }
-    }
+{
+    "charged_energy_wh": 0,
+    "charging_duration_s": 84,
+    "datetime": "2022-10-11T16:48:35.747Z",
+    "discharged_energy_wh": 0,
+    "latest_total_w": 0.0,
+    "state": "Unplugged",
+    "active_permanent_faults": [],
+    "active_errors": [],
+    "active_enable_disable_source": {
+        "source": "Unspecified",
+        "state": "Enable",
+        "priority": 5000
+    },
+    "uk_random_delay": {
+        "remaining_s": 34,
+        "current_limit_after_delay_A": 16.0,
+        "current_limit_during_delay_A": 0.0,
+        "start_time": "2024-02-28T14:11:11.129Z"
+    },
+    "last_enable_disable_source": "Unspecified"
+}
 ```
 
 Example with permanent faults being active:
@@ -77,7 +83,19 @@ Example with permanent faults being active:
   "datetime": "2024-01-15T14:58:15.172Z",
   "discharged_energy_wh": 0,
   "latest_total_w": 0,
-  "state": "Preparing"
+  "state": "Preparing",
+  "active_enable_disable_source": {
+    "source": "Unspecified",
+    "state": "Enable",
+    "priority": 5000
+  },
+  "uk_random_delay": {
+    "remaining_s": 34,
+    "current_limit_after_delay_A": 16.0,
+    "current_limit_during_delay_A": 0.0,
+    "start_time": "2024-02-28T14:11:11.129Z"
+  },
+  "last_enable_disable_source": "Unspecified"
 }
 ```
 
@@ -135,10 +153,13 @@ Example with permanent faults being active:
     - PermanentFault
     - PowermeterTransactionStartFailed
 
-- **active_errors** array of all active errors that do not block charging. This could be shown to the user but the current state should still be shown as it does not interfere with charging. The enum is the same as for active_permanent_faults.
+- **active_errors** array of all active errors that do not block charging.
+This could be shown to the user but the current state should still be shown
+as it does not interfere with charging. The enum is the same as for active_permanent_faults.
 
 ### everest_api/evse_manager/var/limits
-This variable is published every second and contains a json object with information relating to the current limits of this EVSE.
+This variable is published every second and contains a json object with information
+relating to the current limits of this EVSE.
 ```json
     {
         "max_current": 16.0,
@@ -161,7 +182,8 @@ This variable is published every second and contains telemetry of the EVSE.
 ```
 
 ### everest_api/evse_manager/var/powermeter
-This variable is published every second and contains powermeter information of the EVSE.
+This variable is published every second and contains powermeter information
+of the EVSE.
 ```json
     {
         "current_A": {
@@ -201,16 +223,96 @@ This variable is published every second and contains powermeter information of t
 ## Periodically published variables for OCPP
 
 ### everest_api/ocpp/var/connection_status
-This variable is published every second and contains the connection status of the OCPP module.
-If the OCPP module has not yet published its "is_connected" status or no OCPP module is configured "unknown" is published. Otherwise "connected" or "disconnected" are published.
+This variable is published every second and contains the connection
+status of the OCPP module.
+If the OCPP module has not yet published its "is_connected" status or
+no OCPP module is configured "unknown" is published. Otherwise "connected"
+or "disconnected" are published.
 
 
 ## Commands and variables published in response
+### everest_api/evse_manager/cmd/enable_disable
+Command to enable or disable a connector on the EVSE. The payload should be
+the following json:
+
+```json
+    {
+        "connector_id": 0,
+        "source": "LocalAPI",
+        "state": "Enable",
+        "priority": 42
+    }
+```
+connector_id is a positive integer identifying the connector that should be
+enabled. If the connector_id is 0 the whole EVSE is enabled.
+
+The source is an enum of the following source types :
+
+    - Unspecified
+    - LocalAPI
+    - LocalKeyLock
+    - ServiceTechnician
+    - RemoteKeyLock
+    - MobileApp
+    - FirmwareUpdate
+    - CSMS
+
+The state can be either "enable", "disable", or "unassigned".
+
+"enable" and "disable" enforce the state to be enable/disable, while unassigned means
+that the source does not care about the state and other sources may decide.
+
+Each call to this command will update an internal table that looks like this:
+
+| Source       | State      | Priority |
+| ------------ | ---------- | -------- |
+| Unspecified  | unassigned | 10000    |
+| LocalAPI     | disable    | 42       |
+| LocalKeyLock | enable     | 0        |
+
+Evaluation will be done based on priorities. 0 is the highest priority,
+10000 the lowest, so in this example the connector will be enabled regardless
+of what other sources say.
+Imagine LocalKeyLock sends a "unassigned, prio 0", the table will then look like this:
+
+| Source       | State      | Priority |
+| ------------ | ---------- | -------- |
+| Unspecified  | unassigned | 10000    |
+| LocalAPI     | disable    | 42       |
+| LocalKeyLock | unassigned | 0        |
+
+So now the connector will be disabled, because the second highest priority (42) sets it to disabled.
+
+If all sources are unassigned, the connector is enabled.
+If two sources have the same priority, "disabled" has priority over "enabled".
+
 ### everest_api/evse_manager/cmd/enable
-Command to enable a connector on the EVSE. They payload should be a positive integer identifying the connector that should be enabled. If the payload is 0 the whole EVSE is enabled.
+Legacy command to enable a connector on the EVSE kept for compatibility reasons.
+They payload should be a positive integer identifying the connector that should be enabled.
+If the payload is 0 the whole EVSE is enabled.
+It will actually call the following command on everest_api/evse_manager/cmd/enable_enable:
+```json
+    {
+        "connector_id": 1,
+        "source": "LocalAPI",
+        "state": "enable",
+        "priority": 0
+    }
+```
 
 ### everest_api/evse_manager/cmd/disable
-Command to disable a connector on the EVSE. They payload should be a positive integer identifying the connector that should be disabled. If the payload is 0 the whole EVSE is disabled.
+Legacy command to enable a connector on the EVSE kept for compatibility reasons.
+Command to disable a connector on the EVSE. They payload should be a positive integer
+identifying the connector that should be disabled. If the payload is 0 the whole EVSE is disabled.
+It will actually call the following command on everest_api/evse_manager/cmd/enable_disable:
+```json
+    {
+        "connector_id": 1,
+        "source": "LocalAPI",
+        "state": "disable",
+        "priority": 0
+    }
+```
 
 ### everest_api/evse_manager/cmd/pause_charging
 If any arbitrary payload is published to this topic charging will be paused by the EVSE.
@@ -219,7 +321,7 @@ If any arbitrary payload is published to this topic charging will be paused by t
 If any arbitrary payload is published to this topic charging will be paused by the EVSE.
 
 ### everest_api/evse_manager/cmd/set_limit_amps
-Command to set an amps limit for this EVSE that will be considered within the EnergyManager. This does not automatically imply that this limit will be set by the EVSE because the energymanagement might consider limitations from other sources, too. The payload can be a positive or negative number. 
+Command to set an amps limit for this EVSE that will be considered within the EnergyManager. This does not automatically imply that this limit will be set by the EVSE because the energymanagement might consider limitations from other sources, too. The payload can be a positive or negative number.
 
 ### everest_api/evse_manager/cmd/set_limit_watts
 Command to set a watt limit for this EVSE that will be considered within the EnergyManager. This does not automatically imply that this limit will be set by the EVSE because the energymanagement might consider limitations from other sources, too. The payload can be a positive or negative number.

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -1285,31 +1285,131 @@ bool Charger::deauthorize_internal() {
     return false;
 }
 
-bool Charger::disable(int connector_id) {
+bool Charger::enable_disable(int connector_id, const types::evse_manager::EnableDisableSource& source) {
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_disable);
-    if (connector_id not_eq 0) {
-        shared_context.connector_enabled = false;
+
+    // insert the new request into the table
+    bool replaced = false;
+    for (auto& entry : enable_disable_source_table) {
+        if (entry.enable_source == source.enable_source) {
+            // replace this entry as it is an update from the same source
+            entry = source;
+            replaced = true;
+        }
     }
-    shared_context.current_state = EvseState::Disabled;
-    signal_simple_event(types::evse_manager::SessionEventEnum::Disabled);
-    return true;
+
+    if (not replaced) {
+        // Add to the table
+        enable_disable_source_table.push_back(source);
+    }
+
+    // Find out if we are actually enabled or disabled at the moment
+    bool is_enabled = parse_enable_disable_source_table();
+
+    if (is_enabled) {
+        if (connector_id not_eq 0) {
+            shared_context.connector_enabled = true;
+        }
+
+        signal_simple_event(types::evse_manager::SessionEventEnum::Enabled);
+        if (shared_context.current_state == EvseState::Disabled) {
+            if (shared_context.connector_enabled) {
+                shared_context.current_state = EvseState::Idle;
+            }
+            return true;
+        }
+    } else {
+        if (connector_id not_eq 0) {
+            shared_context.connector_enabled = false;
+        }
+        shared_context.current_state = EvseState::Disabled;
+        signal_simple_event(types::evse_manager::SessionEventEnum::Disabled);
+    }
+    return is_enabled;
 }
 
-bool Charger::enable(int connector_id) {
-    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_enable);
+bool Charger::parse_enable_disable_source_table() {
+    /* Decide if we are enabled or disabled from the current table.
+     The logic is as follows:
 
-    if (connector_id not_eq 0) {
-        shared_context.connector_enabled = true;
-    }
+     The source is an enum of the following source types :
 
-    signal_simple_event(types::evse_manager::SessionEventEnum::Enabled);
-    if (shared_context.current_state == EvseState::Disabled) {
-        if (shared_context.connector_enabled) {
-            shared_context.current_state = EvseState::Idle;
+        - Unspecified
+        - LocalAPI
+        - LocalKeyLock
+        - ServiceTechnician
+        - RemoteKeyLock
+        - MobileApp
+        - FirmwareUpdate
+        - CSMS
+
+    The state can be either "enable", "disable", or "unassigned".
+
+    "enable" and "disable" enforce the state to be enable/disable, while unassigned means that the source does not care
+    about the state and other sources may decide.
+
+    Each call to this command will update an internal table that looks like this:
+
+    | Source       | State         | Priority |
+    | ------------ | ------------- | -------- |
+    | Unspecified  | unassigned    |   10000  |
+    | LocalAPI     | disable       |      42  |
+    | LocalKeyLock | enable        |       0  |
+
+    Evaluation will be done based on priorities. 0 is the highest priority, 10000 the lowest, so in this example the
+    connector will be enabled regardless of what other sources say. Imagine LocalKeyLock sends a "unassigned, prio 0",
+    the table will then look like this:
+
+    | Source       | State         | Priority |
+    | ------------ | ------------- | -------- |
+    | Unspecified  | unassigned    |   10000  |
+    | LocalAPI     | disable       |      42  |
+    | LocalKeyLock | unassigned    |       0  |
+
+    So now the connector will be disabled, because the second highest priority (42) sets it to disabled.
+
+    If all sources are unassigned, the connector is enabled.
+    If two sources have the same priority, "disabled" has priority over "enabled".
+    */
+
+    bool is_enabled = true; // By default, it is enabled.
+    types::evse_manager::EnableDisableSource winning_source{types::evse_manager::Enable_source::Unspecified,
+                                                            types::evse_manager::Enable_state::Unassigned, 10000};
+
+    // Walk through table
+    for (const auto& entry : enable_disable_source_table) {
+        // Ignore unassigned entries
+        if (entry.enable_state == types::evse_manager::Enable_state::Unassigned) {
+            continue;
         }
-        return true;
+
+        if (winning_source.enable_state == types::evse_manager::Enable_state::Unassigned) {
+            // Use the first entry that is not Unassigned
+            winning_source = entry;
+            if (entry.enable_state == types::evse_manager::Enable_state::Disable) {
+                is_enabled = false;
+            } else {
+                is_enabled = true;
+            }
+        } else if (entry.enable_priority == winning_source.enable_priority) {
+            // At the same priority, disable has higher priority then enable
+            if (entry.enable_state == types::evse_manager::Enable_state::Disable) {
+                is_enabled = false;
+                winning_source = entry;
+            }
+
+        } else if (entry.enable_priority < winning_source.enable_priority) {
+            winning_source = entry;
+            if (entry.enable_state == types::evse_manager::Enable_state::Disable) {
+                is_enabled = false;
+            } else {
+                is_enabled = true;
+            }
+        }
     }
-    return false;
+
+    active_enable_disable_source = winning_source;
+    return is_enabled;
 }
 
 void Charger::set_faulted() {
@@ -1642,6 +1742,10 @@ void Charger::clear_errors_on_unplug() {
     error_handling->clear_overcurrent_error();
     error_handling->clear_internal_error();
     error_handling->clear_powermeter_transaction_start_failed_error();
+}
+
+types::evse_manager::EnableDisableSource Charger::get_last_enable_disable_source() {
+    return active_enable_disable_source;
 }
 
 } // namespace module

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -181,6 +181,9 @@ void Charger::run_state_machine() {
         auto time_in_current_state =
             std::chrono::duration_cast<std::chrono::milliseconds>(now - internal_context.current_state_started).count();
 
+        // std::cout << "Charger::run_state_machine: " << evse_state_to_string(shared_context.current_state) <<
+        // std::endl;
+
         switch (shared_context.current_state) {
         case EvseState::Disabled:
             if (initialize_state) {
@@ -762,7 +765,10 @@ void Charger::process_event(CPEvent cp_event) {
     run_state_machine();
 
     // Process all event actions that are independent of the current state
-    process_cp_events_independent(cp_event);
+    // except when disabled
+    if (shared_context.current_state != EvseState::Disabled) {
+        process_cp_events_independent(cp_event);
+    }
 
     run_state_machine();
 

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -101,8 +101,7 @@ public:
                bool ac_hlc_enabled, bool ac_hlc_use_5percent, bool ac_enforce_hlc, bool ac_with_soc_timeout,
                float soft_over_current_tolerance_percent, float soft_over_current_measurement_noise_A);
 
-    bool enable(int connector_id);
-    bool disable(int connector_id);
+    bool enable_disable(int connector_id, const types::evse_manager::EnableDisableSource& source);
 
     void set_faulted();
     void set_hlc_error();
@@ -198,6 +197,8 @@ public:
     /// The data is generated when stopping the transaction. The call resets the
     /// internal variable and is thus not idempotent.
     std::optional<types::units_signed::SignedMeterValue> get_stop_signed_meter_value();
+
+    types::evse_manager::EnableDisableSource get_last_enable_disable_source();
 
 private:
     std::optional<types::units_signed::SignedMeterValue>
@@ -366,6 +367,11 @@ private:
     // 4 seconds according to table 3 of ISO15118-3
     static constexpr int T_STEP_EF = 4000;
     static constexpr int SOFT_OVER_CURRENT_TIMEOUT = 7000;
+
+    types::evse_manager::EnableDisableSource active_enable_disable_source{
+        types::evse_manager::Enable_source::Unspecified, types::evse_manager::Enable_state::Unassigned, 10000};
+    std::vector<types::evse_manager::EnableDisableSource> enable_disable_source_table;
+    bool parse_enable_disable_source_table();
 };
 
 } // namespace module

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -885,7 +885,8 @@ void EvseManager::ready() {
 void EvseManager::ready_to_start_charging() {
     timepoint_ready_for_charging = std::chrono::steady_clock::now();
     charger->run();
-    charger->enable(0);
+    charger->enable_disable(
+        0, {types::evse_manager::Enable_source::Unspecified, types::evse_manager::Enable_state::Enable, 10000});
 
     this->p_evse->publish_ready(true);
     EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -37,10 +37,16 @@ void evse_managerImpl::init() {
         [&charger = mod->charger, this](std::string data) { mod->updateLocalMaxWattLimit(std::stof(data)); });
 
     mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/enable", mod->config.connector_id),
-                        [&charger = mod->charger](const std::string& data) { charger->enable(0); });
+                        [&charger = mod->charger](const std::string& data) {
+                            charger->enable_disable(0, {types::evse_manager::Enable_source::LocalAPI,
+                                                        types::evse_manager::Enable_state::Enable, 100});
+                        });
 
     mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/disable", mod->config.connector_id),
-                        [&charger = mod->charger](const std::string& data) { charger->disable(0); });
+                        [&charger = mod->charger](const std::string& data) {
+                            charger->enable_disable(0, {types::evse_manager::Enable_source::LocalAPI,
+                                                        types::evse_manager::Enable_state::Disable, 100});
+                        });
 
     mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/faulted", mod->config.connector_id),
                         [&charger = mod->charger](const std::string& data) { charger->set_faulted(); });
@@ -310,6 +316,9 @@ void evse_managerImpl::ready() {
             types::evse_manager::AuthorizationEvent authorization_event;
             authorization_event.meter_value = mod->get_latest_powermeter_data_billing();
             se.authorization_event = authorization_event;
+
+            // Add source information (Who initiated this state change)
+            se.source = mod->charger->get_last_enable_disable_source();
         }
 
         se.uuid = session_uuid;
@@ -354,9 +363,9 @@ types::evse_manager::Evse evse_managerImpl::handle_get_evse() {
     return evse;
 }
 
-bool evse_managerImpl::handle_enable(int& connector_id) {
+bool evse_managerImpl::handle_enable_disable(int& connector_id, types::evse_manager::EnableDisableSource& cmd_source) {
     connector_status_changed = connector_id != 0;
-    return mod->charger->enable(connector_id);
+    return mod->charger->enable_disable(connector_id, cmd_source);
 };
 
 void evse_managerImpl::handle_authorize_response(types::authorization::ProvidedIdToken& provided_token,
@@ -392,11 +401,6 @@ bool evse_managerImpl::handle_reserve(int& reservation_id) {
 
 void evse_managerImpl::handle_cancel_reservation() {
     mod->cancel_reservation(true);
-};
-
-bool evse_managerImpl::handle_disable(int& connector_id) {
-    connector_status_changed = connector_id != 0;
-    return mod->charger->disable(connector_id);
 };
 
 void evse_managerImpl::handle_set_faulted() {

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -304,6 +304,9 @@ void evse_managerImpl::ready() {
             if (connector_status_changed) {
                 se.connector_id = 1;
             }
+
+            // Add source information (Who initiated this state change)
+            se.source = mod->charger->get_last_enable_disable_source();
         } else if (e == types::evse_manager::SessionEventEnum::ChargingPausedEV or
                    e == types::evse_manager::SessionEventEnum::ChargingPausedEVSE or
                    e == types::evse_manager::SessionEventEnum::ChargingStarted or
@@ -316,9 +319,6 @@ void evse_managerImpl::ready() {
             types::evse_manager::AuthorizationEvent authorization_event;
             authorization_event.meter_value = mod->get_latest_powermeter_data_billing();
             se.authorization_event = authorization_event;
-
-            // Add source information (Who initiated this state change)
-            se.source = mod->charger->get_last_enable_disable_source();
         }
 
         se.uuid = session_uuid;

--- a/modules/EvseManager/evse/evse_managerImpl.hpp
+++ b/modules/EvseManager/evse/evse_managerImpl.hpp
@@ -35,8 +35,8 @@ public:
 protected:
     // command handler functions (virtual)
     virtual types::evse_manager::Evse handle_get_evse() override;
-    virtual bool handle_enable(int& connector_id) override;
-    virtual bool handle_disable(int& connector_id) override;
+    virtual bool handle_enable_disable(int& connector_id,
+                                       types::evse_manager::EnableDisableSource& cmd_source) override;
     virtual void handle_authorize_response(types::authorization::ProvidedIdToken& provided_token,
                                            types::authorization::ValidationResult& validation_result) override;
     virtual void handle_withdraw_authorization() override;

--- a/modules/EvseManager/tests/EvseManagerStub.hpp
+++ b/modules/EvseManager/tests/EvseManagerStub.hpp
@@ -26,6 +26,9 @@ struct evse_managerImplStub : public evse_managerImplBase {
     virtual bool handle_disable(int& connector_id) {
         return true;
     }
+    virtual bool handle_enable_disable(int& connector_id, types::evse_manager::EnableDisableSource& cmd_source) {
+        return true;
+    }
     virtual void handle_authorize_response(types::authorization::ProvidedIdToken& provided_token,
                                            types::authorization::ValidationResult& validation_result) {
     }

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -80,6 +80,7 @@ static ErrorInfo get_error_info(const std::optional<types::evse_manager::Error> 
     case types::evse_manager::ErrorEnum::EnergyManagement:
     case types::evse_manager::ErrorEnum::PermanentFault:
     case types::evse_manager::ErrorEnum::PowermeterTransactionStartFailed:
+    default:
         return {ocpp::v16::ChargePointErrorCode::InternalError, types::evse_manager::error_enum_to_string(error_code)};
     }
 
@@ -627,7 +628,9 @@ void OCPP::ready() {
 
     this->charge_point->register_disable_evse_callback([this](int32_t connector) {
         if (this->connector_evse_index_map.count(connector)) {
-            return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))->call_disable(0);
+            return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))
+                ->call_enable_disable(
+                    0, {types::evse_manager::Enable_source::CSMS, types::evse_manager::Enable_state::Disable, 5000});
         } else {
             return false;
         }
@@ -635,7 +638,9 @@ void OCPP::ready() {
 
     this->charge_point->register_enable_evse_callback([this](int32_t connector) {
         if (this->connector_evse_index_map.count(connector)) {
-            return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))->call_enable(0);
+            return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))
+                ->call_enable_disable(
+                    0, {types::evse_manager::Enable_source::CSMS, types::evse_manager::Enable_state::Enable, 5000});
         } else {
             return false;
         }

--- a/modules/OCPP/README.md
+++ b/modules/OCPP/README.md
@@ -1,0 +1,7 @@
+# Interaction with EVSE Manager
+
+This module sets callbacks into libocpp to receive `ChangeAvailability.req` updates from the CSMS.
+
+These are sent to the EVSE Manager in `enable_disable` commands with a priority of 5000. ('types/energy_manager.yaml' contains the valid range.)
+
+5000 is mid-range.

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -265,11 +265,15 @@ void OCPP201::ready() {
     callbacks.connector_effective_operative_status_changed_callback =
         [this](const int32_t evse_id, const int32_t connector_id, const ocpp::v201::OperationalStatusEnum new_status) {
             if (new_status == ocpp::v201::OperationalStatusEnum::Operative) {
-                if (this->r_evse_manager.at(evse_id - 1)->call_enable(connector_id)) {
+                if (this->r_evse_manager.at(evse_id - 1)
+                        ->call_enable_disable(connector_id, {types::evse_manager::Enable_source::CSMS,
+                                                             types::evse_manager::Enable_state::Enable, 5000})) {
                     this->charge_point->on_enabled(evse_id, connector_id);
                 }
             } else {
-                if (this->r_evse_manager.at(evse_id - 1)->call_disable(connector_id)) {
+                if (this->r_evse_manager.at(evse_id - 1)
+                        ->call_enable_disable(connector_id, {types::evse_manager::Enable_source::CSMS,
+                                                             types::evse_manager::Enable_state::Disable, 5000})) {
                     this->charge_point->on_unavailable(evse_id, connector_id);
                 }
             }

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -345,7 +345,7 @@ types:
         - MobileApp
         - FirmwareUpdate
         - CSMS
-      enable_state: 
+      enable_state:
         description: Specifies the state for this entry
         type: string
         enum:
@@ -377,7 +377,7 @@ types:
         format: date-time
       connector_id:
         description: >-
-          Id of the connector of this EVSE. 
+          Id of the connector of this EVSE.
           If the connector_id is not specified, its assumed to be 1
         type: integer
       event:
@@ -406,13 +406,13 @@ types:
         $ref: /evse_manager#/TransactionFinished
       charging_state_changed_event:
         description: >-
-          Data for ChargingStateChangedEvent. Shall be set for the following SessionEventEnums: 
+          Data for ChargingStateChangedEvent. Shall be set for the following SessionEventEnums:
           ChargingStarted, ChargingResumed, ChargingPausedEV, Charging
         type: object
         $ref: /evse_manager#/ChargingStateChangedEvent
       authorization_event:
         description: >-
-          Data for Authorization event. Shall be set for the following SessionEventEnums: 
+          Data for Authorization event. Shall be set for the following SessionEventEnums:
           Authorized, Deauthorized
         type: object
         $ref: /evse_manager#/AuthorizationEvent

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -324,6 +324,39 @@ types:
       vendor_error:
         description: The error code of the vendor
         type: string
+  EnableDisableSource:
+    description: >-
+      Source of a Enable or Disable command/event
+    type: object
+    required:
+      - enable_source
+      - enable_state
+      - enable_priority
+    properties:
+      enable_source:
+        description: Specifies the source
+        type: string
+        enum:
+        - Unspecified
+        - LocalAPI
+        - LocalKeyLock
+        - ServiceTechnician
+        - RemoteKeyLock
+        - MobileApp
+        - FirmwareUpdate
+        - CSMS
+      enable_state: 
+        description: Specifies the state for this entry
+        type: string
+        enum:
+        - Unassigned
+        - Disable
+        - Enable
+      enable_priority:
+        description: Priority of this entry. The highest priority is 0.
+        type: integer
+        minimum: 0
+        maximum: 10000
   SessionEvent:
     description: Emits all events related to sessions
     type: object
@@ -387,6 +420,11 @@ types:
         description: Details on error type
         type: object
         $ref: /evse_manager#/Error
+      source:
+        description: >-
+          Additional data for Enabled/Disabled events. Specifies the source of the command that changed the state.
+        type: object
+        $ref: /evse_manager#/EnableDisableSource
   Limits:
     description: Limits of this EVSE
     type: object


### PR DESCRIPTION
## Describe your changes

When OCPP ChangeConfiguration to Inoperative is set this is overridden on EVerest restart.
In addition some actions on the CP line were causing the state to leave DISABLED.

This work is based upon:
https://github.com/EVerest/everest-core/pull/505

This changed is linked with 
https://github.com/EVerest/libocpp/pull/623

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

