### PR TITLE
Fix modbus error response handling

### DIFF
--- a/modules/SerialCommHub/tiny_modbus_rtu.cpp
+++ b/modules/SerialCommHub/tiny_modbus_rtu.cpp
@@ -142,7 +142,7 @@ static std::vector<uint16_t> decode_reply(const uint8_t* buf, int len, uint8_t e
         return result;
     } else {
         // handle exception message
-        uint8_t err_code = buf[RES_RX_START_OF_PAYLOAD];
+        uint8_t err_code = buf[RES_EXCEPTION_CODE];
         switch (err_code) {
         case 0x01:
             EVLOG_error << "Modbus exception: Illegal function";

--- a/modules/SerialCommHub/tiny_modbus_rtu.hpp
+++ b/modules/SerialCommHub/tiny_modbus_rtu.hpp
@@ -28,6 +28,7 @@ constexpr int REQ_TX_MULTIPLE_REG_BYTE_COUNT_POS = 0x06;
 constexpr int RES_RX_LEN_POS = 0x02;
 constexpr int RES_RX_START_OF_PAYLOAD = 0x03;
 constexpr int RES_TX_START_OF_PAYLOAD = 0x02;
+constexpr int RES_EXCEPTION_CODE = 0x02;
 
 constexpr int MODBUS_MAX_REPLY_SIZE = 255 + 6;
 constexpr int MODBUS_MIN_REPLY_SIZE = 5;


### PR DESCRIPTION
## Describe your changes
Fixed incorrect modbus error handling.
Up to now the wrong index was taken to get the exception code out of the response buffer. 
This pull request will fix it.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

