### PR TITLE
Fix EvManager crash if no iso 15118 car is connected

### DIFF
--- a/modules/EvManager/main/car_simulation.cpp
+++ b/modules/EvManager/main/car_simulation.cpp
@@ -21,7 +21,9 @@ void CarSimulation::state_machine() {
             // Wait for physical plugin (ev BSP sees state A on CP and not Disconnected)
 
             sim_data.slac_state = "UNMATCHED";
-            r_ev[0]->call_stop_charging();
+            if (!r_ev.empty()) {
+                r_ev[0]->call_stop_charging();
+            }
         }
         break;
     case SimState::PLUGGED_IN:


### PR DESCRIPTION
## Describe your changes
the ev requirement is optional, but this wasn't checked in the call to stop_charging() leading to a crash

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

