### PR TITLE
GenericPowermeter: improve logging and fix Modbus range

### DIFF
--- a/modules/GenericPowermeter/main/powermeterImpl.hpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.hpp
@@ -108,6 +108,9 @@ private:
 
     std::thread output_thread;
 
+    /// @brief Remember whether we already logged the meter's unavailability.
+    bool meter_is_unavailable{false};
+
     void init_default_values();
     void init_register_assignments(const json& loaded_registers);
     int assign_register_data(const json& registers, const PowermeterRegisters register_type,

--- a/modules/GenericPowermeter/manifest.yaml
+++ b/modules/GenericPowermeter/manifest.yaml
@@ -11,8 +11,8 @@ provides:
       powermeter_device_id:
         description: The powermeter's address on the serial bus
         type: integer
-        minimum: 0
-        maximum: 255
+        minimum: 1
+        maximum: 247
         default: 1
       modbus_base_address:
         description: The base address for register access


### PR DESCRIPTION
## Describe your changes

This PR fixes a small issue with the allowed range of Modbus addresses, and it introduces log messages in case the power meter communication is interrupted or restored.

## Issue ticket number and link

The logging part is related to #523, but it not the complete fix for this issue.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
- [x] chargebyte internal review approved this PR
