### PR TITLE
Support SoC in OCPP modules

### DIFF
--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -130,11 +130,12 @@ private:
 
     void init_evse_subscriptions(); // initialize subscriptions to all EVSEs provided by r_evse_manager
     void init_evse_connector_map();
-    void init_evse_ready_map();
+    void init_evse_maps();
     EvseConnectorMap evse_connector_map; // provides access to OCPP connector id by using EVerests evse and connector id
     std::map<int32_t, int32_t>
         connector_evse_index_map; // provides access to r_evse_manager index by using OCPP connector id
     std::map<int32_t, bool> evse_ready_map;
+    std::map<int32_t, std::optional<float>> evse_soc_map;
     std::mutex evse_ready_mutex;
     std::condition_variable evse_ready_cv;
     bool all_evse_ready();

--- a/modules/OCPP/conversions.cpp
+++ b/modules/OCPP/conversions.cpp
@@ -209,6 +209,49 @@ ocpp::v16::BootReasonEnum to_ocpp_boot_reason_enum(const types::system::BootReas
     }
 }
 
+ocpp::Powermeter to_ocpp_power_meter(const types::powermeter::Powermeter& powermeter) {
+    ocpp::Powermeter ocpp_powermeter;
+    ocpp_powermeter.timestamp = powermeter.timestamp;
+    ocpp_powermeter.energy_Wh_import = {powermeter.energy_Wh_import.total, powermeter.energy_Wh_import.L1,
+                                        powermeter.energy_Wh_import.L2, powermeter.energy_Wh_import.L3};
+
+    ocpp_powermeter.meter_id = powermeter.meter_id;
+    ocpp_powermeter.phase_seq_error = powermeter.phase_seq_error;
+
+    if (powermeter.energy_Wh_export.has_value()) {
+        const auto energy_wh_export = powermeter.energy_Wh_export.value();
+        ocpp_powermeter.energy_Wh_export =
+            ocpp::Energy{energy_wh_export.total, energy_wh_export.L1, energy_wh_export.L2, energy_wh_export.L3};
+    }
+
+    if (powermeter.power_W.has_value()) {
+        const auto power_w = powermeter.power_W.value();
+        ocpp_powermeter.power_W = ocpp::Power{power_w.total, power_w.L1, power_w.L2, power_w.L3};
+    }
+
+    if (powermeter.voltage_V.has_value()) {
+        const auto voltage_v = powermeter.voltage_V.value();
+        ocpp_powermeter.voltage_V = ocpp::Voltage{voltage_v.DC, voltage_v.L1, voltage_v.L2, voltage_v.L3};
+    }
+
+    if (powermeter.VAR.has_value()) {
+        const auto var = powermeter.VAR.value();
+        ocpp_powermeter.VAR = ocpp::ReactivePower{var.total, var.L1, var.L2, var.L3};
+    }
+
+    if (powermeter.current_A.has_value()) {
+        const auto current_a = powermeter.current_A.value();
+        ocpp_powermeter.current_A = ocpp::Current{current_a.DC, current_a.L1, current_a.L2, current_a.L3, current_a.N};
+    }
+
+    if (powermeter.frequency_Hz.has_value()) {
+        const auto frequency_hz = powermeter.frequency_Hz.value();
+        ocpp_powermeter.frequency_Hz = ocpp::Frequency{frequency_hz.L1, frequency_hz.L2, frequency_hz.L3};
+    }
+
+    return ocpp_powermeter;
+}
+
 ocpp::v201::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118_charger::HashAlgorithm hash_algorithm) {
     switch (hash_algorithm) {
     case types::iso15118_charger::HashAlgorithm::SHA256:

--- a/modules/OCPP/conversions.hpp
+++ b/modules/OCPP/conversions.hpp
@@ -59,6 +59,9 @@ to_ocpp_hash_algorithm_enum_type(const types::iso15118_charger::HashAlgorithm ha
 /// \brief  Converts a given types::iso15118_charger::Status \p status to a ocpp::v201::Iso15118EVCertificateStatusEnum.
 ocpp::v16::BootReasonEnum to_ocpp_boot_reason_enum(const types::system::BootReason reason);
 
+/// \brief  Converts a given types::powermeter::Powermeter \p powermeter to a ocpp::Powermeter
+ocpp::Powermeter to_ocpp_power_meter(const types::powermeter::Powermeter& powermeter);
+
 /// \brief Converts a given types::iso15118_charger::HashAlgorithm \p hash_algorithm to a ocpp::v201::HashAlgorithmEnum.
 ocpp::v201::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118_charger::HashAlgorithm hash_algorithm);
 

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -104,9 +104,10 @@ private:
 
     // key represents evse_id, value indicates if ready
     std::map<int32_t, bool> evse_ready_map;
+    std::map<int32_t, std::optional<float>> evse_soc_map;
     std::mutex evse_ready_mutex;
     std::condition_variable evse_ready_cv;
-    void init_evse_ready_map();
+    void init_evse_maps();
     bool all_evse_ready();
     std::map<int32_t, int32_t> get_connector_structure();
     void process_session_event(const int32_t evse_id, const types::evse_manager::SessionEvent& session_event);

--- a/modules/OCPP201/conversions.cpp
+++ b/modules/OCPP201/conversions.cpp
@@ -108,11 +108,12 @@ ocpp::v201::DataTransferResponse to_ocpp_data_transfer_response(types::ocpp::Dat
 
 ocpp::v201::SampledValue to_ocpp_sampled_value(const ocpp::v201::ReadingContextEnum& reading_context,
                                                const ocpp::v201::MeasurandEnum& measurand, const std::string& unit,
-                                               const std::optional<ocpp::v201::PhaseEnum> phase) {
+                                               const std::optional<ocpp::v201::PhaseEnum> phase,
+                                               ocpp::v201::LocationEnum location) {
     ocpp::v201::SampledValue sampled_value;
     ocpp::v201::UnitOfMeasure unit_of_measure;
     sampled_value.context = reading_context;
-    sampled_value.location = ocpp::v201::LocationEnum::Outlet;
+    sampled_value.location = location;
     sampled_value.measurand = measurand;
     unit_of_measure.unit = unit;
     sampled_value.unitOfMeasure = unit_of_measure;

--- a/modules/OCPP201/conversions.hpp
+++ b/modules/OCPP201/conversions.hpp
@@ -34,7 +34,8 @@ ocpp::v201::DataTransferResponse to_ocpp_data_transfer_response(types::ocpp::Dat
 /// \brief Converts the provided parameters to an ocpp::v201::SampledValue.
 ocpp::v201::SampledValue to_ocpp_sampled_value(const ocpp::v201::ReadingContextEnum& reading_context,
                                                const ocpp::v201::MeasurandEnum& measurand, const std::string& unit,
-                                               const std::optional<ocpp::v201::PhaseEnum> phase);
+                                               const std::optional<ocpp::v201::PhaseEnum> phase,
+                                               ocpp::v201::LocationEnum location = ocpp::v201::LocationEnum::Outlet);
 
 /// \brief Converts the given types::units_signed::SignedMeterValue \p signed_meter_value  to an
 /// ocpp::v201::SignedMeterValue.


### PR DESCRIPTION
## Describe your changes
* OCPP modules subscribe to EVInfo to retrieve the SoC from the evse_manager
* SoC value is stored in memory per EVSE and included in Measurement (OCPP) and MeterValue (OCPP201)
* SoC value is reset on SessionFinished

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

