### PR TITLE
SlacSimulator initialize state with UNMATCHED

### DIFF
--- a/modules/simulation/SlacSimulator/CMakeLists.txt
+++ b/modules/simulation/SlacSimulator/CMakeLists.txt
@@ -9,6 +9,11 @@ ev_setup_cpp_module()
 
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 # insert your custom targets and additional config variables here
+target_compile_options(${MODULE_NAME}
+    PRIVATE
+        -Wimplicit-fallthrough
+        -Werror=switch-enum
+)
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 
 target_sources(${MODULE_NAME}

--- a/modules/simulation/SlacSimulator/ev/ev_slacImpl.hpp
+++ b/modules/simulation/SlacSimulator/ev/ev_slacImpl.hpp
@@ -52,7 +52,7 @@ private:
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here
-    util::State state;
+    util::State state{util::State::UNMATCHED};
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/simulation/SlacSimulator/evse/slacImpl.hpp
+++ b/modules/simulation/SlacSimulator/evse/slacImpl.hpp
@@ -59,7 +59,7 @@ private:
     void set_state_to_unmatched();
     void set_state_to_matching();
 
-    util::State state;
+    util::State state{util::State::UNMATCHED};
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/simulation/SlacSimulator/util/state.cpp
+++ b/modules/simulation/SlacSimulator/util/state.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 #include "state.hpp"
+#include <stdexcept>
 #include <string>
 
 namespace module::util {
@@ -13,9 +14,8 @@ std::string state_to_string(State state) {
         return "MATCHING";
     case State::MATCHED:
         return "MATCHED";
-    default:
-        return "";
     }
+    throw std::out_of_range("Could not convert State to string");
 }
 
 } // namespace module::util


### PR DESCRIPTION
This could publish an empty string on startup while an enum was expected, leading to failures when running EVerest with schema validation enabled

remove default empty string from state_to_string
enable -Werror=switch-enum for SlacSimulator module

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

