### PR TITLE
EvseSlac: Fix regression that NMK was not regenerated on reset

### DIFF
--- a/lib/staging/slac/fsm/evse/src/states/others.cpp
+++ b/lib/staging/slac/fsm/evse/src/states/others.cpp
@@ -30,6 +30,7 @@ static auto create_cm_set_key_req(uint8_t const* session_nmk) {
 
 void ResetState::enter() {
     ctx.log_info("Entered Reset state");
+    ctx.slac_config.generate_nmk();
 }
 
 FSMSimpleState::HandleEventReturnType ResetState::handle_event(AllocatorType& sa, Event ev) {


### PR DESCRIPTION
## Describe your changes

A regression had been introduced between 2024.2.0 and 2024.3.0 that removed the re-generation of the NMK in between sessions. This PR re-adds this functionality.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

