### PR TITLE
Introduce RequestCompositeScheduleUnit argument in OCPP module

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,7 +66,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 5c7f10cdfd9aa70db80ccf43ace250e3322be00c
+  git_tag: c6a6e01b27c994f170d2b21d2befa13ad5c9ca20
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/EnergyManager/Market.cpp
+++ b/modules/EnergyManager/Market.cpp
@@ -132,6 +132,45 @@ void time_probe::pause() {
     }
 }
 
+// returns the smaller of two optionals. Note that comparison operators on optionals are a little weird if not both
+// sides have a value, we explicitly want:
+// - If both are not set, it should return an empty optional
+// - If either a or b is set but not both, return the one set.
+// - If both have a value, return the smaller one.
+template <typename T> std::optional<T> min_optional(std::optional<T> a, std::optional<T> b) {
+
+    if (a.has_value() and b.has_value()) {
+        if (a < b) {
+            return a;
+        } else {
+            return b;
+        }
+    }
+
+    if (a.has_value()) {
+        return a;
+    }
+
+    return b;
+}
+
+template <typename T> std::optional<T> max_optional(std::optional<T> a, std::optional<T> b) {
+
+    if (a.has_value() and b.has_value()) {
+        if (a > b) {
+            return a;
+        } else {
+            return b;
+        }
+    }
+
+    if (a.has_value()) {
+        return a;
+    }
+
+    return b;
+}
+
 ScheduleReq Market::get_max_available_energy(const ScheduleReq& request) {
 
     ScheduleReq available = globals.empty_schedule_req;
@@ -156,33 +195,31 @@ ScheduleReq Market::get_max_available_energy(const ScheduleReq& request) {
         }
 
         if (r != request.end()) {
-            // apply watt limit from leaf side to root side
-            if ((*r).limits_to_leaves.total_power_W.has_value()) {
-                a.limits_to_root.total_power_W =
-                    (*r).limits_to_leaves.total_power_W.value() / (*r).conversion_efficiency.value_or(1.);
+
+            {
+                auto leaves_power_W = (*r).limits_to_leaves.total_power_W;
+                if (leaves_power_W.has_value()) {
+                    leaves_power_W = leaves_power_W.value() / (*r).conversion_efficiency.value_or(1.);
+                }
+
+                a.limits_to_root.total_power_W = min_optional(leaves_power_W, (*r).limits_to_root.total_power_W);
             }
-            // do we have a lower watt limit on root side?
-            if ((*r).limits_to_root.total_power_W.has_value() && a.limits_to_root.total_power_W.has_value() &&
-                a.limits_to_root.total_power_W.value() > (*r).limits_to_root.total_power_W.value()) {
-                a.limits_to_root.total_power_W = (*r).limits_to_root.total_power_W.value();
-            }
-            // apply ampere limit from leaf side to root side
-            if ((*r).limits_to_leaves.ac_max_current_A.has_value()) {
-                a.limits_to_root.ac_max_current_A =
-                    (*r).limits_to_leaves.ac_max_current_A.value() / (*r).conversion_efficiency.value_or(1.);
-            }
-            // do we have a lower ampere limit on root side?
-            if ((*r).limits_to_root.ac_max_current_A.has_value() and
-                (a.limits_to_root.ac_max_current_A > (*r).limits_to_root.ac_max_current_A.value() or
-                 not(*r).limits_to_leaves.ac_max_current_A.has_value())) {
-                a.limits_to_root.ac_max_current_A = (*r).limits_to_root.ac_max_current_A.value();
-            }
+
+            a.limits_to_root.ac_max_current_A =
+                min_optional((*r).limits_to_leaves.ac_max_current_A, (*r).limits_to_root.ac_max_current_A);
+
+            a.limits_to_root.ac_min_phase_count =
+                max_optional((*r).limits_to_root.ac_min_phase_count, (*r).limits_to_leaves.ac_min_phase_count);
+
+            a.limits_to_root.ac_max_phase_count =
+                min_optional((*r).limits_to_root.ac_max_phase_count, (*r).limits_to_leaves.ac_max_phase_count);
+
+            a.limits_to_root.ac_min_current_A =
+                max_optional((*r).limits_to_root.ac_min_current_A, (*r).limits_to_leaves.ac_min_current_A);
+
             // all request limits have been merged on root side in available.
             // copy other information if any
             a.price_per_kwh = (*r).price_per_kwh;
-            a.limits_to_root.ac_min_current_A = (*r).limits_to_root.ac_min_current_A;
-            a.limits_to_root.ac_min_phase_count = (*r).limits_to_root.ac_min_phase_count;
-            a.limits_to_root.ac_max_phase_count = (*r).limits_to_root.ac_max_phase_count;
             a.limits_to_root.ac_number_of_active_phases = (*r).limits_to_root.ac_number_of_active_phases;
         }
     }

--- a/modules/EnergyManager/Market.cpp
+++ b/modules/EnergyManager/Market.cpp
@@ -132,45 +132,6 @@ void time_probe::pause() {
     }
 }
 
