### PR TITLE
Adding tls key logger for EvseV2G (openssl part)

### DIFF
--- a/config/config-sil-dc-tls.yaml
+++ b/config/config-sil-dc-tls.yaml
@@ -4,6 +4,7 @@ active_modules:
     config_module:
       device: auto
       tls_security: force
+      tls_key_logging: true
     connections:
       security:
         - module_id: evse_security

--- a/lib/staging/tls/openssl_util.hpp
+++ b/lib/staging/tls/openssl_util.hpp
@@ -499,6 +499,7 @@ bool certificate_subject_public_key_sha_1(openssl::sha_1_digest_t& digest, const
 
 enum class log_level_t : std::uint8_t {
     debug,
+    info,
     warning,
     error,
 };
@@ -521,6 +522,10 @@ static inline void log_warning(const std::string& str) {
 
 static inline void log_debug(const std::string& str) {
     log(log_level_t::debug, str);
+}
+
+static inline void log_info(const std::string& str) {
+    log(log_level_t::info, str);
 }
 
 using log_handler_t = void (*)(log_level_t level, const std::string& err);

--- a/lib/staging/tls/tests/gtest_main.cpp
+++ b/lib/staging/tls/tests/gtest_main.cpp
@@ -17,6 +17,9 @@ void log_handler(openssl::log_level_t level, const std::string& str) {
     case openssl::log_level_t::debug:
         // std::cout << "DEBUG:   " << str << std::endl;
         break;
+    case openssl::log_level_t::info:
+        std::cout << "INFO:    " << str << std::endl;
+        break;
     case openssl::log_level_t::warning:
         std::cout << "WARN:    " << str << std::endl;
         break;

--- a/lib/staging/tls/tls.cpp
+++ b/lib/staging/tls/tls.cpp
@@ -6,6 +6,7 @@
 #include "extensions/trusted_ca_keys.hpp"
 #include "openssl_util.hpp"
 
+#include <arpa/inet.h>
 #include <array>
 #include <cassert>
 #include <csignal>
@@ -17,6 +18,7 @@
 #include <fstream>
 #include <memory>
 #include <mutex>
+#include <net/if.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <poll.h>
@@ -698,19 +700,29 @@ std::condition_variable ServerConnection::m_cv;
 namespace {
 
 std::unique_ptr<std::filesystem::path> keylog_file;
+std::unique_ptr<TlsKeyLoggingServer> keylog_server;
 
 void keylog_callback(const SSL* ssl, const char* line) {
     std::string key_log_msg = "TLS Handshake keys: " + std::string(line);
     log_info(key_log_msg);
+
+    if (keylog_server and keylog_server->get_fd() != -1) {
+        const auto result = keylog_server->send(line);
+        if (result not_eq strlen(line)) {
+            log_error("key_logging_server send() failed!");
+        }
+
+        keylog_server.reset();
+    }
 
     if (keylog_file) {
         std::ofstream ofs;
         ofs.open(keylog_file->string(), std::ofstream::out | std::ofstream::app);
         ofs << line << std::endl;
         ofs.close();
-    }
 
-    keylog_file.reset();
+        keylog_file.reset();
+    }
 }
 
 } // namespace
@@ -913,6 +925,7 @@ bool Server::init_ssl(const config_t& cfg) {
                 const auto file_path = std::filesystem::path(cfg.tls_key_logging_path) /= "tls_session_keys.log";
                 keylog_file = std::make_unique<std::filesystem::path>(file_path);
                 SSL_CTX_set_keylog_callback(ctx, keylog_callback);
+                this->m_tls_key_interface = cfg.host;
             }
 
             int mode = SSL_VERIFY_NONE;
@@ -1092,6 +1105,12 @@ void Server::wait_for_connection(const ConnectionHandler& handler) {
                 // new connection, pass to handler
                 auto* ip = BIO_ADDR_hostname_string(peer.get(), 1);
                 auto* service = BIO_ADDR_service_string(peer.get(), 1);
+
+                if (m_tls_key_interface) {
+                    const auto port = std::stoul(service);
+                    keylog_server = std::make_unique<TlsKeyLoggingServer>(std::string(m_tls_key_interface), port);
+                }
+
                 auto connection =
                     std::make_unique<ServerConnection>(m_context->ctx.get(), soc, ip, service, m_timeout_ms);
                 handler(std::move(connection));
@@ -1373,6 +1392,74 @@ Client::override_t Client::default_overrides() {
         &ClientStatusRequestV2::status_request_v2_cb,       &ClientTrustedCaKeys::trusted_ca_keys_add,
         &ClientTrustedCaKeys::trusted_ca_keys_free,
     };
+}
+
+TlsKeyLoggingServer::TlsKeyLoggingServer(const std::string& interface_name, uint16_t port) {
+    static constexpr auto LINK_LOCAL_MULTICAST = "ff02::1";
+
+    fd = socket(AF_INET6, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        log_error("Could not create socket");
+        return;
+    }
+
+    // source setup
+
+    // find port between 49152-65535
+    auto could_bind = false;
+    auto source_port = 49152;
+    for (; source_port < 65535; source_port++) {
+        sockaddr_in6 source_address = {AF_INET6, htons(source_port), 0, {}, 0};
+        if (bind(fd, reinterpret_cast<sockaddr*>(&source_address), sizeof(sockaddr_in6)) == 0) {
+            could_bind = true;
+            break;
+        }
+    }
+
+    if (!could_bind) {
+        log_error("Could not bind");
+        close(fd);
+        return;
+    }
+
+    log_info("UDP socket bound to source port: " + std::to_string(source_port));
+
+    const auto index = if_nametoindex(interface_name.c_str());
+    auto mreq = ipv6_mreq{};
+    mreq.ipv6mr_interface = index;
+    if (inet_pton(AF_INET6, LINK_LOCAL_MULTICAST, &mreq.ipv6mr_multiaddr) <= 0) {
+        close(fd);
+        log_error("Failed to setup multicast address");
+        return;
+    }
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
+        close(fd);
+        log_error("Could not add multicast group membership");
+        return;
+    }
+
+    if (setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &index, sizeof(index)) < 0) {
+        close(fd);
+        log_error("Could not set interface name:" + interface_name);
+        return;
+    }
+
+    destination_address = {AF_INET6, htons(port), 0, {}, 0};
+    if (inet_pton(AF_INET6, LINK_LOCAL_MULTICAST, &destination_address.sin6_addr) <= 0) {
+        close(fd);
+        log_error("Failed to setup server address, reset key_log_fd");
+    }
+}
+
+TlsKeyLoggingServer::~TlsKeyLoggingServer() {
+    if (fd != -1) {
+        close(fd);
+    }
+}
+
+ssize_t TlsKeyLoggingServer::send(const char* line) {
+    return sendto(fd, line, strlen(line), 0, reinterpret_cast<const sockaddr*>(&destination_address),
+                  sizeof(destination_address));
 }
 
 } // namespace tls

