### PR TITLE
Pin node-red-node-ui-table to 0.4.3 in Dockerfile

### DIFF
--- a/cmake/assets/docker/Dockerfile
+++ b/cmake/assets/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM nodered/node-red:2.2.3
 RUN npm install node-red-dashboard
 RUN npm install node-red-contrib-ui-actions
-RUN npm install node-red-node-ui-table
+RUN npm install node-red-node-ui-table@0.4.3
 RUN npm install node-red-contrib-ui-level


### PR DESCRIPTION
This fixes a new issue which node-red-node-ui-table 0.4.4 added which causes this warning and the UI no longer loads:

    Node module cannot be loaded on this version. Requires: >=3.0.0

## Issue ticket number and link
https://github.com/EVerest/everest-dev-environment/issues/49

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [NA] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

