### PR TITLE
Feature/bsp stop transaction

### DIFF
--- a/interfaces/evse_board_support.yaml
+++ b/interfaces/evse_board_support.yaml
@@ -129,5 +129,9 @@ vars:
       need to be implemented and the returned value is not used in those cases.
     type: object
     $ref: /board_support_common#/ProximityPilot
+  request_stop_transaction:
+    description: Publish to stop the transaction gracefully (e.g. user pressed the stop button)
+    type: object
+    $ref: /evse_manager#/StopTransactionRequest
 errors:
   - reference: /errors/evse_board_support

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -902,8 +902,7 @@ void EvseManager::ready_to_start_charging() {
     }
 
     this->p_evse->publish_ready(true);
-    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
-                              "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
+    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
 }
 
 types::powermeter::Powermeter EvseManager::get_latest_powermeter_data_billing() {

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -112,6 +112,9 @@ void EvseManager::init() {
                 [this](const auto& caps) { update_powersupply_capabilities(caps); });
         }
     }
+
+    r_bsp->subscribe_request_stop_transaction(
+        [this](types::evse_manager::StopTransactionRequest r) { charger->cancel_transaction(r); });
 }
 
 void EvseManager::ready() {
@@ -899,7 +902,8 @@ void EvseManager::ready_to_start_charging() {
     }
 
     this->p_evse->publish_ready(true);
-    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
+    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
+                              "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
 }
 
 types::powermeter::Powermeter EvseManager::get_latest_powermeter_data_billing() {


### PR DESCRIPTION
## Describe your changes

Allow the BSP to stop the transaction. In many cases the MCU that is handling the CP signal etc also handles the stop charging button (and or the emergency stop button). With this change it can stop gracefully in case of normal stop button and report an emergency shutdown (after the MCU already performed it)

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

