### PR TITLE
Make soft over current timeout configurable

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -146,14 +146,14 @@ jobs:
     runs-on: ${{ inputs.runner || 'ubuntu-22.04' }}
     steps:
       - name: Download dist dir
-        uses: actions/download-artifact@v4.1.2
+        uses: actions/download-artifact@v4.1.7
         with:
           name: dist
       - name: Extract dist.tar.gz
         run: |
           tar -xzf ${{ github.workspace }}/dist.tar.gz -C ${{ github.workspace }}
       - name: Download wheels
-        uses: actions/download-artifact@v4.1.2
+        uses: actions/download-artifact@v4.1.7
         with:
           name: wheels
           path: wheels

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -1290,7 +1290,8 @@ bool Charger::switch_three_phases_while_charging(bool n) {
 void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _ac_hlc_enabled,
                     bool _ac_hlc_use_5percent, bool _ac_enforce_hlc, bool _ac_with_soc_timeout,
                     float _soft_over_current_tolerance_percent, float _soft_over_current_measurement_noise_A,
-                    const int _switch_3ph1ph_delay_s, const std::string _switch_3ph1ph_cp_state) {
+                    const int _switch_3ph1ph_delay_s, const std::string _switch_3ph1ph_cp_state,
+                    const int _soft_over_current_timeout_ms) {
     // set up board support package
     bsp->setup(has_ventilation);
 
@@ -1300,6 +1301,7 @@ void Charger::setup(bool has_ventilation, const ChargeMode _charge_mode, bool _a
     ac_hlc_enabled_current_session = config_context.ac_hlc_enabled = _ac_hlc_enabled;
     config_context.ac_hlc_use_5percent = _ac_hlc_use_5percent;
     config_context.ac_enforce_hlc = _ac_enforce_hlc;
+    config_context.soft_over_current_timeout_ms = _soft_over_current_timeout_ms;
     shared_context.ac_with_soc_timeout = _ac_with_soc_timeout;
     shared_context.ac_with_soc_timer = 3600000;
     soft_over_current_tolerance_percent = _soft_over_current_tolerance_percent;
@@ -1638,7 +1640,8 @@ void Charger::check_soft_over_current() {
     auto now = std::chrono::steady_clock::now();
     auto time_since_over_current_started =
         std::chrono::duration_cast<std::chrono::milliseconds>(now - internal_context.last_over_current_event).count();
-    if (internal_context.over_current and time_since_over_current_started >= SOFT_OVER_CURRENT_TIMEOUT) {
+    if (internal_context.over_current and
+        time_since_over_current_started >= config_context.soft_over_current_timeout_ms) {
         auto errstr =
             fmt::format("Soft overcurrent event (L1:{}, L2:{}, L3:{}, limit {}) triggered",
                         shared_context.current_drawn_by_vehicle[0], shared_context.current_drawn_by_vehicle[1],

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -105,7 +105,7 @@ public:
     void setup(bool has_ventilation, const ChargeMode charge_mode, bool ac_hlc_enabled, bool ac_hlc_use_5percent,
                bool ac_enforce_hlc, bool ac_with_soc_timeout, float soft_over_current_tolerance_percent,
                float soft_over_current_measurement_noise_A, const int switch_3ph1ph_delay_s,
-               const std::string switch_3ph1ph_cp_state);
+               const std::string switch_3ph1ph_cp_state, const int soft_over_current_timeout_ms);
 
     bool enable_disable(int connector_id, const types::evse_manager::EnableDisableSource& source);
 
@@ -320,6 +320,8 @@ private:
         int switch_3ph1ph_delay_s{10};
         // Use state F if true, otherwise use X1
         bool switch_3ph1ph_cp_state_F{false};
+        // Tolerate soft over current for given time
+        int soft_over_current_timeout_ms{7000};
     } config_context;
 
     // Used by different threads, but requires no complete state machine locking
@@ -399,7 +401,6 @@ private:
     static constexpr int T_STEP_X1 = 3000;
     // 4 seconds according to table 3 of ISO15118-3
     static constexpr int T_STEP_EF = 4000;
-    static constexpr int SOFT_OVER_CURRENT_TIMEOUT = 7000;
     static constexpr int IEC_PWM_MAX_UPDATE_INTERVAL = 5000;
 
     types::evse_manager::EnableDisableSource active_enable_disable_source{

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -812,11 +812,11 @@ void EvseManager::ready() {
     if (config.ac_with_soc) {
         setup_fake_DC_mode();
     } else {
-        charger->setup(config.has_ventilation,
-                       (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC), hlc_enabled,
-                       config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
-                       config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
-                       config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state);
+        charger->setup(
+            config.has_ventilation, (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC),
+            hlc_enabled, config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
+            config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
+            config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms);
     }
 
     telemetryThreadHandle = std::thread([this]() {
@@ -1002,7 +1002,7 @@ void EvseManager::setup_fake_DC_mode() {
     charger->setup(config.has_ventilation, Charger::ChargeMode::DC, hlc_enabled, config.ac_hlc_use_5percent,
                    config.ac_enforce_hlc, false, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
-                   config.switch_3ph1ph_cp_state);
+                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms);
 
     types::iso15118_charger::EVSEID evseid = {config.evse_id, config.evse_id_din};
 
@@ -1040,7 +1040,7 @@ void EvseManager::setup_AC_mode() {
     charger->setup(config.has_ventilation, Charger::ChargeMode::AC, hlc_enabled, config.ac_hlc_use_5percent,
                    config.ac_enforce_hlc, true, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
-                   config.switch_3ph1ph_cp_state);
+                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms);
 
     types::iso15118_charger::EVSEID evseid = {config.evse_id, config.evse_id_din};
 

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -97,6 +97,7 @@ struct Conf {
     int initial_meter_value_timeout_ms;
     int switch_3ph1ph_delay_s;
     std::string switch_3ph1ph_cp_state;
+    int soft_over_current_timeout_ms;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -249,6 +249,7 @@ config:
     description: >-
       Allow for over current to be present for N ms in soft over current checking during AC charging.
     type: integer
+    minimum: 6000
     default: 7000
 provides:
   evse:

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -245,6 +245,11 @@ config:
       - X1
       - F
     default: X1
+  soft_over_current_timeout_ms:
+    description: >-
+      Allow for over current to be present for N ms in soft over current checking during AC charging.
+    type: integer
+    default: 7000
 provides:
   evse:
     interface: evse_manager


### PR DESCRIPTION
## Describe your changes
Some meters are not able to achieve 7s refresh rate. Therefore it makes sense to make this parameter configurable

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

