### PR TITLE
Fix IEC state F

### DIFF
--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -294,7 +294,6 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
             timer = TimerControl::stop;
             call_allow_power_on_bsp(false);
             pwm_running = false;
-            r_bsp->call_pwm_off();
             if (last_cp_state == RawCPState::B || last_cp_state == RawCPState::C || last_cp_state == RawCPState::D) {
                 events.push(CPEvent::BCDtoEF);
             }


### PR DESCRIPTION
## Describe your changes
Removed line in EvseManager IEC state machine that sets pwm off when in state F because that actually reverses moving to state F.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

