### PR TITLE
Auth: Notify Evse also when authorization is rejected

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -224,6 +224,10 @@ void ISO15118_chargerImpl::handle_authorization_response(
     } else if (v2g_ctx->session.iso_selected_payment_option == iso1paymentOptionType_Contract) {
         v2g_ctx->session.certificate_status = certificate_status;
         v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = (uint8_t)iso1EVSEProcessingType_Finished;
+
+        if (authorization_status != types::authorization::AuthorizationStatus::Accepted) {
+            v2g_ctx->session.authorization_rejected = true;
+        }
     }
 }
 

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -223,13 +223,7 @@ void ISO15118_chargerImpl::handle_authorization_response(
         }
     } else if (v2g_ctx->session.iso_selected_payment_option == iso1paymentOptionType_Contract) {
         v2g_ctx->session.certificate_status = certificate_status;
-
-        if (authorization_status == types::authorization::AuthorizationStatus::Accepted &&
-            certificate_status == types::authorization::CertificateStatus::Accepted) {
-            v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = (uint8_t)iso1EVSEProcessingType_Finished;
-        } else {
-            v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = (uint8_t)iso1EVSEProcessingType_Ongoing;
-        }
+        v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = (uint8_t)iso1EVSEProcessingType_Finished;
     }
 }
 

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -1389,6 +1389,8 @@ static enum v2g_event handle_iso_authorization(struct v2g_connection* conn) {
             conn->ctx->session.auth_start_timeout = getmonotonictime();
             res->ResponseCode = iso1responseCodeType_FAILED;
         }
+    } else if (conn->ctx->session.authorization_rejected == true) {
+        res->ResponseCode = iso1responseCodeType_FAILED;
     }
 
 error_out:

--- a/modules/EvseV2G/v2g.hpp
+++ b/modules/EvseV2G/v2g.hpp
@@ -323,6 +323,7 @@ struct v2g_context {
         uint8_t gen_challenge[16];                                  // for PnC
         bool verify_contract_cert_chain;                            // for PnC
         types::authorization::CertificateStatus certificate_status; // for PnC
+        bool authorization_rejected;                                // for PnC
 
         struct {
             bool valid_crt;

--- a/modules/EvseV2G/v2g_ctx.cpp
+++ b/modules/EvseV2G/v2g_ctx.cpp
@@ -284,6 +284,8 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     }
     memset(ctx->session.gen_challenge, 0, sizeof(ctx->session.gen_challenge));
 
+    ctx->session.authorization_rejected = false;
+
     initialize_once = true;
 }
 


### PR DESCRIPTION
## Describe your changes
Extended Auth module so that it notifies the Evse also in case a token was rejected. This is especially required to allow the ISO15118 state machine to escape the authorize loop when a Plug&Charge authorization was rejected.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

