### PR TITLE
fix: everest_api/evse_manager/cmd/force_unlock to also stop any transaction

### DIFF
--- a/modules/API/API.cpp
+++ b/modules/API/API.cpp
@@ -525,7 +525,13 @@ void API::init() {
                                 << ", error: " << e.what();
                 }
             }
-            evse->call_force_unlock(connector_id); //
+            // match processing in ChargePointImpl::handleUnlockConnectorRequest
+            // so that OCPP UnlockConnector and everest_api/evse_manager/cmd/force_unlock
+            // perform the same action
+            types::evse_manager::StopTransactionRequest req;
+            req.reason = types::evse_manager::StopTransactionReason::UnlockCommand;
+            evse->call_stop_transaction(req);
+            evse->call_force_unlock(connector_id);
         });
 
         // Check if a uk_random_delay is connected that matches this evse_manager


### PR DESCRIPTION
## Describe your changes
everest_api/evse_manager/cmd/force_unlock didn't previously stop any transactions first.
OCPP UnlockConnector did stop transaction first and then unlock connector.

This update means that everest_api/evse_manager/cmd/force_unlock does the same as OCPP UnlockConnector

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