--- a/lib/staging/tls/tls.hpp
+++ b/lib/staging/tls/tls.hpp
@@ -76,7 +76,6 @@ public:
 
 private:
     int fd{-1};
-    std::array<uint8_t, 2048> buffer{};
     uint16_t port{0};
     sockaddr_in6 destination_address{};
 };

--- a/lib/staging/tls/tls.hpp
+++ b/lib/staging/tls/tls.hpp
@@ -381,6 +381,9 @@ public:
         ConfigItem service{nullptr}; //!< TLS port number as a string
         int socket{INVALID_SOCKET};  //!< use this specific socket - bypasses socket setup in init_socket() when set
         bool ipv6_only{true};        //!< listen on IPv6 only, when false listen on IPv4 only
+
+        bool tls_key_logging{false};      //!< tls key logging is active when true
+        std::string tls_key_logging_path; //!< tls key logging file path
     };
 
     using ConnectionPtr = std::unique_ptr<ServerConnection>;

--- a/lib/staging/tls/tls.hpp
+++ b/lib/staging/tls/tls.hpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <netinet/in.h>
 #include <openssl/types.h>
 #include <optional>
 #include <pthread.h>
@@ -412,6 +413,8 @@ private:
     static int s_sig_int;                               //!< signal to use to wakeup serve()
     ConfigurationCallback m_init_callback{nullptr};     //!< callback to retrieve SSL configuration
 
+    ConfigItem m_tls_key_interface{nullptr};
+
     /**
      * \brief initialise the server socket
      * \param[in] cfg server configuration
@@ -633,6 +636,23 @@ public:
      * \brief the default SSL callbacks
      */
     static override_t default_overrides();
+};
+
+class TlsKeyLoggingServer {
+public:
+    TlsKeyLoggingServer(const std::string& interface_name, uint16_t port);
+    ~TlsKeyLoggingServer();
+
+    ssize_t send(const char* line);
+
+    auto get_fd() const {
+        return fd;
+    }
+
+private:
+    int fd{-1};
+    uint8_t buffer[2048];
+    sockaddr_in6 destination_address{};
 };
 
 } // namespace tls

