### PR TITLE
The major version of lem_dcbm_400600 should be the components[0] instead of [1]

### DIFF
--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -51,7 +51,7 @@ void LemDCBM400600Controller::fetch_meter_id_from_device() {
         std::string version = data.at("version").at("applicationFirmwareVersion");
         auto components = split(version, '.');
         this->v2_capable =
-            ((components.size() == 4) && (components[1] > "1")); // the major version must be newer than 1
+            ((components.size() == 4) && (components[0] > "1")); // the major version must be newer than 1
     } catch (json::exception& json_error) {
         throw UnexpectedDCBMResponseBody(
             "/v1/status", fmt::format("Json error {} for body {}", json_error.what(), status_response.body));


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

