### PR TITLE
Properly stop OCPP 2.0.1 transaction if reason is ImmediateReset

### DIFF
--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -25,6 +25,8 @@ TxEvent get_tx_event(const ocpp::v201::ReasonEnum reason) {
         return TxEvent::DEAUTHORIZED;
     case ocpp::v201::ReasonEnum::EVDisconnected:
         return TxEvent::EV_DISCONNECTED;
+    case ocpp::v201::ReasonEnum::ImmediateReset:
+        return TxEvent::IMMEDIATE_RESET;
     default:
         return TxEvent::NONE;
     }
@@ -796,6 +798,9 @@ void OCPP201::process_transaction_finished(const int32_t evse_id, const int32_t 
         auto charging_state = transaction_data->charging_state;
         if (reason == ocpp::v201::ReasonEnum::EVDisconnected) {
             charging_state = ocpp::v201::ChargingStateEnum::Idle;
+        } else if (reason == ocpp::v201::ReasonEnum::ImmediateReset &&
+                   charging_state != ocpp::v201::ChargingStateEnum::Idle) {
+            charging_state = ocpp::v201::ChargingStateEnum::EVConnected;
         } else if (tx_event == TxEvent::DEAUTHORIZED) {
             charging_state = ocpp::v201::ChargingStateEnum::EVConnected;
         }

--- a/modules/OCPP201/transaction_handler.hpp
+++ b/modules/OCPP201/transaction_handler.hpp
@@ -35,7 +35,8 @@ enum class TxEvent {
     PARKING_BAY_UNOCCUPIED,
     ENERGY_TRANSFER_STARTED,
     ENERGY_TRANSFER_STOPPED,
-    SIGNED_START_DATA_RECEIVED
+    SIGNED_START_DATA_RECEIVED,
+    IMMEDIATE_RESET
 };
 
 /// \brief Effect to an TxEvent. An effect can either trigger the start of a Transaction, the stop of a transaction or
@@ -53,6 +54,7 @@ struct TxStartStopConditions {
     bool is_parking_bay_occupied = false;
     bool is_energy_transfered = false;
     bool is_signed_data_received = false;
+    bool is_immediate_reset = false;
 
     void submit_event(const TxEvent tx_event) {
 
@@ -85,6 +87,9 @@ struct TxStartStopConditions {
         case TxEvent::SIGNED_START_DATA_RECEIVED:
             is_signed_data_received = true;
             break;
+        case TxEvent::IMMEDIATE_RESET:
+            is_immediate_reset = true;
+            break;
         }
     };
 
@@ -108,6 +113,9 @@ struct TxStartStopConditions {
     };
 
     bool is_stop_condition_fullfilled(const TxStartStopPoint tx_stop_point) {
+        if (is_immediate_reset) {
+            return true;
+        }
         switch (tx_stop_point) {
         case TxStartStopPoint::ParkingBayOccupancy:
             return !is_parking_bay_occupied;


### PR DESCRIPTION
## Describe your changes
Previously this wasn't properly handled and would for example not let OCTT testcase B_22 pass in certain configurations

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

