### PR TITLE
umwc: move external MQTT to MicroMegaWattBSP, throw MREC8 emergencyst…

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -1129,7 +1129,15 @@ bool Charger::cancel_transaction(const types::evse_manager::StopTransactionReque
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_cancel_transaction);
 
     if (shared_context.transaction_active) {
+
         if (shared_context.hlc_charging_active) {
+
+            if (request.reason == types::evse_manager::StopTransactionReason::EmergencyStop) {
+                signal_hlc_error(types::iso15118::EvseError::Error_EmergencyShutdown);
+            } else if (request.reason == types::evse_manager::StopTransactionReason::PowerLoss) {
+                signal_hlc_error(types::iso15118::EvseError::Error_UtilityInterruptEvent);
+            }
+
             shared_context.current_state = EvseState::StoppingCharging;
             signal_hlc_stop_charging();
         } else {

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -166,6 +166,7 @@ public:
     sigslot::signal<> signal_slac_start;
 
     sigslot::signal<> signal_hlc_stop_charging;
+    sigslot::signal<types::iso15118::EvseError> signal_hlc_error;
 
     void process_event(CPEvent event);
 

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -245,6 +245,10 @@ void EvseManager::ready() {
         // Ask HLC to stop charging session
         charger->signal_hlc_stop_charging.connect([this] { r_hlc[0]->call_stop_charging(true); });
 
+        // Charger needs to inform ISO stack about emergency stop
+        charger->signal_hlc_error.connect(
+            [this](types::iso15118::EvseError error) { r_hlc[0]->call_send_error(error); });
+
         auto sae_mode = types::iso15118::SaeJ2847BidiMode::None;
 
         // Set up energy transfer modes for HLC. For now we only support either DC or AC, not both at the same time.

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -70,43 +70,6 @@ void evse_managerImpl::init() {
     mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/resume_charging", mod->config.connector_id),
                         [&charger = mod->charger](const std::string& data) { charger->resume_charging(); });
 
-    mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/stop_transaction", mod->config.connector_id),
-                        [this](const std::string& data) {
-                            types::evse_manager::StopTransactionRequest request;
-                            request.reason = types::evse_manager::StopTransactionReason::Local;
-                            mod->charger->cancel_transaction(request);
-                        });
-
-    mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/emergency_stop", mod->config.connector_id),
-                        [this](const std::string& data) {
-                            if (mod->get_hlc_enabled()) {
-                                mod->r_hlc[0]->call_send_error(types::iso15118::EvseError::Error_EmergencyShutdown);
-                            }
-                            types::evse_manager::StopTransactionRequest request;
-                            request.reason = types::evse_manager::StopTransactionReason::EmergencyStop;
-                            mod->charger->cancel_transaction(request);
-                        });
-
-    mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/evse_malfunction", mod->config.connector_id),
-                        [this](const std::string& data) {
-                            if (mod->get_hlc_enabled()) {
-                                mod->r_hlc[0]->call_send_error(types::iso15118::EvseError::Error_Malfunction);
-                            }
-                            types::evse_manager::StopTransactionRequest request;
-                            request.reason = types::evse_manager::StopTransactionReason::Other;
-                            mod->charger->cancel_transaction(request);
-                        });
-
-    mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/evse_utility_int", mod->config.connector_id),
-                        [this](const std::string& data) {
-                            if (mod->get_hlc_enabled()) {
-                                mod->r_hlc[0]->call_send_error(types::iso15118::EvseError::Error_UtilityInterruptEvent);
-                            }
-                            types::evse_manager::StopTransactionRequest request;
-                            request.reason = types::evse_manager::StopTransactionReason::Other;
-                            mod->charger->cancel_transaction(request);
-                        });
-
     // /Interface to Node-RED debug UI
 
     if (mod->r_powermeter_billing().size() > 0) {

--- a/modules/MicroMegaWattBSP/MicroMegaWattBSP.hpp
+++ b/modules/MicroMegaWattBSP/MicroMegaWattBSP.hpp
@@ -28,6 +28,7 @@ struct Conf {
     std::string reset_gpio_chip;
     int reset_gpio;
     int dc_max_voltage;
+    int connector_id;
 };
 
 class MicroMegaWattBSP : public Everest::ModuleBase {

--- a/modules/MicroMegaWattBSP/manifest.yaml
+++ b/modules/MicroMegaWattBSP/manifest.yaml
@@ -25,6 +25,10 @@ config:
     minimum: 50
     maximum: 1000
     default: 1000
+  connector_id:
+    description: Connector id
+    type: integer
+    default: 1
 provides:
   dc_supply:
     interface: power_supply_DC


### PR DESCRIPTION
…op error

Support for MREC8 error code. Also removes some (deprecated) external MQTT commands from EvseManager as a cleanup, and adds them to umwc bsp (the only product where they are used)

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

