### PR TITLE
OCPP&OCPP201: explicitly handle all cases in switch statements

### DIFF
--- a/lib/staging/ocpp/CMakeLists.txt
+++ b/lib/staging/ocpp/CMakeLists.txt
@@ -14,6 +14,12 @@ target_include_directories(ocpp_evse_security
     "$<TARGET_PROPERTY:generate_cpp_files,EVEREST_GENERATED_INCLUDE_DIR>"
 )
 
+target_compile_options(ocpp_evse_security
+    PRIVATE
+        -Wimplicit-fallthrough
+        -Werror=switch-enum
+)
+
 add_dependencies(ocpp_evse_security generate_cpp_files)
 
 target_link_libraries(ocpp_evse_security
@@ -37,6 +43,12 @@ target_include_directories(ocpp_conversions
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     "$<TARGET_PROPERTY:generate_cpp_files,EVEREST_GENERATED_INCLUDE_DIR>"
+)
+
+target_compile_options(ocpp_conversions
+    PRIVATE
+        -Wimplicit-fallthrough
+        -Werror=switch-enum
 )
 
 add_dependencies(ocpp_conversions generate_cpp_files)

--- a/lib/staging/ocpp/evse_security_ocpp.cpp
+++ b/lib/staging/ocpp/evse_security_ocpp.cpp
@@ -140,10 +140,8 @@ ocpp::CaCertificateType to_ocpp(types::evse_security::CaCertificateType other) {
         return ocpp::CaCertificateType::CSMS;
     case types::evse_security::CaCertificateType::MF:
         return ocpp::CaCertificateType::MF;
-    default:
-        throw std::runtime_error(
-            "Could not convert types::evse_security::CaCertificateType to ocpp::CaCertificateType");
     }
+    throw std::runtime_error("Could not convert types::evse_security::CaCertificateType to ocpp::CaCertificateType");
 }
 
 ocpp::LeafCertificateType to_ocpp(types::evse_security::LeafCertificateType other) {
@@ -156,10 +154,9 @@ ocpp::LeafCertificateType to_ocpp(types::evse_security::LeafCertificateType othe
         return ocpp::LeafCertificateType::MF;
     case types::evse_security::LeafCertificateType::MO:
         return ocpp::LeafCertificateType::MO;
-    default:
-        throw std::runtime_error(
-            "Could not convert types::evse_security::LeafCertificateType to ocpp::CertificateSigningUseEnum");
     }
+    throw std::runtime_error(
+        "Could not convert types::evse_security::LeafCertificateType to ocpp::CertificateSigningUseEnum");
 }
 
 ocpp::CertificateType to_ocpp(types::evse_security::CertificateType other) {
@@ -174,9 +171,8 @@ ocpp::CertificateType to_ocpp(types::evse_security::CertificateType other) {
         return ocpp::CertificateType::V2GCertificateChain;
     case types::evse_security::CertificateType::MFRootCertificate:
         return ocpp::CertificateType::MFRootCertificate;
-    default:
-        throw std::runtime_error("Could not convert types::evse_security::CertificateType to ocpp::CertificateType");
     }
+    throw std::runtime_error("Could not convert types::evse_security::CertificateType to ocpp::CertificateType");
 }
 
 ocpp::HashAlgorithmEnumType to_ocpp(types::evse_security::HashAlgorithm other) {
@@ -187,10 +183,8 @@ ocpp::HashAlgorithmEnumType to_ocpp(types::evse_security::HashAlgorithm other) {
         return ocpp::HashAlgorithmEnumType::SHA384;
     case types::evse_security::HashAlgorithm::SHA512:
         return ocpp::HashAlgorithmEnumType::SHA512;
-    default:
-        throw std::runtime_error(
-            "Could not convert types::evse_security::HashAlgorithm to ocpp::HashAlgorithmEnumType");
     }
+    throw std::runtime_error("Could not convert types::evse_security::HashAlgorithm to ocpp::HashAlgorithmEnumType");
 }
 
 ocpp::InstallCertificateResult to_ocpp(types::evse_security::InstallCertificateResult other) {
@@ -213,10 +207,9 @@ ocpp::InstallCertificateResult to_ocpp(types::evse_security::InstallCertificateR
         return ocpp::InstallCertificateResult::WriteError;
     case types::evse_security::InstallCertificateResult::Accepted:
         return ocpp::InstallCertificateResult::Accepted;
-    default:
-        throw std::runtime_error(
-            "Could not convert types::evse_security::InstallCertificateResult to ocpp::InstallCertificateResult");
     }
+    throw std::runtime_error(
+        "Could not convert types::evse_security::InstallCertificateResult to ocpp::InstallCertificateResult");
 }
 
 ocpp::CertificateValidationResult to_ocpp(types::evse_security::CertificateValidationResult other) {
@@ -233,10 +226,11 @@ ocpp::CertificateValidationResult to_ocpp(types::evse_security::CertificateValid
         return ocpp::CertificateValidationResult::InvalidChain;
     case types::evse_security::CertificateValidationResult::Unknown:
         return ocpp::CertificateValidationResult::Unknown;
-    default:
-        throw std::runtime_error("Could not convert types::evse_security::CertificateValidationResult to "
-                                 "ocpp::CertificateValidationResult");
+    case types::evse_security::CertificateValidationResult::Expired:
+        return ocpp::CertificateValidationResult::Expired;
     }
+    throw std::runtime_error("Could not convert types::evse_security::CertificateValidationResult to "
+                             "ocpp::CertificateValidationResult");
 }
 
 ocpp::GetCertificateInfoStatus to_ocpp(types::evse_security::GetCertificateInfoStatus other) {
@@ -251,10 +245,9 @@ ocpp::GetCertificateInfoStatus to_ocpp(types::evse_security::GetCertificateInfoS
         return ocpp::GetCertificateInfoStatus::NotFoundValid;
     case types::evse_security::GetCertificateInfoStatus::PrivateKeyNotFound:
         return ocpp::GetCertificateInfoStatus::PrivateKeyNotFound;
-    default:
-        throw std::runtime_error("Could not convert types::evse_security::GetCertificateInfoStatus to "
-                                 "ocpp::GetCertificateInfoStatus");
     }
+    throw std::runtime_error("Could not convert types::evse_security::GetCertificateInfoStatus to "
+                             "ocpp::GetCertificateInfoStatus");
 }
 
 ocpp::DeleteCertificateResult to_ocpp(types::evse_security::DeleteCertificateResult other) {
@@ -265,10 +258,9 @@ ocpp::DeleteCertificateResult to_ocpp(types::evse_security::DeleteCertificateRes
         return ocpp::DeleteCertificateResult::Failed;
     case types::evse_security::DeleteCertificateResult::NotFound:
         return ocpp::DeleteCertificateResult::NotFound;
-    default:
-        throw std::runtime_error(
-            "Could not convert types::evse_security::DeleteCertificateResult to ocpp::DeleteCertificateResult");
     }
+    throw std::runtime_error(
+        "Could not convert types::evse_security::DeleteCertificateResult to ocpp::DeleteCertificateResult");
 }
 
 ocpp::GetCertificateSignRequestStatus to_ocpp(types::evse_security::GetCertificateSignRequestStatus other) {
@@ -281,10 +273,9 @@ ocpp::GetCertificateSignRequestStatus to_ocpp(types::evse_security::GetCertifica
         return ocpp::GetCertificateSignRequestStatus::KeyGenError;
     case types::evse_security::GetCertificateSignRequestStatus::GenerationError:
         return ocpp::GetCertificateSignRequestStatus::GenerationError;
-    default:
-        throw std::runtime_error("Could not convert types::evse_security::GetCertificateSignRequestStatus to "
-                                 "ocpp::GetCertificateSignRequestStatus");
     }
+    throw std::runtime_error("Could not convert types::evse_security::GetCertificateSignRequestStatus to "
+                             "ocpp::GetCertificateSignRequestStatus");
 }
 
 ocpp::CertificateHashDataType to_ocpp(types::evse_security::CertificateHashData other) {
@@ -362,10 +353,8 @@ types::evse_security::CaCertificateType from_ocpp(ocpp::CaCertificateType other)
         return types::evse_security::CaCertificateType::CSMS;
     case ocpp::CaCertificateType::MF:
         return types::evse_security::CaCertificateType::MF;
-    default:
-        throw std::runtime_error(
-            "Could not convert types::evse_security::CaCertificateType to ocpp::CaCertificateType");
     }
