### PR TITLE
OCPP201: Add trigger_reason argument

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: f58617351f2edf9ea3e7ebe0e9212884fad7cad6
+  git_tag: feature/add-trigger-reason-to-transaction-finished
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: feature/add-trigger-reason-to-transaction-finished
+  git_tag: d6064d733c21a25fbff879c635c9583070f80217
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -63,6 +63,51 @@ std::set<TxStartStopPoint> get_tx_start_stop_points(const std::string& tx_start_
     return tx_start_stop_points;
 }
 
+ocpp::v201::TriggerReasonEnum stop_reason_to_trigger_reason_enum(const ocpp::v201::ReasonEnum& stop_reason) {
+    switch (stop_reason) {
+    case ocpp::v201::ReasonEnum::DeAuthorized:
+        return ocpp::v201::TriggerReasonEnum::Deauthorized;
+    case ocpp::v201::ReasonEnum::EmergencyStop:
+        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v201::ReasonEnum::EnergyLimitReached:
+        return ocpp::v201::TriggerReasonEnum::EnergyLimitReached;
+    case ocpp::v201::ReasonEnum::EVDisconnected:
+        return ocpp::v201::TriggerReasonEnum::EVCommunicationLost;
+    case ocpp::v201::ReasonEnum::GroundFault:
+        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v201::ReasonEnum::ImmediateReset:
+        return ocpp::v201::TriggerReasonEnum::ResetCommand;
+    case ocpp::v201::ReasonEnum::Local:
+        return ocpp::v201::TriggerReasonEnum::StopAuthorized;
+    case ocpp::v201::ReasonEnum::LocalOutOfCredit:
+        return ocpp::v201::TriggerReasonEnum::ChargingStateChanged;
+    case ocpp::v201::ReasonEnum::MasterPass:
+        return ocpp::v201::TriggerReasonEnum::StopAuthorized;
+    case ocpp::v201::ReasonEnum::Other:
+        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v201::ReasonEnum::OvercurrentFault:
+        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v201::ReasonEnum::PowerLoss:
+        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v201::ReasonEnum::PowerQuality:
+        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v201::ReasonEnum::Reboot:
+        return ocpp::v201::TriggerReasonEnum::ResetCommand;
+    case ocpp::v201::ReasonEnum::Remote:
+        return ocpp::v201::TriggerReasonEnum::RemoteStop;
+    case ocpp::v201::ReasonEnum::SOCLimitReached:
+        return ocpp::v201::TriggerReasonEnum::EnergyLimitReached;
+    case ocpp::v201::ReasonEnum::StoppedByEV:
+        return ocpp::v201::TriggerReasonEnum::StopAuthorized;
+    case ocpp::v201::ReasonEnum::TimeLimitReached:
+        return ocpp::v201::TriggerReasonEnum::TimeLimitReached;
+    case ocpp::v201::ReasonEnum::Timeout:
+        return ocpp::v201::TriggerReasonEnum::EVConnectTimeout;
+    default:
+        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
+    }
+}
+
 void OCPP201::init_evse_maps() {
     std::lock_guard<std::mutex> lk(this->evse_ready_mutex);
     for (size_t evse_id = 1; evse_id <= this->r_evse_manager.size(); evse_id++) {
@@ -612,6 +657,7 @@ void OCPP201::ready() {
 
 void OCPP201::process_session_event(const int32_t evse_id, const types::evse_manager::SessionEvent& session_event) {
     const auto connector_id = session_event.connector_id.value_or(1);
+    std::lock_guard<std::mutex> lg(this->session_event_mutex);
     switch (session_event.event) {
     case types::evse_manager::SessionEventEnum::SessionStarted: {
         this->process_session_started(evse_id, connector_id, session_event);
@@ -698,8 +744,9 @@ void OCPP201::process_tx_event_effect(const int32_t evse_id, const TxEventEffect
             get_meter_value(session_event), ocpp::v201::ReadingContextEnum::Transaction_End,
             get_signed_meter_value(session_event));
         this->charge_point->on_transaction_finished(evse_id, transaction_data->timestamp, transaction_data->meter_value,
-                                                    transaction_data->stop_reason, transaction_data->id_token,
-                                                    std::nullopt, transaction_data->charging_state);
+                                                    transaction_data->stop_reason, transaction_data->trigger_reason,
+                                                    transaction_data->id_token, std::nullopt,
+                                                    transaction_data->charging_state);
         this->transaction_handler->reset_transaction_data(evse_id);
     }
 }
@@ -761,6 +808,7 @@ void OCPP201::process_session_finished(const int32_t evse_id, const int32_t conn
     if (transaction_data != nullptr) {
         transaction_data->charging_state = ocpp::v201::ChargingStateEnum::Idle;
         transaction_data->stop_reason = ocpp::v201::ReasonEnum::EVDisconnected;
+        transaction_data->trigger_reason = ocpp::v201::TriggerReasonEnum::EVCommunicationLost;
     }
     const auto tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::EV_DISCONNECTED);
     this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
@@ -849,10 +897,13 @@ void OCPP201::process_transaction_finished(const int32_t evse_id, const int32_t 
         } else if (tx_event == TxEvent::DEAUTHORIZED) {
             charging_state = ocpp::v201::ChargingStateEnum::EVConnected;
         }
+        transaction_data->trigger_reason = stop_reason_to_trigger_reason_enum(reason);
         transaction_data->stop_reason = reason;
         transaction_data->id_token = id_token;
         transaction_data->charging_state = charging_state;
     }
+
+    // tx_event could be DEAUTHORIZED or EV_DISCONNECTED
     const auto tx_event_effect = this->transaction_handler->submit_event(evse_id, tx_event);
     this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
 
@@ -864,6 +915,15 @@ void OCPP201::process_transaction_finished(const int32_t evse_id, const int32_t 
             this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::EVConnected,
                                                           ocpp::v201::TriggerReasonEnum::StopAuthorized);
         }
+    } else {
+        // TODO(piet): If StopTxOnEVSideDisconnect is false, authorization shall still be present. This cannot only be
+        // handled within this module, but probably also within EvseManager and Auth
+
+        // authorization is always withdrawn in case of TransactionFinished, so in case we haven't updated the
+        // transaction handler yet, we have to do it
+        // now
+        const auto tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::DEAUTHORIZED);
+        this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
     }
 }
 

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -108,6 +108,7 @@ private:
     std::map<int32_t, bool> evse_ready_map;
     std::map<int32_t, std::optional<float>> evse_soc_map;
     std::mutex evse_ready_mutex;
+    std::mutex session_event_mutex;
     std::condition_variable evse_ready_cv;
     void init_evse_maps();
     bool all_evse_ready();


### PR DESCRIPTION
## Describe your changes
Added trigger_reason to on_transaction_finished since libocpp API is updated. Moved conversion from stop_reason to trigger_reason from libocpp to OCPP201 module

## Issue ticket number and link
Companion PR in libocpp: https://github.com/EVerest/libocpp/pull/698

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

