### PR TITLE
Feature/multi root trusted ca

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -56,11 +56,11 @@ libcurl:
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBCURL"
 
 # EvseSecurity
-# This has to appear before libocpp in this file since it is also a direct dependency of libocpp
-# and would otherwise be overwritten by the version used there
+# This has to appear before libocpp in this file since it is also a direct dependency 
+# of libocpp and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: v0.9.0
+  git_tag: v0.9.1
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ libcurl:
 # and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: v0.8.0
+  git_tag: 5c0b6655a49167e8140f08e155fa43c823134897
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -60,7 +60,7 @@ libcurl:
 # and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: 5c0b6655a49167e8140f08e155fa43c823134897
+  git_tag: v0.9.0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP

--- a/interfaces/evse_security.yaml
+++ b/interfaces/evse_security.yaml
@@ -154,6 +154,26 @@ cmds:
       description: The response to the requested command
       type: object
       $ref: /evse_security#/GetCertificateInfoResult
+  get_all_valid_certificates_info:
+    description:  >-
+        Finds the latest valid leafs, for each root certificate that is present on the filesystem,
+        and returns all the newest valid leafs that are present for different roots
+    arguments:
+      certificate_type: 
+        description: Specifies the leaf certificate type
+        type: string
+        $ref: /evse_security#/LeafCertificateType
+      encoding:
+        description: Specifies the encoding of the key
+        type: string
+        $ref: /evse_security#/EncodingFormat
+      include_ocsp:
+        description: Specifies whether per-certificate OCSP data is also requested
+        type: boolean
+    result:
+      description: The response to the requested command
+      type: object
+      $ref: /evse_security#/GetCertificateFullInfoResult
   get_verify_file:
     description: Command to get the file path of a CA bundle that can be used for verification
     arguments:

--- a/lib/staging/evse_security/conversions.cpp
+++ b/lib/staging/evse_security/conversions.cpp
@@ -455,7 +455,7 @@ types::evse_security::CertificateInfo to_everest(evse_security::CertificateInfo 
     lhs.certificate = other.certificate;
     lhs.certificate_single = other.certificate_single;
     lhs.password = other.password;
-    lhs.certificate_count = other.certificate_count;    
+    lhs.certificate_count = other.certificate_count;
     return lhs;
 }
 

