### PR TITLE
Adding ISO15118-20 dynamic mode support

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -47,7 +47,7 @@ libcbv2g:
 # libiso15118
 libiso15118:
   git: https://github.com/EVerest/libiso15118.git
-  git_tag: a135d7d3cc62a2206b1128b267a388e209b3cd2c
+  git_tag: a6eebd36578f810524212bb82f78ed41af870159
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBISO15118"
 
 # LEM DCBM 400/600 module
@@ -72,7 +72,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: 4abfad56331332d56a87e40cc361744f87e65c39
+  git_tag: 434f5f2a98cce4b716b5bb4d31eff6b19d8d85ca
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT AND EVEREST_DEPENDENCY_ENABLED_JOSEV"
 # mbedtls
 ext-mbedtls:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -47,7 +47,7 @@ libcbv2g:
 # libiso15118
 libiso15118:
   git: https://github.com/EVerest/libiso15118.git
-  git_tag: v0.2.0
+  git_tag: a135d7d3cc62a2206b1128b267a388e209b3cd2c
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBISO15118"
 
 # LEM DCBM 400/600 module
@@ -72,7 +72,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: 2024.9.0
+  git_tag: 4abfad56331332d56a87e40cc361744f87e65c39
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT AND EVEREST_DEPENDENCY_ENABLED_JOSEV"
 # mbedtls
 ext-mbedtls:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -72,7 +72,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: 434f5f2a98cce4b716b5bb4d31eff6b19d8d85ca
+  git_tag: 2024.10.0
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT AND EVEREST_DEPENDENCY_ENABLED_JOSEV"
 # mbedtls
 ext-mbedtls:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -47,7 +47,7 @@ libcbv2g:
 # libiso15118
 libiso15118:
   git: https://github.com/EVerest/libiso15118.git
-  git_tag: a6eebd36578f810524212bb82f78ed41af870159
+  git_tag: v0.3.0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBISO15118"
 
 # LEM DCBM 400/600 module

--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -351,3 +351,14 @@ vars:
       Parameters that may be displayed on the EVSE (Soc, battery capacity)
     type: object
     $ref: /iso15118_charger#/DisplayParameters
+  d20_dc_dynamic_charge_mode:
+    description: >-
+      The parameters the EVCC offers and sets for dynamic control mode
+    type: object
+    $ref: /iso15118_charger#/DcChargeDynamicModeValues
+  dc_ev_present_voltage:
+    description: Present Voltage measured from the EV
+    type: number
+  meter_info_requested:
+    description: The EV requested meter infos from the EVSE
+    type: "null"

--- a/modules/Evse15118D20/Evse15118D20.hpp
+++ b/modules/Evse15118D20/Evse15118D20.hpp
@@ -28,6 +28,9 @@ struct Conf {
     bool enable_ssl_logging;
     bool enable_tls_key_logging;
     bool enable_sdp_server;
+    bool supported_dynamic_mode;
+    bool supported_mobility_needs_mode_provided_by_secc;
+    bool supported_scheduled_mode;
 };
 
 class Evse15118D20 : public Everest::ModuleBase {

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -225,13 +225,39 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
             if (const auto* scheduled_mode = std::get_if<ScheduleControlMode>(dc_control_mode)) {
                 const auto target_voltage = iso15118::message_20::from_RationalNumber(scheduled_mode->target_voltage);
                 const auto target_current = iso15118::message_20::from_RationalNumber(scheduled_mode->target_current);
+
                 publish_dc_ev_target_voltage_current({target_voltage, target_current});
+
+                if (scheduled_mode->max_charge_current and scheduled_mode->max_voltage and
+                    scheduled_mode->max_charge_power) {
+                    const auto max_current =
+                        iso15118::message_20::from_RationalNumber(scheduled_mode->max_charge_current.value());
+                    const auto max_voltage =
+                        iso15118::message_20::from_RationalNumber(scheduled_mode->max_voltage.value());
+                    const auto max_power =
+                        iso15118::message_20::from_RationalNumber(scheduled_mode->max_charge_power.value());
+                    publish_dc_ev_maximum_limits({max_current, max_power, max_voltage});
+                }
+
             } else if (const auto* bpt_scheduled_mode = std::get_if<BPT_ScheduleReqControlMode>(dc_control_mode)) {
                 const auto target_voltage =
                     iso15118::message_20::from_RationalNumber(bpt_scheduled_mode->target_voltage);
                 const auto target_current =
                     iso15118::message_20::from_RationalNumber(bpt_scheduled_mode->target_current);
                 publish_dc_ev_target_voltage_current({target_voltage, target_current});
+
+                if (bpt_scheduled_mode->max_charge_current and bpt_scheduled_mode->max_voltage and
+                    bpt_scheduled_mode->max_charge_power) {
+                    const auto max_current =
+                        iso15118::message_20::from_RationalNumber(bpt_scheduled_mode->max_charge_current.value());
+                    const auto max_voltage =
+                        iso15118::message_20::from_RationalNumber(bpt_scheduled_mode->max_voltage.value());
+                    const auto max_power =
+                        iso15118::message_20::from_RationalNumber(bpt_scheduled_mode->max_charge_power.value());
+                    publish_dc_ev_maximum_limits({max_current, max_power, max_voltage});
+                }
+
+                // publish_dc_ev_maximum_limits({max_limits.current, max_limits.power, max_limits.voltage});
             } else if (const auto* dynamic_mode = std::get_if<DynamicReqControlMode>(dc_control_mode)) {
                 publish_d20_dc_dynamic_charge_mode(convert_dynamic_values(*dynamic_mode));
             } else if (const auto* bpt_dynamic_mode = std::get_if<BPT_DynamicReqControlMode>(dc_control_mode)) {

--- a/modules/Evse15118D20/manifest.yaml
+++ b/modules/Evse15118D20/manifest.yaml
@@ -43,6 +43,20 @@ config:
       Enable the built-in SDP server
     type: boolean
     default: true
+  supported_dynamic_mode:
+    description: The EVSE should support dynamic mode
+    type: boolean
+    default: true
+  supported_mobility_needs_mode_provided_by_secc:
+    description: >-
+      The EVSE should support the mobility needs mode provided by the SECC.
+      Mobility needs mode provided by the EVCC is always provided.
+    type: boolean
+    default: false
+  supported_scheduled_mode:
+    description: The EVSE should support scheduled mode
+    type: boolean
+    default: false
 provides:
   charger:
     interface: ISO15118_charger

--- a/modules/IsoMux/charger/ISO15118_chargerImpl.cpp
+++ b/modules/IsoMux/charger/ISO15118_chargerImpl.cpp
@@ -435,6 +435,36 @@ void ISO15118_chargerImpl::init() {
             publish_display_parameters(o);
         }
     });
