### PR TITLE
Fix OC detection after wakeup and introduce 750ms X1 pause after t_st…

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -348,6 +348,7 @@ void Charger::run_state_machine() {
                                 // Figure 4 of ISO15118-3: X1 start, PnC and EIM
                                 internal_context.t_step_EF_return_state = target_state;
                                 internal_context.t_step_EF_return_pwm = 0.;
+                                internal_context.t_step_EF_return_ampere = 0.;
                                 // fall back to nominal PWM after the t_step_EF break. Note that
                                 // ac_hlc_enabled_current_session remains untouched as HLC can still start later in
                                 // nominal PWM mode
@@ -363,6 +364,7 @@ void Charger::run_state_machine() {
                                                "t_step_X1 and disable 5 percent.");
                                     internal_context.t_step_X1_return_state = target_state;
                                     internal_context.t_step_X1_return_pwm = 0.;
+                                    internal_context.t_step_EF_return_ampere = 0.;
                                     hlc_use_5percent_current_session = false;
                                     shared_context.current_state = EvseState::T_step_X1;
                                 } else {
@@ -451,16 +453,23 @@ void Charger::run_state_machine() {
         case EvseState::T_step_EF:
             if (initialize_state) {
                 session_log.evse(false, "Enter T_step_EF");
+                internal_context.t_step_ef_x1_pause = false;
                 pwm_F();
             }
-            if (time_in_current_state >= T_STEP_EF) {
+            if (time_in_current_state >= T_STEP_EF + STAY_IN_X1_AFTER_TSTEP_EF_MS) {
                 session_log.evse(false, "Exit T_step_EF");
                 if (internal_context.t_step_EF_return_pwm == 0.) {
                     pwm_off();
                 } else {
                     update_pwm_now(internal_context.t_step_EF_return_pwm);
+                    internal_context.pwm_set_last_ampere = internal_context.t_step_EF_return_ampere;
                 }
                 shared_context.current_state = internal_context.t_step_EF_return_state;
+            } else if (time_in_current_state >= T_STEP_EF and not internal_context.t_step_ef_x1_pause) {
+                internal_context.t_step_ef_x1_pause = true;
+                // stay in X1 for a little while as required by EV READY regulations
+                session_log.evse(false, "Pause in X1 for EV READY regulations");
+                pwm_off();
             }
             break;
 
@@ -475,6 +484,7 @@ void Charger::run_state_machine() {
                     pwm_off();
                 } else {
                     update_pwm_now(internal_context.t_step_X1_return_pwm);
+                    internal_context.pwm_set_last_ampere = internal_context.t_step_EF_return_ampere;
                 }
                 shared_context.current_state = internal_context.t_step_X1_return_state;
             }
@@ -532,6 +542,7 @@ void Charger::run_state_machine() {
                             shared_context.legacy_wakeup_done = true;
                             internal_context.t_step_EF_return_state = EvseState::PrepareCharging;
                             internal_context.t_step_EF_return_pwm = ampere_to_duty_cycle(get_max_current_internal());
+                            internal_context.t_step_EF_return_ampere = get_max_current_internal();
                             shared_context.current_state = EvseState::T_step_EF;
                         } else if (not shared_context.hlc_charging_active and shared_context.legacy_wakeup_done and
                                    time_in_current_state > PREPARING_TIMEOUT_PAUSED_BY_EV) {
@@ -1669,6 +1680,7 @@ void Charger::request_error_sequence() {
     if (shared_context.current_state == EvseState::WaitingForAuthentication or
         shared_context.current_state == EvseState::PrepareCharging) {
         internal_context.t_step_EF_return_state = shared_context.current_state;
+        internal_context.t_step_EF_return_ampere = 0.;
         shared_context.current_state = EvseState::T_step_EF;
         signal_slac_reset();
         if (hlc_use_5percent_current_session) {
@@ -1748,6 +1760,7 @@ void Charger::dlink_error() {
             // the t_step_EF state.
             internal_context.t_step_X1_return_state = EvseState::T_step_EF;
             internal_context.t_step_X1_return_pwm = 0.;
+            internal_context.t_step_EF_return_ampere = 0.;
             shared_context.current_state = EvseState::T_step_X1;
 
             // After returning from T_step_EF, go to Waiting for Auth (We are restarting the session)
@@ -1758,6 +1771,7 @@ void Charger::dlink_error() {
 
             // [V2G3-M07-05] says we need to go through X1 at the end of the sequence
             internal_context.t_step_EF_return_pwm = 0.;
+            internal_context.t_step_EF_return_ampere = 0.;
         }
         // else {
         // [V2G3-M07-10] Gives us two options for nominal PWM mode and HLC in case of error: We choose

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -342,6 +342,7 @@ private:
 
         EvseState t_step_EF_return_state;
         float t_step_EF_return_pwm;
+        float t_step_EF_return_ampere;
 
         EvseState switching_phases_return_state;
 
@@ -358,6 +359,7 @@ private:
         bool pp_warning_printed{false};
         bool no_energy_warning_printed{false};
         float pwm_set_last_ampere{0};
+        bool t_step_ef_x1_pause{false};
     } internal_context;
 
     // main Charger thread
@@ -401,6 +403,10 @@ private:
     static constexpr int T_STEP_EF = 4000;
     static constexpr int SOFT_OVER_CURRENT_TIMEOUT = 7000;
     static constexpr int IEC_PWM_MAX_UPDATE_INTERVAL = 5000;
+    // EV READY certification requires a small pause of 500-1000 ms in X1 after a t_step_EF sequence before going to X2-
+    // This is not required by IEC61851-1, but it is allowed by the IEC. It helps some older EVs to start charging
+    // after the wake-up sequence.
+    static constexpr int STAY_IN_X1_AFTER_TSTEP_EF_MS = 750;
 
     types::evse_manager::EnableDisableSource active_enable_disable_source{
         types::evse_manager::Enable_source::Unspecified, types::evse_manager::Enable_state::Unassigned, 10000};


### PR DESCRIPTION
…ep_EF

## Describe your changes

- Fixed wrong ampere limit for OC detection in basic charging mode after legacy wakeup sequence.
- Introduce 750ms delay in X1 after t_step_EF to comply with French EV READY regulations

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