+    throw std::runtime_error("Could not convert types::evse_security::CaCertificateType to ocpp::CaCertificateType");
 }
 
 types::evse_security::LeafCertificateType from_ocpp(ocpp::CertificateSigningUseEnum other) {
@@ -376,10 +365,9 @@ types::evse_security::LeafCertificateType from_ocpp(ocpp::CertificateSigningUseE
         return types::evse_security::LeafCertificateType::V2G;
     case ocpp::CertificateSigningUseEnum::ManufacturerCertificate:
         return types::evse_security::LeafCertificateType::MF;
-    default:
-        throw std::runtime_error(
-            "Could not convert ocpp::CertificateSigningUseEnum to types::evse_security::LeafCertificateType");
     }
+    throw std::runtime_error(
+        "Could not convert ocpp::CertificateSigningUseEnum to types::evse_security::LeafCertificateType");
 }
 
 types::evse_security::LeafCertificateType from_ocpp(ocpp::LeafCertificateType other) {
@@ -392,10 +380,9 @@ types::evse_security::LeafCertificateType from_ocpp(ocpp::LeafCertificateType ot
         return types::evse_security::LeafCertificateType::MF;
     case ocpp::LeafCertificateType::MO:
         return types::evse_security::LeafCertificateType::MO;
-    default:
-        throw std::runtime_error(
-            "Could not convert ocpp::CertificateSigningUseEnum to types::evse_security::LeafCertificateType");
     }
+    throw std::runtime_error(
+        "Could not convert ocpp::CertificateSigningUseEnum to types::evse_security::LeafCertificateType");
 }
 
 types::evse_security::CertificateType from_ocpp(ocpp::CertificateType other) {
@@ -410,9 +397,8 @@ types::evse_security::CertificateType from_ocpp(ocpp::CertificateType other) {
         return types::evse_security::CertificateType::V2GCertificateChain;
     case ocpp::CertificateType::MFRootCertificate:
         return types::evse_security::CertificateType::MFRootCertificate;
-    default:
-        throw std::runtime_error("Could not convert ocpp::CertificateType to types::evse_security::CertificateType");
     }
+    throw std::runtime_error("Could not convert ocpp::CertificateType to types::evse_security::CertificateType");
 }
 
 types::evse_security::HashAlgorithm from_ocpp(ocpp::HashAlgorithmEnumType other) {
@@ -423,10 +409,8 @@ types::evse_security::HashAlgorithm from_ocpp(ocpp::HashAlgorithmEnumType other)
         return types::evse_security::HashAlgorithm::SHA384;
     case ocpp::HashAlgorithmEnumType::SHA512:
         return types::evse_security::HashAlgorithm::SHA512;
-    default:
-        throw std::runtime_error(
-            "Could not convert ocpp::HashAlgorithmEnumType to types::evse_security::HashAlgorithm");
     }
+    throw std::runtime_error("Could not convert ocpp::HashAlgorithmEnumType to types::evse_security::HashAlgorithm");
 }
 
 types::evse_security::InstallCertificateResult from_ocpp(ocpp::InstallCertificateResult other) {
@@ -449,10 +433,9 @@ types::evse_security::InstallCertificateResult from_ocpp(ocpp::InstallCertificat
         return types::evse_security::InstallCertificateResult::WriteError;
     case ocpp::InstallCertificateResult::Accepted:
         return types::evse_security::InstallCertificateResult::Accepted;
-    default:
-        throw std::runtime_error(
-            "Could not convert ocpp::InstallCertificateResult to types::evse_security::InstallCertificateResult");
     }
+    throw std::runtime_error(
+        "Could not convert ocpp::InstallCertificateResult to types::evse_security::InstallCertificateResult");
 }
 
 types::evse_security::DeleteCertificateResult from_ocpp(ocpp::DeleteCertificateResult other) {
@@ -463,10 +446,9 @@ types::evse_security::DeleteCertificateResult from_ocpp(ocpp::DeleteCertificateR
         return types::evse_security::DeleteCertificateResult::Failed;
     case ocpp::DeleteCertificateResult::NotFound:
         return types::evse_security::DeleteCertificateResult::NotFound;
-    default:
-        throw std::runtime_error(
-            "Could not convert ocpp::DeleteCertificateResult to types::evse_security::DeleteCertificateResult");
     }
+    throw std::runtime_error(
+        "Could not convert ocpp::DeleteCertificateResult to types::evse_security::DeleteCertificateResult");
 }
 
 types::evse_security::CertificateHashData from_ocpp(ocpp::CertificateHashDataType other) {

--- a/lib/staging/ocpp/ocpp_conversions.cpp
+++ b/lib/staging/ocpp/ocpp_conversions.cpp
@@ -12,10 +12,9 @@ to_everest_display_message_priority(const ocpp::v201::MessagePriorityEnum& prior
         return types::display_message::MessagePriorityEnum::InFront;
     case ocpp::v201::MessagePriorityEnum::NormalCycle:
         return types::display_message::MessagePriorityEnum::NormalCycle;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v201::MessagePriorityEnum to types::display_message::MessagePriorityEnum");
     }
+    throw std::out_of_range(
+        "Could not convert ocpp::v201::MessagePriorityEnum to types::display_message::MessagePriorityEnum");
 }
 
 ocpp::v201::MessagePriorityEnum
