### PR TITLE
feature(OCPP1.6): forward VendorWarning appropriately

### DIFF
--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -48,8 +48,22 @@ static ocpp::v16::ErrorInfo get_error_info(const Everest::error::Error& error) {
                                     "EVerest", "caused_by:" + error.message};
     }
 
-    // check if is VendorError
-    if (error_type.find("VendorError") != std::string::npos) {
+    const auto is_vendor_specific = [](const std::string& error_type) {
+        // NOTE (aw): probably `find` is used here in order to also
+        // match vendor related errors from differen modules
+        if (error_type.find("VendorError") != std::string::npos) {
+            return true;
+        }
+
+        if (error_type.find("VendorWarning") != std::string::npos) {
+            return true;
+        }
+
+        return false;
+    };
+
+    // handle vendor specific errors
+    if (is_vendor_specific(error.type)) {
         return ocpp::v16::ErrorInfo{
             uuid,          ocpp::v16::ChargePointErrorCode::OtherError, false, error.message, error.origin.to_string(),
             error.sub_type};

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -1,18 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #include "OCPP.hpp"
+
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+
 #include "generated/types/ocpp.hpp"
 #include "ocpp/common/types.hpp"
 #include "ocpp/v16/types.hpp"
 #include <fmt/core.h>
-#include <fstream>
 #include <ocpp_conversions.hpp>
 
 #include <conversions.hpp>
 #include <error_mapping.hpp>
 #include <evse_security_ocpp.hpp>
 #include <external_energy_limits.hpp>
-#include <optional>
 
 namespace module {
 
@@ -48,30 +52,44 @@ static ocpp::v16::ErrorInfo get_error_info(const Everest::error::Error& error) {
                                     "EVerest", "caused_by:" + error.message};
     }
 
-    const auto is_vendor_specific = [](const std::string& error_type) {
-        // NOTE (aw): probably `find` is used here in order to also
-        // match vendor related errors from differen modules
-        if (error_type.find("VendorError") != std::string::npos) {
-            return true;
+    const auto get_simplified_error_type = [](const std::string& error_type) {
+        // this function should return everything after the first '/'
+        // delimiter - if there is no delimiter or the delimiter is at
+        // the end, it should return the input itself
+        static constexpr auto TYPE_INTERFACE_DELIMITER = '/';
+
+        auto input = std::istringstream(error_type);
+        std::string tmp;
+
+        // move right after the first delimiter
+        std::getline(input, tmp, TYPE_INTERFACE_DELIMITER);
+
+        if (!input) {
+            // no delimiter found or delimiter at the end
+            return error_type;
         }
 
-        if (error_type.find("VendorWarning") != std::string::npos) {
-            return true;
-        }
+        // get the rest of the input
+        std::getline(input, tmp);
 
+        return tmp;
+    };
+
+    const auto is_fault = [](const Everest::error::Error&) {
+        // NOTE (aw): this could be customized, depending on the error
         return false;
     };
 
-    // handle vendor specific errors
-    if (is_vendor_specific(error.type)) {
-        return ocpp::v16::ErrorInfo{
-            uuid,          ocpp::v16::ChargePointErrorCode::OtherError, false, error.message, error.origin.to_string(),
-            error.sub_type};
-    }
+    static constexpr auto TYPE_DELIMITER = '/';
 
-    // Default case
-    return ocpp::v16::ErrorInfo{
-        uuid, ocpp::v16::ChargePointErrorCode::InternalError, false, error.description, std::nullopt, error_type};
+    return {
+        uuid,
+        ocpp::v16::ChargePointErrorCode::OtherError,
+        is_fault(error),
+        error.origin.to_string(),                                                // info
+        error.message,                                                           // vendor id
+        get_simplified_error_type(error.type) + TYPE_DELIMITER + error.sub_type, // vendor error code
+    };
 }
 
 void create_empty_user_config(const fs::path& user_config_path) {

--- a/modules/OCPP/doc.rst
+++ b/modules/OCPP/doc.rst
@@ -276,15 +276,32 @@ it initiates a **StatusNotification.req** that contains information about the er
 The field **status** of the **StatusNotification.req** will be set to faulted only in case the error is of the special type  
 **evse_manager/Inoperative**. The field **connectorId** is set based on the mapping (for EVSE id and connector id) of the origin of the error.  
 If no mapping is provided, the error will be reported on connectorId 0. Note that the mapping can be configured per module inside the  
-EVerest config file. The field **errorCode** is set based on the **type** property of the error.
+EVerest config file.
 
-The fields **info**, **vendorId**, and **vendorErrorCode** are set based on the error type and the provided error properties. Please see the  
-definition of `get_error_info` to see how the **StatusNotification.req** is constructed based on the given error.
+For all other errors, raised in everest, the following mapping to an
+ocpp status notification will be used:
 
-The **StatusNotification.req** message has some limitations with respect to reporting errors:
+* status notification charge point `errorCode` will always be
+  `OtherError`
+* status notification `status` will reflect the present status of the
+  charge point
+* status notification `info` -> origin of everest error
+* status notification `vendorErrorCode` -> everest error type and
+  subtype (the error type is simplified, meaning, that its leading part,
+  the interface name, is stripped)
+* status notification `vendorId` -> everest error message
 
-* Single errors cannot simply be cleared. If multiple errors are raised, it is not possible to clear individual errors.
-* Some fields of the message have relatively small character limits (e.g., **info** with 50 characters, **vendorErrorCode** with 50 characters).
+  The main choice for using the status notification `vendorId` for the
+  error message is that it can carry the largest string (255
+  characters), whereas the other fields (`info` and `vendorErrorCode`)
+  only allow up to 50 characters.
+
+The **StatusNotification.req** message has some limitations with respect
+to reporting errors:
+
+* Single errors cannot simply be cleared. If multiple errors are raised,
+  it is not possible to clear individual errors.
+* `vendorId`, `info` and `vendorErrorCode`` are limited in length (see above).
 
 This module attempts to follow the Minimum Required Error Codes (MRECS): https://inl.gov/chargex/mrec/. This proposes a unified  
 methodology to define and classify a minimum required set of error codes and how to report them via OCPP1.6.

--- a/modules/OCPP/doc.rst
+++ b/modules/OCPP/doc.rst
@@ -296,6 +296,22 @@ ocpp status notification will be used:
   characters), whereas the other fields (``info`` and
   ``vendorErrorCode``) only allow up to 50 characters.
 
+If for example the module with id `yeti_driver` within its
+implementation with id `board_support` creates the following error:
+.. code-block:: cpp
+
+  error_factory->create_error("evse_board_support/EnergyManagement", "OutOfEnergy", "someone cut the wires")
+
+the corresponding fields in the **StatusNotification.req** message will
+look like this:
+.. code-block:: JSON
+
+  {
+    "info": "yeti_driver->board_support",
+    "vendorErrorCode": "EnergyManagement/OutOfEnergy",
+    "vendorId": "someone cut the wires"
+  }
+
 The **StatusNotification.req** message has some limitations with respect
 to reporting errors:
 

--- a/modules/OCPP/doc.rst
+++ b/modules/OCPP/doc.rst
@@ -278,23 +278,23 @@ The field **status** of the **StatusNotification.req** will be set to faulted on
 If no mapping is provided, the error will be reported on connectorId 0. Note that the mapping can be configured per module inside the  
 EVerest config file.
 
-For all other errors, raised in everest, the following mapping to an
-ocpp status notification will be used:
+For all other errors, raised in EVerest, the following mapping to an
+OCPP **StatusNotification.req** will be used:
 
-* status notification charge point ``errorCode`` will always be
+* **StatusNotification.req** property ``errorCode`` will always be
   ``OtherError``
-* status notification ``status`` will reflect the present status of the
+* **StatusNotification.req** property ``status`` will reflect the present status of the
   charge point
-* status notification ``info`` -> origin of everest error
-* status notification ``vendorErrorCode`` -> everest error type and
+* **StatusNotification.req** property ``info`` -> origin of EVerest error
+* **StatusNotification.req** property ``vendorErrorCode`` -> EVerest error type and
   subtype (the error type is simplified, meaning, that its leading part,
   the interface name, is stripped)
-* status notification ``vendorId`` -> everest error message
+* **StatusNotification.req** property ``vendorId`` -> EVerest error message
 
-The reason for using the status notification ``vendorId`` for the error
-message is that it can carry the largest string (255 characters),
-whereas the other fields (``info`` and ``vendorErrorCode``) only allow
-up to 50 characters.
+The reason for using the **StatusNotification.req** property property
+``vendorId`` for the error message is that it can carry the largest
+string (255 characters), whereas the other fields (``info`` and
+``vendorErrorCode``) only allow up to 50 characters.
 
 If for example the module with id `yeti_driver` within its
 implementation with id `board_support` creates the following error:

--- a/modules/OCPP/doc.rst
+++ b/modules/OCPP/doc.rst
@@ -281,27 +281,28 @@ EVerest config file.
 For all other errors, raised in everest, the following mapping to an
 ocpp status notification will be used:
 
-* status notification charge point `errorCode` will always be
-  `OtherError`
-* status notification `status` will reflect the present status of the
+* status notification charge point ``errorCode`` will always be
+  ``OtherError``
+* status notification ``status`` will reflect the present status of the
   charge point
-* status notification `info` -> origin of everest error
-* status notification `vendorErrorCode` -> everest error type and
+* status notification ``info`` -> origin of everest error
+* status notification ``vendorErrorCode`` -> everest error type and
   subtype (the error type is simplified, meaning, that its leading part,
   the interface name, is stripped)
-* status notification `vendorId` -> everest error message
+* status notification ``vendorId`` -> everest error message
 
-  The main choice for using the status notification `vendorId` for the
+  The main choice for using the status notification ``vendorId`` for the
   error message is that it can carry the largest string (255
-  characters), whereas the other fields (`info` and `vendorErrorCode`)
-  only allow up to 50 characters.
+  characters), whereas the other fields (``info`` and
+  ``vendorErrorCode``) only allow up to 50 characters.
 
 The **StatusNotification.req** message has some limitations with respect
 to reporting errors:
 
 * Single errors cannot simply be cleared. If multiple errors are raised,
   it is not possible to clear individual errors.
-* `vendorId`, `info` and `vendorErrorCode`` are limited in length (see above).
+* ``vendorId``, ``info`` and ``vendorErrorCode`` are limited in length
+  (see above).
 
 This module attempts to follow the Minimum Required Error Codes (MRECS): https://inl.gov/chargex/mrec/. This proposes a unified  
 methodology to define and classify a minimum required set of error codes and how to report them via OCPP1.6.

--- a/modules/OCPP/doc.rst
+++ b/modules/OCPP/doc.rst
@@ -291,10 +291,10 @@ ocpp status notification will be used:
   the interface name, is stripped)
 * status notification ``vendorId`` -> everest error message
 
-  The main choice for using the status notification ``vendorId`` for the
-  error message is that it can carry the largest string (255
-  characters), whereas the other fields (``info`` and
-  ``vendorErrorCode``) only allow up to 50 characters.
+The reason for using the status notification ``vendorId`` for the error
+message is that it can carry the largest string (255 characters),
+whereas the other fields (``info`` and ``vendorErrorCode``) only allow
+up to 50 characters.
 
 If for example the module with id `yeti_driver` within its
 implementation with id `board_support` creates the following error:

--- a/modules/OCPP/doc.rst
+++ b/modules/OCPP/doc.rst
@@ -298,12 +298,15 @@ ocpp status notification will be used:
 
 If for example the module with id `yeti_driver` within its
 implementation with id `board_support` creates the following error:
+
 .. code-block:: cpp
 
-  error_factory->create_error("evse_board_support/EnergyManagement", "OutOfEnergy", "someone cut the wires")
+  error_factory->create_error("evse_board_support/EnergyManagement",
+                              "OutOfEnergy", "someone cut the wires")
 
 the corresponding fields in the **StatusNotification.req** message will
 look like this:
+
 .. code-block:: JSON
 
   {


### PR DESCRIPTION
- this change will treat the `VendorWarning` the same way as `VendorError`, so that also the `error.message` becomes visible in the OCPP StatusNotification message

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

