### PR TITLE
setup_ev_cli should not return after find_program

### DIFF
--- a/cmake/ev-cli.cmake
+++ b/cmake/ev-cli.cmake
@@ -6,18 +6,18 @@ macro(setup_ev_cli)
     endif()
     if(NOT ${${PROJECT_NAME}_USE_PYTHON_VENV})
         find_program(EV_CLI ev-cli REQUIRED)
-        return()
+    else()
+        ev_is_python_venv_active(
+            RESULT_VAR IS_PYTHON_VENV_ACTIVE
+        )
+        if(NOT ${IS_PYTHON_VENV_ACTIVE})
+            message(FATAL_ERROR "Python venv is not active. Please activate the python venv before running this command.")
+        endif()
+        set(EV_CLI "${${PROJECT_NAME}_PYTHON_VENV_PATH}/bin/ev-cli")
+        add_dependencies(ev-cli
+            ev-dev-tools_pip_install_dist
+        )
     endif()
-    ev_is_python_venv_active(
-        RESULT_VAR IS_PYTHON_VENV_ACTIVE
-    )
-    if(NOT ${IS_PYTHON_VENV_ACTIVE})
-        message(FATAL_ERROR "Python venv is not active. Please activate the python venv before running this command.")
-    endif()
-    set(EV_CLI "${${PROJECT_NAME}_PYTHON_VENV_PATH}/bin/ev-cli")
-    add_dependencies(ev-cli
-        ev-dev-tools_pip_install_dist
-    )
 endmacro()
 
 function(require_ev_cli_version EV_CLI_VERSION_REQUIRED)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -81,7 +81,7 @@ ext-mbedtls:
     - ENABLE_PROGRAMS OFF
     - ENABLE_TESTING OFF
     - MBEDTLS_FATAL_WARNINGS OFF  # disables setting warnings as errors  FIXME: workaround until upstream-fixes are included
-# everest-testing
+# everest-testing and ev-dev-tools
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
   git_tag: v0.3.1

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -84,8 +84,7 @@ ext-mbedtls:
 # everest-testing
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
-  git_tag: v0.3.0
-  cmake_condition: "EVEREST_CORE_BUILD_TESTING"
+  git_tag: v0.3.1
 
 # unit testing
 gtest:


### PR DESCRIPTION
otherwise the return() calls can have unintended consquences like interrupting the include of everest-generate.cmake in ev-project-bootstrap

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

