### PR TITLE
feat: add support for new EVSE security API

### DIFF
--- a/lib/staging/tls/openssl_util.hpp
+++ b/lib/staging/tls/openssl_util.hpp
@@ -336,6 +336,14 @@ DER bn_to_signature(const std::uint8_t* r, const std::uint8_t* s);
 bool signature_to_bn(openssl::bn_t& r, openssl::bn_t& s, const std::uint8_t* sig_p, std::size_t len);
 
 /**
+ * \brief load any PEM encoded certificates from a string
+ * \param[in] pem_string
+ * \return a list of 0 or more certificates
+ * \note PEM string only supports certificates and not other PEM types
+ */
+certificate_list load_certificates_pem(const char* pem_string);
+
+/**
  * \brief load any PEM encoded certificates from a file
  * \param[in] filename
  * \return a list of 0 or more certificates

--- a/lib/staging/tls/tests/openssl_util_test.cpp
+++ b/lib/staging/tls/tests/openssl_util_test.cpp
@@ -540,6 +540,36 @@ TEST(certificate, toPem) {
     // std::cout << pem << std::endl;
 }
 
+TEST(certificate, loadPemSingle) {
+    auto certs = ::openssl::load_certificates("client_ca_cert.pem");
+    ASSERT_EQ(certs.size(), 1);
+    auto pem = ::openssl::certificate_to_pem(certs[0].get());
+    EXPECT_FALSE(pem.empty());
+
+    auto pem_certs = ::openssl::load_certificates_pem(pem.c_str());
+    ASSERT_EQ(pem_certs.size(), 1);
+    EXPECT_EQ(certs[0], pem_certs[0]);
+}
+
+TEST(certificate, loadPemMulti) {
+    auto certs = ::openssl::load_certificates("client_chain.pem");
+    ASSERT_GT(certs.size(), 1);
+    std::string pem;
+    for (const auto& cert : certs) {
+        pem += ::openssl::certificate_to_pem(cert.get());
+    }
+    EXPECT_FALSE(pem.empty());
+    // std::cout << pem << std::endl << "Output" << std::endl;
+
+    auto pem_certs = ::openssl::load_certificates_pem(pem.c_str());
+    ASSERT_EQ(pem_certs.size(), certs.size());
+    for (auto i = 0; i < certs.size(); i++) {
+        SCOPED_TRACE(std::to_string(i));
+        // std::cout << ::openssl::certificate_to_pem(pem_certs[i].get()) << std::endl;
+        EXPECT_EQ(certs[i], pem_certs[i]);
+    }
+}
+
 TEST(certificate, verify) {
     auto client = ::openssl::load_certificates("client_cert.pem");
     auto chain = ::openssl::load_certificates("client_chain.pem");

--- a/lib/staging/tls/tls.cpp
+++ b/lib/staging/tls/tls.cpp
@@ -934,7 +934,11 @@ bool Server::init_certificates(const std::vector<certificate_config_t>& chain_fi
     for (const auto& i : chain_files) {
         auto certs = openssl::load_certificates(i.certificate_chain_file);
         auto tas = openssl::load_certificates(i.trust_anchor_file);
+        auto tas_pem = openssl::load_certificates_pem(i.trust_anchor_pem);
         auto pkey = openssl::load_private_key(i.private_key_file, i.private_key_password);
+
+        // combine all trust anchor certificates
+        std::move(tas_pem.begin(), tas_pem.end(), std::back_inserter(tas));
 
         if (certs.size() > 0) {
             openssl::chain_t chain;

--- a/lib/staging/tls/tls.hpp
+++ b/lib/staging/tls/tls.hpp
@@ -359,6 +359,7 @@ public:
         //!< server certificate is the first certificate in the file followed by any intermediate CAs
         ConfigItem certificate_chain_file{nullptr};
         ConfigItem trust_anchor_file{nullptr};       //!< one or more trust anchor PEM certificates
+        ConfigItem trust_anchor_pem{nullptr};        //!< one or more trust anchor PEM certificates
         ConfigItem private_key_file{nullptr};        //!< key associated with the server certificate
         ConfigItem private_key_password{nullptr};    //!< optional password to read private key
         std::vector<ConfigItem> ocsp_response_files; //!< list of OCSP files in certificate chain order


### PR DESCRIPTION
## Describe your changes

Now uses call_get_all_valid_certificates_info() to obtain multiple server certificate chains in order to support trusted_ca_keys.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

