### PR TITLE
Fix bug to initialize signed meter data for TransactionFinished event

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -1209,8 +1209,6 @@ void Charger::cleanup_transactions_on_startup() {
         EVLOG_info << "Cleaning up transaction with UUID " << session_uuid << " on start up";
         store->clear_session();
 
-        types::evse_manager::TransactionFinished transaction_finished;
-
         // If yes, try to close nicely with the ID we remember and trigger a transaction finished event on success
         for (const auto& meter : r_powermeter_billing) {
             const auto response = meter->call_stop_transaction(session_uuid);
@@ -1220,8 +1218,8 @@ void Charger::cleanup_transactions_on_startup() {
                 break;
             } else if (response.status == types::powermeter::TransactionRequestStatus::OK) {
                 // Fill in OCMF from the recovered transaction
-                transaction_finished.start_signed_meter_value = response.start_signed_meter_value;
-                transaction_finished.signed_meter_value = response.signed_meter_value;
+                shared_context.start_signed_meter_value = response.start_signed_meter_value;
+                shared_context.stop_signed_meter_value = response.signed_meter_value;
                 break;
             }
         }


### PR DESCRIPTION
## Describe your changes
Signed meter data was not properly initialized when cleaning up a transaction at startup, which lead to the fact that it was not included within the TransactionFinished event.

This change assigns the from the storage retrieved signed data to the shared_context, which is also used when the TransactionFinished event is created. 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

