### PR TITLE
Install edm and deps on the fly

### DIFF
--- a/.github/workflows/bazel_build_and_test.yaml
+++ b/.github/workflows/bazel_build_and_test.yaml
@@ -15,9 +15,6 @@ jobs:
           key: ${{ runner.os }}-bazel-${{ hashFiles('dependencies.yaml', '.bazelversion', '.bazelrc', 'WORKSPACE.bazel', 'third-party/bazel/*') }}
           restore-keys: |
             ${{ runner.os }}-bazel-
-      - name: Setup edm
-        run: |
-          pip install git+https://github.com/Everest/everest-dev-environment.git#subdirectory=dependency_manager
       - name: Build all
         run: >
           bazelisk build //...

--- a/third-party/bazel/edm-wrapper.sh
+++ b/third-party/bazel/edm-wrapper.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+EDM_LINK=git+https://github.com/Everest/everest-dev-environment.git#subdirectory=dependency_manager
+mkdir -p venv > /dev/null
+TARGET_PATH=$(realpath venv)
+pip3 install --upgrade -t $TARGET_PATH $EDM_LINK > /dev/null
+export PYTHONPATH=$TARGET_PATH
+export PATH=$TARGET_PATH/bin:$PATH
+
+edm "$@"

--- a/third-party/bazel/edm.bzl
+++ b/third-party/bazel/edm.bzl
@@ -5,8 +5,9 @@ def _edm_repositories_impl(rctx):
         build_files_args.append("--build-file")
         build_files_args.append(str(build_file))
     print("build_files_args: ", build_files_args)
+    edm_tool = rctx.attr._edm_tool
     exec_result = rctx.execute(
-        ["edm", "bazel", rctx.attr.dependencies_yaml] + 
+        [edm_tool, "bazel", rctx.attr.dependencies_yaml] + 
         build_files_args,
     )
     if exec_result.return_code != 0:
@@ -26,6 +27,11 @@ edm_repositories = repository_rule(
         "build_files": attr.label_list(
             allow_files=True,
             doc="List of build files for external repositories",
+        ),
+        "_edm_tool": attr.label(
+            default=Label("@everest-core//third-party/bazel:edm-wrapper.sh"),
+            allow_single_file=True,
+            doc="Path to the edm script",
         ),
     },  
 )


### PR DESCRIPTION
## Describe your changes
Current version of everest requires edm to be installed in the system to run bazel-build. Which is fine for the everest developers, but may be annoying for the downstream repositories (to ensure every developer has edm on the laptop).

Now the edm is fetched on the fly into virtual environment.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

