### PR TITLE
Disable temporarily build of build-kit-everest-core image

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -71,7 +71,7 @@ jobs:
 
   build:
     name: Build and Unit Tests
-    needs: build-and-push-build-kit
+    # needs: build-and-push-build-kit
     runs-on: ${{ inputs.runner || 'ubuntu-22.04' }}
     env:
       # Currently the build-kit-base image is used to allow running ci on PRs from forks
@@ -146,7 +146,7 @@ jobs:
     name: Integration Tests
     needs:
       - build
-      - build-and-push-build-kit
+      # - build-and-push-build-kit
     env:
       # Currently the build-kit-base image is used to allow running ci on PRs from forks
       # BUILD_KIT_IMAGE: ${{ needs.build-and-push-build-kit.outputs.one_image_tag_long }}

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -36,6 +36,8 @@ jobs:
 
   # Since env variables can't be passed to reusable workflows, we need to pass them as outputs
   setup-env:
+    # This job is currently disabled to allow running ci on PRs from forks
+    if: false
     name: Setup Environment
     runs-on: ${{ inputs.runner || 'ubuntu-22.04' }}
     outputs:
@@ -46,6 +48,8 @@ jobs:
         run: |
           echo "Setting up environment"
   build-and-push-build-kit:
+    # This job is currently disabled to allow running ci on PRs from forks
+    if: false
     name: Build and Push Build Kit
     uses: everest/everest-ci/.github/workflows/deploy-single-docker-image.yml@v1.3.1
     needs: setup-env
@@ -70,7 +74,9 @@ jobs:
     needs: build-and-push-build-kit
     runs-on: ${{ inputs.runner || 'ubuntu-22.04' }}
     env:
-      BUILD_KIT_IMAGE: ${{ needs.build-and-push-build-kit.outputs.one_image_tag_long }}
+      # Currently the build-kit-base image is used to allow running ci on PRs from forks
+      # BUILD_KIT_IMAGE: ${{ needs.build-and-push-build-kit.outputs.one_image_tag_long }}
+      BUILD_KIT_IMAGE: ghcr.io/everest-core/build-kit-base:v1.3.1
     steps:
       - name: Format branch name for cache key
         run: |
@@ -142,7 +148,9 @@ jobs:
       - build
       - build-and-push-build-kit
     env:
-      BUILD_KIT_IMAGE: ${{ needs.build-and-push-build-kit.outputs.one_image_tag_long }}
+      # Currently the build-kit-base image is used to allow running ci on PRs from forks
+      # BUILD_KIT_IMAGE: ${{ needs.build-and-push-build-kit.outputs.one_image_tag_long }}
+      BUILD_KIT_IMAGE: ghcr.io/everest-core/build-kit-base:v1.3.1
     runs-on: ${{ inputs.runner || 'ubuntu-22.04' }}
     steps:
       - name: Download dist dir

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -76,7 +76,7 @@ jobs:
     env:
       # Currently the build-kit-base image is used to allow running ci on PRs from forks
       # BUILD_KIT_IMAGE: ${{ needs.build-and-push-build-kit.outputs.one_image_tag_long }}
-      BUILD_KIT_IMAGE: ghcr.io/everest-core/build-kit-base:v1.3.1
+      BUILD_KIT_IMAGE: ghcr.io/everest/everest-ci/build-kit-base:v1.3.1
     steps:
       - name: Format branch name for cache key
         run: |
@@ -150,7 +150,7 @@ jobs:
     env:
       # Currently the build-kit-base image is used to allow running ci on PRs from forks
       # BUILD_KIT_IMAGE: ${{ needs.build-and-push-build-kit.outputs.one_image_tag_long }}
-      BUILD_KIT_IMAGE: ghcr.io/everest-core/build-kit-base:v1.3.1
+      BUILD_KIT_IMAGE: ghcr.io/everest/everest-ci/build-kit-base:v1.3.1
     runs-on: ${{ inputs.runner || 'ubuntu-22.04' }}
     steps:
       - name: Download dist dir


### PR DESCRIPTION
## Describe your changes

Use build-kit-base instead. Since github doesn't pass secrets to ci runs in forks the current workflow technically doesn't work for forks. To provide a quick solution the feature of modifying the build-kit-base image is disabled.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

