### PR TITLE
fix: support <ctrl>-c to stop nodered-sil containers

### DIFF
--- a/cmake/assets/run_nodered_template.sh.in
+++ b/cmake/assets/run_nodered_template.sh.in
@@ -14,4 +14,4 @@ docker cp @FLOW_FILE@ everest-nodered-config-container:/data/flows.json
 docker rm everest-nodered-config-container
 
 # Start nodered container with the volume mounted to /data
-docker run --rm --network host --name everest_nodered --mount type=volume,source=everest-nodered-config-volume,target=/data ghcr.io/everest/everest-dev-environment/nodered:docker-images-v0.1.0
+docker run -it --rm --network host --name everest_nodered --mount type=volume,source=everest-nodered-config-volume,target=/data ghcr.io/everest/everest-dev-environment/nodered:docker-images-v0.1.0


### PR DESCRIPTION
## Describe your changes

support <ctrl>-c to stop nodered-sil containers

stopping a nodered script requires listing running containers and then manually stopping the correct one.
This change means that <crtl>-c in the correct window will stop the container.


## Issue ticket number and link

## Checklist before requesting a review
- [ X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

