### PR TITLE
Remove external libtimer dependency

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -26,13 +26,6 @@ pugixml:
   git_tag: v1.12.1
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_PUGIXML"
 
-# Auth module
-libtimer:
-  git: https://github.com/EVerest/libtimer.git
-  git_tag: v0.1.1
-  cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBTIMER"
-  options: ["BUILD_EXAMPLES OFF"]
-
 # Slac module
 libslac:
   git: https://github.com/EVerest/libslac.git

--- a/lib/staging/CMakeLists.txt
+++ b/lib/staging/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(can_dpm1000)
+add_subdirectory(async_timer)
 if(EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY)
     add_subdirectory(evse_security)
     add_subdirectory(tls)

--- a/lib/staging/async_timer/CMakeLists.txt
+++ b/lib/staging/async_timer/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(async_timer INTERFACE)
+add_library(everest::async_timer ALIAS async_timer)
+
+target_include_directories(async_timer INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+

--- a/lib/staging/async_timer/async_timer.hpp
+++ b/lib/staging/async_timer/async_timer.hpp
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+#ifndef EVEREST_TIMER_HPP
+#define EVEREST_TIMER_HPP
+
+#include <boost/asio.hpp>
+#include <chrono>
+#include <condition_variable>
+#include <date/date.h>
+#include <date/tz.h>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+namespace Everest {
+// template <typename TimerClock = date::steady_clock> class Timer {
+template <typename TimerClock = date::utc_clock> class Timer {
+private:
+    boost::asio::basic_waitable_timer<TimerClock>* timer = nullptr;
+    std::function<void()> callback;
+    std::function<void(const boost::system::error_code& e)> callback_wrapper;
+    std::chrono::nanoseconds interval_nanoseconds;
+    std::condition_variable cv;
+    std::mutex wait_mutex;
+    bool running = false;
+    boost::asio::io_context io_context;
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work;
+    std::thread* timer_thread = nullptr;
+
+public:
+    /// This timer will initialize a boost::asio::io_context
+    explicit Timer() : work(boost::asio::make_work_guard(this->io_context)) {
+        this->timer = new boost::asio::basic_waitable_timer<TimerClock>(this->io_context);
+        this->timer_thread = new std::thread([this]() { this->io_context.run(); });
+    }
+
+    explicit Timer(const std::function<void()>& callback) : work(boost::asio::make_work_guard(this->io_context)) {
+        this->timer = new boost::asio::basic_waitable_timer<TimerClock>(this->io_context);
+        this->timer_thread = new std::thread([this]() { this->io_context.run(); });
+        this->callback = callback;
+    }
+
+    explicit Timer(boost::asio::io_context* io_context) : work(boost::asio::make_work_guard(*io_context)) {
+        this->timer = new boost::asio::basic_waitable_timer<TimerClock>(*io_context);
+    }
+
+    explicit Timer(boost::asio::io_context* io_context, const std::function<void()>& callback) :
+        work(boost::asio::make_work_guard(*io_context)) {
+        this->timer = new boost::asio::basic_waitable_timer<TimerClock>(*io_context);
+        this->callback = callback;
+    }
+
+    ~Timer() {
+        if (this->timer != nullptr) {
+            // stop asio timer
+            this->timer->cancel();
+
+            if (this->timer_thread != nullptr) {
+                this->io_context.stop();
+                this->timer_thread->join();
+            }
+
+            delete this->timer;
+            delete this->timer_thread;
+        }
+    }
+
+    /// Executes the given callback at the given timepoint
+    template <class Clock, class Duration = typename Clock::duration>
+    void at(const std::function<void()>& callback, const std::chrono::time_point<Clock, Duration>& time_point) {
+        this->stop();
+
+        this->callback = callback;
+
+        this->at(time_point);
+    }
+
+    /// Executes the at the given timepoint
+    template <class Clock, class Duration = typename Clock::duration>
+    void at(const std::chrono::time_point<Clock, Duration>& time_point) {
+        this->stop();
+
+        if (this->callback == nullptr) {
+            return;
+        }
+
+        if (this->timer != nullptr) {
+            // use asio timer
+            this->timer->expires_at(time_point);
+            this->timer->async_wait([this](const boost::system::error_code& e) {
+                if (e) {
+                    return;
+                }
+
+                this->callback();
+            });
+        }
+    }
+
+    /// Execute the given callback peridically from now in the given interval
+    template <class Rep, class Period>
+    void interval(const std::function<void()>& callback, const std::chrono::duration<Rep, Period>& interval) {
+        this->stop();
+
+        this->callback = callback;
+
+        this->interval(interval);
+    }
+
+    /// Execute peridically from now in the given interval
+    template <class Rep, class Period> void interval(const std::chrono::duration<Rep, Period>& interval) {
+        this->stop();
+        this->interval_nanoseconds = interval;
+        if (interval_nanoseconds == std::chrono::nanoseconds(0)) {
+            return;
+        }
+
+        if (this->callback == nullptr) {
+            return;
+        }
+
+        if (this->timer != nullptr) {
+            // use asio timer
+            this->callback_wrapper = [this](const boost::system::error_code& e) {
+                if (e) {
+                    return;
+                }
+
+                this->timer->expires_from_now(this->interval_nanoseconds);
+                this->timer->async_wait(this->callback_wrapper);
+
+                this->callback();
+            };
+
+            this->timer->expires_from_now(this->interval_nanoseconds);
+            this->timer->async_wait(this->callback_wrapper);
+        }
+    }
+
+    // Execute the given callback once after the given interval
+    template <class Rep, class Period>
+    void timeout(const std::function<void()>& callback, const std::chrono::duration<Rep, Period>& interval) {
+        this->stop();
+
+        this->callback = callback;
+
+        this->timeout(interval);
+    }
+
+    // Execute the given callback once after the given interval
+    template <class Rep, class Period> void timeout(const std::chrono::duration<Rep, Period>& interval) {
+        this->stop();
+
+        if (this->callback == nullptr) {
+            return;
+        }
+
+        if (this->timer != nullptr) {
+            // use asio timer
+            this->timer->expires_from_now(interval);
+            this->timer->async_wait([this](const boost::system::error_code& e) {
+                if (e) {
+                    return;
+                }
+
+                this->callback();
+            });
+        }
+    }
+
+    /// Stop timer from excuting its callback
+    void stop() {
+        if (this->timer != nullptr) {
+            // asio based timer
+            this->timer->cancel();
+        }
+    }
+};
+
+using SteadyTimer = Timer<date::utc_clock>;
+using SystemTimer = Timer<date::utc_clock>;
+} // namespace Everest
+
+#endif // EVEREST_TIMER_HPP

