### PR TITLE
Fix the power DC mode spurrious Import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14.7)
 
 project(everest-core
-    VERSION 2024.7.0
+    VERSION 2024.7.1
     DESCRIPTION "The open operating system for e-mobility charging stations"
 	LANGUAGES CXX C
 )

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1558,7 +1558,7 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
 
     auto caps = get_powersupply_capabilities();
 
-    if ((((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and current_demand_active) and
+    if (((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and current_demand_active) and
         is_actually_exporting_to_grid) {
         if (not last_is_actually_exporting_to_grid) {
             // switching from import from grid to export to grid
@@ -1593,7 +1593,7 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
         return false;
 
     } else {
-        if ((((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and
+        if (((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and
               last_is_actually_exporting_to_grid) and current_demand_active) {
             // switching from export to grid to import from grid
             session_log.evse(false, "DC power supply: switch ON in export mode");

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1594,7 +1594,8 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
 
     } else {
         if (((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and
-              last_is_actually_exporting_to_grid) and current_demand_active) {
+              last_is_actually_exporting_to_grid) and 
+              current_demand_active) {
             // switching from export to grid to import from grid
             session_log.evse(false, "DC power supply: switch ON in export mode");
             r_powersupply_DC[0]->call_setMode(types::power_supply_DC::Mode::Export, power_supply_DC_charging_phase);

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -965,7 +965,8 @@ void EvseManager::ready_to_start_charging() {
     }
 
     this->p_evse->publish_ready(true);
-    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
+    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
+                              "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
     if (!initial_powermeter_value_received) {
         EVLOG_warning << "No powermeter value received yet!";
     }
@@ -1594,8 +1595,8 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
 
     } else {
         if (((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and
-              last_is_actually_exporting_to_grid) and 
-              current_demand_active) {
+             last_is_actually_exporting_to_grid) and
+            current_demand_active) {
             // switching from export to grid to import from grid
             session_log.evse(false, "DC power supply: switch ON in export mode");
             r_powersupply_DC[0]->call_setMode(types::power_supply_DC::Mode::Export, power_supply_DC_charging_phase);

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1593,7 +1593,6 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
         return false;
 
     } else {
-
         if ((((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and
               last_is_actually_exporting_to_grid) and current_demand_active) {
             // switching from export to grid to import from grid

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -965,7 +965,8 @@ void EvseManager::ready_to_start_charging() {
     }
 
     this->p_evse->publish_ready(true);
-    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
+    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
+                              "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
     if (!initial_powermeter_value_received) {
         EVLOG_warning << "No powermeter value received yet!";
     }
@@ -1558,9 +1559,9 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
 
     auto caps = get_powersupply_capabilities();
 
-    if ((((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and is_actually_exporting_to_grid) or
-         charging_phase_changed) and
-        current_demand_active) {
+    if ((((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) or charging_phase_changed) and
+         current_demand_active) and
+        is_actually_exporting_to_grid) {
         if (not last_is_actually_exporting_to_grid) {
             // switching from import from grid to export to grid
             session_log.evse(false, "DC power supply: switch ON in import mode");

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1593,9 +1593,9 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
         return false;
 
     } else {
-        if (((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and
-             last_is_actually_exporting_to_grid) and
-            current_demand_active) {
+        if (charging_phase_changed or (((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and
+                                        last_is_actually_exporting_to_grid) and
+                                       current_demand_active)) {
             // switching from export to grid to import from grid
             session_log.evse(false, "DC power supply: switch ON in export mode");
             r_powersupply_DC[0]->call_setMode(types::power_supply_DC::Mode::Export, power_supply_DC_charging_phase);

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -965,8 +965,7 @@ void EvseManager::ready_to_start_charging() {
     }
 
     this->p_evse->publish_ready(true);
-    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
-                              "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
+    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
     if (!initial_powermeter_value_received) {
         EVLOG_warning << "No powermeter value received yet!";
     }

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1558,8 +1558,7 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
 
     auto caps = get_powersupply_capabilities();
 
-    if ((((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) or charging_phase_changed) and
-         current_demand_active) and
+    if ((((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and current_demand_active) and
         is_actually_exporting_to_grid) {
         if (not last_is_actually_exporting_to_grid) {
             // switching from import from grid to export to grid
@@ -1596,9 +1595,7 @@ bool EvseManager::powersupply_DC_set(double _voltage, double _current) {
     } else {
 
         if ((((config.hack_allow_bpt_with_iso2 or config.sae_j2847_2_bpt_enabled) and
-              last_is_actually_exporting_to_grid) or
-             charging_phase_changed) and
-            current_demand_active) {
+              last_is_actually_exporting_to_grid) and current_demand_active) {
             // switching from export to grid to import from grid
             session_log.evse(false, "DC power supply: switch ON in export mode");
             r_powersupply_DC[0]->call_setMode(types::power_supply_DC::Mode::Export, power_supply_DC_charging_phase);


### PR DESCRIPTION
## Describe your changes
The charging_phase_changed variable is partly no longer used in the powersuply_DC_set method.

## Issue ticket number and link
The power_supply dc mode was falsely set to Import from the EvseManager directly when switching from PowerDelivery to CurrentDemand. Although both config options `hack_allow_bpt_with_iso2` and `sae_j2847_2_bpt_enabled` were not active.
Due to the phase change, the `charge_phase_changed` variable became active in the EvseManager and set the power_supply mode to import despite the two inactive config options.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