+
+    mod->r_iso20->subscribe_d20_dc_dynamic_charge_mode([this](const auto o) {
+        if (mod->selected_iso20()) {
+            publish_d20_dc_dynamic_charge_mode(o);
+        }
+    });
+
+    mod->r_iso2->subscribe_dc_ev_present_voltage([this](const auto o) {
+        if (not mod->selected_iso20()) {
+            publish_dc_ev_present_voltage(o);
+        }
+    });
+
+    mod->r_iso20->subscribe_dc_ev_present_voltage([this](const auto o) {
+        if (mod->selected_iso20()) {
+            publish_dc_ev_present_voltage(o);
+        }
+    });
+
+    mod->r_iso2->subscribe_meter_info_requested([this]() {
+        if (not mod->selected_iso20()) {
+            publish_meter_info_requested(nullptr);
+        }
+    });
+
+    mod->r_iso20->subscribe_meter_info_requested([this]() {
+        if (mod->selected_iso20()) {
+            publish_meter_info_requested(nullptr);
+        }
+    });
 }
 
 void ISO15118_chargerImpl::ready() {

--- a/types/iso15118_charger.yaml
+++ b/types/iso15118_charger.yaml
@@ -586,3 +586,77 @@ types:
       inlet_hot:
         description: Inlet temperature is too high
         type: boolean
+  DcChargeDynamicModeValues:
+    description: Parameters for dynamic control mode
+    type: object
+    additionalProperties: false
+    required:
+      - target_energy_request
+      - max_energy_request
+      - min_energy_request
+      - max_charge_power
+      - min_charge_power
+      - max_charge_current
+      - max_voltage
+      - min_voltage
+    properties:
+      departure_time:
+        description: The time when the EV wants to finish charging
+        type: number
+        minimum: 0
+      target_energy_request:
+        description: Energy request to fulfil the target SoC
+        type: number
+        minimum: 0
+      max_energy_request:
+        description: Maximum acceptable energy level of the EV
+        type: number
+        minimum: 0
+      min_energy_request:
+        description: Energy request to fulfil the minimum SoC
+        type: number
+        minimum: 0
+      max_charge_power:
+        description: Maximum charge power allowed by the EV
+        type: number
+        minimum: 0
+      min_charge_power:
+        description: Minimum charge power allowed by the EV
+        type: number
+        minimum: 0
+      max_charge_current:
+        description: Maximum charge current allowed by the EV
+        type: number
+        minimum: 0
+      max_voltage:
+        description: Maximum voltage allowed by the EV
+        type: number
+        minimum: 0
+      min_voltage:
+        description: Minimum voltage allowd by the EV
+        type: number
+        minimum: 0
+      max_discharge_power:
+        description: Maximum discharge current allowed by the EV
+        type: number
+        minimum: 0
+      min_discharge_power:
+        description: Minimum discharge current allowed by the EVodo
+        type: number
+        minimum: 0
+      max_discharge_current:
+        description: Maximum discharge current allowed by the EV
+        type: number
+        minimum: 0
+      max_v2x_energy_request:
+        description: >-
+          Energy which may be charged until the PresentSOC has left the range
+          dedicated for cycling activity.
+        type: number
+        minimum: 0
+      min_v2x_energy_request:
+        description: >-
+          Energy which needs to be charged until the PresentSOC has left the
+          range dedicated for cycling activity.
+        type: number
+        minimum: 0

--- a/types/iso15118_charger.yaml
+++ b/types/iso15118_charger.yaml
@@ -579,6 +579,9 @@ types:
         description: Remaining time it takes to reach maximum SoC
         type: number
         minimum: 0
+      charging_complete:
+        description: Indication if the charging is complete
+        type: boolean
       battery_energy_capacity:
         description: Energy capacity in Wh of the EV battery
         type: number

--- a/types/iso15118_charger.yaml
+++ b/types/iso15118_charger.yaml
@@ -644,7 +644,7 @@ types:
         type: number
         minimum: 0
       min_discharge_power:
-        description: Minimum discharge current allowed by the EVodo
+        description: Minimum discharge current allowed by the EV
         type: number
         minimum: 0
       max_discharge_current:


### PR DESCRIPTION
## Describe your changes
This PR adds with this libiso15118 [Adding basic dynamic mode](https://github.com/EVerest/libiso15118/pull/42) PR a basic support for ISO15118-20 dynamic mode.

## Issue ticket number and link
Right now only a basic scheduled mode in the Evse15118D20 module was supported.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