@@ -27,10 +26,9 @@ to_ocpp_201_message_priority(const types::display_message::MessagePriorityEnum& 
         return ocpp::v201::MessagePriorityEnum::InFront;
     case types::display_message::MessagePriorityEnum::NormalCycle:
         return ocpp::v201::MessagePriorityEnum::NormalCycle;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::display_message::MessagePriorityEnum to ocpp::v201::MessagePriorityEnum");
     }
+    throw std::out_of_range(
+        "Could not convert types::display_message::MessagePriorityEnum to ocpp::v201::MessagePriorityEnum");
 }
 
 types::display_message::MessageStateEnum to_everest_display_message_state(const ocpp::v201::MessageStateEnum& state) {
@@ -43,10 +41,9 @@ types::display_message::MessageStateEnum to_everest_display_message_state(const 
         return types::display_message::MessageStateEnum::Idle;
     case ocpp::v201::MessageStateEnum::Unavailable:
         return types::display_message::MessageStateEnum::Unavailable;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v201::MessageStateEnum to types::display_message::MessageStateEnum");
     }
+    throw std::out_of_range(
+        "Could not convert ocpp::v201::MessageStateEnum to types::display_message::MessageStateEnum");
 }
 
 ocpp::v201::MessageStateEnum to_ocpp_201_display_message_state(const types::display_message::MessageStateEnum& state) {
@@ -59,10 +56,9 @@ ocpp::v201::MessageStateEnum to_ocpp_201_display_message_state(const types::disp
         return ocpp::v201::MessageStateEnum::Idle;
     case types::display_message::MessageStateEnum::Unavailable:
         return ocpp::v201::MessageStateEnum::Unavailable;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::display_message::MessageStateEnum to ocpp::v201::MessageStateEnum");
     }
+    throw std::out_of_range(
+        "Could not convert types::display_message::MessageStateEnum to ocpp::v201::MessageStateEnum");
 }
 
 types::display_message::MessageFormat
@@ -76,10 +72,8 @@ to_everest_display_message_format(const ocpp::v201::MessageFormatEnum& message_f
         return types::display_message::MessageFormat::URI;
     case ocpp::v201::MessageFormatEnum::UTF8:
         return types::display_message::MessageFormat::UTF8;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v201::MessageFormat to types::display_message::MessageFormatEnum");
     }