--- a/modules/EvseV2G/EvseV2G.cpp
+++ b/modules/EvseV2G/EvseV2G.cpp
@@ -16,6 +16,9 @@ void log_handler(openssl::log_level_t level, const std::string& str) {
     case openssl::log_level_t::debug:
         // ignore debug logs
         break;
+    case openssl::log_level_t::info:
+        EVLOG_info << str;
+        break;
     case openssl::log_level_t::warning:
         EVLOG_warning << str;
         break;

--- a/modules/EvseV2G/connection/tls_connection.cpp
+++ b/modules/EvseV2G/connection/tls_connection.cpp
@@ -139,6 +139,9 @@ bool build_config(tls::Server::config_t& config, struct v2g_context* ctx) {
     config.socket = ctx->tls_socket.fd;
     config.io_timeout_ms = static_cast<std::int32_t>(ctx->network_read_timeout_tls);
 
+    config.tls_key_logging = ctx->tls_key_logging;
+    config.tls_key_logging_path = ctx->tls_key_logging_path;
+
     // information from libevse-security
     const auto cert_info =
         ctx->r_security->call_get_all_valid_certificates_info(LeafCertificateType::V2G, EncodingFormat::PEM, true);

--- a/modules/EvseV2G/connection/tls_connection.cpp
+++ b/modules/EvseV2G/connection/tls_connection.cpp
@@ -141,6 +141,7 @@ bool build_config(tls::Server::config_t& config, struct v2g_context* ctx) {
 
     config.tls_key_logging = ctx->tls_key_logging;
     config.tls_key_logging_path = ctx->tls_key_logging_path;
+    config.host = ctx->if_name;
 
     // information from libevse-security
     const auto cert_info =

--- a/modules/IsoMux/IsoMux.cpp
+++ b/modules/IsoMux/IsoMux.cpp
@@ -6,6 +6,27 @@
 #include "log.hpp"
 #include "sdp.hpp"
 
+#include <openssl_util.hpp>
+namespace {
+void log_handler(openssl::log_level_t level, const std::string& str) {
+    switch (level) {
+    case openssl::log_level_t::debug:
+        // ignore debug logs
+        break;
+    case openssl::log_level_t::info:
+        EVLOG_info << str;
+        break;
+    case openssl::log_level_t::warning:
+        EVLOG_warning << str;
+        break;
+    case openssl::log_level_t::error:
+    default:
+        EVLOG_error << str;
+        break;
+    }
+}
+} // namespace
+
 struct v2g_context* v2g_ctx = nullptr;
 
 namespace module {
@@ -21,6 +42,9 @@ void IsoMux::init() {
     v2g_ctx->proxy_port_iso20 = config.proxy_port_iso20;
     v2g_ctx->selected_iso20 = false;
 
+    v2g_ctx->tls_key_logging = config.tls_key_logging;
+
+    (void)openssl::set_log_handler(log_handler);
     v2g_ctx->tls_server = &tls_server;
 
     invoke_init(*p_charger);

--- a/modules/IsoMux/connection/tls_connection.cpp
+++ b/modules/IsoMux/connection/tls_connection.cpp
@@ -122,6 +122,8 @@ bool build_config(tls::Server::config_t& config, struct v2g_context* ctx) {
     config.socket = ctx->tls_socket.fd;
     config.io_timeout_ms = static_cast<std::int32_t>(ctx->network_read_timeout_tls);
 
+    config.tls_key_logging = ctx->tls_key_logging;
+
     // information from libevse-security
     const auto cert_info =
         ctx->r_security->call_get_leaf_certificate_info(LeafCertificateType::V2G, EncodingFormat::PEM, false);

--- a/modules/IsoMux/v2g.hpp
+++ b/modules/IsoMux/v2g.hpp
@@ -146,6 +146,8 @@ struct v2g_context {
     } tls_socket;
     tls::Server* tls_server;
 
+    bool tls_key_logging;
+
     enum V2gMsgTypeId current_v2g_msg;         /* holds the last v2g msg type */
     int state;                                 /* holds the current state id */
     std::atomic_bool is_connection_terminated; /* Is set to true if the connection is terminated (CP State A/F, shutdown


### PR DESCRIPTION
## Describe your changes
Right now only the EvseV2G mbedtls side had the functionality to store the tls session key. Now if you build EvseV2G with openssl, you can store the tls session key, too. For debugging pcap files with a tls connection this key is absolutely necessary.

## Issue ticket number and link
#857 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

