### PR TITLE
Extending 1ph/3ph feature

### DIFF
--- a/config/config-sil.yaml
+++ b/config/config-sil.yaml
@@ -52,6 +52,12 @@ active_modules:
   energy_manager:
     config_module:
       switch_3ph1ph_while_charging_mode: Both
+      switch_3ph1ph_max_nr_of_switches_per_session: 5
+      switch_3ph1ph_time_hyteresis_s: 20
+      switch_3ph1ph_power_hyteresis_W: 1000
+      switch_3ph1ph_switch_limit_stickyness: SinglePhase
+      schedule_interval_duration: 60
+      schedule_total_duration: 10
       debug: false
     connections:
       energy_trunk:

--- a/config/config-sil.yaml
+++ b/config/config-sil.yaml
@@ -53,8 +53,8 @@ active_modules:
     config_module:
       switch_3ph1ph_while_charging_mode: Both
       switch_3ph1ph_max_nr_of_switches_per_session: 5
-      switch_3ph1ph_time_hyteresis_s: 20
-      switch_3ph1ph_power_hyteresis_W: 1000
+      switch_3ph1ph_time_hysteresis_s: 20
+      switch_3ph1ph_power_hysteresis_W: 1000
       switch_3ph1ph_switch_limit_stickyness: SinglePhase
       schedule_interval_duration: 60
       schedule_total_duration: 10

