### PR TITLE
Add start_precharge variable to iso15118_charger interface

### DIFF
--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -193,6 +193,9 @@ vars:
   Start_CableCheck:
     description: The charger should now start a cable check
     type: "null"
+  Start_PreCharge:
+    description: The charger should now start a pre charge
+    type: "null"
   DC_Open_Contactor:
     description: The contactor should be opened
     type: "null"

--- a/modules/EvseV2G/din_server.cpp
+++ b/modules/EvseV2G/din_server.cpp
@@ -1007,7 +1007,8 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
         dlog(DLOG_LEVEL_TRACE, "Handling PreChargeReq");
         conn->ctx->current_v2g_msg = V2G_PRE_CHARGE_MSG;
         if (conn->ctx->last_v2g_msg == V2G_CABLE_CHECK_MSG) {
-            dlog(DLOG_LEVEL_INFO, "Precharge-phase started");
+            conn->ctx->p_charger->publish_Start_PreCharge(nullptr);
+            dlog(DLOG_LEVEL_INFO, "Precharge-phase started");            
         }
         exi_out->V2G_Message.Body.PreChargeRes_isUsed = 1u;
         init_din_PreChargeResType(&exi_out->V2G_Message.Body.PreChargeRes);

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -2112,6 +2112,7 @@ enum v2g_event iso_handle_request(v2g_connection* conn) {
         /* At first send mqtt charging phase signal to the customer interface */
         if (V2G_CHARGE_PARAMETER_DISCOVERY_MSG == conn->ctx->last_v2g_msg) {
             conn->ctx->p_charger->publish_Start_CableCheck(nullptr);
+            dlog(DLOG_LEVEL_INFO, "Isolation-phase started");
         }
 
         exi_out->V2G_Message.Body.CableCheckRes_isUsed = 1u;
@@ -2122,6 +2123,7 @@ enum v2g_event iso_handle_request(v2g_connection* conn) {
         conn->ctx->current_v2g_msg = V2G_PRE_CHARGE_MSG;
         /* At first send  mqtt charging phase signal to the customer interface */
         if (conn->ctx->last_v2g_msg == V2G_CABLE_CHECK_MSG) {
+            conn->ctx->p_charger->publish_Start_PreCharge(nullptr);
             dlog(DLOG_LEVEL_INFO, "Precharge-phase started");
         }
 


### PR DESCRIPTION
feat: add start_precharge to iso15118_charger, so other modules such as dc power supply can know what stage it is at.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

