### PR TITLE
OCPP2.0.1: Return type of remote start and remote stop callback changed

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,7 +66,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.17.0
+  git_tag: fa801934853ca1f7f4afdb9bb7cd344e1ffea36c
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -395,14 +395,20 @@ void OCPP201::ready() {
             provided_token.connectors = std::vector<int32_t>{request.evseId.value()};
         }
         this->p_auth_provider->publish_provided_token(provided_token);
+        return ocpp::v201::RequestStartStopStatusEnum::Accepted;
     };
 
     callbacks.stop_transaction_callback = [this](const int32_t evse_id, const ocpp::v201::ReasonEnum& stop_reason) {
-        if (evse_id > 0 && evse_id <= this->r_evse_manager.size()) {
-            types::evse_manager::StopTransactionRequest req;
-            req.reason = conversions::to_everest_stop_transaction_reason(stop_reason);
-            this->r_evse_manager.at(evse_id - 1)->call_stop_transaction(req);
+        if (evse_id <= 0 or evse_id > this->r_evse_manager.size()) {
+            return ocpp::v201::RequestStartStopStatusEnum::Rejected;
         }
+
+        types::evse_manager::StopTransactionRequest req;
+        req.reason = conversions::to_everest_stop_transaction_reason(stop_reason);
+
+        return this->r_evse_manager.at(evse_id - 1)->call_stop_transaction(req)
+                   ? ocpp::v201::RequestStartStopStatusEnum::Accepted
+                   : ocpp::v201::RequestStartStopStatusEnum::Rejected;
     };
 
     callbacks.pause_charging_callback = [this](const int32_t evse_id) {


### PR DESCRIPTION

## Describe your changes
This PR targets an API change of libocpp for OCPP2.0.1 which is a changed return type for the remote start and remote stop transaction callbacks

TODO: Update libocpp dependency once libocpp PR is merged.

## Issue ticket number and link
Companion PR in libocpp: https://github.com/EVerest/libocpp/pull/817

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

