### PR TITLE
fix: event PluginTimeout to trigger State::Finished in API module

### DIFF
--- a/modules/API/API.cpp
+++ b/modules/API/API.cpp
@@ -111,6 +111,7 @@ void SessionInfo::update_state(const types::evse_manager::SessionEventEnum event
         this->state = State::WaitingForEnergy;
         break;
     case Event::ChargingFinished:
+    case Event::PluginTimeout:
     case Event::StoppingCharging:
     case Event::TransactionFinished:
         this->state = State::Finished;
@@ -138,7 +139,6 @@ void SessionInfo::update_state(const types::evse_manager::SessionEventEnum event
         break;
     case Event::ReplugStarted:
     case Event::ReplugFinished:
-    case Event::PluginTimeout:
     default:
         break;
     }


### PR DESCRIPTION
## Describe your changes

OCPP 1.6 sends a StatusNotification "Finishing" on PluginTimeout event.
The API module remained in AuthRequired.

This change makes the API session_info.state reflect the change in state

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

