### PR TITLE
EvManager: Move subscribe_to_external_mqtt to ready()

### DIFF
--- a/modules/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EvManager/main/car_simulatorImpl.cpp
@@ -18,7 +18,7 @@ void car_simulatorImpl::init() {
 }
 
 void car_simulatorImpl::ready() {
-    this->is_ready = true;
+    is_ready = true;
 
     car_simulation = std::make_unique<CarSimulation>(mod->r_ev_board_support, mod->r_ev, mod->r_slac);
 
@@ -35,7 +35,7 @@ void car_simulatorImpl::ready() {
 }
 
 void car_simulatorImpl::handle_enable(bool& value) {
-    if (not this->is_ready) {
+    if (not is_ready) {
         // ignore if not yet ready
         EVLOG_warning << "Not ready yet, ignoring enable!";
         return;

--- a/modules/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EvManager/main/car_simulatorImpl.cpp
@@ -18,6 +18,7 @@ void car_simulatorImpl::init() {
 }
 
 void car_simulatorImpl::ready() {
+    this->is_ready = true;
 
     car_simulation = std::make_unique<CarSimulation>(mod->r_ev_board_support, mod->r_ev, mod->r_slac);
 
@@ -34,6 +35,11 @@ void car_simulatorImpl::ready() {
 }
 
 void car_simulatorImpl::handle_enable(bool& value) {
+    if (not this->is_ready) {
+        // ignore if not yet ready
+        EVLOG_warning << "Not ready yet, ignoring enable!";
+        return;
+    }
     if (enabled == value) {
         // ignore if value is the same
         EVLOG_warning << "Enabled value didn't change, ignoring enable!";

--- a/modules/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EvManager/main/car_simulatorImpl.cpp
@@ -11,14 +11,13 @@ namespace module::main {
 void car_simulatorImpl::init() {
     loop_interval_ms = constants::DEFAULT_LOOP_INTERVAL_MS;
     register_all_commands();
-    subscribe_to_external_mqtt();
     subscribe_to_variables_on_init();
 
     std::thread(&car_simulatorImpl::run, this).detach();
 }
 
 void car_simulatorImpl::ready() {
-    is_ready = true;
+    subscribe_to_external_mqtt();
 
     car_simulation = std::make_unique<CarSimulation>(mod->r_ev_board_support, mod->r_ev, mod->r_slac);
 
@@ -35,11 +34,6 @@ void car_simulatorImpl::ready() {
 }
 
 void car_simulatorImpl::handle_enable(bool& value) {
-    if (not is_ready) {
-        // ignore if not yet ready
-        EVLOG_warning << "Not ready yet, ignoring enable!";
-        return;
-    }
     if (enabled == value) {
         // ignore if value is the same
         EVLOG_warning << "Enabled value didn't change, ignoring enable!";

--- a/modules/EvManager/main/car_simulatorImpl.hpp
+++ b/modules/EvManager/main/car_simulatorImpl.hpp
@@ -71,6 +71,7 @@ private:
 
     bool enabled{false};
     std::atomic<bool> execution_active{false};
+    std::atomic<bool> is_ready{false};
     size_t loop_interval_ms{};
 
     std::queue<SimulationCommand> command_queue;

--- a/modules/EvManager/main/car_simulatorImpl.hpp
+++ b/modules/EvManager/main/car_simulatorImpl.hpp
@@ -71,7 +71,6 @@ private:
 
     bool enabled{false};
     std::atomic<bool> execution_active{false};
-    std::atomic<bool> is_ready{false};
     size_t loop_interval_ms{};
 
     std::queue<SimulationCommand> command_queue;


### PR DESCRIPTION
This avoids problems with potentially triggering enable too early which could happen when using the external mqtt api

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