--- a/module-dependencies.cmake
+++ b/module-dependencies.cmake
@@ -15,10 +15,6 @@ ev_define_dependency(
     DEPENDENT_MODULES_LIST EvseManager)
 
 ev_define_dependency(
-    DEPENDENCY_NAME libtimer
-    DEPENDENT_MODULES_LIST Auth LemDCBM400600 System)
-
-ev_define_dependency(
     DEPENDENCY_NAME libslac
     DEPENDENT_MODULES_LIST EvSlac EvseSlac)
 

--- a/modules/Auth/BUILD.bazel
+++ b/modules/Auth/BUILD.bazel
@@ -6,7 +6,6 @@ cc_library(
     hdrs = glob(["include/*.hpp"]),
     strip_include_prefix = "include",
     deps = [
-        "@libtimer//:libtimer",
         "//third-party/bazel:boost_asio",
         "@everest-framework//:framework",
         "@com_github_HowardHinnant_date//:date",
@@ -23,7 +22,6 @@ IMPLS = [
 cc_everest_module(
     name = "Auth",
     deps = [
-        "@libtimer//:libtimer",
         ":auth_handler",
     ],
     impls = IMPLS,

--- a/modules/Auth/CMakeLists.txt
+++ b/modules/Auth/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(${MODULE_NAME}
         auth_handler
         date::date
         date::date-tz
-        everest::timer
+	everest::async_timer
 )
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 

--- a/modules/Auth/include/Connector.hpp
+++ b/modules/Auth/include/Connector.hpp
@@ -6,7 +6,7 @@
 
 #include <optional>
 
-#include <everest/timer.hpp>
+#include <async_timer.hpp>
 
 #include <utils/types.hpp>
 

--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include <Connector.hpp>
-#include <everest/timer.hpp>
+#include <async_timer.hpp>
 #include <generated/types/reservation.hpp>
 #include <utils/types.hpp>
 

--- a/modules/Auth/lib/CMakeLists.txt
+++ b/modules/Auth/lib/CMakeLists.txt
@@ -20,7 +20,7 @@ add_dependencies(auth_handler generate_cpp_files)
 
 target_link_libraries(auth_handler
 PRIVATE
-    everest::timer
+    everest::async_timer
     date::date
     date::date-tz
     everest::framework

--- a/modules/Auth/tests/CMakeLists.txt
+++ b/modules/Auth/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(${TEST_TARGET_NAME} PUBLIC
 target_link_libraries(${TEST_TARGET_NAME} PRIVATE
     GTest::gmock
     GTest::gtest_main
-    everest::timer
+    everest::async_timer
     ${CMAKE_DL_LIBS}
     everest::log
     everest::framework

--- a/modules/LemDCBM400600/tests/CMakeLists.txt
+++ b/modules/LemDCBM400600/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(${TEST_TARGET_NAME} PRIVATE
 #
 target_link_libraries(${TEST_TARGET_NAME} PRIVATE
         GTest::gmock_main
-        everest::timer
+        everest::async_timer
         everest::framework
         nlohmann_json::nlohmann_json
         CURL::libcurl
@@ -58,7 +58,7 @@ target_include_directories(${TEST_TARGET_NAME} PRIVATE
 #
 target_link_libraries(${TEST_TARGET_NAME} PRIVATE
         GTest::gmock_main
-        everest::timer
+        everest::async_timer
         everest::framework
         nlohmann_json::nlohmann_json
         CURL::libcurl
@@ -83,7 +83,7 @@ target_include_directories(integration_test_http_client PRIVATE
 #
 target_link_libraries(integration_test_http_client PRIVATE
         GTest::gmock_main
-        everest::timer
+        everest::async_timer
         everest::framework
         nlohmann_json::nlohmann_json
         CURL::libcurl

--- a/modules/OCPP/CMakeLists.txt
+++ b/modules/OCPP/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(${MODULE_NAME}
         everest::ocpp
         everest::ocpp_evse_security
         everest::ocpp_conversions
+	everest::async_timer
 )
 
 target_compile_options(${MODULE_NAME}

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -33,7 +33,7 @@
 #include <chrono>
 #include <date/date.h>
 #include <date/tz.h>
-#include <everest/timer.hpp>
+#include <async_timer.hpp>
 #include <filesystem>
 #include <memory>
 #include <mutex>

--- a/modules/System/CMakeLists.txt
+++ b/modules/System/CMakeLists.txt
@@ -9,11 +9,11 @@ ev_setup_cpp_module()
 
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 # insert your custom targets and additional config variables here
-set (ADDITIONAL_MODULE_LIBS everest::timer)
 
 list(APPEND ADDITIONAL_MODULE_LIBS
     date::date
     date::date-tz
+    everest::async_timer
 )
 
 target_link_libraries(${MODULE_NAME}

--- a/modules/System/main/systemImpl.hpp
+++ b/modules/System/main/systemImpl.hpp
@@ -16,7 +16,7 @@
 // insert your custom include headers here
 #include <filesystem>
 
-#include <everest/timer.hpp>
+#include <async_timer.hpp>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {

--- a/third-party/bazel/BUILD.libtimer.bazel
+++ b/third-party/bazel/BUILD.libtimer.bazel
@@ -1,7 +1,0 @@
-cc_library(
-    name = "libtimer",
-    hdrs = ["include/everest/timer.hpp"],
-    deps = [],
-    strip_include_prefix = "include",
-    visibility = ["//visibility:public"],
-)

--- a/third-party/bazel/repos.bzl
+++ b/third-party/bazel/repos.bzl
@@ -54,7 +54,6 @@ def everest_core_repos():
         dependencies_yaml = "@everest-core//:dependencies.yaml",
         build_files = [
             "@everest-core//third-party/bazel:BUILD.libmodbus.bazel",
-            "@everest-core//third-party/bazel:BUILD.libtimer.bazel",
             "@everest-core//third-party/bazel:BUILD.pugixml.bazel",
             "@everest-core//third-party/bazel:BUILD.sigslot.bazel",
         ],


### PR DESCRIPTION
Copy the libtimer header file to lib/staging. Maintaining an external repository for a single header file only used in everest-core seems overkill.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

