### PR TITLE
Charger: Fix soft over current detection when PWM changes often

### DIFF
--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -95,6 +95,7 @@ public:
     // external input to charger: update max_current and new validUntil
     bool set_max_current(float ampere, std::chrono::time_point<date::utc_clock> validUntil);
     float get_max_current();
+
     sigslot::signal<float> signal_max_current;
 
     void setup(bool three_phases, bool has_ventilation, const std::string& country_code, const ChargeMode charge_mode,
@@ -206,6 +207,7 @@ private:
 
     bool errors_prevent_charging_internal();
     float get_max_current_internal();
+    float get_max_current_signalled_to_ev_internal();
     bool deauthorize_internal();
     bool pause_charging_wait_for_power_internal();
 
@@ -218,7 +220,8 @@ private:
 
     void update_pwm_now(float dc);
     void update_pwm_now_if_changed(float dc);
-    void update_pwm_max_every_5seconds(float dc);
+    void update_pwm_now_if_changed_ampere(float dc);
+    void update_pwm_max_every_5seconds_ampere(float dc);
     void pwm_off();
     void pwm_F();
 
@@ -327,6 +330,7 @@ private:
 
         bool pp_warning_printed{false};
         bool no_energy_warning_printed{false};
+        float pwm_set_last_ampere{0};
     } internal_context;
 
     // main Charger thread
@@ -368,6 +372,7 @@ private:
     // 4 seconds according to table 3 of ISO15118-3
     static constexpr int T_STEP_EF = 4000;
     static constexpr int SOFT_OVER_CURRENT_TIMEOUT = 7000;
+    static constexpr int IEC_PWM_MAX_UPDATE_INTERVAL = 5000;
 
     types::evse_manager::EnableDisableSource active_enable_disable_source{
         types::evse_manager::Enable_source::Unspecified, types::evse_manager::Enable_state::Unassigned, 10000};


### PR DESCRIPTION
## Describe your changes

Soft over current detection triggers when the EV draws more current then the PWM limit for several seconds. The current implementation checked the EV's current against the internally set current limit, which may be different from the PWM signalled current limit for up to 5 seconds (as IEC allows PWM updates only every 5 seconds).
If PWM is changed frequently (e.g. due to solar charging) this may lead to unintended over current triggers (it takes 5 seconds for the PWM to change and another 6s or so for some EVs to actually reduce current).
With this PR, the OC detection is based on the current actually signalled on the PWM for basic AC charging.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