+    throw std::out_of_range("Could not convert ocpp::v201::MessageFormat to types::display_message::MessageFormatEnum");
 }
 
 ocpp::v201::MessageFormatEnum to_ocpp_201_message_format_enum(const types::display_message::MessageFormat& format) {
@@ -205,9 +199,8 @@ types::session_cost::SessionStatus to_everest_running_cost_state(const ocpp::Run
         return types::session_cost::SessionStatus::Idle;
     case ocpp::RunningCostState::Finished:
         return types::session_cost::SessionStatus::Finished;
-    default:
-        throw std::out_of_range("Could not convert ocpp::RunningCostState to types::session_cost::SessionStatus");
     }
+    throw std::out_of_range("Could not convert ocpp::RunningCostState to types::session_cost::SessionStatus");
 }
 
 types::session_cost::SessionCostChunk create_session_cost_chunk(const double& price, const uint32_t& number_of_decimals,

--- a/modules/OCPP/CMakeLists.txt
+++ b/modules/OCPP/CMakeLists.txt
@@ -19,6 +19,12 @@ target_link_libraries(${MODULE_NAME}
         everest::ocpp_evse_security
         everest::ocpp_conversions
 )
+
+target_compile_options(${MODULE_NAME}
+    PRIVATE
+        -Wimplicit-fallthrough
+        -Werror=switch-enum
+)
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 
 target_sources(${MODULE_NAME}

--- a/modules/OCPP/conversions.cpp
+++ b/modules/OCPP/conversions.cpp
@@ -38,9 +38,8 @@ to_ocpp_firmware_status_notification(const types::system::FirmwareUpdateStatusEn
         return ocpp::FirmwareStatusNotification::InvalidSignature;
     case types::system::FirmwareUpdateStatusEnum::SignatureVerified:
         return ocpp::FirmwareStatusNotification::SignatureVerified;
-    default:
-        throw std::out_of_range("Could not convert FirmwareUpdateStatusEnum to FirmwareStatusNotification");
     }
+    throw std::out_of_range("Could not convert FirmwareUpdateStatusEnum to FirmwareStatusNotification");
 }
 
 ocpp::SessionStartedReason to_ocpp_session_started_reason(const types::evse_manager::StartSessionReason reason) {
@@ -49,10 +48,8 @@ ocpp::SessionStartedReason to_ocpp_session_started_reason(const types::evse_mana
         return ocpp::SessionStartedReason::EVConnected;
     case types::evse_manager::StartSessionReason::Authorized:
         return ocpp::SessionStartedReason::Authorized;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::evse_manager::StartSessionReason to ocpp::SessionStartedReason");
     }
+    throw std::out_of_range("Could not convert types::evse_manager::StartSessionReason to ocpp::SessionStartedReason");
 }
 
 ocpp::v16::DataTransferStatus to_ocpp_data_transfer_status(const types::ocpp::DataTransferStatus status) {
@@ -65,9 +62,10 @@ ocpp::v16::DataTransferStatus to_ocpp_data_transfer_status(const types::ocpp::Da
         return ocpp::v16::DataTransferStatus::UnknownMessageId;
     case types::ocpp::DataTransferStatus::UnknownVendorId:
         return ocpp::v16::DataTransferStatus::UnknownVendorId;
-    default:
+    case types::ocpp::DataTransferStatus::Offline:
         return ocpp::v16::DataTransferStatus::UnknownVendorId;
     }
+    return ocpp::v16::DataTransferStatus::UnknownVendorId;
 }
 
 ocpp::v16::Reason to_ocpp_reason(const types::evse_manager::StopTransactionReason reason) {
@@ -104,9 +102,8 @@ ocpp::v16::Reason to_ocpp_reason(const types::evse_manager::StopTransactionReaso
     case types::evse_manager::StopTransactionReason::Timeout:
     case types::evse_manager::StopTransactionReason::Other:
         return ocpp::v16::Reason::Other;
-    default:
-        throw std::out_of_range("Could not convert types::evse_manager::StopTransactionReason to ocpp::v16::Reason");
     }
+    throw std::out_of_range("Could not convert types::evse_manager::StopTransactionReason to ocpp::v16::Reason");
 }
 
 ocpp::v201::CertificateActionEnum
@@ -116,10 +113,9 @@ to_ocpp_certificate_action_enum(const types::iso15118_charger::CertificateAction
         return ocpp::v201::CertificateActionEnum::Install;
     case types::iso15118_charger::CertificateActionEnum::Update:
         return ocpp::v201::CertificateActionEnum::Update;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::iso15118_charger::CertificateActionEnum to ocpp::v201::CertificateActionEnum");
     }
+    throw std::out_of_range(
+        "Could not convert types::iso15118_charger::CertificateActionEnum to ocpp::v201::CertificateActionEnum");
 }
 
 ocpp::v16::ReservationStatus to_ocpp_reservation_status(const types::reservation::ReservationResult result) {
@@ -134,10 +130,8 @@ ocpp::v16::ReservationStatus to_ocpp_reservation_status(const types::reservation
         return ocpp::v16::ReservationStatus::Rejected;
     case types::reservation::ReservationResult::Unavailable:
         return ocpp::v16::ReservationStatus::Unavailable;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::reservation::ReservationResult to ocpp::v16::ReservationStatus");
     }
+    throw std::out_of_range("Could not convert types::reservation::ReservationResult to ocpp::v16::ReservationStatus");
 }
 
 ocpp::v16::LogStatusEnumType to_ocpp_log_status_enum_type(const types::system::UploadLogsStatus status) {
@@ -148,9 +142,8 @@ ocpp::v16::LogStatusEnumType to_ocpp_log_status_enum_type(const types::system::U
         return ocpp::v16::LogStatusEnumType::Rejected;
     case types::system::UploadLogsStatus::AcceptedCanceled:
         return ocpp::v16::LogStatusEnumType::AcceptedCanceled;
-    default:
-        throw std::out_of_range("Could not convert types::system::UploadLogsStatus to ocpp::v16::LogStatusEnumType");
     }
+    throw std::out_of_range("Could not convert types::system::UploadLogsStatus to ocpp::v16::LogStatusEnumType");
 }
 
 ocpp::v16::UpdateFirmwareStatusEnumType
@@ -164,10 +157,11 @@ to_ocpp_update_firmware_status_enum_type(const types::system::UpdateFirmwareResp
         return ocpp::v16::UpdateFirmwareStatusEnumType::AcceptedCanceled;
     case types::system::UpdateFirmwareResponse::InvalidCertificate:
         return ocpp::v16::UpdateFirmwareStatusEnumType::InvalidCertificate;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::system::UpdateFirmwareResponse to ocpp::v16::UpdateFirmwareStatusEnumType");
+    case types::system::UpdateFirmwareResponse::RevokedCertificate:
+        return ocpp::v16::UpdateFirmwareStatusEnumType::RevokedCertificate;
     }
+    throw std::out_of_range(
+        "Could not convert types::system::UpdateFirmwareResponse to ocpp::v16::UpdateFirmwareStatusEnumType");
 }
 
 ocpp::v16::HashAlgorithmEnumType
@@ -179,10 +173,9 @@ to_ocpp_hash_algorithm_enum_type(const types::iso15118_charger::HashAlgorithm ha
         return ocpp::v16::HashAlgorithmEnumType::SHA384;
     case types::iso15118_charger::HashAlgorithm::SHA512:
         return ocpp::v16::HashAlgorithmEnumType::SHA512;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::iso15118_charger::HashAlgorithm to ocpp::v16::HashAlgorithmEnumType");
     }
+    throw std::out_of_range(
+        "Could not convert types::iso15118_charger::HashAlgorithm to ocpp::v16::HashAlgorithmEnumType");
 }
 
 ocpp::v16::BootReasonEnum to_ocpp_boot_reason_enum(const types::system::BootReason reason) {
@@ -205,9 +198,8 @@ ocpp::v16::BootReasonEnum to_ocpp_boot_reason_enum(const types::system::BootReas
         return ocpp::v16::BootReasonEnum::Unknown;
     case types::system::BootReason::Watchdog:
         return ocpp::v16::BootReasonEnum::Watchdog;
-    default:
-        throw std::runtime_error("Could not convert BootReasonEnum");
     }
+    throw std::runtime_error("Could not convert BootReasonEnum");
 }
 
 ocpp::Powermeter to_ocpp_power_meter(const types::powermeter::Powermeter& powermeter) {
@@ -261,10 +253,9 @@ ocpp::v201::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118_
         return ocpp::v201::HashAlgorithmEnum::SHA384;
     case types::iso15118_charger::HashAlgorithm::SHA512:
         return ocpp::v201::HashAlgorithmEnum::SHA512;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::iso15118_charger::HashAlgorithm to ocpp::v16::HashAlgorithmEnumType");
     }
