### PR TITLE
Removed enabling of EVSE on startup

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -888,7 +888,8 @@ void EvseManager::ready_to_start_charging() {
     timepoint_ready_for_charging = std::chrono::steady_clock::now();
     charger->run();
 
-    // this will publish a session event Enabled or Disabled that allows other modules the retrieve this state on startup
+    // this will publish a session event Enabled or Disabled that allows other modules the retrieve this state on
+    // startup
     if (this->charger->get_current_state() == Charger::EvseState::Disabled) {
         this->charger->disable(0);
     } else {

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -887,7 +887,6 @@ void EvseManager::ready() {
 void EvseManager::ready_to_start_charging() {
     timepoint_ready_for_charging = std::chrono::steady_clock::now();
     charger->run();
-    charger->enable(0);
 
     this->p_evse->publish_ready(true);
     EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -888,6 +888,13 @@ void EvseManager::ready_to_start_charging() {
     timepoint_ready_for_charging = std::chrono::steady_clock::now();
     charger->run();
 
+    // this will publish a session event Enabled or Disabled that allows other modules the retrieve this state on startup
+    if (this->charger->get_current_state() == Charger::EvseState::Disabled) {
+        this->charger->disable(0);
+    } else {
+        this->charger->enable(0);
+    }
+
     this->p_evse->publish_ready(true);
     EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
 }


### PR DESCRIPTION
## Describe your changes
Removed automatic enabling of evse on startup.

This change is required because otherwise a previously communicated Inoperative state could be overriden. The charger is enabled by default, so there is no reason the call enable on startup.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

