### PR TITLE
Fix incorrect sentinel value in YetiDriver

### DIFF
--- a/modules/YetiDriver/board_support/evse_board_supportImpl.cpp
+++ b/modules/YetiDriver/board_support/evse_board_supportImpl.cpp
@@ -146,7 +146,7 @@ void evse_board_supportImpl::wait_for_caps() {
             break;
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    if (i == 49) {
+    if (i == 50) {
         EVLOG_AND_THROW(
             Everest::EverestTimeoutError("Did not receive hardware capabilities from Yeti hardware, exiting."));
     }


### PR DESCRIPTION
## Describe your changes
The sentinel value used in `wait_for_caps()` to determine if the for loop reaches the end without breaking before is incorrect. The for loop exits when `i` reaches 50, not 49.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