+    throw std::out_of_range(
+        "Could not convert types::iso15118_charger::HashAlgorithm to ocpp::v16::HashAlgorithmEnumType");
 }
 
 types::evse_manager::StopTransactionReason to_everest_stop_transaction_reason(const ocpp::v16::Reason reason) {
@@ -291,9 +282,8 @@ types::evse_manager::StopTransactionReason to_everest_stop_transaction_reason(co
         return types::evse_manager::StopTransactionReason::DeAuthorized;
     case ocpp::v16::Reason::Other:
         return types::evse_manager::StopTransactionReason::Other;
-    default:
-        throw std::out_of_range("Could not convert ocpp::v16::Reason to types::evse_manager::StopTransactionReason");
     }
+    throw std::out_of_range("Could not convert ocpp::v16::Reason to types::evse_manager::StopTransactionReason");
 }
 
 types::system::ResetType to_everest_reset_type(const ocpp::v16::ResetType type) {
@@ -302,9 +292,8 @@ types::system::ResetType to_everest_reset_type(const ocpp::v16::ResetType type) 
         return types::system::ResetType::Hard;
     case ocpp::v16::ResetType::Soft:
         return types::system::ResetType::Soft;
-    default:
-        throw std::out_of_range("Could not convert ocpp::v16::ResetType to types::system::ResetType");
     }
+    throw std::out_of_range("Could not convert ocpp::v16::ResetType to types::system::ResetType");
 }
 
 types::iso15118_charger::Status
@@ -314,10 +303,9 @@ to_everest_iso15118_charger_status(const ocpp::v201::Iso15118EVCertificateStatus
         return types::iso15118_charger::Status::Accepted;
     case ocpp::v201::Iso15118EVCertificateStatusEnum::Failed:
         return types::iso15118_charger::Status::Failed;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v201::Iso15118EVCertificateStatusEnum to types::iso15118_charger::Status");
     }
+    throw std::out_of_range(
+        "Could not convert ocpp::v201::Iso15118EVCertificateStatusEnum to types::iso15118_charger::Status");
 }
 
 types::iso15118_charger::CertificateActionEnum
@@ -327,10 +315,9 @@ to_everest_certificate_action_enum(const ocpp::v201::CertificateActionEnum actio
         return types::iso15118_charger::CertificateActionEnum::Install;
     case ocpp::v201::CertificateActionEnum::Update:
         return types::iso15118_charger::CertificateActionEnum::Update;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v201::CertificateActionEnum to types::iso15118_charger::CertificateActionEnum");
     }
+    throw std::out_of_range(
+        "Could not convert ocpp::v201::CertificateActionEnum to types::iso15118_charger::CertificateActionEnum");
 }
 
 types::authorization::CertificateStatus
@@ -350,10 +337,9 @@ to_everest_certificate_status(const ocpp::v201::AuthorizeCertificateStatusEnum s
         return types::authorization::CertificateStatus::CertChainError;
     case ocpp::v201::AuthorizeCertificateStatusEnum::ContractCancelled:
         return types::authorization::CertificateStatus::ContractCancelled;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v201::AuthorizeCertificateStatusEnum to types::authorization::CertificateStatus");
     }
+    throw std::out_of_range(
+        "Could not convert ocpp::v201::AuthorizeCertificateStatusEnum to types::authorization::CertificateStatus");
 }
 
 types::authorization::AuthorizationStatus to_everest_authorization_status(const ocpp::v16::AuthorizationStatus status) {
@@ -368,10 +354,9 @@ types::authorization::AuthorizationStatus to_everest_authorization_status(const 
         return types::authorization::AuthorizationStatus::Invalid;
     case ocpp::v16::AuthorizationStatus::ConcurrentTx:
         return types::authorization::AuthorizationStatus::ConcurrentTx;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v16::AuthorizationStatus to types::authorization::AuthorizationStatus");
     }
+    throw std::out_of_range(
+        "Could not convert ocpp::v16::AuthorizationStatus to types::authorization::AuthorizationStatus");
 }
 
 types::authorization::AuthorizationStatus
@@ -397,10 +382,9 @@ to_everest_authorization_status(const ocpp::v201::AuthorizationStatusEnum status
         return types::authorization::AuthorizationStatus::NotAtThisTime;
     case ocpp::v201::AuthorizationStatusEnum::Unknown:
         return types::authorization::AuthorizationStatus::Unknown;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v201::AuthorizationStatusEnum to types::authorization::AuthorizationStatus");
     }
+    throw std::out_of_range(
+        "Could not convert ocpp::v201::AuthorizationStatusEnum to types::authorization::AuthorizationStatus");
 }
 
 types::ocpp::ChargingSchedulePeriod
@@ -449,37 +433,34 @@ to_everest_registration_status(const ocpp::v16::RegistrationStatus& registration
         return types::ocpp::RegistrationStatus::Pending;
     case ocpp::v16::RegistrationStatus::Rejected:
         return types::ocpp::RegistrationStatus::Rejected;
-    default:
-        throw std::out_of_range("Could not convert ocpp::v201::RegistrationStatus to types::ocpp::RegistrationStatus");
     }
