### PR TITLE
- Set state F for 300ms (configurable) after fault when in state C.

### DIFF
--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -105,7 +105,8 @@ public:
     void setup(bool has_ventilation, const ChargeMode charge_mode, bool ac_hlc_enabled, bool ac_hlc_use_5percent,
                bool ac_enforce_hlc, bool ac_with_soc_timeout, float soft_over_current_tolerance_percent,
                float soft_over_current_measurement_noise_A, const int switch_3ph1ph_delay_s,
-               const std::string switch_3ph1ph_cp_state, const int soft_over_current_timeout_ms);
+               const std::string switch_3ph1ph_cp_state, const int soft_over_current_timeout_ms,
+               const int _state_F_after_fault_ms);
 
     bool enable_disable(int connector_id, const types::evse_manager::EnableDisableSource& source);
 
@@ -192,6 +193,8 @@ public:
     void set_hlc_allow_close_contactor(bool on);
 
     bool stop_charging_on_fatal_error();
+    bool entered_fatal_error_state();
+    int time_in_fatal_error_state_ms();
 
     /// @brief Returns the OCMF start data.
     ///
@@ -322,6 +325,8 @@ private:
         bool switch_3ph1ph_cp_state_F{false};
         // Tolerate soft over current for given time
         int soft_over_current_timeout_ms{7000};
+        // Switch to F for configured ms after a fatal error
+        int state_F_after_fault_ms{300};
     } config_context;
 
     // Used by different threads, but requires no complete state machine locking
@@ -362,6 +367,10 @@ private:
         bool no_energy_warning_printed{false};
         float pwm_set_last_ampere{0};
         bool t_step_ef_x1_pause{false};
+        bool pwm_F_active{false};
+
+        std::chrono::time_point<std::chrono::steady_clock> fatal_error_became_active;
+        bool fatal_error_timer_running{false};
     } internal_context;
 
     // main Charger thread

