### PR TITLE
Add warning to verify IPv6 ll address if bind fails

### DIFF
--- a/modules/EvseV2G/connection.cpp
+++ b/modules/EvseV2G/connection.cpp
@@ -103,6 +103,8 @@ static int connection_create_socket(struct sockaddr_in6* sockaddr) {
     if (bind(s, reinterpret_cast<struct sockaddr*>(sockaddr), addrlen) == -1) {
         if (!error_once) {
             dlog(DLOG_LEVEL_WARNING, "bind() failed: %s", strerror(errno));
+            dlog(DLOG_LEVEL_WARNING,
+                 "Verify that the configured interface has a valid IPv6 link local address configured.");
             error_once = true;
         }
         close(s);


### PR DESCRIPTION
## Describe your changes

If the interface used for HLC communication does not have an IPv6 link local address, bind fails in EvseV2G. 
This PR adds a hint to check the ipv6 ll address if bind fails as we see this quite often in support requests on the mailing list or in zulip.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

