### PR TITLE
Rename UINT32_MAX as it collides with definition in /usr/include/stdi…

### DIFF
--- a/modules/EvseV2G/v2g_server.cpp
+++ b/modules/EvseV2G/v2g_server.cpp
@@ -25,7 +25,6 @@
 #include "v2g_server.hpp"
 
 #define MAX_RES_TIME 98
-#define UINT32_MAX   0xFFFFFFFF
 
 static types::iso15118_charger::V2G_Message_ID get_V2G_Message_ID(enum V2gMsgTypeId v2g_msg,
                                                                   enum v2g_protocol selected_protocol, bool is_req) {


### PR DESCRIPTION
…nt.h

UINT32_MAX is already defined in a system header

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

