### PR TITLE
Fix(EvseV2G): If AC is supported, DIN70121 can be no longer falsely selected

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -121,6 +121,11 @@ void ISO15118_chargerImpl::handle_setup(
                 break;
             }
         }
+
+        if (mod->config.supported_DIN70121 == true and v2g_ctx->is_dc_charger == false) {
+            v2g_ctx->supported_protocols &= ~(1 << V2G_PROTO_DIN70121);
+            dlog(DLOG_LEVEL_WARNING, "Removed DIN70121 from the list of supported protocols as AC is enabled");
+        }
     }
 
     v2g_ctx->debugMode = debug_mode;


### PR DESCRIPTION
## Describe your changes
Adding a check if DIN is supported and the charger enabled AC. If this is the case, DIN is removed from the SupportedAppProtocol message.

## Issue ticket number and link
Right now if AC is supported, DIN70121 can be falsely selected.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

