### PR TITLE
refactor(slac): remove dead code

### DIFF
--- a/modules/EvSlac/main/ev_slacImpl.cpp
+++ b/modules/EvSlac/main/ev_slacImpl.cpp
@@ -16,13 +16,6 @@ namespace module {
 namespace main {
 
 void ev_slacImpl::init() {
-    // validate config settings
-    if (config.ev_id.length() != slac::defs::STATION_ID_LEN) {
-        EVLOG_AND_THROW(
-            Everest::EverestConfigError(fmt::format("The EVSE id config needs to be exactly {} octets (got {}).",
-                                                    slac::defs::STATION_ID_LEN, config.ev_id.length())));
-    }
-
     // setup evse fsm thread
     std::thread(&ev_slacImpl::run, this).detach();
 }

--- a/modules/EvSlac/main/ev_slacImpl.hpp
+++ b/modules/EvSlac/main/ev_slacImpl.hpp
@@ -21,7 +21,6 @@ namespace main {
 
 struct Conf {
     std::string device;
-    std::string ev_id;
     int set_key_timeout_ms;
 };
 

--- a/modules/EvSlac/manifest.yaml
+++ b/modules/EvSlac/manifest.yaml
@@ -8,10 +8,6 @@ provides:
         description: Ethernet device used for PLC.
         type: string
         default: eth1
-      ev_id:
-        description: EVSE id - 17 octets.
-        type: string
-        default: PIONIX_SAYS_HELLO
       set_key_timeout_ms:
         description: Timeout for CM_SET_KEY.REQ. Default works for QCA7000/QCA7005/CG5317.
         type: integer

--- a/modules/EvseSlac/main/slacImpl.cpp
+++ b/modules/EvseSlac/main/slacImpl.cpp
@@ -26,18 +26,6 @@ static std::string mac_to_ascii(const std::string& mac_binary) {
 }
 
 void slacImpl::init() {
-    // validate config settings
-    if (config.evse_id.length() != slac::defs::STATION_ID_LEN) {
-        EVLOG_AND_THROW(
-            Everest::EverestConfigError(fmt::format("The EVSE id config needs to be exactly {} octets (got {}).",
-                                                    slac::defs::STATION_ID_LEN, config.evse_id.length())));
-    }
-
-    if (config.nid.length() != slac::defs::NID_LEN) {
-        EVLOG_AND_THROW(Everest::EverestConfigError(fmt::format(
-            "The NID config needs to be exactly {} octets (got {}).", slac::defs::NID_LEN, config.nid.length())));
-    }
-
     // setup evse fsm thread
     std::thread(&slacImpl::run, this).detach();
 }

--- a/modules/EvseSlac/main/slacImpl.hpp
+++ b/modules/EvseSlac/main/slacImpl.hpp
@@ -21,8 +21,6 @@ namespace main {
 
 struct Conf {
     std::string device;
-    std::string evse_id;
-    std::string nid;
     int number_of_sounds;
     bool ac_mode_five_percent;
     int set_key_timeout_ms;

--- a/modules/EvseSlac/manifest.yaml
+++ b/modules/EvseSlac/manifest.yaml
@@ -8,14 +8,6 @@ provides:
         description: Ethernet device used for PLC.
         type: string
         default: eth1
-      evse_id:
-        description: EVSE id - 17 octets.
-        type: string
-        default: PIONIX_SAYS_HELLO
-      nid:
-        description: NID (Network Identification Key) - 7 octets.
-        type: string
-        default: pionix!
       number_of_sounds:
         description: SLAC number of sounds.
         type: integer


### PR DESCRIPTION
- the EvseSlac module had config options for `evse_id` and `nid`, which both are not used at all
- the specification states, that the `nid` needs to be derived from the `nmk`, and hence shouldn't be set directly anyway
- furthermore, the specification states, that the `evse_id` should have the value of `0x00` (which the current implementation also does)
- the same is true for the option `ev_id` in the EvSlac module
- all of these, therefore, unused options have been removed
- NOTE: the JsSlacSimulator still has these config options and might need to be changed too

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

