### PR TITLE
Move error handling in OCPP201

### DIFF
--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -299,26 +299,6 @@ void OCPP201::init() {
             }
         });
     }
-
-    const auto error_handler = [this](const Everest::error::Error& error) {
-        if (error.type == EVSE_MANAGER_INOPERATIVE_ERROR) {
-            // handled by specific evse_manager error handler
-            return;
-        }
-        const auto event_data = get_event_data(error, false, this->event_id_counter++);
-        this->charge_point->on_event({event_data});
-    };
-
-    const auto error_cleared_handler = [this](const Everest::error::Error& error) {
-        if (error.type == EVSE_MANAGER_INOPERATIVE_ERROR) {
-            // handled by specific evse_manager error handler
-            return;
-        }
-        const auto event_data = get_event_data(error, true, this->event_id_counter++);
-        this->charge_point->on_event({event_data});
-    };
-
-    subscribe_global_all_errors(error_handler, error_cleared_handler);
 }
 
 void OCPP201::ready() {
@@ -699,6 +679,26 @@ void OCPP201::ready() {
         evse_connector_structure, std::move(device_model_storage), this->ocpp_share_path.string(),
         this->config.CoreDatabasePath, sql_init_path.string(), this->config.MessageLogPath,
         std::make_shared<EvseSecurity>(*this->r_security), callbacks);
+
+    const auto error_handler = [this](const Everest::error::Error& error) {
+        if (error.type == EVSE_MANAGER_INOPERATIVE_ERROR) {
+            // handled by specific evse_manager error handler
+            return;
+        }
+        const auto event_data = get_event_data(error, false, this->event_id_counter++);
+        this->charge_point->on_event({event_data});
+    };
+
+    const auto error_cleared_handler = [this](const Everest::error::Error& error) {
+        if (error.type == EVSE_MANAGER_INOPERATIVE_ERROR) {
+            // handled by specific evse_manager error handler
+            return;
+        }
+        const auto event_data = get_event_data(error, true, this->event_id_counter++);
+        this->charge_point->on_event({event_data});
+    };
+
+    subscribe_global_all_errors(error_handler, error_cleared_handler);
 
     // publish charging schedules at least once on startup
     charging_schedules_callback();


### PR DESCRIPTION

## Describe your changes
Move error reporting to ready function to ensure charge_point object is initialized. This ensures charge_point is not accessed before it is initialized.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

