### PR TITLE
Fix(EvseV2G): Deleting an unnecessary reset when the contract chain certificates are validated locally

### DIFF
--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -956,7 +956,6 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
                 break;
             case crypto::verify_result_t::NoCertificateAvailable:
                 res->ResponseCode = iso2_responseCodeType_FAILED_NoCertificateAvailable;
-                err = -2;
                 break;
             case crypto::verify_result_t::CertChainError:
             default:
@@ -970,6 +969,7 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
                 res->EVSETimeStamp = time(NULL);
                 memset(res->GenChallenge.bytes, 0, GEN_CHALLENGE_SIZE);
                 res->GenChallenge.bytesLen = GEN_CHALLENGE_SIZE;
+                goto error_out;
             }
 
             dlog(DLOG_LEVEL_INFO, "Validation of the contract certificate was successful!");

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -972,11 +972,6 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
                 res->GenChallenge.bytesLen = GEN_CHALLENGE_SIZE;
             }
 
-            if (err != 0) {
-                memset(res, 0, sizeof(*res));
-                goto error_out;
-            }
-
             dlog(DLOG_LEVEL_INFO, "Validation of the contract certificate was successful!");
 
             // contract chain ocsp data can only be retrieved if the MO root is present and the chain could be verified


### PR DESCRIPTION
## Describe your changes
Deleting the payement_details_res reset and adding better handling if the local verification of the contract chain certs fails

## Issue ticket number and link
If the local contract chain certs verification with a `NoCertificateAvailable` error failed, the payment_details_res was resetted. This is not correct.
If the local contract chain certs verification generally failed, then the code does not go to `error_out`. 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

