### PR TITLE
refactor: correct include order

### DIFF
--- a/modules/EvseV2G/v2g_server.cpp
+++ b/modules/EvseV2G/v2g_server.cpp
@@ -1,9 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2023 chargebyte GmbH
 // Copyright (C) 2023 Contributors to EVerest
+#include "v2g_server.hpp"
 
 #include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <cstdint>
+
 #include <mbedtls/base64.h>
+
 #include <openv2g/appHandEXIDatatypesDecoder.h>
 #include <openv2g/appHandEXIDatatypesEncoder.h>
 #include <openv2g/dinEXIDatatypes.h>
@@ -13,19 +21,14 @@
 #include <openv2g/iso1EXIDatatypesDecoder.h>
 #include <openv2g/iso1EXIDatatypesEncoder.h>
 #include <openv2g/v2gtp.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
 
 #include "connection.hpp"
 #include "din_server.hpp"
 #include "iso_server.hpp"
 #include "log.hpp"
 #include "tools.hpp"
-#include "v2g_server.hpp"
 
 #define MAX_RES_TIME 98
-#define UINT32_MAX   0xFFFFFFFF
 
 static types::iso15118_charger::V2G_Message_ID get_V2G_Message_ID(enum V2gMsgTypeId v2g_msg,
                                                                   enum v2g_protocol selected_protocol, bool is_req) {


### PR DESCRIPTION
- delete unnecessary redefinition of UINT32_MAX
- group and sort include files

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

