### PR TITLE
Slac: avoid second chip reset if it was already performed before unplug

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -703,8 +703,12 @@ void EvseManager::ready() {
                 car_manufacturer = types::evse_manager::CarManufacturer::Unknown;
                 r_slac[0]->call_enter_bcd();
             } else if (event == CPEvent::CarUnplugged) {
+                // Make a local copy as leave_bcd() will overwrite the slac_unmatched flag
+                bool unmatched_on_unplug = not slac_unmatched;
                 r_slac[0]->call_leave_bcd();
-                r_slac[0]->call_reset(false);
+                if (unmatched_on_unplug) {
+                    r_slac[0]->call_reset(false);
+                }
             }
         }
 
@@ -796,8 +800,10 @@ void EvseManager::ready() {
             // Notify charger whether matching was started (or is done) or not
             if (s == "UNMATCHED") {
                 charger->set_matching_started(false);
+                slac_unmatched = true;
             } else {
                 charger->set_matching_started(true);
+                slac_unmatched = false;
             }
         });
 

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -351,6 +351,7 @@ private:
     static constexpr int CABLECHECK_SELFTEST_TIMEOUT{30};
 
     std::atomic_bool current_demand_active{false};
+    std::atomic_bool slac_unmatched{false};
     std::mutex powermeter_mutex;
     std::condition_variable powermeter_cv;
     bool initial_powermeter_value_received{false};


### PR DESCRIPTION
## Describe your changes

On unplug, slac was reset every time. Slac also needs to be reset whenever the iso session ends, leading to an unneccessary reset if the unplug happens directly after the session end (with no resumed charging etc)

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