+    throw std::out_of_range("Could not convert ocpp::v201::RegistrationStatus to types::ocpp::RegistrationStatus");
+}
+
+ocpp::v16::DataTransferStatus
+to_ocpp_data_transfer_status(const types::display_message::DisplayMessageStatusEnum display_message_status_enum) {
+    switch (display_message_status_enum) {
+    case types::display_message::DisplayMessageStatusEnum::Accepted:
+        return ocpp::v16::DataTransferStatus::Accepted;
+    case types::display_message::DisplayMessageStatusEnum::NotSupportedMessageFormat:
+        return ocpp::v16::DataTransferStatus::Rejected;
+    case types::display_message::DisplayMessageStatusEnum::Rejected:
+        return ocpp::v16::DataTransferStatus::Rejected;
+    case types::display_message::DisplayMessageStatusEnum::NotSupportedPriority:
+        return ocpp::v16::DataTransferStatus::Rejected;
+    case types::display_message::DisplayMessageStatusEnum::NotSupportedState:
+        return ocpp::v16::DataTransferStatus::Rejected;
+    case types::display_message::DisplayMessageStatusEnum::UnknownTransaction:
+        return ocpp::v16::DataTransferStatus::Rejected;
+    }
+    throw std::out_of_range(
+        "Could not convert types::display_message::DisplayMessageStatusEnum to ocpp::v16::DataTransferStatus");
 }
 
 ocpp::v16::DataTransferResponse
 to_ocpp_data_transfer_response(const types::display_message::SetDisplayMessageResponse& set_display_message_response) {
     ocpp::v16::DataTransferResponse response;
-    switch (set_display_message_response.status) {
-    case types::display_message::DisplayMessageStatusEnum::Accepted:
-        response.status = ocpp::v16::DataTransferStatus::Accepted;
-        break;
-    case types::display_message::DisplayMessageStatusEnum::NotSupportedMessageFormat:
-        response.status = ocpp::v16::DataTransferStatus::Rejected;
-        break;
-    case types::display_message::DisplayMessageStatusEnum::Rejected:
-        response.status = ocpp::v16::DataTransferStatus::Rejected;
-        break;
-    case types::display_message::DisplayMessageStatusEnum::NotSupportedPriority:
-        response.status = ocpp::v16::DataTransferStatus::Rejected;
-        break;
-    case types::display_message::DisplayMessageStatusEnum::NotSupportedState:
-        response.status = ocpp::v16::DataTransferStatus::Rejected;
-        break;
-    case types::display_message::DisplayMessageStatusEnum::UnknownTransaction:
-        response.status = ocpp::v16::DataTransferStatus::Rejected;
-        break;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::display_message::DisplayMessageStatusEnum to ocpp::v16::DataTransferStatus");
-    }
+    response.status = to_ocpp_data_transfer_status(set_display_message_response.status);
 
     response.data = set_display_message_response.status_info;
     return response;

--- a/modules/OCPP201/CMakeLists.txt
+++ b/modules/OCPP201/CMakeLists.txt
@@ -19,6 +19,12 @@ target_link_libraries(${MODULE_NAME}
         everest::ocpp_evse_security
         everest::ocpp_conversions
 )
+
+target_compile_options(${MODULE_NAME}
+    PRIVATE
+        -Wimplicit-fallthrough
+        -Werror=switch-enum
+)
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 
 target_sources(${MODULE_NAME}

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -30,9 +30,22 @@ TxEvent get_tx_event(const ocpp::v201::ReasonEnum reason) {
         return TxEvent::EV_DISCONNECTED;
     case ocpp::v201::ReasonEnum::ImmediateReset:
         return TxEvent::IMMEDIATE_RESET;
-    default:
+    // FIXME(kai): these reasons definitely do not all map to NONE
+    case ocpp::v201::ReasonEnum::EmergencyStop:
+    case ocpp::v201::ReasonEnum::EnergyLimitReached:
+    case ocpp::v201::ReasonEnum::GroundFault:
+    case ocpp::v201::ReasonEnum::LocalOutOfCredit:
+    case ocpp::v201::ReasonEnum::Other:
+    case ocpp::v201::ReasonEnum::OvercurrentFault:
+    case ocpp::v201::ReasonEnum::PowerLoss:
+    case ocpp::v201::ReasonEnum::PowerQuality:
+    case ocpp::v201::ReasonEnum::Reboot:
+    case ocpp::v201::ReasonEnum::SOCLimitReached:
+    case ocpp::v201::ReasonEnum::TimeLimitReached:
+    case ocpp::v201::ReasonEnum::Timeout:
         return TxEvent::NONE;
     }
+    return TxEvent::NONE;
 }
 
 std::set<TxStartStopPoint> get_tx_start_stop_points(const std::string& tx_start_stop_point_csl) {
@@ -829,8 +842,21 @@ void OCPP201::process_session_event(const int32_t evse_id, const types::evse_man
         this->process_deauthorized(evse_id, connector_id, session_event);
         break;
     }
-
-        // missing AuthRequired, PrepareCharging and many more
+    // explicitly ignore the following session events for now
+    // TODO(kai): implement
+    case types::evse_manager::SessionEventEnum::AuthRequired:
+    case types::evse_manager::SessionEventEnum::PrepareCharging:
+    case types::evse_manager::SessionEventEnum::WaitingForEnergy:
+    case types::evse_manager::SessionEventEnum::StoppingCharging:
+    case types::evse_manager::SessionEventEnum::ChargingFinished:
+    case types::evse_manager::SessionEventEnum::ReservationStart:
+    case types::evse_manager::SessionEventEnum::ReservationEnd:
+    case types::evse_manager::SessionEventEnum::ReplugStarted:
+    case types::evse_manager::SessionEventEnum::ReplugFinished:
+    case types::evse_manager::SessionEventEnum::PluginTimeout:
+    case types::evse_manager::SessionEventEnum::SwitchingPhases:
+    case types::evse_manager::SessionEventEnum::SessionResumed:
+        break;
     }
 
     // process authorized event which will inititate a TransactionEvent(Updated) message in case the token has not yet

--- a/modules/OCPP201/conversions.cpp
+++ b/modules/OCPP201/conversions.cpp
@@ -36,9 +36,8 @@ ocpp::v201::FirmwareStatusEnum to_ocpp_firmware_status_enum(const types::system:
         return ocpp::v201::FirmwareStatusEnum::InvalidSignature;
     case types::system::FirmwareUpdateStatusEnum::SignatureVerified:
         return ocpp::v201::FirmwareStatusEnum::SignatureVerified;
-    default:
-        throw std::out_of_range("Could not convert FirmwareUpdateStatusEnum to FirmwareStatusEnum");
     }
+    throw std::out_of_range("Could not convert FirmwareUpdateStatusEnum to FirmwareStatusEnum");
 }
 
 ocpp::v201::DataTransferStatusEnum to_ocpp_data_transfer_status_enum(types::ocpp::DataTransferStatus status) {
@@ -51,9 +50,10 @@ ocpp::v201::DataTransferStatusEnum to_ocpp_data_transfer_status_enum(types::ocpp
         return ocpp::v201::DataTransferStatusEnum::UnknownMessageId;
     case types::ocpp::DataTransferStatus::UnknownVendorId:
         return ocpp::v201::DataTransferStatusEnum::UnknownVendorId;
-    default:
+    case types::ocpp::DataTransferStatus::Offline:
         return ocpp::v201::DataTransferStatusEnum::UnknownVendorId;
     }
+    return ocpp::v201::DataTransferStatusEnum::UnknownVendorId;
 }
 
 ocpp::v201::DataTransferRequest to_ocpp_data_transfer_request(types::ocpp::DataTransferRequest request) {
@@ -482,9 +482,8 @@ ocpp::v201::LogStatusEnum to_ocpp_log_status_enum(types::system::UploadLogsStatu
         return ocpp::v201::LogStatusEnum::Rejected;
     case types::system::UploadLogsStatus::AcceptedCanceled:
         return ocpp::v201::LogStatusEnum::AcceptedCanceled;
-    default:
-        throw std::runtime_error("Could not convert UploadLogsStatus");
     }
+    throw std::runtime_error("Could not convert UploadLogsStatus");
 }
 
 ocpp::v201::GetLogResponse to_ocpp_get_log_response(const types::system::UploadLogsResponse& response) {
@@ -507,9 +506,8 @@ to_ocpp_update_firmware_status_enum(const types::system::UpdateFirmwareResponse&
         return ocpp::v201::UpdateFirmwareStatusEnum::InvalidCertificate;
     case types::system::UpdateFirmwareResponse::RevokedCertificate:
         return ocpp::v201::UpdateFirmwareStatusEnum::RevokedCertificate;
-    default:
-        throw std::runtime_error("Could not convert UpdateFirmwareResponse");
     }
+    throw std::runtime_error("Could not convert UpdateFirmwareResponse");
 }
 
 ocpp::v201::UpdateFirmwareResponse