--- a/modules/EnergyManager/Broker.cpp
+++ b/modules/EnergyManager/Broker.cpp
@@ -7,8 +7,9 @@
 
 namespace module {
 
-Broker::Broker(Market& _market) :
+Broker::Broker(Market& _market, BrokerContext& _context) :
     local_market(_market),
+    context(_context),
     first_trade(globals.schedule_length, true),
     slot_type(globals.schedule_length, SlotType::Undecided),
     num_phases(globals.schedule_length, 0) {

--- a/modules/EnergyManager/Broker.hpp
+++ b/modules/EnergyManager/Broker.hpp
@@ -14,10 +14,27 @@ enum class SlotType {
     Undecided
 };
 
+// All context data that is stored in between optimization runs
+struct BrokerContext {
+    BrokerContext() {
+        clear();
+    };
+
+    void clear() {
+        number_1ph3ph_cycles = 0;
+        last_ac_number_of_active_phases_import = 0;
+        ts_1ph_optimal = date::utc_clock::now();
+    };
+
+    int number_1ph3ph_cycles;
+    int last_ac_number_of_active_phases_import;
+    std::chrono::time_point<date::utc_clock> ts_1ph_optimal;
+};
+
 // base class for different Brokers
 class Broker {
 public:
-    Broker(Market& market);
+    Broker(Market& market, BrokerContext& context);
     virtual ~Broker(){};
     virtual bool trade(Offer& offer) = 0;
     Market& get_local_market();
@@ -28,6 +45,8 @@ protected:
     std::vector<bool> first_trade;
     std::vector<SlotType> slot_type;
     std::vector<int> num_phases;
+
+    BrokerContext& context;
 };
 
 } // namespace module

--- a/modules/EnergyManager/BrokerFastCharging.cpp
+++ b/modules/EnergyManager/BrokerFastCharging.cpp
@@ -122,7 +122,7 @@ bool BrokerFastCharging::trade(Offer& _offer) {
                 // If an additional watt limit is set check phases, else it is max_phases (typically 3)
                 // First decide if we would like to charge 1 phase or 3 phase (if switching is possible at all)
                 //   - Check if we are below e.g. 4.2kW (min_current*voltage*3) -> we have to do single phase
-                //   - Check if we are above e.g. 4.4kW (min_current*voltage*3 + watt_hyteresis) -> we want to go three
+                //   - Check if we are above e.g. 4.4kW (min_current*voltage*3 + watt_hysteresis) -> we want to go three
                 //   phase
                 //   - If we are in between, use what is currently active (hysteresis)
 
@@ -141,7 +141,7 @@ bool BrokerFastCharging::trade(Offer& _offer) {
                             // We have to do single phase, it is impossible with 3ph
                             number_of_phases = min_phases_import;
                         } else if (config.switch_1ph_3ph_mode == Switch1ph3phMode::Both and
-                                   total_power_import.value() > min_power_3ph + config.power_hyteresis_W) {
+                                   total_power_import.value() > min_power_3ph + config.power_hysteresis_W) {
                             number_of_phases = max_phases_import;
                         } else {
                             // Keep number of phases as they are
@@ -169,7 +169,7 @@ bool BrokerFastCharging::trade(Offer& _offer) {
                             context.ts_1ph_optimal = date::utc_clock::now();
                         }
 
-                        if (config.time_hyteresis_s > 0 and time_slot_is_active) {
+                        if (config.time_hysteresis_s > 0 and time_slot_is_active) {
                             // Check time based hysteresis:
                             // - store timestamp whenever 1ph is optimal (update continously)
                             // Then now-timestamp is the stable time period for a 3ph condition.
@@ -180,7 +180,7 @@ bool BrokerFastCharging::trade(Offer& _offer) {
                                                         globals.start_time - context.ts_1ph_optimal)
                                                         .count();
 
-                            if (stable_3ph < config.time_hyteresis_s and number_of_phases == max_phases_import) {
+                            if (stable_3ph < config.time_hysteresis_s and number_of_phases == max_phases_import) {
                                 number_of_phases = min_phases_import;
                             }
                         }

--- a/modules/EnergyManager/BrokerFastCharging.hpp
+++ b/modules/EnergyManager/BrokerFastCharging.hpp
@@ -26,8 +26,8 @@ public:
         Switch1ph3phMode switch_1ph_3ph_mode{Switch1ph3phMode::Never};
         StickyNess stickyness{StickyNess::DontChange};
         int max_nr_of_switches_per_session{0};
-        int power_hyteresis_W{200};
-        int time_hyteresis_s{600};
+        int power_hysteresis_W{200};
+        int time_hysteresis_s{600};
     };
 
     explicit BrokerFastCharging(Market& market, BrokerContext& context, Config config);

--- a/modules/EnergyManager/BrokerFastCharging.hpp
+++ b/modules/EnergyManager/BrokerFastCharging.hpp
@@ -15,7 +15,22 @@ public:
         Oneway,
         Both,
     };
-    explicit BrokerFastCharging(Market& market, Switch1ph3phMode mode);
+
+    enum class StickyNess {
+        SinglePhase,
+        ThreePhase,
+        DontChange,
+    };
+
+    struct Config {
+        Switch1ph3phMode switch_1ph_3ph_mode{Switch1ph3phMode::Never};
+        StickyNess stickyness{StickyNess::DontChange};
+        int max_nr_of_switches_per_session{0};
+        int power_hyteresis_W{200};
+        int time_hyteresis_s{600};
+    };
+
+    explicit BrokerFastCharging(Market& market, BrokerContext& context, Config config);
     virtual bool trade(Offer& offer) override;
 
 private:
@@ -35,7 +50,7 @@ private:
     Offer* offer{nullptr};
     bool traded{false};
 
-    Switch1ph3phMode switch_1ph3ph_mode;
+    Config config;
 };
 
 } // namespace module

--- a/modules/EnergyManager/EnergyManager.cpp
+++ b/modules/EnergyManager/EnergyManager.cpp
@@ -98,9 +98,9 @@ static BrokerFastCharging::Config to_broker_fast_charging_config(Conf module_con
     BrokerFastCharging::Config broker_conf;
 
     broker_conf.max_nr_of_switches_per_session = module_config.switch_3ph1ph_max_nr_of_switches_per_session;
-    broker_conf.power_hyteresis_W = module_config.switch_3ph1ph_power_hyteresis_W;
+    broker_conf.power_hysteresis_W = module_config.switch_3ph1ph_power_hysteresis_W;
     broker_conf.switch_1ph_3ph_mode = to_switch_1ph3ph_mode(module_config.switch_3ph1ph_while_charging_mode);
-    broker_conf.time_hyteresis_s = module_config.switch_3ph1ph_time_hyteresis_s;
+    broker_conf.time_hysteresis_s = module_config.switch_3ph1ph_time_hysteresis_s;
     broker_conf.stickyness = to_stickyness(module_config.switch_3ph1ph_switch_limit_stickyness);
 
     return broker_conf;
@@ -134,7 +134,7 @@ std::vector<types::energy::EnforcedLimits> EnergyManager::run_optimizer(types::e
             m->energy_flow_request.evse_state == types::energy::EvseState::Finished) {
             contexts[m->energy_flow_request.uuid].clear();
             contexts[m->energy_flow_request.uuid].ts_1ph_optimal =
-                globals.start_time - std::chrono::seconds(config.switch_3ph1ph_time_hyteresis_s);
+                globals.start_time - std::chrono::seconds(config.switch_3ph1ph_time_hysteresis_s);
         }
 
         // FIXME: check for actual optimizer_targets and create correct broker for this evse

--- a/modules/EnergyManager/EnergyManager.cpp
+++ b/modules/EnergyManager/EnergyManager.cpp
@@ -94,7 +94,7 @@ static BrokerFastCharging::StickyNess to_stickyness(const std::string& m) {
     }
 }
 
-static BrokerFastCharging::Config to_broker_fast_charging_config(Conf module_config) {
+static BrokerFastCharging::Config to_broker_fast_charging_config(const Conf& module_config) {
     BrokerFastCharging::Config broker_conf;
 
     broker_conf.max_nr_of_switches_per_session = module_config.switch_3ph1ph_max_nr_of_switches_per_session;

--- a/modules/EnergyManager/EnergyManager.hpp
+++ b/modules/EnergyManager/EnergyManager.hpp
@@ -50,8 +50,8 @@ struct Conf {
     std::string switch_3ph1ph_while_charging_mode;
     int switch_3ph1ph_max_nr_of_switches_per_session;
     std::string switch_3ph1ph_switch_limit_stickyness;
-    int switch_3ph1ph_power_hyteresis_W;
-    int switch_3ph1ph_time_hyteresis_s;
+    int switch_3ph1ph_power_hysteresis_W;
+    int switch_3ph1ph_time_hysteresis_s;
 };
 
 class EnergyManager : public Everest::ModuleBase {

--- a/modules/EnergyManager/EnergyManager.hpp
+++ b/modules/EnergyManager/EnergyManager.hpp
@@ -25,6 +25,8 @@
 
 #include <mutex>
 
+#include "Broker.hpp"
+
 #ifdef BUILD_TESTING_MODULE_ENERGY_MANAGER
 #include <gtest/gtest_prod.h>
 namespace module::test {
@@ -46,6 +48,10 @@ struct Conf {
     double slice_watt;
     bool debug;
     std::string switch_3ph1ph_while_charging_mode;
+    int switch_3ph1ph_max_nr_of_switches_per_session;
+    std::string switch_3ph1ph_switch_limit_stickyness;
+    int switch_3ph1ph_power_hyteresis_W;
+    int switch_3ph1ph_time_hyteresis_s;
 };
 
 class EnergyManager : public Everest::ModuleBase {
@@ -86,6 +92,8 @@ private:
 
     std::condition_variable mainloop_sleep_condvar;
     std::mutex mainloop_sleep_mutex;
+
+    std::map<std::string, BrokerContext> contexts;
 
 #ifdef BUILD_TESTING_MODULE_ENERGY_MANAGER
     FRIEND_TEST(EnergyManagerTest, empty);

--- a/modules/EnergyManager/manifest.yaml
+++ b/modules/EnergyManager/manifest.yaml
@@ -60,7 +60,7 @@ config:
       - ThreePhase
       - DontChange
     default: DontChange
-  switch_3ph1ph_power_hyteresis_W:
+  switch_3ph1ph_power_hysteresis_W:
     description: >-
       Power based hysteresis in Watt. If set to 200W for example,
       the hysteresis for PWM based charging will be 4.2kW to 4.4kW.
@@ -68,7 +68,7 @@ config:
       PWM vs ISO based charging in the future.
     type: integer
     default: 200
-  switch_3ph1ph_time_hyteresis_s:
+  switch_3ph1ph_time_hysteresis_s:
     description: >-
       Time based hysteresis. It will only switch to 3 phases if the condition to select 3 phases
       is stable for the configured number of seconds. It will always switch to 1ph mode without

--- a/modules/EnergyManager/manifest.yaml
+++ b/modules/EnergyManager/manifest.yaml
@@ -42,6 +42,40 @@ config:
       - Oneway
       - Both
     default: Never
+  switch_3ph1ph_max_nr_of_switches_per_session:
+    description: >-
+      Limit the maximum number of switches between 1ph and 3ph per charging session.
+      Set to 0 for no limit.
+    type: integer
+    default: 0
+  switch_3ph1ph_switch_limit_stickyness:
+    description: >-
+      If the maximum number of switches between 1ph and 3ph is reached, select what should happen:
+        - SinglePhase: Switch to 1ph mode
+        - ThreePhase: Switch to 3ph mode
+        - DontChange: Stay in the mode it is currently in
+    type: string
+    enum:
+      - SinglePhase
+      - ThreePhase
+      - DontChange
+    default: DontChange
+  switch_3ph1ph_power_hyteresis_W:
+    description: >-
+      Power based hysteresis in Watt. If set to 200W for example,
+      the hysteresis for PWM based charging will be 4.2kW to 4.4kW.
+      Actual values will depend on configured nominal AC voltage, and they may be different for
+      PWM vs ISO based charging in the future.
+    type: integer
+    default: 200
+  switch_3ph1ph_time_hyteresis_s:
+    description: >-
+      Time based hysteresis. It will only switch to 3 phases if the condition to select 3 phases
+      is stable for the configured number of seconds. It will always switch to 1ph mode without
+      waiting for this delay.
+      Set to 0 to disable time based hysteresis.
+    type: integer
+    default: 600
 provides:
   main:
     description: Main interface of the energy manager

--- a/modules/EnergyManager/tests/EnergyManagerTest.cpp
+++ b/modules/EnergyManager/tests/EnergyManagerTest.cpp
@@ -456,6 +456,7 @@ types::energy::EnergyFlowRequest energy_flow_request{
     "evse_manager",                // UUID for this node
     types::energy::NodeType::Evse, // node_type
     false,                         // optional - bool priority_request
+    std::nullopt,                  // optional - EvseState
     std::nullopt,                  // optional - types::energy::OptimizerTarget
     c_energy_usage_root,           // optional - types::powermeter::Powermeter - root
     std::nullopt,                  // optional - types::powermeter::Powermeter - leaf
@@ -542,6 +543,7 @@ const types::energy::EnergyFlowRequest c_efr_evse_manager{
     "evse_manager",                   // UUID for this node
     types::energy::NodeType::Evse,    // node_type
     false,                            // optional - bool priority_request
+    std::nullopt,                     // optional - EvseState
     std::nullopt,                     // optional - types::energy::OptimizerTarget
     c_energy_usage_root_evse_manager, // optional - types::powermeter::Powermeter - root
     std::nullopt,                     // optional - types::powermeter::Powermeter - leaf
@@ -574,6 +576,7 @@ const types::energy::EnergyFlowRequest c_efr_cls_energy_node{
     "cls_energy_node",                   // UUID for this node
     types::energy::NodeType::Generic,    // node_type
     std::nullopt,                        // optional - bool priority_request
+    std::nullopt,                        // optional - EvseState
     std::nullopt,                        // optional - types::energy::OptimizerTarget
     std::nullopt,                        // optional - types::powermeter::Powermeter - root
     std::nullopt,                        // optional - types::powermeter::Powermeter - leaf
@@ -606,6 +609,7 @@ const types::energy::EnergyFlowRequest c_efr_grid_connection_point{
     "grid_connection_point",                   // UUID for this node
     types::energy::NodeType::Generic,          // node_type
     std::nullopt,                              // optional - bool priority_request
+    std::nullopt,                              // optional - EvseState
     std::nullopt,                              // optional - types::energy::OptimizerTarget
     std::nullopt,                              // optional - types::powermeter::Powermeter - root
     std::nullopt,                              // optional - types::powermeter::Powermeter - leaf
@@ -757,6 +761,7 @@ TEST(EnergyManagerTest, noSchedules) {
         types::energy::NodeType::Evse, // node_type
         false,                         // optional - bool priority_request
         std::nullopt,                  // optional - types::energy::OptimizerTarget
+        std::nullopt,                  // optional - EvseState
         c_energy_usage_root,           // optional - types::powermeter::Powermeter - root
         std::nullopt,                  // optional - types::powermeter::Powermeter - leaf
         std::nullopt,                  // optional - std::vector<types::energy::ScheduleReqEntry> - import
@@ -816,6 +821,7 @@ TEST(EnergyManagerTest, schedules) {
         "evse_manager",                // UUID for this node
         types::energy::NodeType::Evse, // node_type
         false,                         // optional - bool priority_request
+        std::nullopt,                  // optional - EvseState
         std::nullopt,                  // optional - types::energy::OptimizerTarget
         c_energy_usage_root,           // optional - types::powermeter::Powermeter - root
         std::nullopt,                  // optional - types::powermeter::Powermeter - leaf

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -300,6 +300,7 @@ private:
         bool ac_with_soc_timeout;
         bool contactor_welded{false};
         bool switch_3ph1ph_threephase{false};
+        bool switch_3ph1ph_threephase_ongoing{false};
 
         std::optional<types::units_signed::SignedMeterValue> stop_signed_meter_value;
         std::optional<types::units_signed::SignedMeterValue> start_signed_meter_value;

--- a/modules/EvseManager/doc.rst
+++ b/modules/EvseManager/doc.rst
@@ -201,7 +201,7 @@ To use this feature several things need to be enabled:
 - BSP driver capabilities: Also make sure that minimum phases are set to one and maximum phases to 3
 - BSP driver: make sure the ``ac_switch_three_phases_while_charging`` command is correctly implemented
 - EnergyManager: Adjust ``switch_3ph1ph_while_charging_mode``, ``switch_3ph1ph_max_nr_of_switches_per_session``,
-  ``switch_3ph1ph_switch_limit_stickyness``, ``switch_3ph1ph_power_hyteresis_W``, ``switch_3ph1ph_time_hyteresis_s``
+  ``switch_3ph1ph_switch_limit_stickyness``, ``switch_3ph1ph_power_hysteresis_W``, ``switch_3ph1ph_time_hysteresis_s``
   config options to your needs
 
 If all of this is properly set up, the EnergyManager will drive the 1ph/3ph switching. In order to do so,

--- a/modules/EvseManager/doc.rst
+++ b/modules/EvseManager/doc.rst
@@ -199,8 +199,10 @@ To use this feature several things need to be enabled:
 - In the BSP driver, set ``supports_changing_phases_during_charging`` to true in the reported capabilities.
   If your bsp hardware detects e.g. the Zoe, you can set that flag to false and publish updated capabilities any time.
 - BSP driver capabilities: Also make sure that minimum phases are set to one and maximum phases to 3
-- BSP driver: make sure the ``ac_switch_three_phases_while_charging`` command correctly
-- EnergyManager: Adjust ``switch_3ph1ph_while_charging_mode`` config option to your needs
+- BSP driver: make sure the ``ac_switch_three_phases_while_charging`` command is correctly implemented
+- EnergyManager: Adjust ``switch_3ph1ph_while_charging_mode``, ``switch_3ph1ph_max_nr_of_switches_per_session``,
+  ``switch_3ph1ph_switch_limit_stickyness``, ``switch_3ph1ph_power_hyteresis_W``, ``switch_3ph1ph_time_hyteresis_s``
+  config options to your needs
 
 If all of this is properly set up, the EnergyManager will drive the 1ph/3ph switching. In order to do so,
 it needs an (external) limit to be set. There are two options: The external limit can be in Watt (not in Ampere),
@@ -211,13 +213,9 @@ The second option is to set a limit in Ampere and set a limitation on the number
 This will enforce switching and can be used to decide the switching time externally. EnergyManager does not have the
 freedom to make the choice in this case.
 
-In general, it works best in a configuration with 32A per phase and a limit in Watt.
-In this scenario there is an actual hysteresis as the two intervals overlap:
-1ph charging can be done from 1.3kW to 7.4kW and 3ph charging works from 4.2kW to 22kW(or 11kW)
-
-If the single phase and three phase intervals do not overlap, there is no hysteresis.
-Note that many cars support 32A on 1ph even if they are limited to 16A on 3ph. Some however are limited to 16A
-in 1ph mode and will hence charge slower then expected in 1ph mode.
+Take care especially with the power(watt) and time based hysteresis settings. They should be adjusted to the
+actual use case to avoid relays wearing due too a lot of switching cycles. Consider also to limit the maximum
+number of switching cycles per charging session.
 
 Error Handling
 ==============

--- a/modules/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EvseManager/energy_grid/energyImpl.cpp
@@ -129,6 +129,54 @@ void energyImpl::ready() {
     });
 }
 
+types::energy::EvseState to_energy_evse_state(const Charger::EvseState charger_state) {
+    switch (charger_state) {
+    case Charger::EvseState::Disabled:
+        return types::energy::EvseState::Disabled;
+        break;
+    case Charger::EvseState::Idle:
+        return types::energy::EvseState::Unplugged;
+        break;
+    case Charger::EvseState::WaitingForAuthentication:
+        return types::energy::EvseState::WaitForAuth;
+        break;
+    case Charger::EvseState::PrepareCharging:
+        return types::energy::EvseState::PrepareCharging;
+        break;
+    case Charger::EvseState::WaitingForEnergy:
+        return types::energy::EvseState::WaitForEnergy;
+        break;
+    case Charger::EvseState::Charging:
+        return types::energy::EvseState::Charging;
+        break;
+    case Charger::EvseState::ChargingPausedEV:
+        return types::energy::EvseState::PausedEV;
+        break;
+    case Charger::EvseState::ChargingPausedEVSE:
+        return types::energy::EvseState::PausedEVSE;
+        break;
+    case Charger::EvseState::StoppingCharging:
+        return types::energy::EvseState::Finished;
+        break;
+    case Charger::EvseState::Finished:
+        return types::energy::EvseState::Finished;
+        break;
+    case Charger::EvseState::T_step_EF:
+        return types::energy::EvseState::PrepareCharging;
+        break;
+    case Charger::EvseState::T_step_X1:
+        return types::energy::EvseState::PrepareCharging;
+        break;
+    case Charger::EvseState::SwitchPhases:
+        return types::energy::EvseState::Charging;
+        break;
+    case Charger::EvseState::Replug:
+        return types::energy::EvseState::PrepareCharging;
+        break;
+    }
+    return types::energy::EvseState::Disabled;
+}
+
 void energyImpl::request_energy_from_energy_manager(bool priority_request) {
     std::lock_guard<std::mutex> lock(this->energy_mutex);
     clear_import_request_schedule();
@@ -250,6 +298,9 @@ void energyImpl::request_energy_from_energy_manager(bool priority_request) {
     } else {
         energy_flow_request.priority_request = false;
     }
+
+    // Attach our state
+    energy_flow_request.evse_state = to_energy_evse_state(charger_state);
 
     publish_energy_flow_request(energy_flow_request);
     // EVLOG_info << "Outgoing request " << energy_flow_request;

--- a/types/energy.yaml
+++ b/types/energy.yaml
@@ -7,6 +7,19 @@ types:
       - Undefined
       - Evse
       - Generic
+  EvseState:
+    description: Enum for simplified EVSE state
+    type: string
+    enum:
+      - Unplugged
+      - WaitForAuth
+      - WaitForEnergy
+      - PrepareCharging
+      - PausedEV
+      - PausedEVSE
+      - Charging
+      - Finished
+      - Disabled
   LimitsReq:
     description: Energy flow limiting object request (Evses to EnergyManager)
     type: object
@@ -180,6 +193,10 @@ types:
           If set to true, this is a high priority request that needs to be handled now. 
           Otherwise energymanager may merge multiple requests and address them later.
         type: boolean
+      evse_state:
+        description: State of the EVSE
+        type: object
+        $ref: /energy#/EvseState
       optimizer_target:
         description: User defined optimizer targets for this evse
         type: object


### PR DESCRIPTION
Adds the following config options:

- Power (watt) hysteresis
- Time based hysteresis for switching to 3ph
- Max number of switching cycles per session
- Stickyness (aka what happens if max switching cycles are reached)

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

