### PR TITLE
Adding ev allow_power_on cmd call for AC

### DIFF
--- a/interfaces/ev_board_support.yaml
+++ b/interfaces/ev_board_support.yaml
@@ -15,8 +15,7 @@ cmds:
         $ref: /ev_board_support#/EvCpState
   allow_power_on:
     description: >-
-      Sets allow_power_on flag. If false, contactor must never be switched
-      on. Onyly for dc charging
+      Sets allow_power_on flag. If false, contactor must never be switched on.
     arguments:
       value:
         description: 'True: allow power on, false: do not allow power on.'

--- a/modules/EvManager/main/car_simulation.cpp
+++ b/modules/EvManager/main/car_simulation.cpp
@@ -38,8 +38,10 @@ void CarSimulation::state_machine() {
             // do not draw power if EVSE paused by stopping PWM
             if (sim_data.pwm_duty_cycle > 7.0 && sim_data.pwm_duty_cycle < 97.0) {
                 r_ev_board_support->call_set_cp_state(EvCpState::C);
+                r_ev_board_support->call_allow_power_on(true);
             } else {
                 r_ev_board_support->call_set_cp_state(EvCpState::B);
+                r_ev_board_support->call_allow_power_on(false);
             }
         }
         break;
@@ -49,6 +51,7 @@ void CarSimulation::state_machine() {
             // Also draw power if EVSE stopped PWM - this is a break the rules simulator->mode to test the charging
             // implementation!
             r_ev_board_support->call_set_cp_state(EvCpState::C);
+            r_ev_board_support->call_allow_power_on(true);
         }
         break;
 
@@ -72,6 +75,7 @@ void CarSimulation::state_machine() {
     case SimState::ISO_CHARGING_REGULATED:
         if (state_has_changed) {
             r_ev_board_support->call_set_cp_state(EvCpState::C);
+            r_ev_board_support->call_allow_power_on(true);
         }
         break;
     case SimState::BCB_TOGGLE:


### PR DESCRIPTION
## Describe your changes
see title

## Issue ticket number and link
Right now it is not possible to close/open the ac relais with the ev_manager with actual hw. This PR fixes this.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