-// returns the smaller of two optionals. Note that comparison operators on optionals are a little weird if not both
-// sides have a value, we explicitly want:
-// - If both are not set, it should return an empty optional
-// - If either a or b is set but not both, return the one set.
-// - If both have a value, return the smaller one.
-template <typename T> std::optional<T> min_optional(std::optional<T> a, std::optional<T> b) {
-
-    if (a.has_value() and b.has_value()) {
-        if (a < b) {
-            return a;
-        } else {
-            return b;
-        }
-    }
-
-    if (a.has_value()) {
-        return a;
-    }
-
-    return b;
-}
-
-template <typename T> std::optional<T> max_optional(std::optional<T> a, std::optional<T> b) {
-
-    if (a.has_value() and b.has_value()) {
-        if (a > b) {
-            return a;
-        } else {
-            return b;
-        }
-    }
-
-    if (a.has_value()) {
-        return a;
-    }
-
-    return b;
-}
-
 ScheduleReq Market::get_max_available_energy(const ScheduleReq& request) {
 
     ScheduleReq available = globals.empty_schedule_req;
@@ -195,31 +156,33 @@ ScheduleReq Market::get_max_available_energy(const ScheduleReq& request) {
         }
 
         if (r != request.end()) {
-
-            {
-                auto leaves_power_W = (*r).limits_to_leaves.total_power_W;
-                if (leaves_power_W.has_value()) {
-                    leaves_power_W = leaves_power_W.value() / (*r).conversion_efficiency.value_or(1.);
-                }
-
-                a.limits_to_root.total_power_W = min_optional(leaves_power_W, (*r).limits_to_root.total_power_W);
+            // apply watt limit from leaf side to root side
+            if ((*r).limits_to_leaves.total_power_W.has_value()) {
+                a.limits_to_root.total_power_W =
+                    (*r).limits_to_leaves.total_power_W.value() / (*r).conversion_efficiency.value_or(1.);
             }
-
-            a.limits_to_root.ac_max_current_A =
-                min_optional((*r).limits_to_leaves.ac_max_current_A, (*r).limits_to_root.ac_max_current_A);
-
-            a.limits_to_root.ac_min_phase_count =
-                max_optional((*r).limits_to_root.ac_min_phase_count, (*r).limits_to_leaves.ac_min_phase_count);
-
-            a.limits_to_root.ac_max_phase_count =
-                min_optional((*r).limits_to_root.ac_max_phase_count, (*r).limits_to_leaves.ac_max_phase_count);
-
-            a.limits_to_root.ac_min_current_A =
-                max_optional((*r).limits_to_root.ac_min_current_A, (*r).limits_to_leaves.ac_min_current_A);
-
+            // do we have a lower watt limit on root side?
+            if ((*r).limits_to_root.total_power_W.has_value() && a.limits_to_root.total_power_W.has_value() &&
+                a.limits_to_root.total_power_W.value() > (*r).limits_to_root.total_power_W.value()) {
+                a.limits_to_root.total_power_W = (*r).limits_to_root.total_power_W.value();
+            }
+            // apply ampere limit from leaf side to root side
+            if ((*r).limits_to_leaves.ac_max_current_A.has_value()) {
+                a.limits_to_root.ac_max_current_A =
+                    (*r).limits_to_leaves.ac_max_current_A.value() / (*r).conversion_efficiency.value_or(1.);
+            }
+            // do we have a lower ampere limit on root side?
+            if ((*r).limits_to_root.ac_max_current_A.has_value() and
+                (a.limits_to_root.ac_max_current_A > (*r).limits_to_root.ac_max_current_A.value() or
+                 not(*r).limits_to_leaves.ac_max_current_A.has_value())) {
+                a.limits_to_root.ac_max_current_A = (*r).limits_to_root.ac_max_current_A.value();
+            }
             // all request limits have been merged on root side in available.
             // copy other information if any
             a.price_per_kwh = (*r).price_per_kwh;
+            a.limits_to_root.ac_min_current_A = (*r).limits_to_root.ac_min_current_A;
+            a.limits_to_root.ac_min_phase_count = (*r).limits_to_root.ac_min_phase_count;
+            a.limits_to_root.ac_max_phase_count = (*r).limits_to_root.ac_max_phase_count;
             a.limits_to_root.ac_number_of_active_phases = (*r).limits_to_root.ac_number_of_active_phases;
         }
     }

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -83,11 +83,11 @@ void OCPP::set_external_limits(const std::map<int32_t, ocpp::v16::EnhancedChargi
             types::energy::LimitsReq limits_req;
             const auto timestamp = start_time.to_time_point() + std::chrono::seconds(period.startPeriod);
             schedule_req_entry.timestamp = ocpp::DateTime(timestamp).to_rfc3339();
+            if (period.numberPhases.has_value()) {
+                limits_req.ac_max_phase_count = period.numberPhases.value();
+            }
             if (schedule.chargingRateUnit == ocpp::v16::ChargingRateUnit::A) {
                 limits_req.ac_max_current_A = period.limit;
-                if (period.numberPhases.has_value()) {
-                    limits_req.ac_max_phase_count = period.numberPhases.value();
-                }
                 if (schedule.minChargingRate.has_value()) {
                     limits_req.ac_min_current_A = schedule.minChargingRate.value();
                 }

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -63,6 +63,7 @@ struct Conf {
     int PublishChargingScheduleDurationS;
     std::string MessageLogPath;
     int MessageQueueResumeDelay;
+    std::string RequestCompositeScheduleUnit;
 };
 
 class OCPP : public Everest::ModuleBase {
@@ -138,6 +139,7 @@ private:
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
     std::filesystem::path ocpp_share_path;
+    ocpp::v16::ChargingRateUnit composite_schedule_charging_rate_unit;
     void set_external_limits(const std::map<int32_t, ocpp::v16::EnhancedChargingSchedule>& charging_schedules);
     void publish_charging_schedules(const std::map<int32_t, ocpp::v16::EnhancedChargingSchedule>& charging_schedules);
 
@@ -162,6 +164,7 @@ private:
 };
 
 // ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+// insert other definitions here
 // ev@087e516b-124c-48df-94fb-109508c7cda9:v1
 
 } // namespace module

--- a/modules/OCPP/manifest.yaml
+++ b/modules/OCPP/manifest.yaml
@@ -41,7 +41,7 @@ config:
       Amps for AC and Watts for DC charging stations.
       Allowed values:
         - 'A' for Amps
-        . 'W' for Watts 
+        - 'W' for Watts 
     type: string
     default: 'A'
 provides:

--- a/modules/OCPP/manifest.yaml
+++ b/modules/OCPP/manifest.yaml
@@ -35,6 +35,15 @@ config:
     description: Time (seconds) to delay resuming the message queue after reconnecting
     type: integer
     default: 0
+  RequestCompositeScheduleUnit:
+    description: >-
+      Unit in which composite schedules are requested and shared within EVerest. It is recommended to use
+      Amps for AC and Watts for DC charging stations.
+      Allowed values:
+        - 'A' for Amps
+        . 'W' for Watts 
+    type: string
+    default: 'A'
 provides:
   main:
     description: This is a OCPP 1.6 charge point


### PR DESCRIPTION
## Describe your changes

Libocpp so far had always reported composite schedules using  the ChargingRateUnit::A (amps). This is now configurable with [this PR](https://github.com/EVerest/libocpp/pull/834), allowing to specify the unit as an argument.

This PR introduces the `RequestCompositeScheduleUnit` as an argument in the OCPP module, which is then used when requesting the composite schedule. The same was already done for the OCPP201 module.

Additionally, this PR also sets the `ac_max_phase_count` for DC schedules, to allow phase switching in the Energymanagement. It was only set for AC schedules so far.

## TODOs

~* Update libocpp dependency once https://github.com/EVerest/libocpp/pull/834 is merged.~
~* Update module documentation pointing  to this parameter~ : Will be done as part of https://github.com/EVerest/everest-core/pull/908

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

