### PR TITLE
Config option: Limit to 10A in simplified mode

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -119,6 +119,11 @@ void EvseManager::init() {
 
 void EvseManager::ready() {
     bsp = std::unique_ptr<IECStateMachine>(new IECStateMachine(r_bsp));
+
+    if (config.hack_simplified_mode_limit_10A) {
+        bsp->set_ev_simplified_mode_evse_limit(true);
+    }
+
     error_handling =
         std::unique_ptr<ErrorHandling>(new ErrorHandling(r_bsp, r_hlc, r_connector_lock, r_ac_rcd, p_evse));
 

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -78,6 +78,7 @@ struct Conf {
     int hack_present_current_offset;
     bool hack_pause_imd_during_precharge;
     bool hack_allow_bpt_with_iso2;
+    bool hack_simplified_mode_limit_10A;
     bool autocharge_use_slac_instead_of_hlc;
     bool enable_autocharge;
     std::string logfile_suffix;

--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -337,6 +337,12 @@ void IECStateMachine::set_pwm(double value) {
         }
     }
 
+    if (ev_simplified_mode_evse_limit and ev_simplified_mode and value > ev_simplified_mode_evse_limit_pwm) {
+        EVLOG_warning
+            << "Simplified mode: Limiting output PWM to 10A due to config option \"hack_simplified_mode_limit_10A\"";
+        value = ev_simplified_mode_evse_limit_pwm;
+    }
+
     r_bsp->call_pwm_on(value * 100);
 
     feed_state_machine();

--- a/modules/EvseManager/IECStateMachine.hpp
+++ b/modules/EvseManager/IECStateMachine.hpp
@@ -89,6 +89,10 @@ public:
 
     void connector_force_unlock();
 
+    void set_ev_simplified_mode_evse_limit(bool l) {
+        ev_simplified_mode_evse_limit = l;
+    }
+
     // Signal for internal events type
     sigslot::signal<CPEvent> signal_event;
     sigslot::signal<> signal_lock;
@@ -103,6 +107,9 @@ private:
     bool pwm_running{false};
     bool last_pwm_running{false};
 
+    static constexpr float ev_simplified_mode_evse_limit_pwm{10 / 0.6 / 100.}; // Fixed 10A limit
+    // If set to true, EVSE will limit to 10A in case of simplified charging
+    bool ev_simplified_mode_evse_limit{false};
     bool ev_simplified_mode{false};
     bool has_ventilation{false};
     bool power_on_allowed{false};

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -142,6 +142,13 @@ config:
       always be positive but power supply may actually discharge the car.
     type: boolean
     default: false
+  hack_simplified_mode_limit_10A:
+    description:
+      Limit PWM to 10A if EV uses simplified charging mode. Set to false to be compliant with IEC61851-1:2019 section A.2.3.
+      It is the responsibility of the EV to limit to 10A according to the norm. Enable this option to deviate from the norm
+      and limit from the EVSE side.
+    type: boolean
+    default: false
   autocharge_use_slac_instead_of_hlc:
     description: Use slac ev mac address for autocharge instead of EVCCID from HLC
     type: boolean

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -143,7 +143,7 @@ config:
     type: boolean
     default: false
   hack_simplified_mode_limit_10A:
-    description:
+    description: >-
       Limit PWM to 10A if EV uses simplified charging mode. Set to false to be compliant with IEC61851-1:2019 section A.2.3.
       It is the responsibility of the EV to limit to 10A according to the norm. Enable this option to deviate from the norm
       and limit from the EVSE side.


### PR DESCRIPTION
## Describe your changes

This adds a config option to limit to 10A in simplified charging from the EVSE side. It is off by default as it deviates from IEC61851-1:2019. Some certification labs require to deviate from the norm though, and this option can be used to make them happy.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

