### PR TITLE
Fix ev-cli version check if not using venv

### DIFF
--- a/cmake/ev-project-bootstrap.cmake
+++ b/cmake/ev-project-bootstrap.cmake
@@ -4,7 +4,10 @@ include(${CMAKE_CURRENT_LIST_DIR}/ev-cli.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/config-run-script.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/config-run-nodered-script.cmake)
 
-set(EVEREST_REQUIRED_EV_CLI_VERSION "0.2.0")
+set_property(
+    GLOBAL
+    PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION "0.2.0"
+)
 
 # source generate scripts / setup
 include(${CMAKE_CURRENT_LIST_DIR}/everest-generate.cmake)

--- a/cmake/everest-generate.cmake
+++ b/cmake/everest-generate.cmake
@@ -127,7 +127,6 @@ endfunction()
 
 macro(ev_add_project)
     ev_setup_cmake_variables_python_wheel()
-    option(${PROJECT_NAME}_INSTALL_EV_CLI_IN_PYTHON_VENV "Install ev-cli in python venv instead of using system" ON)
     set(${PROJECT_NAME}_PYTHON_VENV_PATH "${CMAKE_BINARY_DIR}/venv" CACHE PATH "Path to python venv")
 
     ev_setup_python_executable(
@@ -136,7 +135,7 @@ macro(ev_add_project)
     )
 
     setup_ev_cli()
-    if(NOT ${${PROJECT_NAME}_INSTALL_EV_CLI_IN_PYTHON_VENV})
+    if(NOT ${${PROJECT_NAME}_USE_PYTHON_VENV})
         get_property(EVEREST_REQUIRED_EV_CLI_VERSION
             GLOBAL
             PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION

--- a/cmake/everest-generate.cmake
+++ b/cmake/everest-generate.cmake
@@ -137,6 +137,10 @@ macro(ev_add_project)
 
     setup_ev_cli()
     if(NOT ${${PROJECT_NAME}_INSTALL_EV_CLI_IN_PYTHON_VENV})
+        get_property(EVEREST_REQUIRED_EV_CLI_VERSION
+            GLOBAL
+            PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION
+        )
         require_ev_cli_version(${EVEREST_REQUIRED_EV_CLI_VERSION})
     endif()
 

--- a/cmake/everest-generate.cmake
+++ b/cmake/everest-generate.cmake
@@ -136,11 +136,14 @@ macro(ev_add_project)
 
     setup_ev_cli()
     if(NOT ${${PROJECT_NAME}_USE_PYTHON_VENV})
+        message(STATUS "Using system ev-cli instead of installing it in the build venv.")
         get_property(EVEREST_REQUIRED_EV_CLI_VERSION
             GLOBAL
             PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION
         )
         require_ev_cli_version(${EVEREST_REQUIRED_EV_CLI_VERSION})
+    else()
+        message(STATUS "Installing ev-cli in the build venv.")
     endif()
 
     # FIXME (aw): resort to proper argument handling!


### PR DESCRIPTION
## Describe your changes
This now uses a global property to store the ev-cli version, the variable used before could sometimes be empty leading to errors.
Additionally remove a redundant cmake option

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

