### PR TITLE
Support for Lumissil reset in EvseSlac

### DIFF
--- a/lib/staging/slac/fsm/evse/include/slac/fsm/evse/context.hpp
+++ b/lib/staging/slac/fsm/evse/include/slac/fsm/evse/context.hpp
@@ -166,7 +166,8 @@ struct EvseSlacConfig {
     struct chip_reset_struct {
         bool enabled = false;
         int timeout_ms = 500;
-        int delay_ms = 100;
+        int delay_before_reset_ms = 100;
+        int delay_after_reset_ms = 100;
     } chip_reset;
 
     // Settings for LINK_STATUS detection

--- a/lib/staging/slac/fsm/evse/include/slac/fsm/evse/states/others.hpp
+++ b/lib/staging/slac/fsm/evse/include/slac/fsm/evse/states/others.hpp
@@ -15,11 +15,20 @@ struct ResetState : public FSMSimpleState {
 
     void enter() final;
     CallbackReturnType callback() final;
+};
+
+struct UpdateNMKState : public FSMSimpleState {
+    using FSMSimpleState::FSMSimpleState;
+
+    HandleEventReturnType handle_event(AllocatorType&, Event) final;
+
+    void enter() final;
+    CallbackReturnType callback() final;
 
     // for now returns true if CM_SET_KEY_CNF is received
     bool handle_slac_message(slac::messages::HomeplugMessage&);
 
-    bool setup_has_been_send{false};
+    bool set_key_req_has_been_send{false};
 };
 
 struct ResetChipState : public FSMSimpleState {
@@ -37,10 +46,11 @@ struct ResetChipState : public FSMSimpleState {
     bool chip_reset_has_been_sent{false};
 
     enum class SubState {
-        DELAY,
+        DELAY_BEFORE_RESET,
         SEND_RESET,
+        DELAY_AFTER_RESET,
         DONE,
-    } sub_state{SubState::DELAY};
+    } sub_state{SubState::DELAY_BEFORE_RESET};
 };
 
 struct IdleState : public FSMSimpleState {

--- a/modules/EvseSlac/main/slacImpl.cpp
+++ b/modules/EvseSlac/main/slacImpl.cpp
@@ -77,7 +77,7 @@ void slacImpl::run() {
     fsm_ctx.slac_config.sounding_atten_adjustment = config.sounding_attenuation_adjustment;
 
     fsm_ctx.slac_config.chip_reset.enabled = config.do_chip_reset;
-    fsm_ctx.slac_config.chip_reset.delay_ms = config.chip_reset_delay_ms;
+    fsm_ctx.slac_config.chip_reset.delay_before_reset_ms = config.chip_reset_delay_ms;
     fsm_ctx.slac_config.chip_reset.timeout_ms = config.chip_reset_timeout_ms;
 
     fsm_ctx.slac_config.link_status.do_detect = config.link_status_detection;


### PR DESCRIPTION
## Describe your changes

Lumissil PLC chip also requires resetting after each charging session in some setups. This PR adds this option for Lumissil.

Still in draft, as there is still a hardcoded 10s delay after the reset. We need to find a better way to detect when the chip is back on line. If it has no attached EEPROM, it takes quite a while for the host loading service to upload the firmware and config again. 10s is sufficient but we need to check if there is a better way.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

