### PR TITLE
PN532TokenProvider: Raise CommunicationFault instead of throwing exception

### DIFF
--- a/modules/PN532TokenProvider/main/auth_token_providerImpl.cpp
+++ b/modules/PN532TokenProvider/main/auth_token_providerImpl.cpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 
 #include "auth_token_providerImpl.hpp"
+
+#include <fmt/core.h>
 
 namespace module {
 namespace main {
@@ -13,8 +15,13 @@ void auth_token_providerImpl::init() {
         EVLOG_info << "Serial port: " << config.serial_port << " baud rate: " << config.baud_rate;
     }
     if (!serial.openDevice(config.serial_port.c_str(), config.baud_rate)) {
-        EVLOG_AND_THROW(EVEXCEPTION(Everest::EverestConfigError, "Could not open serial port ", config.serial_port,
-                                    " with baud rate ", config.baud_rate));
+        if (!this->error_state_monitor->is_error_active("generic/CommunicationFault", "Communication timed out")) {
+            auto error_message =
+                fmt::format("Could not open serial port {} with baud rate {}", config.serial_port, config.baud_rate);
+            auto error = this->error_factory->create_error("generic/CommunicationFault", "Communication timed out",
+                                                           error_message);
+            raise_error(error);
+        }
         return;
     }
 }


### PR DESCRIPTION
## Describe your changes

This replaces the exception that is thrown during initialization of the PN532TokenProvider if the serial port could not be accessed with an error. 

TODO: Integration with Auth and/or EvseManager error handling. How do we want to handle this, do we want to perform periodic retries? If this error happens the module is non-functional afterwards

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

