### PR TITLE
bump libocpp version to 673bc5bf5db3a02d03f4f06cc2d9a575cbe53f39

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 21b00339eb309c7bf22f8ef66f630da9fe72bdce
+  git_tag: 673bc5bf5db3a02d03f4f06cc2d9a575cbe53f39
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:


### PR DESCRIPTION
## Describe your changes
Update libocpp version to 673bc5bf5db3a02d03f4f06cc2d9a575cbe53f39 . This introdcues a timeout for OCPP messages initiated by the libocpp consumer and enables persisting those messages in case of a powerloss 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