@@ -537,9 +535,8 @@ ocpp::v201::UploadLogStatusEnum to_ocpp_upload_logs_status_enum(types::system::L
         return ocpp::v201::UploadLogStatusEnum::Uploading;
     case types::system::LogStatusEnum::AcceptedCanceled:
         return ocpp::v201::UploadLogStatusEnum::AcceptedCanceled;
-    default:
-        throw std::runtime_error("Could not convert UploadLogStatusEnum");
     }
+    throw std::runtime_error("Could not convert UploadLogStatusEnum");
 }
 
 ocpp::v201::BootReasonEnum to_ocpp_boot_reason(types::system::BootReason reason) {
@@ -562,9 +559,8 @@ ocpp::v201::BootReasonEnum to_ocpp_boot_reason(types::system::BootReason reason)
         return ocpp::v201::BootReasonEnum::Unknown;
     case types::system::BootReason::Watchdog:
         return ocpp::v201::BootReasonEnum::Watchdog;
-    default:
-        throw std::runtime_error("Could not convert BootReasonEnum");
     }
+    throw std::runtime_error("Could not convert BootReasonEnum");
 }
 
 ocpp::v201::ReasonEnum to_ocpp_reason(types::evse_manager::StopTransactionReason reason) {
@@ -607,9 +603,11 @@ ocpp::v201::ReasonEnum to_ocpp_reason(types::evse_manager::StopTransactionReason
         return ocpp::v201::ReasonEnum::TimeLimitReached;
     case types::evse_manager::StopTransactionReason::Timeout:
         return ocpp::v201::ReasonEnum::Timeout;
-    default:
+    case types::evse_manager::StopTransactionReason::SoftReset:
+    case types::evse_manager::StopTransactionReason::UnlockCommand:
         return ocpp::v201::ReasonEnum::Other;
     }
+    return ocpp::v201::ReasonEnum::Other;
 }
 
 ocpp::v201::IdTokenEnum to_ocpp_id_token_enum(types::authorization::IdTokenType id_token_type) {
@@ -630,9 +628,8 @@ ocpp::v201::IdTokenEnum to_ocpp_id_token_enum(types::authorization::IdTokenType 
         return ocpp::v201::IdTokenEnum::Local;
     case types::authorization::IdTokenType::NoAuthorization:
         return ocpp::v201::IdTokenEnum::NoAuthorization;
-    default:
-        throw std::runtime_error("Could not convert IdTokenEnum");
     }
+    throw std::runtime_error("Could not convert IdTokenEnum");
 }
 
 ocpp::v201::IdToken to_ocpp_id_token(const types::authorization::IdToken& id_token) {
@@ -700,9 +697,8 @@ to_everest_stop_transaction_reason(const ocpp::v201::ReasonEnum& stop_reason) {
         return types::evse_manager::StopTransactionReason::TimeLimitReached;
     case ocpp::v201::ReasonEnum::Timeout:
         return types::evse_manager::StopTransactionReason::Timeout;
-    default:
-        return types::evse_manager::StopTransactionReason::Other;
     }
+    return types::evse_manager::StopTransactionReason::Other;
 }
 
 std::vector<ocpp::v201::OCSPRequestData> to_ocpp_ocsp_request_data_vector(
@@ -729,10 +725,9 @@ ocpp::v201::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118_
         return ocpp::v201::HashAlgorithmEnum::SHA384;
     case types::iso15118_charger::HashAlgorithm::SHA512:
         return ocpp::v201::HashAlgorithmEnum::SHA512;
-    default:
-        throw std::out_of_range(
-            "Could not convert types::iso15118_charger::HashAlgorithm to ocpp::v201::HashAlgorithmEnum");
     }
+    throw std::out_of_range(
+        "Could not convert types::iso15118_charger::HashAlgorithm to ocpp::v201::HashAlgorithmEnum");
 }
 
 std::vector<ocpp::v201::GetVariableData>
@@ -811,9 +806,8 @@ ocpp::v201::AttributeEnum to_ocpp_attribute_enum(const types::ocpp::AttributeEnu
         return ocpp::v201::AttributeEnum::MinSet;
     case types::ocpp::AttributeEnum::MaxSet:
         return ocpp::v201::AttributeEnum::MaxSet;
-    default:
-        throw std::out_of_range("Could not convert AttributeEnum");
     }
+    throw std::out_of_range("Could not convert AttributeEnum");
 }
 
 ocpp::v201::Get15118EVCertificateRequest
@@ -883,9 +877,8 @@ types::ocpp::DataTransferStatus to_everest_data_transfer_status(ocpp::v201::Data
         return types::ocpp::DataTransferStatus::UnknownMessageId;
     case ocpp::v201::DataTransferStatusEnum::UnknownVendorId:
         return types::ocpp::DataTransferStatus::UnknownVendorId;
-    default:
-        return types::ocpp::DataTransferStatus::UnknownVendorId;
     }
