### PR TITLE
Command "iso_wait_for_stop" now works as intended in EvManager

### DIFF
--- a/modules/EvManager/main/car_simulation.cpp
+++ b/modules/EvManager/main/car_simulation.cpp
@@ -94,8 +94,8 @@ bool CarSimulation::sleep(const CmdArguments& arguments, size_t loop_interval_ms
         const auto sleep_time_ms = sleep_time * 1000;
         sim_data.sleep_ticks_left = static_cast<long long>(sleep_time_ms / loop_interval_ms) + 1;
     }
-    sim_data.sleep_ticks_left = sim_data.sleep_ticks_left.value() - 1;
-    if (!(sim_data.sleep_ticks_left > 0)) {
+    sim_data.sleep_ticks_left.value() -= 1;
+    if (not(sim_data.sleep_ticks_left.value() > 0)) {
         sim_data.sleep_ticks_left.reset();
         return true;
     } else {
@@ -234,21 +234,23 @@ bool CarSimulation::iso_stop_charging(const CmdArguments& arguments) {
 }
 
 bool CarSimulation::iso_wait_for_stop(const CmdArguments& arguments, size_t loop_interval_ms) {
-    if (!sim_data.sleep_ticks_left.has_value()) {
-        sim_data.sleep_ticks_left =
-            std::stoll(arguments[0]) * static_cast<long>(1 / static_cast<float>(loop_interval_ms)) + 1;
+    if (not sim_data.sleep_ticks_left.has_value()) {
+        const auto sleep_time_ms = std::stold(arguments[0]) * 1000;
+        sim_data.sleep_ticks_left = static_cast<long long>(sleep_time_ms / loop_interval_ms) + 1;
     }
-    sim_data.sleep_ticks_left = sim_data.sleep_ticks_left.value() - 1;
-    if (!sim_data.sleep_ticks_left > 0) {
+    sim_data.sleep_ticks_left.value() -= 1;
+    if (not(sim_data.sleep_ticks_left.value() > 0)) {
         r_ev[0]->call_stop_charging();
         r_ev_board_support->call_allow_power_on(false);
         sim_data.state = SimState::PLUGGED_IN;
+        sim_data.sleep_ticks_left.reset();
         return true;
     }
     if (sim_data.iso_stopped) {
         EVLOG_info << "POWER OFF iso stopped";
         r_ev_board_support->call_allow_power_on(false);
         sim_data.state = SimState::PLUGGED_IN;
+        sim_data.sleep_ticks_left.reset();
         return true;
     }
     return false;


### PR DESCRIPTION
## Describe your changes
The "iso_wait_for_stop" implementation was not correct. 

## Issue ticket number and link
`r_ev[0]->call_stop_charging();` was not called

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

