### PR TITLE
EvseManager: Wait for initial meter value

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -678,7 +678,7 @@ void EvseManager::ready() {
             }
 
             {
-                std::lock_guard<std::mutex> lg(powermeter_mutex);
+                std::scoped_lock<std::mutex> lk(powermeter_mutex);
                 initial_powermeter_value_received = true;
             }
             powermeter_cv.notify_one();

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -899,10 +899,12 @@ void EvseManager::ready() {
         }
     });
 
-    // wait for first powermeter value
-    std::unique_lock<std::mutex> lk(powermeter_mutex);
-    this->powermeter_cv.wait_for(lk, std::chrono::milliseconds(this->config.initial_meter_value_timeout_ms),
-                                 [this] { return initial_powermeter_value_received; });
+    {
+        // wait for first powermeter value
+        std::unique_lock<std::mutex> lk(powermeter_mutex);
+        this->powermeter_cv.wait_for(lk, std::chrono::milliseconds(this->config.initial_meter_value_timeout_ms),
+                                     [this] { return initial_powermeter_value_received; });
+    }
 
     //  start with a limit of 0 amps. We will get a budget from EnergyManager that is locally limited by hw
     //  caps.

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -94,6 +94,7 @@ struct Conf {
     bool uk_smartcharging_random_delay_enable;
     int uk_smartcharging_random_delay_max_duration;
     bool uk_smartcharging_random_delay_at_any_change;
+    int initial_meter_value_timeout_ms;
 };
 
 class EvseManager : public Everest::ModuleBase {
@@ -324,6 +325,9 @@ private:
     static constexpr int CABLECHECK_SELFTEST_TIMEOUT{30};
 
     std::atomic_bool current_demand_active{false};
+    std::mutex powermeter_mutex;
+    std::condition_variable powermeter_cv;
+    bool initial_powermeter_value_received{false};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -230,6 +230,12 @@ config:
       "True: use random delays on any current change during charging. False: Only use if current is reduced to zero or increased from zero."
     type: boolean
     default: true
+  initial_meter_value_timeout_ms:
+    description: >-
+      This timeout in ms defines for how long the EvseManager waits for an initial meter value from a powermeter before it becomes ready to start charging.
+      If configured to 0, the EvseManager will not wait for an initial meter value before it becomes ready to start charging.
+    type: integer
+    default: 1000
 provides:
   evse:
     interface: evse_manager

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -235,7 +235,7 @@ config:
       This timeout in ms defines for how long the EvseManager waits for an initial meter value from a powermeter before it becomes ready to start charging.
       If configured to 0, the EvseManager will not wait for an initial meter value before it becomes ready to start charging.
     type: integer
-    default: 1000
+    default: 5000
 provides:
   evse:
     interface: evse_manager


### PR DESCRIPTION
## Describe your changes

If EVerest starts up with an EV plugged in (and authorization is present immediately), there is a race condition between the TransactionStarted event and the first powermeter value received. Without this change, transactions may start and use an initial meter value of 0.

This PR adds handling to wait for an initial powermeter value before the EvseManager becomes operational (is ready to start charging). The waiting time is configurable ( `initial_meter_value_timeout_ms` ) or can be disabled (by configuring 0)

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

