### PR TITLE
Added in patch which supports PNC

### DIFF
--- a/modules/PyEvJosev/module.py
+++ b/modules/PyEvJosev/module.py
@@ -95,6 +95,7 @@ class PyEVJosevModule():
 
     def _handler_start_charging(self, args) -> bool:
 
+        self._es.PaymentOption =args['PaymentOption']
         self._es.EnergyTransferMode = args['EnergyTransferMode']
 
         self._ready_event.set()

--- a/modules/simulation/JsEvManager/index.js
+++ b/modules/simulation/JsEvManager/index.js
@@ -362,17 +362,27 @@ function registerAllCmds(mod) {
   });
 
   if (mod.uses_list.ev.length > 0) {
-    registerCmd(mod, 'iso_start_v2g_session', 1, (mod, c) => {
-      switch (c.args[0]) {
+    registerCmd(mod, 'iso_start_v2g_session', 2, (mod, c) => {
+      if (c.args[0] === 'externalpayment') mod.payment = 'ExternalPayment';
+        else if (c.args[0] === 'contract') mod.payment = 'Contract';
+      else {
+        evlog.debug('Found invalid payment method' + c.args[0]);
+	return false;
+      }
+
+      switch (c.args[1]) {
         case 'ac':
           if (mod.config.module.three_phases !== true) mod.energymode = 'AC_single_phase_core';
           else mod.energymode = 'AC_three_phase_core';
           break;
         case 'dc': mod.energymode = 'DC_extended'; break;
-        default: return false;
+        default:
+          evlog.debug('Found invalid payment method' + c.args[1]);
+	        return false;
       }
 
-      mod.uses_list.ev[0].call.start_charging({ EnergyTransferMode: mod.energymode });
+      args = { PaymentOption: mod.payment, EnergyTransferMode: mod.energymode };
+      mod.uses_list.ev[0].call.start_charging(args);
 
       return true;
     });


### PR DESCRIPTION
## Describe your changes

Hello everyone, I am apart of the team over at NREL who has been working on the SIL demos in `everest/everest-demo`. Recently, @shankari went to the CharIN Testival and showcased EVerest by running a custom demo that was tailored to have PnC functioning, found [here](https://github.com/US-JOET/everest-demo/blob/charin-e2e-demo/demo-iso15118-2-ac-plus-ocpp.sh). To get PnC to work, she had to apply a handful of patches to different parts of EVerest, all which can be found [here](https://github.com/US-JOET/everest-demo/blob/879548aafdf9ff2366de45f1b77cd25d5667ebb2/demo-iso15118-2-ac-plus-ocpp.sh#L354). We now would like to slowly integrate these patches into EVerest so that it can fully support PnC.

This patch in particular involves adding in support for a `Contract` payment method to `PyEvJosev`.

**Testing Done**

As mentioned above, this patch is one of many, so it has only been tested in conjunction with the other patches in the SIL demo. The particular demo which has PnC working can be found linked above. To run this demo, I would recommend...

1. Clone repo and check out branch.
   ```
   git clone https://github.com/US-JOET/everest-demo.git
   git checkout -b test-demo origin/charin-e2e-demo  
   ```
2. Run the software simulation demo.
   ```
   bash demo-iso15118-2-ac-plus-ocpp.sh -r $(pwd) -b test-demo -3   
   ```
3. Wait until the EVerest software boots up and you see the following.
   ```
   2024-06-18 18:23:22.836788 [INFO] ocpp:OCPP201     :: Received BootNotificationResponse: {
       "currentTime": "2024-06-18T18:23:22.000Z",
       "interval": 300,
       "status": "Accepted"
   }
   ```
4. Navigate to http://localhost:1880/ui/, choose from the `Car Simulation` dropdown menu `AC ISO15118-2 Plug&Charge`, then plug the car in and observe it authenticate on its own.

## Issue ticket number and link

The issue can be found [here](https://github.com/EVerest/everest-demo/issues/61) in `everest-demo`. 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

