### PR TITLE
Fixed issue when recursively creating Market objects

### DIFF
--- a/modules/EnergyManager/EnergyManager.cpp
+++ b/modules/EnergyManager/EnergyManager.cpp
@@ -185,7 +185,7 @@ std::vector<types::energy::EnforcedLimits> EnergyManager::run_optimizer(types::e
     std::vector<types::energy::EnforcedLimits> optimized_values;
     optimized_values.reserve(brokers.size());
 
-    for (auto broker : brokers) {
+    for (auto& broker : brokers) {
         auto& local_market = broker->get_local_market();
         const auto sold_energy = local_market.get_sold_energy();
 

--- a/modules/EnergyManager/EnergyManager.cpp
+++ b/modules/EnergyManager/EnergyManager.cpp
@@ -186,7 +186,7 @@ std::vector<types::energy::EnforcedLimits> EnergyManager::run_optimizer(types::e
     optimized_values.reserve(brokers.size());
 
     for (auto broker : brokers) {
-        auto local_market = broker->get_local_market();
+        auto& local_market = broker->get_local_market();
         const auto sold_energy = local_market.get_sold_energy();
 
         if (sold_energy.size() > 0) {

--- a/modules/EnergyManager/Market.cpp
+++ b/modules/EnergyManager/Market.cpp
@@ -245,12 +245,8 @@ Market::Market(types::energy::EnergyFlowRequest& _energy_flow_request, const flo
 
     // Recursion: create one Market for each child
     for (auto& flow_child : _energy_flow_request.children) {
-        _children.emplace_back(flow_child, _nominal_ac_voltage, this);
+        _children.emplace_back(std::make_unique<Market>(flow_child, _nominal_ac_voltage, this));
     }
-}
-
-const std::vector<Market>& Market::children() {
-    return _children;
 }
 
 ScheduleRes Market::get_sold_energy() {
@@ -271,7 +267,7 @@ void Market::get_list_of_evses(std::vector<Market*>& list) {
     }
 
     for (auto& child : _children) {
-        child.get_list_of_evses(list);
+        child->get_list_of_evses(list);
     }
 }
 
@@ -282,7 +278,7 @@ std::vector<Market*> Market::get_list_of_evses() {
     }
 
     for (auto& child : _children) {
-        child.get_list_of_evses(list);
+        child->get_list_of_evses(list);
     }
     return list;
 }

--- a/modules/EnergyManager/Market.cpp
+++ b/modules/EnergyManager/Market.cpp
@@ -245,7 +245,7 @@ Market::Market(types::energy::EnergyFlowRequest& _energy_flow_request, const flo
 
     // Recursion: create one Market for each child
     for (auto& flow_child : _energy_flow_request.children) {
-        _children.emplace_back(std::make_unique<Market>(flow_child, _nominal_ac_voltage, this));
+        _children.emplace_back(flow_child, _nominal_ac_voltage, this);
     }
 }
 
@@ -267,7 +267,7 @@ void Market::get_list_of_evses(std::vector<Market*>& list) {
     }
 
     for (auto& child : _children) {
-        child->get_list_of_evses(list);
+        child.get_list_of_evses(list);
     }
 }
 
@@ -278,7 +278,7 @@ std::vector<Market*> Market::get_list_of_evses() {
     }
 
     for (auto& child : _children) {
-        child->get_list_of_evses(list);
+        child.get_list_of_evses(list);
     }
     return list;
 }

--- a/modules/EnergyManager/Market.hpp
+++ b/modules/EnergyManager/Market.hpp
@@ -68,7 +68,6 @@ public:
     ScheduleRes get_sold_energy();
 
     Market* parent();
-    const std::vector<Market>& children();
 
     float nominal_ac_voltage();
 
@@ -77,7 +76,7 @@ public:
 
 private:
     Market* _parent;
-    std::vector<Market> _children;
+    std::vector<std::unique_ptr<Market>> _children;
     float _nominal_ac_voltage;
 
     // main data structures

--- a/modules/EnergyManager/Market.hpp
+++ b/modules/EnergyManager/Market.hpp
@@ -76,7 +76,7 @@ public:
 
 private:
     Market* _parent;
-    std::vector<std::unique_ptr<Market>> _children;
+    std::list<Market> _children;
     float _nominal_ac_voltage;
 
     // main data structures


### PR DESCRIPTION
## Issue
The Market class previously used a `std::vector<Market> _children` to store child `Market` objects, which were initialized recursively within the `Market` constructor:

```cpp
for (auto& flow_child : _energy_flow_request.children) {
    _children.emplace_back(flow_child, _nominal_ac_voltage, this); // third argument is _parent of the object
}
```

The problem with that is that `std::vector` may need to resize and move its elements to a new memory location when additional elements are added. When this happens, all existing `Market` elements are moved, which invalidates any pointers or references to those elements. In this case, the `_parent` pointer in could end up pointing to an invalid memory location, leading to segmentation faults when accessed.

## Changes
* Switched `_children` from `std::vector` to `std::list`, as it guarantees that its elements remain at stable memory addresses even when new elements are inserted. This ensures that `_parent` pointers remain valid and point to the correct objects
* Removed the `children()` function because it was dead code and no longer needed.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

