### PR TITLE
Add timeout to token validation status

### DIFF
--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -80,7 +80,7 @@ TokenHandlingResult AuthHandler::on_token(const ProvidedIdToken& provided_token)
     case TokenHandlingResult::ALREADY_IN_PROCESS:
         break;
     case TokenHandlingResult::TIMEOUT:  // Timeout means accepted but failed to pick contactor
-        this->publish_token_validation_status_callback(provided_token, TokenValidationStatus::TokenTimedOut);
+        this->publish_token_validation_status_callback(provided_token, TokenValidationStatus::TimedOut);
         break;
     case TokenHandlingResult::ACCEPTED: // Handled in handle_token internally
         break;

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -79,6 +79,8 @@ TokenHandlingResult AuthHandler::on_token(const ProvidedIdToken& provided_token)
     switch (result) {
     case TokenHandlingResult::ALREADY_IN_PROCESS:
     case TokenHandlingResult::TIMEOUT:  // Timeout means accepted but failed to pick contactor
+        this->publish_token_validation_status_callback(provided_token, TokenValidationStatus::TokenTimedOut);
+        break;
     case TokenHandlingResult::ACCEPTED: // Handled in handle_token internally
         break;
     case TokenHandlingResult::NO_CONNECTOR_AVAILABLE:
@@ -201,8 +203,6 @@ TokenHandlingResult AuthHandler::handle_token(const ProvidedIdToken& provided_to
                     EVLOG_info << "parent_id_token of validation result is equal to master_pass_group_id. Not allowed "
                                   "to authorize "
                                   "this token for starting transactions!";
-                    this->publish_token_validation_status_callback(
-                        provided_token, types::authorization::TokenValidationStatus::Rejected);
                     return TokenHandlingResult::REJECTED;
                 }
 

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -79,7 +79,7 @@ TokenHandlingResult AuthHandler::on_token(const ProvidedIdToken& provided_token)
     switch (result) {
     case TokenHandlingResult::ALREADY_IN_PROCESS:
         break;
-    case TokenHandlingResult::TIMEOUT:  // Timeout means accepted but failed to pick contactor
+    case TokenHandlingResult::TIMEOUT: // Timeout means accepted but failed to pick contactor
         this->publish_token_validation_status_callback(provided_token, TokenValidationStatus::TimedOut);
         break;
     case TokenHandlingResult::ACCEPTED: // Handled in handle_token internally

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -78,6 +78,7 @@ TokenHandlingResult AuthHandler::on_token(const ProvidedIdToken& provided_token)
 
     switch (result) {
     case TokenHandlingResult::ALREADY_IN_PROCESS:
+        break;
     case TokenHandlingResult::TIMEOUT:  // Timeout means accepted but failed to pick contactor
         this->publish_token_validation_status_callback(provided_token, TokenValidationStatus::TokenTimedOut);
         break;

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -1217,7 +1217,7 @@ TEST_F(AuthTest, test_token_timed_out) {
     ProvidedIdToken provided_token = get_provided_token(VALID_TOKEN_1, connectors);
 
     EXPECT_CALL(mock_publish_token_validation_status_callback,
-            Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Processing));
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Processing));
     EXPECT_CALL(mock_publish_token_validation_status_callback,
                 Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Accepted));
     EXPECT_CALL(mock_publish_token_validation_status_callback,

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -1206,7 +1206,7 @@ TEST_F(AuthTest, test_master_pass_group_id) {
     ASSERT_FALSE(this->auth_receiver->get_authorization(1));
 }
 
-/// \brief Test TokenTimedOut is published when authorization was provided but transaction has not yet been started.
+/// \brief Test TokenTimedOut is published when authorization was provided but transaction has never been started.
 TEST_F(AuthTest, test_token_timed_out) {
     // In order to time-out waiting for a plug-in event, we need to get select_connector to wait for a plug-in event
     // in the first place.

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -260,7 +260,7 @@ TEST_F(AuthTest, test_swipe_multiple_times_with_timeout) {
                 Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Accepted))
         .Times(2);
     EXPECT_CALL(mock_publish_token_validation_status_callback,
-                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::TokenTimedOut))
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::TimedOut))
         .Times(1);
 
     TokenHandlingResult result1;
@@ -954,7 +954,7 @@ TEST_F(AuthTest, test_authorization_timeout_and_reswipe) {
                 Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Accepted))
         .Times(2);
     EXPECT_CALL(mock_publish_token_validation_status_callback,
-                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::TokenTimedOut))
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::TimedOut))
         .Times(1);
 
     TokenHandlingResult result;
@@ -1206,7 +1206,7 @@ TEST_F(AuthTest, test_master_pass_group_id) {
     ASSERT_FALSE(this->auth_receiver->get_authorization(1));
 }
 
-/// \brief Test TokenTimedOut is published when authorization was provided but transaction has never been started.
+/// \brief Test TimedOut is published when authorization was provided but transaction has never been started.
 TEST_F(AuthTest, test_token_timed_out) {
     // In order to time-out waiting for a plug-in event, we need to get select_connector to wait for a plug-in event
     // in the first place.
@@ -1221,7 +1221,7 @@ TEST_F(AuthTest, test_token_timed_out) {
     EXPECT_CALL(mock_publish_token_validation_status_callback,
                 Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Accepted));
     EXPECT_CALL(mock_publish_token_validation_status_callback,
-                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::TokenTimedOut));
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::TimedOut));
 
     TokenHandlingResult result;
     std::thread t1([this, provided_token, &result]() { result = this->auth_handler->on_token(provided_token); });
@@ -1229,7 +1229,7 @@ TEST_F(AuthTest, test_token_timed_out) {
 
     ASSERT_TRUE(result == TokenHandlingResult::TIMEOUT);
 
-    // wait for timeout, after which TokenTimedOut should be published.
+    // wait for timeout, after which TimedOut should be published.
     std::this_thread::sleep_for(std::chrono::seconds(CONNECTION_TIMEOUT + 1));
 }
 

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -32,6 +32,7 @@ types:
       - Processing
       - Accepted
       - Rejected
+      - TokenTimedOut
   CustomIdToken:
     description: Type for a custom id token with a free-form type
     type: object

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -32,7 +32,8 @@ types:
       - Processing
       - Accepted
       - Rejected
-      - TokenTimedOut
+      # Occurs when the token has been authorized but no connector is selected within connection_timeout seconds
+      - TimedOut
   CustomIdToken:
     description: Type for a custom id token with a free-form type
     type: object


### PR DESCRIPTION
## Describe your changes
The Auth module previously never published an indication for a validated token timing out due to no connector being connected within the timeout. I added this status (TokenTimedOut), and published it in the appropriate place in the logic.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

