### PR TITLE
Lock connector in CP state B defined by config

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -153,7 +153,7 @@ void EvseManager::init() {
 }
 
 void EvseManager::ready() {
-    bsp = std::unique_ptr<IECStateMachine>(new IECStateMachine(r_bsp));
+    bsp = std::unique_ptr<IECStateMachine>(new IECStateMachine(r_bsp, config.lock_connector_in_state_b));
 
     if (config.hack_simplified_mode_limit_10A) {
         bsp->set_ev_simplified_mode_evse_limit(true);

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -161,6 +161,10 @@ void EvseManager::ready() {
 
     error_handling = std::unique_ptr<ErrorHandling>(
         new ErrorHandling(r_bsp, r_hlc, r_connector_lock, r_ac_rcd, p_evse, r_imd, r_powersupply_DC));
+    if (not config.lock_connector_in_state_b) {
+        EVLOG_warning << "Unlock connector in CP state B. This violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and "
+                         "should not be used in public environments!";
+    }
 
     charger = std::make_unique<Charger>(bsp, error_handling, r_powermeter_billing(), store,
                                         hw_capabilities.connector_type, config.evse_id);

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -98,6 +98,7 @@ struct Conf {
     int switch_3ph1ph_delay_s;
     std::string switch_3ph1ph_cp_state;
     int soft_over_current_timeout_ms;
+    bool lock_connector_in_state_b;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -186,9 +186,6 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
             if (lock_connector_in_state_b) {
                 connector_lock();
             } else {
-                EVLOG_warning <<
-                    "Unlock connector in CP state B. "
-                    "This violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!";
                 connector_unlock();
             }
 

--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -77,8 +77,9 @@ const std::string cpevent_to_string(CPEvent e) {
     throw std::out_of_range("No known string conversion for provided enum of type CPEvent");
 }
 
-IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp, bool lock_connector_in_state_b) :
-    r_bsp(r_bsp), lock_connector_in_state_b(lock_connector_in_state_b) {
+IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_,
+                                 bool lock_connector_in_state_b_) :
+    r_bsp(r_bsp_), lock_connector_in_state_b(lock_connector_in_state_b_) {
     // feed the state machine whenever the timer expires
     timeout_state_c1.signal_reached.connect(&IECStateMachine::feed_state_machine_no_thread, this);
 

--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -77,7 +77,8 @@ const std::string cpevent_to_string(CPEvent e) {
     throw std::out_of_range("No known string conversion for provided enum of type CPEvent");
 }
 
-IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp) : r_bsp(r_bsp) {
+IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp, bool lock_connector_in_state_b) :
+    r_bsp(r_bsp), lock_connector_in_state_b(lock_connector_in_state_b) {
     // feed the state machine whenever the timer expires
     timeout_state_c1.signal_reached.connect(&IECStateMachine::feed_state_machine_no_thread, this);
 
@@ -182,7 +183,11 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
             // Table A.6: Sequence 7 EV stops charging
             // Table A.6: Sequence 8.2 EV supply equipment
             // responds to EV opens S2 (w/o PWM)
-            connector_lock();
+            if (lock_connector_in_state_b) {
+                connector_lock();
+            } else {
+                connector_unlock();
+            }
 
             if (last_cp_state != RawCPState::A && last_cp_state != RawCPState::B) {
 

--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -186,6 +186,9 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
             if (lock_connector_in_state_b) {
                 connector_lock();
             } else {
+                EVLOG_warning <<
+                    "Unlock connector in CP state B. "
+                    "This violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!";
                 connector_unlock();
             }
 

--- a/modules/EvseManager/IECStateMachine.hpp
+++ b/modules/EvseManager/IECStateMachine.hpp
@@ -106,7 +106,7 @@ private:
     void connector_unlock();
     void check_connector_lock();
     const std::unique_ptr<evse_board_supportIntf>& r_bsp;
-    bool lock_connector_in_state_b{false};
+    bool lock_connector_in_state_b{true};
 
     bool pwm_running{false};
     bool last_pwm_running{false};

--- a/modules/EvseManager/IECStateMachine.hpp
+++ b/modules/EvseManager/IECStateMachine.hpp
@@ -67,8 +67,7 @@ enum class RawCPState {
 class IECStateMachine {
 public:
     // We need the r_bsp reference to be able to talk to the bsp driver module
-    explicit IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp);
-
+    IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp, bool lock_connector_in_state_b);
     // Call when new events from BSP requirement come in. Will signal internal events
     void process_bsp_event(const types::board_support_common::BspEvent bsp_event);
     // Allow power on from Charger state machine
@@ -107,6 +106,7 @@ private:
     void connector_unlock();
     void check_connector_lock();
     const std::unique_ptr<evse_board_supportIntf>& r_bsp;
+    bool lock_connector_in_state_b;
 
     bool pwm_running{false};
     bool last_pwm_running{false};

--- a/modules/EvseManager/IECStateMachine.hpp
+++ b/modules/EvseManager/IECStateMachine.hpp
@@ -67,7 +67,8 @@ enum class RawCPState {
 class IECStateMachine {
 public:
     // We need the r_bsp reference to be able to talk to the bsp driver module
-    IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp, bool lock_connector_in_state_b = false);
+    explicit IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp,
+                             bool lock_connector_in_state_b = false);
     // Call when new events from BSP requirement come in. Will signal internal events
     void process_bsp_event(const types::board_support_common::BspEvent bsp_event);
     // Allow power on from Charger state machine
@@ -106,7 +107,7 @@ private:
     void connector_unlock();
     void check_connector_lock();
     const std::unique_ptr<evse_board_supportIntf>& r_bsp;
-    bool lock_connector_in_state_b;
+    bool lock_connector_in_state_b{false};
 
     bool pwm_running{false};
     bool last_pwm_running{false};

--- a/modules/EvseManager/IECStateMachine.hpp
+++ b/modules/EvseManager/IECStateMachine.hpp
@@ -67,7 +67,7 @@ enum class RawCPState {
 class IECStateMachine {
 public:
     // We need the r_bsp reference to be able to talk to the bsp driver module
-    IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp, bool lock_connector_in_state_b);
+    IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp, bool lock_connector_in_state_b = false);
     // Call when new events from BSP requirement come in. Will signal internal events
     void process_bsp_event(const types::board_support_common::BspEvent bsp_event);
     // Allow power on from Charger state machine

--- a/modules/EvseManager/IECStateMachine.hpp
+++ b/modules/EvseManager/IECStateMachine.hpp
@@ -67,8 +67,7 @@ enum class RawCPState {
 class IECStateMachine {
 public:
     // We need the r_bsp reference to be able to talk to the bsp driver module
-    explicit IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp,
-                             bool lock_connector_in_state_b = false);
+    IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_, bool lock_connector_in_state_b_);
     // Call when new events from BSP requirement come in. Will signal internal events
     void process_bsp_event(const types::board_support_common::BspEvent bsp_event);
     // Allow power on from Charger state machine

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -254,7 +254,7 @@ config:
   lock_connector_in_state_b:
     description: >-
       Indicates if the connector lock should be locked in state B. If set to false, connector will remain unlocked in CP state B
-      Warning: This violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!
+      and this violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!
     type: boolean
     default: true
 provides:

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -251,6 +251,11 @@ config:
     type: integer
     minimum: 6000
     default: 7000
+  lock_connector_in_state_b:
+    description: >-
+      Indicates if the connector lock should be locked in state B. If set to false, connector will remain unlocked in CP state B
+    type: boolean
+    default: true
 provides:
   evse:
     interface: evse_manager

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -254,6 +254,7 @@ config:
   lock_connector_in_state_b:
     description: >-
       Indicates if the connector lock should be locked in state B. If set to false, connector will remain unlocked in CP state B
+      Warning: This violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!
     type: boolean
     default: true
 provides:

--- a/modules/EvseManager/tests/IECStateMachineTest.cpp
+++ b/modules/EvseManager/tests/IECStateMachineTest.cpp
@@ -85,7 +85,7 @@ TEST(IECStateMachine, init) {
     module::stub::ModuleAdapterStub module_adapter = module::stub::ModuleAdapterStub();
     std::unique_ptr<evse_board_supportIntf> bsp_if =
         std::make_unique<module::stub::evse_board_supportIntfStub>(module_adapter);
-    module::IECStateMachine state_machine(std::move(bsp_if));
+    module::IECStateMachine state_machine(std::move(bsp_if), true);
 }
 
 #if 0
@@ -108,7 +108,7 @@ TEST(IECStateMachine, init_subscribe) {
 
     BspStubTimeout bsp;
     std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
-    module::IECStateMachine state_machine(std::move(bsp_if));
+    module::IECStateMachine state_machine(std::move(bsp_if), true);
 
     state_machine.enable(true);
     state_machine.allow_power_on(true, Reason::FullPowerCharging);
@@ -215,7 +215,7 @@ TEST(IECStateMachine, deadlock_test) {
 
     BspStubDeadlock bsp;
     std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
-    module::IECStateMachine state_machine(std::move(bsp_if));
+    module::IECStateMachine state_machine(std::move(bsp_if), true);
 
     std::uint8_t signal_lock_count = 0;
 
@@ -281,7 +281,7 @@ TEST(IECStateMachine, deadlock_fix) {
 
     BspStubDeadlock bsp;
     std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
-    module::IECStateMachine state_machine(std::move(bsp_if));
+    module::IECStateMachine state_machine(std::move(bsp_if), true);
 
     std::uint8_t signal_lock_count = 0;
 


### PR DESCRIPTION
## Describe your changes
Since state B is already detected when user plugs in the cable for some boards, it makes sense to not lock the cable in state B. Making this configurable gives us more flexibility

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

