### PR TITLE
bug(EvseManager): legacy wakeup

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -524,12 +524,10 @@ void Charger::run_state_machine() {
                             internal_context.t_step_EF_return_state = EvseState::PrepareCharging;
                             internal_context.t_step_EF_return_pwm = ampere_to_duty_cycle(get_max_current_internal());
                             shared_context.current_state = EvseState::T_step_EF;
-                        }
-
-                        // We are still here after the wakeup plus some extra delay, so probably the EV really does not
-                        // want to charge. Switch to ChargingPausedEV state.
-                        if (not shared_context.hlc_charging_active and shared_context.legacy_wakeup_done and
-                            time_in_current_state > PREPARING_TIMEOUT_PAUSED_BY_EV) {
+                        } else if (not shared_context.hlc_charging_active and shared_context.legacy_wakeup_done and
+                                   time_in_current_state > PREPARING_TIMEOUT_PAUSED_BY_EV) {
+                            // We are still here after the wakeup plus some extra delay, so probably the EV really does
+                            // not want to charge. Switch to ChargingPausedEV state.
                             shared_context.current_state = EvseState::ChargingPausedEV;
                         }
                     }


### PR DESCRIPTION
- a previous commit #757 probably introduced a bug
- it should bring the EVSE state machine into state B1 back from B2 after the legacy wakeup routine using state F didn't succeed
- but the code (which checks for the timeout in order start the wakeup) unconditionally runs into the code which transitions back to B1, effectively disabling the legacy wakeup

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

