### PR TITLE
Setting the correct EvseStatusCode during cable check

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -419,8 +419,16 @@ void ISO15118_chargerImpl::handle_send_error(types::iso15118_charger::EvseError&
 
 void ISO15118_chargerImpl::handle_reset_error() {
     v2g_ctx->evse_v2g_data.rcd = 0;
-    memset(v2g_ctx->evse_v2g_data.evse_status_code, (int)iso1DC_EVSEStatusCodeType_EVSE_Ready,
-           sizeof(v2g_ctx->evse_v2g_data.evse_status_code));
+
+    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_INIT] = iso1DC_EVSEStatusCodeType_EVSE_NotReady;
+    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_AUTH] = iso1DC_EVSEStatusCodeType_EVSE_NotReady;
+    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_PARAMETER] = iso1DC_EVSEStatusCodeType_EVSE_Ready; // [V2G-DC-453]
+    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_ISOLATION] = iso1DC_EVSEStatusCodeType_EVSE_IsolationMonitoringActive;
+    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_PRECHARGE] = iso1DC_EVSEStatusCodeType_EVSE_Ready;
+    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE] = iso1DC_EVSEStatusCodeType_EVSE_Ready;
+    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_WELDING] = iso1DC_EVSEStatusCodeType_EVSE_NotReady;
+    v2g_ctx->evse_v2g_data.evse_status_code[PHASE_STOP] = iso1DC_EVSEStatusCodeType_EVSE_NotReady;
+
     // Todo(sl): check if emergency should be cleared here?
 }
 

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -2004,9 +2004,14 @@ static enum v2g_event handle_iso_cable_check(struct v2g_connection* conn) {
     res->DC_EVSEStatus.EVSEIsolationStatus = (iso1isolationLevelType)conn->ctx->evse_v2g_data.evse_isolation_status;
     res->DC_EVSEStatus.EVSEIsolationStatus_isUsed = conn->ctx->evse_v2g_data.evse_isolation_status_is_used;
     res->DC_EVSEStatus.EVSENotification = (iso1EVSENotificationType)conn->ctx->evse_v2g_data.evse_notification;
-    res->DC_EVSEStatus.EVSEStatusCode = get_emergency_status_code(conn->ctx, PHASE_ISOLATION);
     res->DC_EVSEStatus.NotificationMaxDelay = (uint16_t)conn->ctx->evse_v2g_data.notification_max_delay;
     res->EVSEProcessing = (iso1EVSEProcessingType)conn->ctx->evse_v2g_data.evse_processing[PHASE_ISOLATION];
+
+    if (conn->ctx->intl_emergency_shutdown == false && res->EVSEProcessing == dinEVSEProcessingType_Finished) {
+        res->DC_EVSEStatus.EVSEStatusCode = iso1DC_EVSEStatusCodeType_EVSE_Ready;
+    } else {
+        res->DC_EVSEStatus.EVSEStatusCode = get_emergency_status_code(conn->ctx, PHASE_ISOLATION);
+    }
 
     /* Check the current response code and check if no external error has occurred */
     next_event = (v2g_event)iso_validate_response_code(&res->ResponseCode, conn);

--- a/modules/EvseV2G/v2g_ctx.cpp
+++ b/modules/EvseV2G/v2g_ctx.cpp
@@ -149,10 +149,14 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     ctx->evse_v2g_data.evse_isolation_status = (uint8_t)iso1isolationLevelType_Invalid;
     ctx->evse_v2g_data.evse_isolation_status_is_used = (unsigned int)1; // Shall be used in DIN
     ctx->evse_v2g_data.evse_notification = (uint8_t)0;
+    ctx->evse_v2g_data.evse_status_code[PHASE_INIT] = iso1DC_EVSEStatusCodeType_EVSE_NotReady;
+    ctx->evse_v2g_data.evse_status_code[PHASE_AUTH] = iso1DC_EVSEStatusCodeType_EVSE_NotReady;
     ctx->evse_v2g_data.evse_status_code[PHASE_PARAMETER] = iso1DC_EVSEStatusCodeType_EVSE_Ready; // [V2G-DC-453]
-    ctx->evse_v2g_data.evse_status_code[PHASE_ISOLATION] = iso1DC_EVSEStatusCodeType_EVSE_Ready;
+    ctx->evse_v2g_data.evse_status_code[PHASE_ISOLATION] = iso1DC_EVSEStatusCodeType_EVSE_IsolationMonitoringActive;
     ctx->evse_v2g_data.evse_status_code[PHASE_PRECHARGE] = iso1DC_EVSEStatusCodeType_EVSE_Ready;
     ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE] = iso1DC_EVSEStatusCodeType_EVSE_Ready;
+    ctx->evse_v2g_data.evse_status_code[PHASE_WELDING] = iso1DC_EVSEStatusCodeType_EVSE_NotReady;
+    ctx->evse_v2g_data.evse_status_code[PHASE_STOP] = iso1DC_EVSEStatusCodeType_EVSE_NotReady;
     memset(ctx->evse_v2g_data.evse_processing, iso1EVSEProcessingType_Ongoing, PHASE_LENGTH);
     ctx->evse_v2g_data.evse_processing[PHASE_PARAMETER] = iso1EVSEProcessingType_Finished; // Skip parameter phase
 


### PR DESCRIPTION
## Describe your changes
Setting the correct EvseStatusCode (EVSE_IsolationMonitoringActive) during cable check

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

