### PR TITLE
Add plc chip reset to ev_slac

### DIFF
--- a/lib/staging/slac/fsm/ev/include/slac/fsm/ev/fsm.hpp
+++ b/lib/staging/slac/fsm/ev/include/slac/fsm/ev/fsm.hpp
@@ -16,6 +16,7 @@ enum class Event {
 
     // internal events
     FAILED,
+    SUCCESS,
 };
 
 using FSMReturnType = int;

--- a/lib/staging/slac/fsm/ev/include/slac/fsm/ev/states/others.hpp
+++ b/lib/staging/slac/fsm/ev/include/slac/fsm/ev/states/others.hpp
@@ -18,6 +18,27 @@ struct ResetState : public FSMSimpleState {
     CallbackReturnType callback() final;
 };
 
+struct ResetChipState : public FSMSimpleState {
+    using FSMSimpleState::FSMSimpleState;
+
+    HandleEventReturnType handle_event(AllocatorType&, Event) final;
+
+    void enter() final;
+    CallbackReturnType callback() final;
+
+    // for now returns true if CM_RESET_CNF is received
+    bool check_for_valid_reset_conf();
+
+    bool reset_delay_done{false};
+    bool chip_reset_has_been_sent{false};
+
+    enum class SubState {
+        DELAY,
+        SEND_RESET,
+        DONE,
+    } sub_state{SubState::DELAY};
+};
+
 struct InitSlacState : public FSMSimpleState {
     using FSMSimpleState::FSMSimpleState;
 

--- a/modules/EvSlac/main/ev_slacImpl.cpp
+++ b/modules/EvSlac/main/ev_slacImpl.cpp
@@ -56,10 +56,9 @@ void ev_slacImpl::run() {
     callbacks.log = [](const std::string& text) { EVLOG_info << "EvSlac: " << text; };
 
     auto fsm_ctx = slac::fsm::ev::Context(callbacks);
-    // fsm_ctx.slac_config.set_key_timeout_ms = config.set_key_timeout_ms;
-    // fsm_ctx.slac_config.ac_mode_five_percent = config.ac_mode_five_percent;
-    // fsm_ctx.slac_config.sounding_atten_adjustment = config.sounding_attenuation_adjustment;
-    // fsm_ctx.slac_config.generate_nmk();
+    fsm_ctx.chip_reset.enabled = config.do_chip_reset;
+    fsm_ctx.chip_reset.delay_ms = config.chip_reset_delay_ms;
+    fsm_ctx.chip_reset.timeout_ms = config.chip_reset_timeout_ms;
 
     fsm_ctrl = std::make_unique<FSMController>(fsm_ctx);
 

--- a/modules/EvSlac/main/ev_slacImpl.hpp
+++ b/modules/EvSlac/main/ev_slacImpl.hpp
@@ -22,6 +22,9 @@ namespace main {
 struct Conf {
     std::string device;
     int set_key_timeout_ms;
+    bool do_chip_reset;
+    int chip_reset_delay_ms;
+    int chip_reset_timeout_ms;
 };
 
 class ev_slacImpl : public ev_slacImplBase {

--- a/modules/EvSlac/manifest.yaml
+++ b/modules/EvSlac/manifest.yaml
@@ -12,8 +12,21 @@ provides:
         description: Timeout for CM_SET_KEY.REQ. Default works for QCA7000/QCA7005/CG5317.
         type: integer
         default: 500
+      do_chip_reset:
+        description: Perform a chip reset after setting NMK using the RS_DEV.REQ Vendor MME Extension (Only works on Qualcomm chips)
+        type: boolean
+        default: false
+      chip_reset_delay_ms:
+        description: Delay between SET_KEY.CNF and RS_DEV.REQ
+        type: integer
+        default: 100
+      chip_reset_timeout_ms:
+        description: Timeout for RS_DEV.REQ (waiting for RS_DEV.CNF)
+        type: integer
+        default: 500
 metadata:
   base_license: https://directory.fsf.org/wiki/License:BSD-3-Clause-Clear
   license: https://opensource.org/licenses/Apache-2.0
   authors:
     - aw@pionix.de
+    - Sebastian Lukas


### PR DESCRIPTION
## Describe your changes
The reset function from the Evse ported to the Ev.

## Issue ticket number and link
The Ev Slac module lacks the function to reset the PLC chip after each session

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

