### PR TITLE
API: differntiate between Finished EVSE and EV

### DIFF
--- a/modules/API/API.cpp
+++ b/modules/API/API.cpp
@@ -76,13 +76,13 @@ static void remove_error_from_list(std::vector<module::SessionInfo::Error>& list
                list.end());
 }
 
-void SessionInfo::update_state(const types::evse_manager::SessionEventEnum event) {
+void SessionInfo::update_state(const types::evse_manager::SessionEvent event) {
     std::lock_guard<std::mutex> lock(this->session_info_mutex);
     using Event = types::evse_manager::SessionEventEnum;
 
     // using switch since some code analysis tools can detect missing cases
     // (when new events are added)
-    switch (event) {
+    switch (event.event) {
     case Event::Enabled:
         this->state = State::Unplugged;
         break;
@@ -111,10 +111,21 @@ void SessionInfo::update_state(const types::evse_manager::SessionEventEnum event
         this->state = State::WaitingForEnergy;
         break;
     case Event::ChargingFinished:
-    case Event::PluginTimeout:
-    case Event::StoppingCharging:
-    case Event::TransactionFinished:
         this->state = State::Finished;
+        break;
+    case Event::StoppingCharging:
+        this->state = State::FinishedEV;
+        break;
+    case Event::TransactionFinished: {
+        if (event.transaction_finished->reason == types::evse_manager::StopTransactionReason::Local) {
+            this->state = State::FinishedEVSE;
+        } else {
+            this->state = State::Finished;
+        }
+        break;
+    }
+    case Event::PluginTimeout:
+        this->state = State::AuthTimeout;
         break;
     case Event::ReservationStart:
         this->state = State::Reserved;
@@ -154,6 +165,12 @@ std::string SessionInfo::state_to_string(SessionInfo::State s) {
         return "Charging";
     case SessionInfo::State::Finished:
         return "Finished";
+    case SessionInfo::State::FinishedEVSE:
+        return "FinishedEVSE";
+    case SessionInfo::State::FinishedEV:
+        return "FinishedEV";
+    case SessionInfo::State::AuthTimeout:
+        return "AuthTimeout";
     }
     return "Unknown";
 }
@@ -364,7 +381,7 @@ void API::init() {
 
         evse->subscribe_session_event(
             [this, var_session_info, var_logging_path, &session_info](types::evse_manager::SessionEvent session_event) {
-                session_info->update_state(session_event.event);
+                session_info->update_state(session_event);
 
                 if (session_event.source.has_value()) {
                     const auto source = session_event.source.value();

--- a/modules/API/API.hpp
+++ b/modules/API/API.hpp
@@ -54,7 +54,7 @@ public:
         false}; ///< Indicate if end export energy value (optional) has been received or not
 
     void reset();
-    void update_state(const types::evse_manager::SessionEventEnum event);
+    void update_state(const types::evse_manager::SessionEvent event);
     void set_start_energy_import_wh(int32_t start_energy_import_wh);
     void set_end_energy_import_wh(int32_t end_energy_import_wh);
     void set_latest_energy_import_wh(int32_t latest_energy_wh);
@@ -95,7 +95,10 @@ private:
         ChargingPausedEV,
         ChargingPausedEVSE,
         Charging,
-        Finished
+        AuthTimeout,
+        Finished,
+        FinishedEVSE,
+        FinishedEV
     } state;
 
     bool is_state_charging(const SessionInfo::State current_state);

--- a/modules/API/README.md
+++ b/modules/API/README.md
@@ -77,6 +77,9 @@ This variable is published every second and contains a json object with informat
     - ChargingPausedEV
     - ChargingPausedEVSE
     - Finished
+    - FinishedEV
+    - FinishedEVSE
+    - AuthTimeout
 
 ### everest_api/evse_manager/var/limits
 This variable is published every second and contains a json object with information

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -735,7 +735,7 @@ void Charger::run_state_machine() {
         case EvseState::StoppingCharging:
             if (initialize_state) {
                 bcb_toggle_reset();
-                if (shared_context.transaction_active or shared_context.session_active) {
+                if (shared_context.transaction_active) {
                     signal_simple_event(types::evse_manager::SessionEventEnum::StoppingCharging);
                 }
 


### PR DESCRIPTION
## Describe your changes

One of the chargeX requirements is to show a different Finished state depending on whether the EV or the EVSE initiated the session stop.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

