### PR TITLE
API: fix documentation for legacy enable/disable

### DIFF
--- a/modules/API/README.md
+++ b/modules/API/README.md
@@ -216,8 +216,8 @@ It will actually call the following command on everest_api/evse_manager/cmd/enab
     {
         "connector_id": 1,
         "source": "LocalAPI",
-        "state": "enable",
-        "priority": 0
+        "state": "Enable",
+        "priority": 100
     }
 ```
 
@@ -230,8 +230,8 @@ It will actually call the following command on everest_api/evse_manager/cmd/enab
     {
         "connector_id": 1,
         "source": "LocalAPI",
-        "state": "disable",
-        "priority": 0
+        "state": "Disable",
+        "priority": 100
     }
 ```
 


### PR DESCRIPTION
## Describe your changes
The API module provides an "easy" legacy interface for enabling/disabling a connector.

The generic enable/disable call it maps to was not documented correctly. A value used incorrect case, and the priority did not reflect what the actual code did.

I'm not sure whether it was actually intentional that the priority is set to 100 in the code.
https://github.com/EVerest/everest-core/blob/1e06aaab914d4e65e4b01fd0a7fb13ee0c8d6f21/modules/API/API.cpp#L408-L409
The priority is a range from 0 to 10000, and 0 seems more reasonable:
https://github.com/EVerest/everest-core/blob/1e06aaab914d4e65e4b01fd0a7fb13ee0c8d6f21/modules/EvseManager/Charger.cpp#L1511

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

