### PR TITLE
feature(ocpp): transmit error message instead of description

### DIFF
--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -47,12 +47,9 @@ static ocpp::v16::ErrorInfo get_error_info(const Everest::error::Error& error) {
 
     // check if is VendorError
     if (error_type.find("VendorError") != std::string::npos) {
-        return ocpp::v16::ErrorInfo{uuid,
-                                    ocpp::v16::ChargePointErrorCode::OtherError,
-                                    false,
-                                    error.message,
-                                    error.origin.to_string(),
-                                    error.sub_type};
+        return ocpp::v16::ErrorInfo{
+            uuid,          ocpp::v16::ChargePointErrorCode::OtherError, false, error.message, error.origin.to_string(),
+            error.sub_type};
     }
 
     // Default case

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -50,7 +50,7 @@ static ocpp::v16::ErrorInfo get_error_info(const Everest::error::Error& error) {
         return ocpp::v16::ErrorInfo{uuid,
                                     ocpp::v16::ChargePointErrorCode::OtherError,
                                     false,
-                                    error.description,
+                                    error.message,
                                     error.origin.to_string(),
                                     error.sub_type};
     }


### PR DESCRIPTION
## Describe your changes
- previously the transmitted error info inside OCPPs StatusNotification message contained the error description of a `VendorError`, that was raised within everest -- now it contains the error message
- this should be more appropriate, as the error description is fixed (static), whereas the message can be specified at runtime
- note, that the difference between an error description and an error message is definitely not self-explanatory and probably lead to this behaviour (this should be fixed in the error api)
- when using this, keep in mind, that OCPPs `info` property within the StatusNotification message can only contain up to 50 characters -- if the error message is longer, it will get truncated

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