+    return types::ocpp::DataTransferStatus::UnknownVendorId;
 }
 
 types::ocpp::DataTransferRequest to_everest_data_transfer_request(ocpp::v201::DataTransferRequest request) {
@@ -986,10 +979,9 @@ to_everest_authorization_status(const ocpp::v201::AuthorizationStatusEnum status
         return types::authorization::AuthorizationStatus::NotAtThisTime;
     case ocpp::v201::AuthorizationStatusEnum::Unknown:
         return types::authorization::AuthorizationStatus::Unknown;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v201::AuthorizationStatusEnum to types::authorization::AuthorizationStatus");
     }
+    throw std::out_of_range(
+        "Could not convert ocpp::v201::AuthorizationStatusEnum to types::authorization::AuthorizationStatus");
 }
 
 types::authorization::IdTokenType to_everest_id_token_type(const ocpp::v201::IdTokenEnum& type) {
@@ -1010,9 +1002,8 @@ types::authorization::IdTokenType to_everest_id_token_type(const ocpp::v201::IdT
         return types::authorization::IdTokenType::MacAddress;
     case ocpp::v201::IdTokenEnum::NoAuthorization:
         return types::authorization::IdTokenType::NoAuthorization;
-    default:
-        throw std::out_of_range("Could not convert ocpp::v201::IdTokenEnum to types::authorization::IdTokenType");
     }
+    throw std::out_of_range("Could not convert ocpp::v201::IdTokenEnum to types::authorization::IdTokenType");
 }
 
 types::authorization::IdToken to_everest_id_token(const ocpp::v201::IdToken& id_token) {
@@ -1039,10 +1030,9 @@ to_everest_certificate_status(const ocpp::v201::AuthorizeCertificateStatusEnum s
         return types::authorization::CertificateStatus::CertChainError;
     case ocpp::v201::AuthorizeCertificateStatusEnum::ContractCancelled:
         return types::authorization::CertificateStatus::ContractCancelled;
-    default:
-        throw std::out_of_range("Could not convert ocpp::v201::AuthorizeCertificateStatusEnum to "
-                                "types::authorization::CertificateStatus");
     }
+    throw std::out_of_range("Could not convert ocpp::v201::AuthorizeCertificateStatusEnum to "
+                            "types::authorization::CertificateStatus");
 }
 
 types::ocpp::OcppTransactionEvent
@@ -1091,9 +1081,8 @@ types::display_message::MessageFormat to_everest_message_format(const ocpp::v201
         return types::display_message::MessageFormat::URI;
     case ocpp::v201::MessageFormatEnum::UTF8:
         return types::display_message::MessageFormat::UTF8;
-    default:
-        throw std::out_of_range("Could not convert ocpp::v201::MessageFormatEnum to types::ocpp::MessageFormat");
     }
+    throw std::out_of_range("Could not convert ocpp::v201::MessageFormatEnum to types::ocpp::MessageFormat");
 }
 
 types::display_message::MessageContent to_everest_message_content(const ocpp::v201::MessageContent& message_content) {
@@ -1140,10 +1129,8 @@ to_everest_registration_status(const ocpp::v201::RegistrationStatusEnum& registr
         return types::ocpp::RegistrationStatus::Pending;
     case ocpp::v201::RegistrationStatusEnum::Rejected:
         return types::ocpp::RegistrationStatus::Rejected;
-    default:
-        throw std::out_of_range(
-            "Could not convert ocpp::v201::RegistrationStatusEnum to types::ocpp::RegistrationStatus");
     }
+    throw std::out_of_range("Could not convert ocpp::v201::RegistrationStatusEnum to types::ocpp::RegistrationStatus");
 }
 
 types::ocpp::StatusInfoType to_everest_status_info_type(const ocpp::v201::StatusInfo& status_info) {
@@ -1231,9 +1218,8 @@ types::ocpp::AttributeEnum to_everest_attribute_enum(const ocpp::v201::Attribute
         return types::ocpp::AttributeEnum::MinSet;
     case ocpp::v201::AttributeEnum::MaxSet:
         return types::ocpp::AttributeEnum::MaxSet;
-    default:
-        throw std::out_of_range("Could not convert AttributeEnum");
     }
+    throw std::out_of_range("Could not convert AttributeEnum");
 }
 
 types::ocpp::GetVariableStatusEnumType
@@ -1249,9 +1235,8 @@ to_everest_get_variable_status_enum_type(const ocpp::v201::GetVariableStatusEnum
         return types::ocpp::GetVariableStatusEnumType::UnknownVariable;
     case ocpp::v201::GetVariableStatusEnum::NotSupportedAttributeType:
         return types::ocpp::GetVariableStatusEnumType::NotSupportedAttributeType;
-    default:
-        throw std::out_of_range("Could not convert GetVariableStatusEnumType");
     }
+    throw std::out_of_range("Could not convert GetVariableStatusEnumType");
 }
 
 types::ocpp::SetVariableStatusEnumType
@@ -1269,9 +1254,8 @@ to_everest_set_variable_status_enum_type(const ocpp::v201::SetVariableStatusEnum
         return types::ocpp::SetVariableStatusEnumType::NotSupportedAttributeType;
     case ocpp::v201::SetVariableStatusEnum::RebootRequired:
         return types::ocpp::SetVariableStatusEnumType::RebootRequired;
-    default:
-        throw std::out_of_range("Could not convert GetVariableStatusEnumType");
     }
+    throw std::out_of_range("Could not convert GetVariableStatusEnumType");
 }
 
 types::ocpp::ChargingSchedules

--- a/modules/OCPP201/transaction_handler.hpp
+++ b/modules/OCPP201/transaction_handler.hpp
@@ -90,6 +90,8 @@ struct TxStartStopConditions {
         case TxEvent::IMMEDIATE_RESET:
             is_immediate_reset = true;
             break;
+        case TxEvent::NONE:
+            break;
         }
     };
 
@@ -127,9 +129,10 @@ struct TxStartStopConditions {
             return !is_authorized or !is_ev_connected;
         case TxStartStopPoint::EnergyTransfer:
             return !is_energy_transfered;
-        default:
+        case TxStartStopPoint::DataSigned:
             return false;
         }
+        return false;
     };
 };
 


### PR DESCRIPTION
Remove default: statements, turn on compiler error on enum conversion switch-case statements. This ensures that all cases are explicitly handled. This should also ensure that throw statements in the conversions functions are never be reached, they remain to prevent "control reaches end of non-void function" compiler warnings

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