--- a/lib/staging/evse_security/conversions.cpp
+++ b/lib/staging/evse_security/conversions.cpp
@@ -451,10 +451,11 @@ types::evse_security::OCSPRequestDataList to_everest(evse_security::OCSPRequestD
 types::evse_security::CertificateInfo to_everest(evse_security::CertificateInfo other) {
     types::evse_security::CertificateInfo lhs;
     lhs.key = other.key;
+    lhs.certificate_root = other.certificate_root;
     lhs.certificate = other.certificate;
     lhs.certificate_single = other.certificate_single;
     lhs.password = other.password;
-    lhs.certificate_count = other.certificate_count;
+    lhs.certificate_count = other.certificate_count;    
     return lhs;
 }
 

--- a/modules/EvseSecurity/main/evse_securityImpl.cpp
+++ b/modules/EvseSecurity/main/evse_securityImpl.cpp
@@ -123,16 +123,17 @@ evse_securityImpl::handle_get_leaf_certificate_info(types::evse_security::LeafCe
 
 types::evse_security::GetCertificateFullInfoResult
 evse_securityImpl::handle_get_all_valid_certificates_info(types::evse_security::LeafCertificateType& certificate_type,
-                                           types::evse_security::EncodingFormat& encoding, bool& include_ocsp) {
+                                                          types::evse_security::EncodingFormat& encoding,
+                                                          bool& include_ocsp) {
     types::evse_security::GetCertificateFullInfoResult response;
 
     const auto full_leaf_info = this->evse_security->get_all_valid_certificates_info(
         conversions::from_everest(certificate_type), conversions::from_everest(encoding), include_ocsp);
-    
+
     response.status = conversions::to_everest(full_leaf_info.status);
 
     if (full_leaf_info.status == evse_security::GetCertificateInfoStatus::Accepted) {
-        for(const auto& info : full_leaf_info.info) {
+        for (const auto& info : full_leaf_info.info) {
             response.info.push_back(conversions::to_everest(info));
         }
     }

--- a/modules/EvseSecurity/main/evse_securityImpl.cpp
+++ b/modules/EvseSecurity/main/evse_securityImpl.cpp
@@ -121,6 +121,25 @@ evse_securityImpl::handle_get_leaf_certificate_info(types::evse_security::LeafCe
     return response;
 }
 
+types::evse_security::GetCertificateFullInfoResult
+evse_securityImpl::handle_get_all_valid_certificates_info(types::evse_security::LeafCertificateType& certificate_type,
+                                           types::evse_security::EncodingFormat& encoding, bool& include_ocsp) {
+    types::evse_security::GetCertificateFullInfoResult response;
+
+    const auto full_leaf_info = this->evse_security->get_all_valid_certificates_info(
+        conversions::from_everest(certificate_type), conversions::from_everest(encoding), include_ocsp);
+    
+    response.status = conversions::to_everest(full_leaf_info.status);
+
+    if (full_leaf_info.status == evse_security::GetCertificateInfoStatus::Accepted) {
+        for(const auto& info : full_leaf_info.info) {
+            response.info.push_back(conversions::to_everest(info));
+        }
+    }
+
+    return response;
+}
+
 std::string evse_securityImpl::handle_get_verify_file(types::evse_security::CaCertificateType& certificate_type) {
     return this->evse_security->get_verify_file(conversions::from_everest(certificate_type));
 }

--- a/modules/EvseSecurity/main/evse_securityImpl.hpp
+++ b/modules/EvseSecurity/main/evse_securityImpl.hpp
@@ -60,6 +60,9 @@ protected:
     virtual types::evse_security::GetCertificateInfoResult
     handle_get_leaf_certificate_info(types::evse_security::LeafCertificateType& certificate_type,
                                      types::evse_security::EncodingFormat& encoding, bool& include_ocsp) override;
+    virtual types::evse_security::GetCertificateFullInfoResult
+    handle_get_all_valid_certificates_info(types::evse_security::LeafCertificateType& certificate_type,
+                                           types::evse_security::EncodingFormat& encoding, bool& include_ocsp) override;
     virtual std::string handle_get_verify_file(types::evse_security::CaCertificateType& certificate_type) override;
     virtual int handle_get_leaf_expiry_days_count(types::evse_security::LeafCertificateType& certificate_type) override;
     virtual bool handle_verify_file_signature(std::string& file_path, std::string& signing_certificate,

--- a/types/evse_security.yaml
+++ b/types/evse_security.yaml
@@ -227,6 +227,9 @@ types:
       key:
         description: The path of the PEM or DER encoded private key
         type: string
+      certificate_root: 
+        description: The PEM of the root certificate that issued this leaf
+        type: string
       certificate:
         description: The path of the PEM or DER encoded certificate chain
         type: string
@@ -260,4 +263,21 @@ types:
         description: The requested info
         type: object
         $ref: /evse_security#/CertificateInfo
+  GetCertificateFullInfoResult:
+    description: Response to the command get_all_valid_certificates_info
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        description: The status of the requested command
+        type: string
+        $ref: /evse_security#/GetCertificateInfoStatus
+      info:
+        description: The requested info
+        type: array
+        items:
+          minimum: 0
+          type: object
+          $ref: /evse_security#/CertificateInfo
 

--- a/types/evse_security.yaml
+++ b/types/evse_security.yaml
@@ -268,6 +268,7 @@ types:
     type: object
     required:
       - status
+      - info
     properties:
       status:
         description: The status of the requested command


### PR DESCRIPTION
## Describe your changes

Introduces one interface API call that allows the retrieval of multiple leaf certificate chains, that are linked to different roots.

## Issue ticket number and link

https://github.com/EVerest/libevse-security/pull/91

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

