### PR TITLE
fix: adjust location of openssl_types.hpp

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -54,7 +54,7 @@ libcurl:
 # and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: 8a300f39b94fb6364759dfbb57e8501facb94b2f
+  git_tag: aec383634d4def547ea4e8a5743576b697ea9987
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP

--- a/lib/staging/tls/CMakeLists.txt
+++ b/lib/staging/tls/CMakeLists.txt
@@ -10,6 +10,10 @@ target_sources(tls
         tls.cpp
 )
 
+target_compile_definitions(tls PRIVATE
+    -DLIBEVSE_CRYPTO_SUPPLIER_OPENSSL
+)
+
 target_include_directories(tls
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/lib/staging/tls/openssl_conv.cpp
+++ b/lib/staging/tls/openssl_conv.cpp
@@ -3,7 +3,7 @@
 
 #include <openssl_conv.hpp>
 
-#include <evse_security/detail/openssl/openssl_types.hpp>
+#include <evse_security/crypto/openssl/openssl_types.hpp>
 #include <memory>
 #include <openssl/x509.h>
 

--- a/lib/staging/tls/tests/CMakeLists.txt
+++ b/lib/staging/tls/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(${TLS_GTEST_NAME} PRIVATE
 
 target_compile_definitions(${TLS_GTEST_NAME} PRIVATE
     -DUNIT_TEST
+    -DLIBEVSE_CRYPTO_SUPPLIER_OPENSSL
 )
 
 target_sources(${TLS_GTEST_NAME} PRIVATE


### PR DESCRIPTION
fix: adjust location of openssl_types.hpp
plus some compiler defines

## Describe your changes

changed #include to match change in libevse-security

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

