### PR TITLE
EvseV2G/IsoMux: check if if_name is nullptr

### DIFF
--- a/modules/EvseV2G/connection/connection.cpp
+++ b/modules/EvseV2G/connection/connection.cpp
@@ -192,6 +192,10 @@ int check_interface(struct v2g_context* v2g_ctx) {
         v2g_ctx->if_name = choose_first_ipv6_interface();
     }
 
+    if (v2g_ctx->if_name == nullptr) {
+        return -1;
+    }
+
     mreq.ipv6mr_interface = if_nametoindex(v2g_ctx->if_name);
     if (!mreq.ipv6mr_interface) {
         dlog(DLOG_LEVEL_ERROR, "No such interface: %s", v2g_ctx->if_name);

--- a/modules/IsoMux/connection/connection.cpp
+++ b/modules/IsoMux/connection/connection.cpp
@@ -112,6 +112,10 @@ int check_interface(struct v2g_context* v2g_ctx) {
         v2g_ctx->if_name = choose_first_ipv6_interface();
     }
 
+    if (v2g_ctx->if_name == nullptr) {
+        return -1;
+    }
+
     mreq.ipv6mr_interface = if_nametoindex(v2g_ctx->if_name);
     if (!mreq.ipv6mr_interface) {
         dlog(DLOG_LEVEL_ERROR, "No such interface: %s", v2g_ctx->if_name);


### PR DESCRIPTION
This can happen if there are no interfaces with IPv6 addresses and would lead to a segfault later on

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

