### PR TITLE
Add "Offline" value for DataTransferStatus

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: feature/data-transfer-return-immediately-when-offline
+  git_tag: f58617351f2edf9ea3e7ebe0e9212884fad7cad6
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 673bc5bf5db3a02d03f4f06cc2d9a575cbe53f39
+  git_tag: feature/data-transfer-return-immediately-when-offline
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/OCPP/data_transfer/ocpp_data_transferImpl.cpp
+++ b/modules/OCPP/data_transfer/ocpp_data_transferImpl.cpp
@@ -31,8 +31,12 @@ types::ocpp::DataTransferResponse
 ocpp_data_transferImpl::handle_data_transfer(types::ocpp::DataTransferRequest& request) {
     auto ocpp_response = mod->charge_point->data_transfer(request.vendor_id, request.message_id, request.data);
     types::ocpp::DataTransferResponse response;
-    response.status = to_everest(ocpp_response.status);
-    response.data = ocpp_response.data;
+    if (ocpp_response.has_value()) {
+        response.status = to_everest(ocpp_response.value().status);
+        response.data = ocpp_response.value().data;
+    } else {
+        response.status = types::ocpp::DataTransferStatus::Offline;
+    }
     return response;
 }
 

--- a/modules/OCPP201/data_transfer/ocpp_data_transferImpl.cpp
+++ b/modules/OCPP201/data_transfer/ocpp_data_transferImpl.cpp
@@ -18,7 +18,14 @@ types::ocpp::DataTransferResponse
 ocpp_data_transferImpl::handle_data_transfer(types::ocpp::DataTransferRequest& request) {
     ocpp::v201::DataTransferRequest ocpp_request = conversions::to_ocpp_data_transfer_request(request);
     auto ocpp_response = mod->charge_point->data_transfer_req(ocpp_request);
-    types::ocpp::DataTransferResponse response = conversions::to_everest_data_transfer_response(ocpp_response);
+
+    types::ocpp::DataTransferResponse response;
+
+    if (ocpp_response.has_value()) {
+        response = conversions::to_everest_data_transfer_response(ocpp_response.value());
+    } else {
+        response.status = types::ocpp::DataTransferStatus::Offline;
+    }
     return response;
 }
 

--- a/types/ocpp.yaml
+++ b/types/ocpp.yaml
@@ -163,6 +163,7 @@ types:
       - Rejected
       - UnknownMessageId
       - UnknownVendorId
+      - Offline
   DataTransferRequest:
     description: Type for data transfer request provided by OCPP
     type: object


### PR DESCRIPTION

## Describe your changes
Addressing changes required by interface changes in libocpp. Added additional value for type DataTransferStatus which allows to indicate that the charging station is offline when a data_transfer command is executed. If the charging station is offline, this command will return immedieately without waiting for a response from the csms

## Issue ticket number and link
Companion PR in libocpp: https://github.com/EVerest/libocpp/pull/699

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

