### PR TITLE
If LEM is returning from Communication Error, try to get its state id…

### DIFF
--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -51,6 +51,33 @@ std::string LemDCBM400600Controller::get_current_transaction() {
     }
 }
 
+void LemDCBM400600Controller::update_lem_status() {
+    // should call this after a communication error to figure out what has been happening
+    auto status_response = this->http_client->get("/v1/status");
+
+    if (status_response.status_code != 200) {
+        throw UnexpectedDCBMResponseCode("/v1/status", 200, status_response);
+    }
+    try {
+        json data = json::parse(status_response.body);
+        this->transaction_is_ongoing_at_startup = data.at("status").at("bits").at("transactionIsOnGoing");
+        this->current_transaction_id = get_current_transaction();
+        if (this->transaction_is_ongoing_at_startup) {
+            // we need to get the current transaction id or the last known transaction id since we might
+            // receive a stop transaction with id 0 or with the last known transaction if
+            // meaning that the system had a failure and the transaction was started but id was not saved
+            // and we try to recover from the error, thus we need to cancel the transaction
+            EVLOG_warning << "LEM DCBM 400/600: A transaction is already ongoing and it has the id:"
+                          << this->current_transaction_id;
+        } else {
+            EVLOG_info << "LEM DCBM 400/600: The last known transaction has the id:" << this->current_transaction_id;
+        }
+    } catch (json::exception& json_error) {
+        throw UnexpectedDCBMResponseBody(
+            "/v1/status", fmt::format("Json error {} for body {}", json_error.what(), status_response.body));
+    }
+}
+
 void LemDCBM400600Controller::fetch_meter_id_from_device() {
     auto status_response = this->http_client->get("/v1/status");
 

--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
@@ -86,6 +86,8 @@ public:
         }
     };
 
+    void update_lem_status();
+
 private:
     const std::unique_ptr<HttpClientInterface> http_client;
     std::string meter_id;
@@ -110,8 +112,8 @@ private:
 
     template <typename Callable>
     static auto call_with_retry(Callable func, int number_of_retries, int retry_wait_in_milliseconds,
-                                bool retry_on_http_client_error = true, bool retry_on_dcbm_reponse_error = true)
-        -> decltype(func()) {
+                                bool retry_on_http_client_error = true,
+                                bool retry_on_dcbm_reponse_error = true) -> decltype(func()) {
         std::exception_ptr lastException = nullptr;
         for (int attempt = 0; attempt < 1 + number_of_retries; ++attempt) {
             try {

--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
@@ -112,8 +112,8 @@ private:
 
     template <typename Callable>
     static auto call_with_retry(Callable func, int number_of_retries, int retry_wait_in_milliseconds,
-                                bool retry_on_http_client_error = true,
-                                bool retry_on_dcbm_reponse_error = true) -> decltype(func()) {
+                                bool retry_on_http_client_error = true, bool retry_on_dcbm_reponse_error = true)
+        -> decltype(func()) {
         std::exception_ptr lastException = nullptr;
         for (int attempt = 0; attempt < 1 + number_of_retries; ++attempt) {
             try {

--- a/modules/LemDCBM400600/main/powermeterImpl.cpp
+++ b/modules/LemDCBM400600/main/powermeterImpl.cpp
@@ -42,6 +42,8 @@ void powermeterImpl::ready() {
                 // if the communication error is set, clear the error
                 if (this->error_state_monitor->is_error_active("powermeter/CommunicationFault",
                                                                "Communication timed out")) {
+                    // need to update LEM status since we have recovered from a communication loss
+                    this->controller->update_lem_status();
                     clear_error("powermeter/CommunicationFault", "Communication timed out");
                 }
             } catch (LemDCBM400600Controller::DCBMUnexpectedResponseException& dcbm_exception) {


### PR DESCRIPTION
…entical to init. Subsequent StopTransactions will be handled correctly since we know if a transaction is open or not

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

