### PR TITLE
Fix locking in select_connector of AuthHandler

### DIFF
--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -19,6 +19,7 @@ private:
     std::map<int, types::reservation::Reservation> reservations;
 
     std::mutex timer_mutex;
+    std::mutex reservation_mutex;
     std::map<int, std::unique_ptr<Everest::SteadyTimer>> connector_to_reservation_timeout_timer_map;
 
     std::function<void(const int& connector_id)> reservation_cancelled_callback;

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -311,46 +311,43 @@ TEST_F(AuthTest, test_swipe_multiple_times_with_timeout) {
     ASSERT_TRUE(this->auth_receiver->get_authorization(1));
 }
 
-// /// \brief Test if swiping two different cars will be processed and used for two seperate transactions
-// TEST_F(AuthTest, test_two_id_tokens) {
-//     std::vector<int32_t> connectors{1, 2};
-//     ProvidedIdToken provided_token_1 = get_provided_token(VALID_TOKEN_1, connectors);
-//     ProvidedIdToken provided_token_2 = get_provided_token(VALID_TOKEN_2, connectors);
+/// \brief Test if swiping two different cars will be processed and used for two seperate transactions
+TEST_F(AuthTest, test_two_id_tokens) {
+    std::vector<int32_t> connectors{1, 2};
+    ProvidedIdToken provided_token_1 = get_provided_token(VALID_TOKEN_1, connectors);
+    ProvidedIdToken provided_token_2 = get_provided_token(VALID_TOKEN_2, connectors);
 
-//     EXPECT_CALL(mock_publish_token_validation_status_callback,
-//                 Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token),
-//                 TokenValidationStatus::Processing));
-//     EXPECT_CALL(mock_publish_token_validation_status_callback,
-//                 Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token),
-//                 TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Processing));
 
-//     EXPECT_CALL(mock_publish_token_validation_status_callback,
-//                 Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Accepted));
-//     EXPECT_CALL(mock_publish_token_validation_status_callback,
-//                 Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Accepted));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Accepted));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Accepted));
 
-//     TokenHandlingResult result1;
-//     TokenHandlingResult result2;
+    TokenHandlingResult result1;
+    TokenHandlingResult result2;
 
-//     std::thread t1([this, provided_token_1, &result1]() { result1 = this->auth_handler->on_token(provided_token_1);
-//     }); std::thread t2([this, provided_token_2, &result2]() { result2 =
-//     this->auth_handler->on_token(provided_token_2); });
+    std::thread t1([this, provided_token_1, &result1]() { result1 = this->auth_handler->on_token(provided_token_1); });
+    std::thread t2([this, provided_token_2, &result2]() { result2 = this->auth_handler->on_token(provided_token_2); });
 
-//     SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::Authorized);
-//     std::thread t3([this, session_event]() { this->auth_handler->handle_session_event(1, session_event); });
-//     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-//     std::thread t4([this, session_event]() { this->auth_handler->handle_session_event(2, session_event); });
+    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::Authorized);
+    std::thread t3([this, session_event]() { this->auth_handler->handle_session_event(1, session_event); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::thread t4([this, session_event]() { this->auth_handler->handle_session_event(2, session_event); });
 
-//     t1.join();
-//     t2.join();
-//     t3.join();
-//     t4.join();
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join();
 
-//     ASSERT_TRUE(result1 == TokenHandlingResult::ACCEPTED);
-//     ASSERT_TRUE(result2 == TokenHandlingResult::ACCEPTED);
-//     ASSERT_TRUE(this->auth_receiver->get_authorization(0));
-//     ASSERT_TRUE(this->auth_receiver->get_authorization(1));
-// }
+    ASSERT_TRUE(result1 == TokenHandlingResult::ACCEPTED);
+    ASSERT_TRUE(result2 == TokenHandlingResult::ACCEPTED);
+    ASSERT_TRUE(this->auth_receiver->get_authorization(0));
+    ASSERT_TRUE(this->auth_receiver->get_authorization(1));
+}
 
 /// \brief Test if two transactions can be started for two succeeding plugins before two card swipes
 TEST_F(AuthTest, test_two_plugins) {
@@ -392,48 +389,46 @@ TEST_F(AuthTest, test_two_plugins) {
     ASSERT_TRUE(this->auth_receiver->get_authorization(1));
 }
 
-// /// \brief Test if a connector receives authorization after subsequent plug-in and plug-out events
-// TEST_F(AuthTest, test_authorization_after_plug_in_and_plug_out) {
-//     TokenHandlingResult result1;
-//     TokenHandlingResult result2;
-//     std::vector<int32_t> connectors{1, 2};
-//     ProvidedIdToken provided_token_1 = get_provided_token(VALID_TOKEN_1, connectors);
+/// \brief Test if a connector receives authorization after subsequent plug-in and plug-out events
+TEST_F(AuthTest, test_authorization_after_plug_in_and_plug_out) {
+    TokenHandlingResult result1;
+    TokenHandlingResult result2;
+    std::vector<int32_t> connectors{1, 2};
+    ProvidedIdToken provided_token_1 = get_provided_token(VALID_TOKEN_1, connectors);
 
-//     // Plug-in and plug-out event on connector 1
-//     SessionEvent session_event_connected =
-//         get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
-//     SessionEvent session_event_disconnected;
-//     session_event_disconnected.event = SessionEventEnum::SessionFinished;
-//     std::thread t1(
-//         [this, session_event_connected]() { this->auth_handler->handle_session_event(1, session_event_connected); });
-//     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-//     std::thread t2([this, session_event_disconnected]() {
-//         this->auth_handler->handle_session_event(1, session_event_disconnected);
-//     });
+    // Plug-in and plug-out event on connector 1
+    SessionEvent session_event_connected =
+        get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
+    SessionEvent session_event_disconnected;
+    session_event_disconnected.event = SessionEventEnum::SessionFinished;
+    std::thread t1(
+        [this, session_event_connected]() { this->auth_handler->handle_session_event(1, session_event_connected); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::thread t2([this, session_event_disconnected]() {
+        this->auth_handler->handle_session_event(1, session_event_disconnected);
+    });
 
-//     // Swipe RFID
-//     EXPECT_CALL(mock_publish_token_validation_status_callback,
-//                 Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token),
-//                 TokenValidationStatus::Processing));
-//     EXPECT_CALL(mock_publish_token_validation_status_callback,
-//                 Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Accepted));
-//     std::thread t3([this, provided_token_1, &result1]() { result1 = this->auth_handler->on_token(provided_token_1);
-//     });
+    // Swipe RFID
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Accepted));
+    std::thread t3([this, provided_token_1, &result1]() { result1 = this->auth_handler->on_token(provided_token_1); });
 
-//     // Plug-in on connector 2, conntector 2 should be authorized
-//     std::thread t4(
-//         [this, session_event_connected]() { this->auth_handler->handle_session_event(2, session_event_connected); });
-//     std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Plug-in on connector 2, conntector 2 should be authorized
+    std::thread t4(
+        [this, session_event_connected]() { this->auth_handler->handle_session_event(2, session_event_connected); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-//     t1.join();
-//     t2.join();
-//     t3.join();
-//     t4.join();
+    t1.join();
+    t2.join();
+    t3.join();
+    t4.join();
 
-//     ASSERT_TRUE(result1 == TokenHandlingResult::ACCEPTED);
-//     ASSERT_FALSE(this->auth_receiver->get_authorization(0));
-//     ASSERT_TRUE(this->auth_receiver->get_authorization(1));
-// }
+    ASSERT_TRUE(result1 == TokenHandlingResult::ACCEPTED);
+    ASSERT_FALSE(this->auth_receiver->get_authorization(0));
+    ASSERT_TRUE(this->auth_receiver->get_authorization(1));
+}
 
 /// \brief Test if transactions can be started for two succeeding plugins before one valid and one invalid card swipe
 TEST_F(AuthTest, test_two_plugins_with_invalid_rfid) {


### PR DESCRIPTION
## Describe your changes

### Locking in select_connector
This PR covers https://github.com/EVerest/everest-core/issues/831 . It fixes the mutex locking when selecting a connector for an authorization request for the `SelectionAlgorithm::PlugEvents`. This could cause the `get_latest_plugin` to return the same connector for two different authorization requests. 

With these changes every connector referenced by an authorization request is locked until this authorization request is processed (which means `handle_token` returns).

### Locking in reservation manager
This PR also adds locking `reservations` map of the reservation manager to make it thread safe.

### Fix test cases
This PR https://github.com/EVerest/everest-core/pull/832 commented out test cases that were sporadically failing in the CI. With this PR they are reactivated, since the changes described above fix the issue. In addition, the auth_tests have been updated by removing all unnecessary `std::chrono::sleep_for` and by making sure that the order of events meet the test cases expectations.

## Issue ticket number and link
https://github.com/EVerest/everest-core/issues/831

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

