### PR TITLE
Fix(JsYetiSimulator): 0 kw charging if pwm duty cycle was set to 5%

### DIFF
--- a/modules/simulation/JsYetiSimulator/index.js
+++ b/modules/simulation/JsYetiSimulator/index.js
@@ -1028,8 +1028,11 @@ function read_from_car(mod) {
   let amps2 = 0.0;
   let amps3 = 0.0;
 
+  let hlc_active = false;
+  if (mod.pwm_duty_cycle >= 0.03 && mod.pwm_duty_cycle <= 0.07) hlc_active = true;
+
   let amps = dutyCycleToAmps(mod.pwm_duty_cycle);
-  if (amps > mod.ev_max_current) amps = mod.ev_max_current;
+  if (amps > mod.ev_max_current || hlc_active === true) amps = mod.ev_max_current;
 
   if (mod.relais_on === true && mod.ev_three_phases > 0) amps1 = amps;
   else amps1 = 0;


### PR DESCRIPTION
## Describe your changes
If the duty cycle was set to 5% (HLC), the current was set to 0 amps. If HLC is now active, the correct current value is set. 

## Issue ticket number and link
Fixed issue #645 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