--- a/modules/EvseManager/ErrorHandling.cpp
+++ b/modules/EvseManager/ErrorHandling.cpp
@@ -169,7 +169,7 @@ void ErrorHandling::raise_inoperative_error(const std::string& caused_by) {
     }
 
     if (r_hlc.size() > 0) {
-        r_hlc[0]->call_send_error(types::iso15118_charger::EvseError::Error_Malfunction);
+        r_hlc[0]->call_send_error(types::iso15118_charger::EvseError::Error_EmergencyShutdown);
     }
 
     // raise externally

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -823,11 +823,12 @@ void EvseManager::ready() {
     if (config.ac_with_soc) {
         setup_fake_DC_mode();
     } else {
-        charger->setup(
-            config.has_ventilation, (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC),
-            hlc_enabled, config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
-            config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
-            config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms);
+        charger->setup(config.has_ventilation,
+                       (config.charge_mode == "DC" ? Charger::ChargeMode::DC : Charger::ChargeMode::AC), hlc_enabled,
+                       config.ac_hlc_use_5percent, config.ac_enforce_hlc, false,
+                       config.soft_over_current_tolerance_percent, config.soft_over_current_measurement_noise_A,
+                       config.switch_3ph1ph_delay_s, config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms,
+                       config.state_F_after_fault_ms);
     }
 
     telemetryThreadHandle = std::thread([this]() {
@@ -1013,7 +1014,7 @@ void EvseManager::setup_fake_DC_mode() {
     charger->setup(config.has_ventilation, Charger::ChargeMode::DC, hlc_enabled, config.ac_hlc_use_5percent,
                    config.ac_enforce_hlc, false, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
-                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms);
+                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms);
 
     types::iso15118_charger::EVSEID evseid = {config.evse_id, config.evse_id_din};
 
@@ -1052,7 +1053,7 @@ void EvseManager::setup_AC_mode() {
     charger->setup(config.has_ventilation, Charger::ChargeMode::AC, hlc_enabled, config.ac_hlc_use_5percent,
                    config.ac_enforce_hlc, true, config.soft_over_current_tolerance_percent,
                    config.soft_over_current_measurement_noise_A, config.switch_3ph1ph_delay_s,
-                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms);
+                   config.switch_3ph1ph_cp_state, config.soft_over_current_timeout_ms, config.state_F_after_fault_ms);
 
     types::iso15118_charger::EVSEID evseid = {config.evse_id, config.evse_id_din};
 

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -99,6 +99,7 @@ struct Conf {
     std::string switch_3ph1ph_cp_state;
     int soft_over_current_timeout_ms;
     bool lock_connector_in_state_b;
+    int state_F_after_fault_ms;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EvseManager/IECStateMachine.cpp
+++ b/modules/EvseManager/IECStateMachine.cpp
@@ -69,6 +69,8 @@ const std::string cpevent_to_string(CPEvent e) {
         return "EFtoBCD";
     case CPEvent::BCDtoEF:
         return "BCDtoEF";
+    case CPEvent::BCDtoE:
+        return "BCDtoE";
     case CPEvent::EvseReplugStarted:
         return "EvseReplugStarted";
     case CPEvent::EvseReplugFinished:
@@ -82,6 +84,7 @@ IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& 
     r_bsp(r_bsp_), lock_connector_in_state_b(lock_connector_in_state_b_) {
     // feed the state machine whenever the timer expires
     timeout_state_c1.signal_reached.connect(&IECStateMachine::feed_state_machine_no_thread, this);
+    timeout_unlock_state_F.signal_reached.connect(&IECStateMachine::feed_state_machine_no_thread, this);
 
     // Subscribe to bsp driver to receive BspEvents from the hardware
     r_bsp->subscribe_event([this](const types::board_support_common::BspEvent event) {
@@ -142,12 +145,17 @@ void IECStateMachine::feed_state_machine_no_thread() {
 std::queue<CPEvent> IECStateMachine::state_machine() {
 
     std::queue<CPEvent> events;
-    auto timer = TimerControl::do_nothing;
+    auto timer_state_C1 = TimerControl::do_nothing;
+    auto timer_unlock_state_F = TimerControl::do_nothing;
 
     {
         // mutex protected section
 
         Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::IEC_state_machine);
+
+        if (cp_state not_eq RawCPState::F and last_cp_state == RawCPState::F) {
+            timer_unlock_state_F = TimerControl::stop;
+        }
 
         switch (cp_state) {
 
@@ -156,7 +164,7 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
                 pwm_running = false;
                 r_bsp->call_pwm_off();
                 ev_simplified_mode = false;
-                timer = TimerControl::stop;
+                timer_state_C1 = TimerControl::stop;
                 call_allow_power_on_bsp(false);
                 connector_unlock();
             }
@@ -169,7 +177,7 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
                 ev_simplified_mode = false;
                 car_plugged_in = false;
                 call_allow_power_on_bsp(false);
-                timer = TimerControl::stop;
+                timer_state_C1 = TimerControl::stop;
                 connector_unlock();
             }
 
@@ -196,13 +204,14 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
                 // Need to switch off according to Table A.6 Sequence 8.1
                 // within 100ms
                 call_allow_power_on_bsp(false);
-                timer = TimerControl::stop;
+                timer_state_C1 = TimerControl::stop;
             }
 
             // Table A.6: Sequence 1.1 Plug-in
             if (last_cp_state == RawCPState::A || last_cp_state == RawCPState::Disabled ||
                 (!car_plugged_in && last_cp_state == RawCPState::F)) {
                 events.push(CPEvent::CarPluggedIn);
+                car_plugged_in = true;
                 ev_simplified_mode = false;
             }
 
@@ -217,7 +226,7 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
             // If state D is not supported switch off.
             if (not has_ventilation) {
                 call_allow_power_on_bsp(false);
-                timer = TimerControl::stop;
+                timer_state_C1 = TimerControl::stop;
                 break;
             }
             // no break, intended fall through: If we support state D it is handled the same way as state C
@@ -229,6 +238,7 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
             if (last_cp_state == RawCPState::A || last_cp_state == RawCPState::Disabled ||
                 (!car_plugged_in && last_cp_state == RawCPState::F)) {
                 events.push(CPEvent::CarPluggedIn);
+                car_plugged_in = true;
                 EVLOG_info << "Detected simplified mode.";
                 ev_simplified_mode = true;
             } else if (last_cp_state == RawCPState::B) {
@@ -238,13 +248,13 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
             if (!pwm_running && last_pwm_running) { // X2->C1
                                                     // Table A.6 Sequence 10.2: EV does not stop drawing power
                                                     // even if PWM stops. Stop within 6 seconds (E.g. Kona1!)
-                timer = TimerControl::start;
+                timer_state_C1 = TimerControl::start;
             }
 
             // PWM switches on while in state C
             if (pwm_running && !last_pwm_running) {
                 // when resuming after a pause before the EV goes to state B, stop the timer.
-                timer = TimerControl::stop;
+                timer_state_C1 = TimerControl::stop;
 
                 // If we resume charging and the EV never left state C during pause we allow non-compliant EVs to switch
                 // on again.
@@ -285,26 +295,31 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
         case RawCPState::E:
             connector_unlock();
             if (last_cp_state != RawCPState::E) {
-                timer = TimerControl::stop;
+                timer_state_C1 = TimerControl::stop;
                 call_allow_power_on_bsp(false);
                 pwm_running = false;
                 r_bsp->call_pwm_off();
                 if (last_cp_state == RawCPState::B || last_cp_state == RawCPState::C ||
                     last_cp_state == RawCPState::D) {
                     events.push(CPEvent::BCDtoEF);
+                    events.push(CPEvent::BCDtoE);
                 }
             }
             break;
 
         case RawCPState::F:
-            connector_unlock();
-            timer = TimerControl::stop;
+            timer_state_C1 = TimerControl::stop;
             call_allow_power_on_bsp(false);
             if (last_cp_state not_eq RawCPState::F) {
+                timer_unlock_state_F = TimerControl::start;
                 pwm_running = false;
             }
             if (last_cp_state == RawCPState::B || last_cp_state == RawCPState::C || last_cp_state == RawCPState::D) {
                 events.push(CPEvent::BCDtoEF);
+            }
+
+            if (timeout_unlock_state_F.reached()) {
+                connector_unlock();
             }
             break;
         }
@@ -320,12 +335,24 @@ std::queue<CPEvent> IECStateMachine::state_machine() {
 
     // stopping the timer could lead to a deadlock when called from the
     // mutex protected section
-    switch (timer) {
+    switch (timer_state_C1) {
     case TimerControl::start:
-        timeout_state_c1.start(std::chrono::seconds(6));
+        timeout_state_c1.start(power_off_under_load_in_c1_timeout);
         break;
     case TimerControl::stop:
         timeout_state_c1.stop();
+        break;
+    case TimerControl::do_nothing:
+    default:
+        break;
+    }
+
+    switch (timer_unlock_state_F) {
+    case TimerControl::start:
+        timeout_unlock_state_F.start(unlock_in_state_f_timeout);
+        break;
+    case TimerControl::stop:
+        timeout_unlock_state_F.stop();
         break;
     case TimerControl::do_nothing:
     default:

--- a/modules/EvseManager/IECStateMachine.hpp
+++ b/modules/EvseManager/IECStateMachine.hpp
@@ -46,6 +46,7 @@ enum class CPEvent {
     CarUnplugged,
     EFtoBCD,
     BCDtoEF,
+    BCDtoE,
     EvseReplugStarted,
     EvseReplugFinished,
 };
@@ -125,6 +126,7 @@ private:
 
     RawCPState cp_state{RawCPState::Disabled}, last_cp_state{RawCPState::Disabled};
     AsyncTimeout timeout_state_c1;
+    AsyncTimeout timeout_unlock_state_F;
 
     Everest::timed_mutex_traceable state_machine_mutex;
     void feed_state_machine();
@@ -140,6 +142,9 @@ private:
 
     std::atomic_bool enabled{false};
     std::atomic_bool relais_on{false};
+
+    static constexpr std::chrono::seconds power_off_under_load_in_c1_timeout{6};
+    static constexpr std::chrono::seconds unlock_in_state_f_timeout{5};
 };
 
 } // namespace module

--- a/modules/EvseManager/Timeout.hpp
+++ b/modules/EvseManager/Timeout.hpp
@@ -51,58 +51,71 @@ private:
 class AsyncTimeout {
 public:
     void start(milliseconds _t) {
+        std::scoped_lock lock(mutex);
+
         if (running) {
-            stop();
+            wait_thread.stop();
+            running = false;
         }
+
         t = _t;
         start_time = steady_clock::now();
-        running = true;
+
         // start waiting thread
         wait_thread = std::thread([this]() {
             while (not wait_thread.shouldExit()) {
                 std::this_thread::sleep_for(resolution);
-                if (reached()) {
+                if (reached_nolock()) {
                     // Note the order is important here.
                     // We first signal reached which will call all callbacks.
-                    // The timer is still running in this in those callbacks, so they can also call reached() and get a
-                    // true as return value.
+                    // The timer is still running in this in those callbacks, so they can also call reached() and
+                    // get a true as return value.
                     signal_reached();
                     // After all signal handlers are called, we stop the timer.
-                    running = false;
-                    return;
+                    break;
                 }
             }
         });
+        running = true;
     }
 
     // Note that stopping the timer may take up to "resolution" amount of time to return
     void stop() {
-        wait_thread.stop();
-        running = false;
+        std::scoped_lock lock(mutex);
+        if (running) {
+            wait_thread.stop();
+            running = false;
+        }
     }
 
     bool is_running() {
+        std::scoped_lock lock(mutex);
         return running;
     }
 
     bool reached() {
+        std::scoped_lock lock(mutex);
+        return reached_nolock();
+    }
+
+    sigslot::signal<> signal_reached;
+
+private:
+    bool reached_nolock() {
         if (!running) {
             return false;
-        }
-        if ((steady_clock::now() - start_time) > t) {
+        } else if ((steady_clock::now() - start_time) > t) {
             return true;
         } else {
             return false;
         }
     }
 
-    sigslot::signal<> signal_reached;
-
-private:
     constexpr static auto resolution = 500ms;
     milliseconds t;
     time_point<steady_clock> start_time;
-    std::atomic_bool running{false};
+    bool running{false};
+    std::mutex mutex;
     Everest::Thread wait_thread;
 };
 

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -257,6 +257,18 @@ config:
       and this violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!
     type: boolean
     default: true
+  state_F_after_fault_ms:
+    description: >-
+      Set state F after any fault that stops charging for the specified time in ms while in Charging mode (CX->F(300ms)->C1/B1).
+      When a fault occurs in state B2, no state F is added (B2->B1 on fault).
+      Some (especially older hybrid vehicles) may go into a permanent fault mode once they detect state F, 
+      in this case EVerest cannot recover the charging session if the fault is cleared.
+      In this case you can set this parameter to 0, which will avoid to use state F in case of a fault
+      and only disables PWM (C2->C1) while switching off power. This will violate IEC 61851-1:2017 however.
+      The default is 300ms as the minimum suggested by IEC 61851-1:2017 Table A.5 (description) to be compliant.
+      This setting is only active in BASIC charging mode.
+    type: integer
+    default: 300
 provides:
   evse:
     interface: evse_manager


### PR DESCRIPTION
- Unlock connector in F after 5s to avoid lock/unlock in all temporary t_step_EFs

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

