### PR TITLE
Fix 0A in EV pause handling

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -843,7 +843,6 @@ void Charger::process_cp_events_state(CPEvent cp_event) {
             session_log.car(false, "B->C transition before PWM is enabled at this stage violates IEC61851-1");
             shared_context.iec_allow_close_contactor = true;
         } else if (cp_event == CPEvent::CarRequestedStopPower) {
-            session_log.car(false, "C->B transition at this stage violates IEC61851-1");
             shared_context.iec_allow_close_contactor = false;
         }
         break;
@@ -1078,7 +1077,8 @@ bool Charger::pause_charging_wait_for_power() {
 
 // pause charging since no power is available at the moment
 bool Charger::pause_charging_wait_for_power_internal() {
-    if (shared_context.current_state == EvseState::Charging) {
+    if (shared_context.current_state == EvseState::Charging or
+        shared_context.current_state == EvseState::ChargingPausedEV) {
         shared_context.current_state = EvseState::WaitingForEnergy;
         return true;
     }


### PR DESCRIPTION
## Describe your changes

This fixes the handling of a 0 amp current limit in EV pause state. It now proceeds to Waiting for energy (effectivly paused by the evse and not the ev).
Also removes a warning that is shown in at least one case where the behaviour was actually valid.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

