### PR TITLE
Fix empty exiResponse

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -213,7 +213,7 @@ void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118_char
 void ISO15118_chargerImpl::handle_certificate_response(
     types::iso15118_charger::ResponseExiStreamStatus& exi_stream_status) {
     pthread_mutex_lock(&v2g_ctx->mqtt_lock);
-    if (exi_stream_status.exi_response.has_value()) {
+    if (exi_stream_status.exi_response.has_value() and not exi_stream_status.exi_response.value().empty()) {
         v2g_ctx->evse_v2g_data.cert_install_res_b64_buffer = std::string(exi_stream_status.exi_response.value());
     }
     v2g_ctx->evse_v2g_data.cert_install_status =

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -761,8 +761,12 @@ void OCPP::ready() {
                const ocpp::v201::CertificateActionEnum& certificate_action) {
             types::iso15118_charger::ResponseExiStreamStatus response;
             response.status = conversions::to_everest_iso15118_charger_status(certificate_response.status);
-            response.exi_response.emplace(certificate_response.exiResponse.get());
             response.certificate_action = conversions::to_everest_certificate_action_enum(certificate_action);
+            if (not certificate_response.exiResponse.get().empty()) {
+                // since exi_response is an optional in the EVerest type we only set it when not empty
+                response.exi_response.emplace(certificate_response.exiResponse.get());
+            }
+
             this->r_evse_manager.at(this->connector_evse_index_map.at(connector_id))
                 ->call_set_get_certificate_response(response);
         });

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -795,10 +795,13 @@ void OCPP201::ready() {
                     conversions::to_ocpp_get_15118_certificate_request(certificate_request));
                 EVLOG_debug << "Received response from get_15118_ev_certificate_request: " << ocpp_response;
                 // transform response, inject action, send to associated EvseManager
-                const auto everest_response_status =
-                    conversions::to_everest_iso15118_charger_status(ocpp_response.status);
-                const types::iso15118_charger::ResponseExiStreamStatus everest_response{
-                    everest_response_status, certificate_request.certificate_action, ocpp_response.exiResponse};
+                types::iso15118_charger::ResponseExiStreamStatus everest_response;
+                everest_response.status = conversions::to_everest_iso15118_charger_status(ocpp_response.status);
+                everest_response.certificate_action = certificate_request.certificate_action;
+                if (not ocpp_response.exiResponse.get().empty()) {
+                    // since exi_response is an optional in the EVerest type we only set it when not empty
+                    everest_response.exi_response = ocpp_response.exiResponse.get();
+                }
                 this->r_evse_manager.at(evse_id - 1)->call_set_get_certificate_response(everest_response);
             });
 


### PR DESCRIPTION
## Describe your changes
Fixed issue in EvseV2G and OCPP modules. The exiResponse is a required value in the OCPP type but its optional in the EVerest type. This could lead to the situation that the EvseV2G module receives an empty exiResponse that could lead to a segmentation fault. This commit only sets the exiResponse in OCPP when not empty and adds an additional check to EvseV2G to check if the exiResponse string is not empty

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

