### PR TITLE
Reservation all connectors reserved (#958)

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ ext-mbedtls:
 # everest-testing and ev-dev-tools
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
-  git_tag: feature/raise_error
+  git_tag: v0.4.4
 
 # unit testing
 gtest:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ ext-mbedtls:
 # everest-testing and ev-dev-tools
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
-  git_tag: v0.4.3
+  git_tag: feature/raise_error
 
 # unit testing
 gtest:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: e7a37da3610e4cbf66dfbc58b9aa98fca2aa6cec
+  git_tag: e52ac969095804144af4896af1984cedaf45a3f8
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -49,8 +49,8 @@ cmds:
     arguments:
       reservation_id:
         description: >-
-          The reservation id (should be added to the TransactionStarted
-          event)
+          The reservation id (should be added to the TransactionStarted event). Negative value if there was
+          no specific reservation id for this evse (if there are 'global' reservations for 'any' evse).
         type: integer
     result:
       description: Returns true if the EVSE accepted the reservation, else false.

--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -49,8 +49,9 @@ cmds:
     arguments:
       reservation_id:
         description: >-
-          The reservation id (should be added to the TransactionStarted event). Negative value if there was
-          no specific reservation id for this evse (if there are 'global' reservations for 'any' evse).
+          The reservation id (should be added to the TransactionStarted event). Set this to a negative value if there is
+          no specific reservation id for this evse but the evse should still move to a Reserved state because of total
+          global reservations.
         type: integer
     result:
       description: Returns true if the EVSE accepted the reservation, else false.

--- a/modules/Auth/Auth.cpp
+++ b/modules/Auth/Auth.cpp
@@ -105,7 +105,7 @@ void Auth::ready() {
         [this](const std::optional<int32_t> evse_id, const int32_t reservation_id, const ReservationEndReason reason,
                const bool send_reservation_update) {
             // Only call the evse manager to cancel the reservation if it was for a specific evse
-            if (evse_id.has_value()) {
+            if (evse_id.has_value() && evse_id.value() > 0) {
                 EVLOG_debug << "Call evse manager to cancel the reservation with evse id " << evse_id.value();
                 this->r_evse_manager.at(evse_id.value() - 1)->call_cancel_reservation();
             }

--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -276,6 +276,7 @@ private:
                               const AuthorizationType& type);
     void submit_event_for_connector(const int32_t evse_id, const int32_t connector_id,
                                     const ConnectorEvent connector_event);
+    void check_evse_reserved_and_send_updates();
 };
 
 } // namespace module

--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -276,6 +276,11 @@ private:
                               const AuthorizationType& type);
     void submit_event_for_connector(const int32_t evse_id, const int32_t connector_id,
                                     const ConnectorEvent connector_event);
+    /**
+     * @brief Check reservations: if there are as many reservations as evse's, all should be set to reserved.
+     *
+     * This will check the reservation status of the evse's and send the statusses to the evse manager.
+     */
     void check_evse_reserved_and_send_updates();
 };
 

--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -134,6 +134,14 @@ public:
                                                                 const types::reservation::ReservationEndReason reason);
 
     ///
+    /// \brief Cancel a reservation.
+    /// \param evse_id              The evse id to cancel the reservation for.
+    /// \param execute_callback     True if the `reservation_cancelled_callback` must be called.
+    /// \return True if the reservation could be cancelled.
+    ///
+    bool cancel_reservation(const uint32_t evse_id, const bool execute_callback);
+
+    ///
     /// \brief Register reservation cancelled callback.
     /// \param callback The callback that should be called when a reservation is cancelled.
     ///

--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <vector>
 
 #include <Connector.hpp>
@@ -14,6 +15,11 @@
 class kvsIntf;
 
 namespace module {
+
+struct ReservationEvseStatus {
+    std::set<int32_t> reserved;
+    std::set<int32_t> available;
+};
 
 class ReservationHandler {
 private: // Members
@@ -44,6 +50,8 @@ private: // Members
     std::function<void(const std::optional<uint32_t>& evse_id, const int32_t reservation_id,
                        const types::reservation::ReservationEndReason reason, const bool send_reservation_update)>
         reservation_cancelled_callback;
+
+    ReservationEvseStatus last_status;
 
     /// \brief worker for the timers.
     boost::shared_ptr<boost::asio::io_service::work> work;
@@ -162,6 +170,8 @@ public:
     /// @return true if reservation for \p evse_id exists and reservation contains a parent_id
     ///
     bool has_reservation_parent_id(const std::optional<uint32_t> evse_id);
+
+    ReservationEvseStatus check_number_reservations_match_number_evses();
 
 private: // Functions
     ///

--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -179,6 +179,13 @@ public:
     ///
     bool has_reservation_parent_id(const std::optional<uint32_t> evse_id);
 
+    ///
+    /// \brief Check if the number of global reservations match the number of available evse's.
+    /// \return The new reservation status of the evse's.
+    ///
+    /// \note The return value has the new reserved and new available statusses (so the ones that were already reserved
+    ///       are not added to those lists).
+    ///
     ReservationEvseStatus check_number_global_reservations_match_number_available_evses();
 
 private: // Functions

--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -333,9 +333,18 @@ private: // Functions
     ///
     void store_reservations();
 
+    ///
+    /// \brief Get new reserved / available status for evse's and store it.
+    /// \param currently_available_evses    Current available evse's.
+    /// \param reserved_evses               Current reserved evse's.
+    /// \return A struct with changed reservation statuses compared with the last time this function was called.
+    ///
+    /// When an evse is reserved and it was available before, it will be added to the set in the struct (return value).
+    /// But when an evse is reserved and last time it was already reserved, it is not added.
+    ///
     ReservationEvseStatus
-    get_evse_global_reserved_status_and_set_new_status(const std::set<int32_t> currently_available_evses,
-                                                       const std::set<int32_t> reserved_evses);
+    get_evse_global_reserved_status_and_set_new_status(const std::set<int32_t>& currently_available_evses,
+                                                       const std::set<int32_t>& reserved_evses);
 
     ///
     /// \brief Helper function to print information about reservations and evses, to find out why a reservation has

--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -51,7 +51,7 @@ private: // Members
                        const types::reservation::ReservationEndReason reason, const bool send_reservation_update)>
         reservation_cancelled_callback;
 
-    ReservationEvseStatus last_status;
+    std::set<int32_t> last_reserved_status;
 
     /// \brief worker for the timers.
     boost::shared_ptr<boost::asio::io_service::work> work;
@@ -171,7 +171,7 @@ public:
     ///
     bool has_reservation_parent_id(const std::optional<uint32_t> evse_id);
 
-    ReservationEvseStatus check_number_reservations_match_number_evses();
+    ReservationEvseStatus check_number_global_reservations_match_number_available_evses();
 
 private: // Functions
     ///
@@ -317,6 +317,10 @@ private: // Functions
     /// \brief Store reservations to key value store.
     ///
     void store_reservations();
+
+    ReservationEvseStatus
+    get_evse_global_reserved_status_and_set_new_status(const std::set<int32_t> currently_available_evses,
+                                                       const std::set<int32_t> reserved_evses);
 
     ///
     /// \brief Helper function to print information about reservations and evses, to find out why a reservation has

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -850,8 +850,7 @@ void AuthHandler::check_evse_reserved_and_send_updates() {
     for (const auto& available_evse : reservation_status.available) {
         EVLOG_warning << "Evse " << available_evse << " is now available";
         this->reservation_cancelled_callback(available_evse, -1,
-                                             // TODO mz add correct reason
-                                             types::reservation::ReservationEndReason::Cancelled, false);
+                                             types::reservation::ReservationEndReason::GlobalReservationConnectorFree, false);
     }
 
     for (const auto& reserved_evse : reservation_status.reserved) {
@@ -859,7 +858,7 @@ void AuthHandler::check_evse_reserved_and_send_updates() {
         // TODO mz something with 'reserved' (what if it is not possible??? Cancel reservation???)
         const bool reserved = this->reserved_callback(reserved_evse, -1);
         if (!reserved) {
-            EVLOG_warning << "Could not reserve " << reserved_evse;
+            EVLOG_warning << "Could not reserve " << reserved_evse << " for non evse specific reservations";
         }
     }
 }

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -849,7 +849,7 @@ void AuthHandler::check_evse_reserved_and_send_updates() {
     for (const auto& available_evse : reservation_status.available) {
         EVLOG_debug << "Evse " << available_evse << " is now available";
         this->reservation_cancelled_callback(
-            available_evse, -1, types::reservation::ReservationEndReason::GlobalReservationConnectorFree, false);
+            available_evse, -1, types::reservation::ReservationEndReason::GlobalReservationRequirementDropped, false);
     }
 
     for (const auto& reserved_evse : reservation_status.reserved) {

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -854,9 +854,11 @@ void AuthHandler::check_evse_reserved_and_send_updates() {
 
     for (const auto& reserved_evse : reservation_status.reserved) {
         EVLOG_debug << "Evse " << reserved_evse << " is now reserved";
-        const bool reserved = this->reserved_callback(reserved_evse, -1);
-        if (!reserved) {
-            EVLOG_warning << "Could not reserve " << reserved_evse << " for non evse specific reservations";
+        if (this->reserved_callback != nullptr) {
+            const bool reserved = this->reserved_callback(reserved_evse, -1);
+            if (!reserved) {
+                EVLOG_warning << "Could not reserve " << reserved_evse << " for non evse specific reservations";
+            }
         }
     }
 }

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -848,8 +848,8 @@ void AuthHandler::check_evse_reserved_and_send_updates() {
         this->reservation_handler.check_number_global_reservations_match_number_available_evses();
     for (const auto& available_evse : reservation_status.available) {
         EVLOG_debug << "Evse " << available_evse << " is now available";
-        this->reservation_cancelled_callback(available_evse, -1,
-                                             types::reservation::ReservationEndReason::GlobalReservationConnectorFree, false);
+        this->reservation_cancelled_callback(
+            available_evse, -1, types::reservation::ReservationEndReason::GlobalReservationConnectorFree, false);
     }
 
     for (const auto& reserved_evse : reservation_status.reserved) {

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -725,7 +725,11 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
         check_reservations = true;
         break;
     case SessionEventEnum::ReservationStart:
+        break;
     case SessionEventEnum::ReservationEnd: {
+        if (reservation_handler.is_evse_reserved(evse_id)) {
+            reservation_handler.cancel_reservation(evse_id, true);
+        }
         break;
     }
     /// explicitly fall through all the SessionEventEnum values we are not handling

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -687,7 +687,6 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
                     }
 
                     this->evses.at(evse_id)->plugged_in = false;
-                    // TODO mz check reservations here as well??
                 },
                 std::chrono::seconds(this->connection_timeout));
         }
@@ -761,10 +760,8 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
     }
     this->evses.at(evse_id)->event_mutex.unlock();
 
-    // TODO mz make sure this does not create a loop.
     // When reservation is started or ended, check if the number of reservations match the number of evses and
     // send 'reserved' notifications to the evse manager accordingly if needed.
-    // TODO mz will 'ReservationEnd' also be sent when a reservation is used???
     if (check_reservations) {
         check_evse_reserved_and_send_updates();
     }

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -625,7 +625,7 @@ void AuthHandler::call_reservation_cancelled(const int32_t reservation_id,
                                              const std::optional<int>& evse_id, const bool send_reservation_update) {
     std::optional<int32_t> evse_index;
     if (evse_id.has_value() && evse_id.value() > 0) {
-        EVLOG_info << "Cancel reservation for evse id" << evse_id.value();
+        EVLOG_info << "Cancel reservation for evse id " << evse_id.value();
     }
 
     this->reservation_cancelled_callback(evse_id, reservation_id, reason, send_reservation_update);
@@ -855,7 +855,6 @@ void AuthHandler::check_evse_reserved_and_send_updates() {
 
     for (const auto& reserved_evse : reservation_status.reserved) {
         EVLOG_warning << "Evse " << reserved_evse << " is now reserved";
-        // TODO mz something with 'reserved' (what if it is not possible??? Cancel reservation???)
         const bool reserved = this->reserved_callback(reserved_evse, -1);
         if (!reserved) {
             EVLOG_warning << "Could not reserve " << reserved_evse << " for non evse specific reservations";

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -844,17 +844,16 @@ void AuthHandler::submit_event_for_connector(const int32_t evse_id, const int32_
 }
 
 void AuthHandler::check_evse_reserved_and_send_updates() {
-    EVLOG_warning << "Check evse reserved and send updates";
     ReservationEvseStatus reservation_status =
         this->reservation_handler.check_number_global_reservations_match_number_available_evses();
     for (const auto& available_evse : reservation_status.available) {
-        EVLOG_warning << "Evse " << available_evse << " is now available";
+        EVLOG_debug << "Evse " << available_evse << " is now available";
         this->reservation_cancelled_callback(available_evse, -1,
                                              types::reservation::ReservationEndReason::GlobalReservationConnectorFree, false);
     }
 
     for (const auto& reserved_evse : reservation_status.reserved) {
-        EVLOG_warning << "Evse " << reserved_evse << " is now reserved";
+        EVLOG_debug << "Evse " << reserved_evse << " is now reserved";
         const bool reserved = this->reserved_callback(reserved_evse, -1);
         if (!reserved) {
             EVLOG_warning << "Could not reserve " << reserved_evse << " for non evse specific reservations";

--- a/modules/Auth/lib/ReservationHandler.cpp
+++ b/modules/Auth/lib/ReservationHandler.cpp
@@ -1,7 +1,6 @@
 #include <ReservationHandler.hpp>
 
 #include <algorithm>
-#include <iostream>
 
 #include <Connector.hpp>
 
@@ -414,7 +413,6 @@ bool ReservationHandler::has_reservation_parent_id(const std::optional<uint32_t>
 }
 
 ReservationEvseStatus ReservationHandler::check_number_global_reservations_match_number_available_evses() {
-    ReservationEvseStatus evse_status;
     std::set<int32_t> available_evses;
     std::unique_lock<std::recursive_mutex> lock(this->evse_mutex);
     // Get all evse's that are not reserved or used.

--- a/modules/Auth/lib/ReservationHandler.cpp
+++ b/modules/Auth/lib/ReservationHandler.cpp
@@ -403,7 +403,7 @@ bool ReservationHandler::has_reservation_parent_id(const std::optional<uint32_t>
 ReservationEvseStatus ReservationHandler::check_number_global_reservations_match_number_available_evses() {
     ReservationEvseStatus evse_status;
     std::set<int32_t> available_evses;
-    // TODO mz mutex
+    std::unique_lock<std::recursive_mutex> lock(this->evse_mutex);
     // Get all evse's that are not reserved or used.
     for (const auto& evse : this->evses) {
         if (get_evse_connector_state_reservation_result(static_cast<uint32_t>(evse.first), this->evse_reservations) ==
@@ -415,7 +415,7 @@ ReservationEvseStatus ReservationHandler::check_number_global_reservations_match
         }
     }
 
-    // TODO mz what if we do not have the correct latest status, is this going well here?
+    std::unique_lock<std::recursive_mutex> reservation_lock(this->reservation_mutex);
     if (available_evses.size() == this->global_reservations.size()) {
         // There are as many evses available as 'global' reservations, so all evse's are reserved. Set all available
         // evse's to reserved.

--- a/modules/Auth/lib/ReservationHandler.cpp
+++ b/modules/Auth/lib/ReservationHandler.cpp
@@ -334,7 +334,7 @@ void ReservationHandler::register_reservation_cancelled_callback(
 
 void ReservationHandler::on_reservation_used(const int32_t reservation_id) {
     const std::pair<bool, std::optional<uint32_t>> cancelled =
-        this->cancel_reservation(reservation_id, true, types::reservation::ReservationEndReason::UsedToStartCharging);
+        this->cancel_reservation(reservation_id, false, types::reservation::ReservationEndReason::UsedToStartCharging);
     if (cancelled.first) {
         if (cancelled.second.has_value()) {
             EVLOG_info << "Reservation (" << reservation_id << ") for evse#" << cancelled.second.value()

--- a/modules/Auth/lib/ReservationHandler.cpp
+++ b/modules/Auth/lib/ReservationHandler.cpp
@@ -804,7 +804,7 @@ void ReservationHandler::store_reservations() {
 }
 
 ReservationEvseStatus ReservationHandler::get_evse_global_reserved_status_and_set_new_status(
-    const std::set<int32_t> currently_available_evses, const std::set<int32_t> reserved_evses) {
+    const std::set<int32_t>& currently_available_evses, const std::set<int32_t>& reserved_evses) {
     ReservationEvseStatus evse_status_to_send;
     std::set<int32_t> new_reserved_evses;
 

--- a/modules/Auth/lib/ReservationHandler.cpp
+++ b/modules/Auth/lib/ReservationHandler.cpp
@@ -313,6 +313,19 @@ ReservationHandler::cancel_reservation(const int reservation_id, const bool exec
     return result;
 }
 
+bool ReservationHandler::cancel_reservation(const uint32_t evse_id, const bool execute_callback) {
+    auto it = this->evse_reservations.find(evse_id);
+    if (it != this->evse_reservations.end()) {
+        int reservation_id = it->second.reservation_id;
+        return this
+            ->cancel_reservation(reservation_id, execute_callback, types::reservation::ReservationEndReason::Cancelled)
+            .first;
+    } else {
+        EVLOG_warning << "Could not cancel reservation with evse id " << evse_id;
+        return false;
+    }
+}
+
 void ReservationHandler::register_reservation_cancelled_callback(
     const std::function<void(const std::optional<uint32_t>& evse_id, const int32_t reservation_id,
                              const types::reservation::ReservationEndReason reason,

--- a/modules/Auth/tests/reservation_tests.cpp
+++ b/modules/Auth/tests/reservation_tests.cpp
@@ -949,14 +949,14 @@ TEST_F(ReservationHandlerTest, reservation_timer) {
     Reservation reservation = create_reservation(types::evse_manager::ConnectorTypeEnum::cCCS2);
     reservation.expiry_time = Everest::Date::to_rfc3339(date::utc_clock::now() + std::chrono::seconds(1));
     EXPECT_EQ(r.make_reservation(std::nullopt, reservation), ReservationResult::Accepted);
-    sleep(1);
+    sleep(2);
     EXPECT_FALSE(evse_id.has_value());
 
     EXPECT_CALL(reservation_callback_mock, Call(_, 0, ReservationEndReason::Expired, true))
         .WillOnce(SaveArg<0>(&evse_id));
     reservation.expiry_time = Everest::Date::to_rfc3339(date::utc_clock::now() + std::chrono::seconds(1));
     EXPECT_EQ(r.make_reservation(0, reservation), ReservationResult::Accepted);
-    sleep(1);
+    sleep(2);
     ASSERT_TRUE(evse_id.has_value());
     EXPECT_EQ(evse_id.value(), 0);
 }
@@ -1153,7 +1153,7 @@ TEST_F(ReservationHandlerTest, on_reservation_used) {
 
     r.register_reservation_cancelled_callback(reservation_callback_mock.AsStdFunction());
 
-    EXPECT_CALL(reservation_callback_mock, Call(_, _, _, true)).Times(3);
+    EXPECT_CALL(reservation_callback_mock, Call(_, _, _, true)).Times(0);
 
     add_connector(0, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
     add_connector(0, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);

--- a/modules/Auth/tests/reservation_tests.cpp
+++ b/modules/Auth/tests/reservation_tests.cpp
@@ -1405,14 +1405,14 @@ TEST_F(ReservationHandlerTest, check_evses_to_reserve_scenario_5) {
 
     EXPECT_TRUE(s.available.empty());
     ASSERT_EQ(s.reserved.size(), 1);
-    EXPECT_EQ(s.reserved.count(1), 1);
+    EXPECT_EQ(s.reserved.count(0), 1);
 
-    this->evses.at(0)->connectors.at(0).submit_event(ConnectorEvent::SESSION_FINISHED);
+    this->evses.at(1)->connectors.at(0).submit_event(ConnectorEvent::SESSION_FINISHED);
 
     s = r.check_number_global_reservations_match_number_available_evses();
 
     ASSERT_EQ(s.available.size(), 1);
-    EXPECT_EQ(s.available.count(1), 1);
+    EXPECT_EQ(s.available.count(0), 1);
     EXPECT_TRUE(s.reserved.empty());
 }
 

--- a/modules/Auth/tests/reservation_tests.cpp
+++ b/modules/Auth/tests/reservation_tests.cpp
@@ -1275,4 +1275,145 @@ TEST_F(ReservationHandlerTest, store_load_reservations_connector_unavailable) {
     EXPECT_EQ(r.reservation_id_to_reservation_timeout_timer_map.size(), 1);
 }
 
+TEST_F(ReservationHandlerTest, check_evses_to_reserve_scenario_1) {
+    add_connector(0, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(0, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+    add_connector(1, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(1, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+
+    ReservationEvseStatus s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    EXPECT_TRUE(s.reserved.empty());
+
+    EXPECT_EQ(r.make_reservation(1, create_reservation(types::evse_manager::ConnectorTypeEnum::cCCS2)),
+              ReservationResult::Accepted);
+
+    s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    EXPECT_TRUE(s.reserved.empty());
+
+    EXPECT_EQ(r.make_reservation(std::nullopt, create_reservation(types::evse_manager::ConnectorTypeEnum::cCCS2)),
+              ReservationResult::Accepted);
+
+    s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    ASSERT_EQ(s.reserved.size(), 1);
+    EXPECT_EQ(s.reserved.count(0), 1);
+}
+
+TEST_F(ReservationHandlerTest, check_evses_to_reserve_scenario_2) {
+    add_connector(0, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(0, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+    add_connector(1, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(1, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+
+    ReservationEvseStatus s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    EXPECT_TRUE(s.reserved.empty());
+
+    EXPECT_EQ(r.make_reservation(std::nullopt, create_reservation(types::evse_manager::ConnectorTypeEnum::cCCS2)),
+              ReservationResult::Accepted);
+
+    s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    EXPECT_TRUE(s.reserved.empty());
+
+    EXPECT_EQ(r.make_reservation(std::nullopt, create_reservation(types::evse_manager::ConnectorTypeEnum::cCCS2)),
+              ReservationResult::Accepted);
+
+    s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    ASSERT_EQ(s.reserved.size(), 2);
+    EXPECT_EQ(s.reserved.count(0), 1);
+    EXPECT_EQ(s.reserved.count(1), 1);
+}
+
+TEST_F(ReservationHandlerTest, check_evses_to_reserve_scenario_3) {
+    add_connector(0, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(1, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(1, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+
+    ReservationEvseStatus s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    EXPECT_TRUE(s.reserved.empty());
+
+    EXPECT_EQ(r.make_reservation(std::nullopt, create_reservation(types::evse_manager::ConnectorTypeEnum::cType2)),
+              ReservationResult::Accepted);
+
+    s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    ASSERT_EQ(s.reserved.size(), 1);
+    EXPECT_EQ(s.reserved.count(1), 1);
+}
+
+TEST_F(ReservationHandlerTest, check_evses_to_reserve_scenario_4) {
+    add_connector(0, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(0, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+    add_connector(1, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(1, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+
+    this->evses.at(0)->plugged_in = true;
+
+    ReservationEvseStatus s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    EXPECT_TRUE(s.reserved.empty());
+
+    EXPECT_EQ(r.make_reservation(std::nullopt, create_reservation(types::evse_manager::ConnectorTypeEnum::cType2)),
+              ReservationResult::Accepted);
+
+    s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    ASSERT_EQ(s.reserved.size(), 1);
+    EXPECT_EQ(s.reserved.count(1), 1);
+
+    this->evses.at(0)->plugged_in = false;
+
+    s = r.check_number_global_reservations_match_number_available_evses();
+
+    ASSERT_EQ(s.available.size(), 1);
+    EXPECT_EQ(s.available.count(1), 1);
+    EXPECT_TRUE(s.reserved.empty());
+}
+
+TEST_F(ReservationHandlerTest, check_evses_to_reserve_scenario_5) {
+    add_connector(0, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(0, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+    add_connector(1, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(1, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+
+    this->evses.at(1)->connectors.at(0).submit_event(ConnectorEvent::TRANSACTION_STARTED);
+
+    ReservationEvseStatus s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    EXPECT_TRUE(s.reserved.empty());
+
+    EXPECT_EQ(r.make_reservation(std::nullopt, create_reservation(types::evse_manager::ConnectorTypeEnum::cType2)),
+              ReservationResult::Accepted);
+
+    s = r.check_number_global_reservations_match_number_available_evses();
+
+    EXPECT_TRUE(s.available.empty());
+    ASSERT_EQ(s.reserved.size(), 1);
+    EXPECT_EQ(s.reserved.count(1), 1);
+
+    this->evses.at(0)->connectors.at(0).submit_event(ConnectorEvent::SESSION_FINISHED);
+
+    s = r.check_number_global_reservations_match_number_available_evses();
+
+    ASSERT_EQ(s.available.size(), 1);
+    EXPECT_EQ(s.available.count(1), 1);
+    EXPECT_TRUE(s.reserved.empty());
+}
+
 } // namespace module

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1270,20 +1270,22 @@ bool EvseManager::reserve(int32_t id, const bool signal_reservation_event) {
 
     const bool overwrite_reservation = (this->reservation_id == id);
 
-    if (reserved) {
-        EVLOG_info << "Rejecting reservation because evse is already reserved";
+    if (reserved && this->reservation_id != -1) {
+        EVLOG_info << "Rejecting reservation because evse is already reserved for reservation id "
+                   << this->reservation_id;
     }
 
     // Check if this evse is not already reserved, or overwrite reservation if it is for the same reservation id.
-    if (not reserved || overwrite_reservation) {
+    if (not reserved || this->reservation_id == -1 || overwrite_reservation) {
         EVLOG_debug << "Make the reservation with id " << id;
         reserved = true;
         if (id >= 0) {
-            reservation_id = id;
+            this->reservation_id = id;
         }
 
         // When overwriting the reservation, don't signal.
-        if (not overwrite_reservation && signal_reservation_event) {
+        if ((not overwrite_reservation || (overwrite_reservation && this->reservation_id == -1)) &&
+            signal_reservation_event) {
             // publish event to other modules
             types::evse_manager::SessionEvent se;
             se.event = types::evse_manager::SessionEventEnum::ReservationStart;
@@ -1305,7 +1307,7 @@ void EvseManager::cancel_reservation(bool signal_event) {
     if (reserved) {
         EVLOG_debug << "Reservation cancelled";
         reserved = false;
-        reservation_id = -1;
+        this->reservation_id = -1;
 
         // publish event to other modules
         if (signal_event) {

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1278,7 +1278,9 @@ bool EvseManager::reserve(int32_t id, const bool signal_reservation_event) {
     if (not reserved || overwrite_reservation) {
         EVLOG_debug << "Make the reservation with id " << id;
         reserved = true;
-        reservation_id = id;
+        if (id >= 0) {
+            reservation_id = id;
+        }
 
         // When overwriting the reservation, don't signal.
         if (not overwrite_reservation && signal_reservation_event) {

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1284,8 +1284,7 @@ bool EvseManager::reserve(int32_t id, const bool signal_reservation_event) {
         }
 
         // When overwriting the reservation, don't signal.
-        if ((not overwrite_reservation || (overwrite_reservation && this->reservation_id == -1)) &&
-            signal_reservation_event) {
+        if ((not overwrite_reservation || this->reservation_id == -1) && signal_reservation_event) {
             // publish event to other modules
             types::evse_manager::SessionEvent se;
             se.event = types::evse_manager::SessionEventEnum::ReservationStart;

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -175,6 +175,9 @@ void evse_managerImpl::ready() {
             session_started.id_tag = provided_id_token;
             if (mod->is_reserved()) {
                 session_started.reservation_id = mod->get_reservation_id();
+                if (start_reason == types::evse_manager::StartSessionReason::Authorized) {
+                    this->mod->cancel_reservation(true);
+                }
             }
 
             session_started.logging_path = session_log.startSession(
@@ -206,7 +209,7 @@ void evse_managerImpl::ready() {
         transaction_started.meter_value = mod->get_latest_powermeter_data_billing();
         if (mod->is_reserved()) {
             transaction_started.reservation_id.emplace(mod->get_reservation_id());
-            mod->cancel_reservation(false);
+            mod->cancel_reservation(true);
         }
 
         transaction_started.id_tag = id_token;
@@ -292,7 +295,7 @@ void evse_managerImpl::ready() {
             // Cancel reservation, reservation might be stored when swiping rfid, but timed out, so we should not
             // set the reservation id here.
             if (mod->is_reserved()) {
-                mod->cancel_reservation(false);
+                mod->cancel_reservation(true);
             }
             session_log.stopSession();
             mod->telemetry.publish("session", "events",

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -1114,7 +1114,9 @@ void OCPP201::process_transaction_started(const int32_t evse_id, const int32_t c
     auto tx_event = TxEvent::AUTHORIZED;
     auto trigger_reason = ocpp::v201::TriggerReasonEnum::Authorized;
     const auto transaction_started = session_event.transaction_started.value();
-    transaction_data->reservation_id = transaction_started.reservation_id;
+    if (transaction_started.reservation_id.has_value()) {
+        transaction_data->reservation_id = transaction_started.reservation_id;
+    }
     transaction_data->remote_start_id = transaction_started.id_tag.request_id;
     const auto id_token = conversions::to_ocpp_id_token(transaction_started.id_tag.id_token);
     transaction_data->id_token = id_token;

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-ocpp201.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-ocpp201.yaml
@@ -125,6 +125,9 @@ active_modules:
       security:
         - module_id: evse_security
           implementation_id: main
+      reservation:
+        - module_id: auth
+          implementation_id: reservation
   persistent_store:
     module: PersistentStore
     config_module:

--- a/tests/ocpp_tests/test_sets/everest_test_utils.py
+++ b/tests/ocpp_tests/test_sets/everest_test_utils.py
@@ -374,6 +374,7 @@ def get_everest_config(function_name, module_name):
         "local_authorization_list",
         "transactions",
         "meterValues",
+        "reservations",
     ]:
         return Path(__file__).parent / Path(
             "everest-aux/config/everest-config-ocpp201.yaml"

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -4661,30 +4661,117 @@ async def test_reservation_connector_rejected(
     )
 
 
-@pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="Libocpp currently doesnt support ReserveConnectorZeroSupported"
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Reservation", "ReserveConnectorZeroSupported", False)])
 )
-async def test_reservation_transaction(
-    charge_point_v16: ChargePoint16, test_utility: TestUtility
+@pytest.mark.asyncio
+async def test_reservation_connector_zero_not_supported(
+    charge_point_v16: ChargePoint16, test_utility: TestUtility, test_config: OcppTestConfiguration
 ):
-    logging.info("######### test_reservation_transaction #########")
+    logging.info("######### test_reservation_connector_zero_not_supported #########")
 
-    # FIXME: implement this missing testcase!
-
-    await charge_point_v16.change_configuration_req(
-        key="ReserveConnectorZeroSupported", value="true"
+    await charge_point_v16.reserve_now_req(
+        connector_id=0,
+        expiry_date=(datetime.utcnow() + timedelta(minutes=10)).isoformat(),
+        id_tag=test_config.authorization_info.valid_id_tag_1,
+        reservation_id=0,
     )
+
+    # expect ReserveNow.conf with status rejected
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
-        "ChangeConfiguration",
-        call_result.ChangeConfigurationPayload(ConfigurationStatus.accepted),
+        "ReserveNow",
+        call_result.ReserveNowPayload(ReservationStatus.rejected),
+    )
+
+
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP16ConfigAdjustment([("Reservation", "ReserveConnectorZeroSupported", True)])
+)
+@pytest.mark.asyncio
+async def test_reservation_connector_zero_supported(
+        charge_point_v16: ChargePoint16,
+        test_utility: TestUtility,
+        test_config: OcppTestConfiguration,
+        test_controller: TestController,
+):
+    logging.info("######### test_reservation_connector_zero_supported #########")
+
+    await charge_point_v16.reserve_now_req(
+        connector_id=0,
+        expiry_date=(datetime.utcnow() + timedelta(minutes=10)).isoformat(),
+        id_tag=test_config.authorization_info.valid_id_tag_1,
+        reservation_id=0,
+    )
+
+    # expect ReserveNow.conf with status rejected
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "ReserveNow",
+        call_result.ReserveNowPayload(ReservationStatus.accepted),
+    )
+
+    # expect StatusNotification with status preparing
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        call.StatusNotificationPayload(
+            0, ChargePointErrorCode.no_error, ChargePointStatus.reserved
+        ),
+    )
+
+    # expect StatusNotification with status preparing
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        call.StatusNotificationPayload(
+            1, ChargePointErrorCode.no_error, ChargePointStatus.reserved
+        ),
+    )
+
+    # swipe valid id tag to authorize
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
+
+    # expect StatusNotification with status preparing
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        call.StatusNotificationPayload(
+            1, ChargePointErrorCode.no_error, ChargePointStatus.preparing
+        ),
+    )
+
+    # start charging session
+    test_controller.plug_in()
+
+    # expect StartTransaction.req
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StartTransaction",
+        call.StartTransactionPayload(
+            1, test_config.authorization_info.valid_id_tag_1, 0, ""
+        ),
+        validate_standard_start_transaction,
+    )
+
+    # expect StatusNotification with status charging
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        call.StatusNotificationPayload(
+            1, ChargePointErrorCode.no_error, ChargePointStatus.charging
+        ),
     )
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="EVerest SIL currently does not support faulted state")
 async def test_reservation_faulted_state(
     test_config: OcppTestConfiguration,
     charge_point_v16: ChargePoint16,
@@ -4693,7 +4780,7 @@ async def test_reservation_faulted_state(
 ):
     logging.info("######### test_reservation_faulted_state #########")
 
-    test_controller.diode_fail()
+    test_controller.raise_error(1)
 
     # expect StatusNotification with status faulted
     assert await wait_for_and_validate(
@@ -4701,7 +4788,7 @@ async def test_reservation_faulted_state(
         charge_point_v16,
         "StatusNotification",
         call.StatusNotificationPayload(
-            1, ChargePointErrorCode.ground_failure, ChargePointStatus.faulted
+            1, ChargePointErrorCode.other_error, ChargePointStatus.faulted
         ),
     )
     await charge_point_v16.reserve_now_req(
@@ -4718,6 +4805,8 @@ async def test_reservation_faulted_state(
         "ReserveNow",
         call_result.ReserveNowPayload(ReservationStatus.faulted),
     )
+
+    test_controller.clear_error(1)
 
 
 @pytest.mark.asyncio
@@ -4899,13 +4988,13 @@ async def test_reservation_cancel_rejected(
 
 
 @pytest.mark.asyncio
-async def test_reservation_with_partentid(
+async def test_reservation_with_parentid(
     test_config: OcppTestConfiguration,
     charge_point_v16: ChargePoint16,
     test_utility: TestUtility,
     test_controller: TestController,
 ):
-    logging.info("######### test_reservation_with_partentid #########")
+    logging.info("######### test_reservation_with_parentid #########")
 
     # authorize.conf with parent id tag
     @on(Action.Authorize)

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -4713,17 +4713,17 @@ async def test_reservation_connector_zero_supported(
         call_result.ReserveNowPayload(ReservationStatus.accepted),
     )
 
-    # expect StatusNotification with status preparing
-    assert await wait_for_and_validate(
-        test_utility,
-        charge_point_v16,
-        "StatusNotification",
-        call.StatusNotificationPayload(
-            0, ChargePointErrorCode.no_error, ChargePointStatus.reserved
-        ),
-    )
+    # # expect StatusNotification with status reserved
+    # assert await wait_for_and_validate(
+    #     test_utility,
+    #     charge_point_v16,
+    #     "StatusNotification",
+    #     call.StatusNotificationPayload(
+    #         0, ChargePointErrorCode.no_error, ChargePointStatus.reserved
+    #     ),
+    # )
 
-    # expect StatusNotification with status preparing
+    # expect StatusNotification with status reserved
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -4798,9 +4798,7 @@ async def test_reservation_faulted_state(
         call_result.ReserveNowPayload(ReservationStatus.faulted),
     )
 
-    test_controller.clear_error(1)
-
-    await asyncio.sleep(1)
+    test_controller.clear_error("MREC6UnderVoltage", 1)
 
 
 @pytest.mark.asyncio

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -4713,16 +4713,6 @@ async def test_reservation_connector_zero_supported(
         call_result.ReserveNowPayload(ReservationStatus.accepted),
     )
 
-    # # expect StatusNotification with status reserved
-    # assert await wait_for_and_validate(
-    #     test_utility,
-    #     charge_point_v16,
-    #     "StatusNotification",
-    #     call.StatusNotificationPayload(
-    #         0, ChargePointErrorCode.no_error, ChargePointStatus.reserved
-    #     ),
-    # )
-
     # expect StatusNotification with status reserved
     assert await wait_for_and_validate(
         test_utility,
@@ -4782,6 +4772,8 @@ async def test_reservation_faulted_state(
 
     test_controller.raise_error(1)
 
+    await asyncio.sleep(1)
+
     # expect StatusNotification with status faulted
     assert await wait_for_and_validate(
         test_utility,
@@ -4807,6 +4799,8 @@ async def test_reservation_faulted_state(
     )
 
     test_controller.clear_error(1)
+
+    await asyncio.sleep(1)
 
 
 @pytest.mark.asyncio

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -4770,7 +4770,7 @@ async def test_reservation_faulted_state(
 ):
     logging.info("######### test_reservation_faulted_state #########")
 
-    test_controller.raise_error(1)
+    test_controller.raise_error("MREC6UnderVoltage", 1)
 
     await asyncio.sleep(1)
 

--- a/tests/ocpp_tests/test_sets/ocpp201/reservations.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/reservations.py
@@ -1,0 +1,1144 @@
+import pytest_asyncio
+import pytest
+import logging
+from unittest.mock import ANY
+
+from everest.testing.ocpp_utils.charge_point_v201 import ChargePoint201
+from everest.testing.ocpp_utils.charge_point_utils import wait_for_and_validate, TestUtility
+from everest.testing.ocpp_utils.fixtures import *
+from everest.testing.core_utils.controller.test_controller_interface import TestController
+from everest.testing.core_utils._configuration.libocpp_configuration_helper import GenericOCPP201ConfigAdjustment
+from everest_test_utils import *
+
+from ocpp.v201.enums import (IdTokenType as IdTokenTypeEnum, ReserveNowStatusType, ConnectorStatusType,
+                             OperationalStatusType, CancelReservationStatusType, SetVariableStatusType,
+                             RequestStartStopStatusType, AttributeType)
+from ocpp.v201.datatypes import *
+from ocpp.v201 import call as call_201
+from ocpp.v201 import call_result as call_result201
+from validations import (validate_standard_start_transaction,
+                         validate_standard_stop_transaction,
+                         validate_remote_start_stop_transaction,
+                         validate_status_notification_201)
+from ocpp.routing import on, create_route_map
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_local_start_tx(
+        test_config: OcppTestConfiguration,
+        charge_point_v201: ChargePoint201,
+        test_controller: TestController,
+        test_utility: TestUtility,
+):
+    """
+    Test making a reservation and start a transaction on the reserved evse id with the correct id token.
+    """
+    logging.info("######### test_reservation_local_start_tx #########")
+
+    t = datetime.utcnow() + timedelta(minutes=10)
+
+    await charge_point_v201.reserve_now_req(
+        id=0,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # expect ReserveNow response with status accepted
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # expect StatusNotification with status reserved
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.reserved, 1, 1
+        ),
+    )
+
+    # swipe invalid id tag
+    test_controller.swipe(test_config.authorization_info.invalid_id_tag)
+
+    # swipe valid id tag to authorize
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
+
+    # expect StatusNotification with status available (reservation is now used)
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.available, 1, 1
+        ),
+    )
+
+    # start charging session
+    test_controller.plug_in()
+
+    # expect TransactionEvent with event type Started and the reservation id.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Started", "reservationId": 0}
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Updated"}
+    )
+
+    # expect StatusNotification with status occupied
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, 'Occupied', 1, 1
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_remote_start_tx(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    """
+    Test making a reservation and start a remote transaction on the reserved evse id with the correct id token.
+    """
+    logging.info("######### test_reservation_remote_start_tx #########")
+
+    t = datetime.utcnow() + timedelta(minutes=10)
+
+    # Make reservation for evse id 1.
+    await charge_point_v201.reserve_now_req(
+        id=0,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # expect ReserveNow response with status accepted
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # expect StatusNotification with status reserved
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.reserved, 1, 1
+        ),
+    )
+
+    # send start transaction request
+    await charge_point_v201.request_start_transaction_req(
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443), remote_start_id=1, evse_id=1
+    )
+
+    # Which should be accepted
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "RequestStartTransaction",
+        call_result201.RequestStartTransactionPayload(status="Accepted"),
+        validate_remote_start_stop_transaction,
+    )
+
+    # start charging session
+    test_controller.plug_in()
+
+    # expect StatusNotification with status available (because reservation is 'used')
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.available, 1, 1
+        ),
+    )
+
+    # expect StatusNotification with status occupied
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, 'Occupied', 1, 1
+        ),
+    )
+
+    # expect StartTransaction with the given reservation id
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Started", "reservationId": 0}
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Updated"}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_connector_expire(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    """
+    Test that a reservation can expire.
+    """
+    logging.info("######### test_reservation_connector_expire #########")
+
+    # Make a reservation with an expiry time ten seconds from now.
+    t = datetime.utcnow() + timedelta(seconds=10)
+
+    await charge_point_v201.reserve_now_req(
+        id=5,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # Reservation is accepted
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # expect StatusNotification with status reserved
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.reserved, 1, 1
+        ),
+    )
+
+    # Request to start transaction for the reserved evse but with another id token.
+    await charge_point_v201.request_start_transaction_req(
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_2,
+                             type=IdTokenTypeEnum.iso14443), remote_start_id=1, evse_id=1
+    )
+
+    # This will not succeed.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "RequestStartTransaction",
+        call_result201.RequestStartTransactionPayload(status="Rejected"),
+        validate_remote_start_stop_transaction,
+    )
+
+    # So we wait until the reservation is expired.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReservationStatusUpdate",
+        call_201.ReservationStatusUpdatePayload(
+            5, "Expired"
+        ),
+    )
+
+    # expect StatusNotification with status available
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.available, 1, 1
+        ),
+    )
+
+    # Try to start a transaction now on the previously reserved evse (which reservation is now expired).
+    await charge_point_v201.request_start_transaction_req(
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_2,
+                             type=IdTokenTypeEnum.iso14443), remote_start_id=1, evse_id=1
+    )
+
+    # Now it succeeds.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "RequestStartTransaction",
+        call_result201.RequestStartTransactionPayload(status="Accepted"),
+        validate_remote_start_stop_transaction,
+    )
+
+    # Start charging session
+    test_controller.plug_in()
+
+    # expect StatusNotification with status occupied
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, 'Occupied', 1, 1
+        ),
+    )
+
+    # expect TransactionEvent with event type 'Started'
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Started"}
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Updated"}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_connector_faulted(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    """
+    Test if an evse can be reserved when the evse status is 'Faulted'
+    """
+    logging.info("######### test_reservation_connector_faulted #########")
+
+    # Set evse in state 'faulted'
+    test_controller.raise_error()
+
+    await asyncio.sleep(10)
+
+    t = datetime.utcnow() + timedelta(minutes=10)
+
+    # Send a reserve new request
+    await charge_point_v201.reserve_now_req(
+        id=0,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # which should return 'faulted'
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.faulted),
+    )
+
+    test_controller.clear_error()
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_connector_faulted_after_reservation(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    """
+    Test if a reservation is cancelled after the evse status is 'Faulted'
+    """
+    logging.info("######### test_reservation_connector_faulted_after_reservation #########")
+
+    t = datetime.utcnow() + timedelta(minutes=10)
+    await charge_point_v201.reserve_now_req(
+        id=42,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # Set evse in state 'faulted'
+    test_controller.raise_error(1)
+
+    # This should result in the reservation being cancelled.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReservationStatusUpdate",
+        call_201.ReservationStatusUpdatePayload(
+            42, "Removed"
+        ),
+    )
+
+    test_controller.clear_error()
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_connector_occupied(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    """
+    Try to make a reservation while a evse is occupied.
+    """
+    logging.info("######### test_reservation_connector_occupied #########")
+
+    # start charging session
+    test_controller.plug_in()
+
+    # TODO mz fix comments everywhere in this file!!!
+    # expect StatusNotification with status occupied
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, 'Occupied', 1, 1
+        ),
+    )
+
+    t = datetime.utcnow() + timedelta(minutes=10)
+
+    await asyncio.sleep(2)
+
+    # Request reservation
+    await charge_point_v201.reserve_now_req(
+        id=0,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # expect ReserveNow response with status occupied
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.occupied),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_connector_unavailable(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_utility: TestUtility,
+):
+    """
+    Test making a reservation with an unavailable connector, this should return 'unavailable' on a reserve now request.
+    """
+    logging.info("######### test_reservation_connector_unavailable #########")
+
+    # Set evse id 1 to inoperative.
+    await charge_point_v201.change_availablility_req(
+        evse={'id': 1}, operational_status=OperationalStatusType.inoperative
+    )
+
+    t = datetime.utcnow() + timedelta(seconds=30)
+
+    # Make a reservation for evse id 1.
+    await charge_point_v201.reserve_now_req(
+        id=0,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # Which should fail (ReserveNow response 'Unavailable').
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.unavailable),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP201ConfigAdjustment(
+        [
+            (
+                OCPP201ConfigVariableIdentifier(
+                    "ReservationCtrlr", "ReservationCtrlrAvailable", "Actual"
+                ),
+                "false",
+            )
+        ]
+    )
+)
+async def test_reservation_connector_rejected(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    """
+    Test if reservation is rejected with the reservation ctrlr is not available.
+    """
+    logging.info("######### test_reservation_connector_rejected #########")
+
+    t = datetime.utcnow() + timedelta(seconds=10)
+
+    # Try to make reservation.
+    await charge_point_v201.reserve_now_req(
+        id=5,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # expect ReserveNow response with status rejected
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.rejected),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP201ConfigAdjustment(
+        [
+            (
+                OCPP201ConfigVariableIdentifier(
+                    "ReservationCtrlr", "ReservationCtrlrNonEvseSpecific", "Actual"
+                ),
+                "false",
+            )
+        ]
+    )
+)
+async def test_reservation_non_evse_specific_rejected(
+        test_config: OcppTestConfiguration,
+        charge_point_v201: ChargePoint201,
+        test_utility: TestUtility,
+        test_controller: TestController,
+):
+    """
+    Try to make a non-evse specific reservation, while that is not allowed according to the settings. That should fail.
+    """
+    logging.info("######### test_reservation_non_evse_specific_rejected #########")
+
+    t = datetime.utcnow() + timedelta(seconds=30)
+
+    # Try to make a reservation without evse id.
+    await charge_point_v201.reserve_now_req(
+        id=5,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat()
+    )
+
+    # expect ReserveNow respone with status rejected
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.rejected),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP201ConfigAdjustment(
+        [
+            (
+                OCPP201ConfigVariableIdentifier(
+                    "ReservationCtrlr", "ReservationCtrlrNonEvseSpecific", "Actual"
+                ),
+                "true",
+            )
+        ]
+    )
+)
+async def test_reservation_non_evse_specific_accepted(
+        test_config: OcppTestConfiguration,
+        charge_point_v201: ChargePoint201,
+        test_utility: TestUtility,
+        test_controller: TestController,
+):
+    """
+    Try to make a non evse specific reservation. This should succeed, according to the settings (devicemodel).
+    """
+    logging.info("######### test_reservation_non_evse_specific_accepted #########")
+
+    t = datetime.utcnow() + timedelta(seconds=30)
+
+    # Make reservation without evse id.
+    await charge_point_v201.reserve_now_req(
+        id=5,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat()
+    )
+
+    # This should be accepted.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # swipe valid id tag to authorize
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
+
+    # start charging session
+    test_controller.plug_in()
+
+    # expect TransactionEvent with event type 'Started' and the correct reservation id.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Started", "reservationId": 5}
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Updated"}
+    )
+
+    # expect StatusNotification with status occupied
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, 'Occupied', 1, 1
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP201ConfigAdjustment(
+        [
+            (
+                OCPP201ConfigVariableIdentifier(
+                    "ReservationCtrlr", "ReservationCtrlrNonEvseSpecific", "Actual"
+                ),
+                "true",
+            )
+        ]
+    )
+)
+async def test_reservation_non_evse_specific_accepted_multiple(
+        test_config: OcppTestConfiguration,
+        charge_point_v201: ChargePoint201,
+        test_utility: TestUtility,
+        test_controller: TestController,
+):
+    """
+    Try to make a non evse specific reservation. This should succeed, according to the settings (devicemodel).
+    When making multiple reservations, as soon as there are as many reservations as evse's available, the evse's should
+    go to occupied.
+    """
+    logging.info("######### test_reservation_non_evse_specific_accepted_multiple #########")
+
+    t = datetime.utcnow() + timedelta(seconds=30)
+
+    # Make reservation
+    await charge_point_v201.reserve_now_req(
+        id=5,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat()
+    )
+
+    # Expect it to be accepted.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # Make another reservation with another reservation id.
+    await charge_point_v201.reserve_now_req(
+        id=6,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat()
+    )
+
+    # expect This should be accepted as well.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # There are now as many reservations as evse's, so all evse's go to 'reserved'.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.reserved, 1, 1
+        ),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.reserved, 2, 1
+        ),
+    )
+
+    # There are now as many reservations as evse's, so another reservation is not possible.
+    await charge_point_v201.reserve_now_req(
+        id=7,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_2,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat()
+    )
+
+    # expect ReserveNow response with status occupied
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.occupied),
+    )
+
+    # swipe valid id tag to authorize
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
+
+    # start charging session
+    test_controller.plug_in()
+
+    # expect TransactionEvent 'Started' with the correct reservation id.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Started", "reservationId": 5}
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Updated"}
+    )
+
+    # expect StatusNotification with status charging
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, 'Occupied', 1, 1
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_faulted_state(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    """
+    Test if making a reservation is possible if the evse is in faulted state.
+    """
+    logging.info("######### test_reservation_faulted_state #########")
+
+    test_controller.raise_error(1)
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, 'Faulted', 1, 1
+        ),
+    )
+
+    t = datetime.utcnow() + timedelta(seconds=30)
+
+    # Try to make the reservation.
+    await charge_point_v201.reserve_now_req(
+        id=0,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # expect ReserveNow response with status 'Faulted'
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.faulted),
+    )
+
+    test_controller.clear_error(1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_cancel(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    """
+    Test if a reservation can be cancelled.
+    """
+    logging.info("######### test_reservation_cancel #########")
+
+    t = datetime.utcnow() + timedelta(minutes=10)
+
+    # Make the reservation
+    await charge_point_v201.reserve_now_req(
+        id=5,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # Expect it to be accepted.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # expect StatusNotification request with status reserved
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.reserved, 1, 1
+        ),
+    )
+
+    # Cancel the reservation.
+    await charge_point_v201.cancel_reservation_req(reservation_id=5)
+
+    # expect CancelReservation response with status accepted
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "CancelReservation",
+        call_result201.CancelReservationPayload(status=CancelReservationStatusType.accepted),
+    )
+
+    # expect StatusNotification with status available
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.available, 1, 1
+        ),
+    )
+
+    # start charging session
+    test_controller.plug_in()
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, 'Occupied', 1, 1
+        ),
+    )
+
+    # send request start transaction
+    await charge_point_v201.request_start_transaction_req(
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443), remote_start_id=1, evse_id=1
+    )
+
+    # Which should be accepted
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "RequestStartTransaction",
+        call_result201.RequestStartTransactionPayload(status="Accepted"),
+        validate_remote_start_stop_transaction,
+    )
+
+    # expect TransactionEvent with eventType 'Started'
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Started"}
+    )
+
+    # expect TransactionEvent with status 'Updated'
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Updated"}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_cancel_rejected(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_utility: TestUtility,
+):
+    """
+    Try to cancel a non existing reservation
+    """
+    logging.info("######### test_reservation_cancel_rejected #########")
+
+    t = datetime.utcnow() + timedelta(minutes=10)
+
+    # Make a reservation with reservation id 5
+    await charge_point_v201.reserve_now_req(
+        id=5,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # expect ReserveNow response with status accepted
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # expect StatusNotification with status reserved
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.reserved, 1, 1
+        ),
+    )
+
+    # Try to cancel reservation with reservation id 2, which does not exist.
+    await charge_point_v201.cancel_reservation_req(reservation_id=2)
+
+    # expect CancelReservation response with status rejected
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "CancelReservation",
+        call_result201.CancelReservationPayload(status=CancelReservationStatusType.rejected),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_with_parentid(
+    test_config: OcppTestConfiguration,
+    charge_point_v201: ChargePoint201,
+    test_utility: TestUtility,
+    test_controller: TestController,
+    central_system_v201: CentralSystem
+):
+    """
+    Test reservation with parent id.
+    """
+    logging.info("######### test_reservation_with_parentid #########")
+
+    # authorize.conf with parent id tag
+    @on(Action.Authorize)
+    def on_authorize(**kwargs):
+        id_tag_info = IdTokenInfoType(
+            status=AuthorizationStatusType.accepted,
+            group_id_token=IdTokenType(
+                id_token=test_config.authorization_info.parent_id_tag, type=IdTokenTypeEnum.iso14443
+            ),
+        )
+        return call_result201.AuthorizePayload(id_token_info=id_tag_info)
+
+    setattr(charge_point_v201, "on_authorize", on_authorize)
+    central_system_v201.chargepoint.route_map = create_route_map(
+        central_system_v201.chargepoint
+    )
+    charge_point_v201.route_map = create_route_map(charge_point_v201)
+
+    r: call_result201.SetVariablesPayload = (
+        await charge_point_v201.set_config_variables_req(
+            "AuthCtrlr", "AuthorizeRemoteStart", "true"
+        )
+    )
+
+    set_variable_result: SetVariableResultType = SetVariableResultType(
+        **r.set_variable_result[0]
+    )
+    assert set_variable_result.attribute_status == SetVariableStatusType.accepted
+
+    # Disable remote authorization so an 'Authorize' request is sent when starting remotely.
+    r: call_result201.SetVariablesPayload = (
+        await charge_point_v201.set_config_variables_req(
+            "AuthCtrlr", "DisableRemoteAuthorization", "false"
+        )
+    )
+
+    set_variable_result: SetVariableResultType = SetVariableResultType(
+        **r.set_variable_result[0]
+    )
+    assert set_variable_result.attribute_status == SetVariableStatusType.accepted
+
+    t = datetime.utcnow() + timedelta(minutes=10)
+
+    # Make a new reservation.
+    await charge_point_v201.reserve_now_req(
+        evse_id=1,
+        expiry_date_time=t.isoformat(),
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        group_id_token=IdTokenType(id_token=test_config.authorization_info.parent_id_tag,
+                             type=IdTokenTypeEnum.iso14443),
+        id=0,
+    )
+
+    # expect ReserveNow response with status accepted
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # expect StatusNotification request with status reserved
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.reserved, 1, 1
+        ),
+    )
+
+    # start charging session
+    test_controller.plug_in()
+
+    # send request start transaction for another id tag than the one from the reservation.
+    await charge_point_v201.request_start_transaction_req(
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_2,
+                             type=IdTokenTypeEnum.iso14443), remote_start_id=1, evse_id=1
+    )
+
+    # This is accepted because the reservation has a group id token.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "RequestStartTransaction",
+        call_result201.RequestStartTransactionPayload(status="Accepted"),
+        validate_remote_start_stop_transaction,
+    )
+
+    # expect Authorize request.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "Authorize",
+        call_201.AuthorizePayload(IdTokenType(id_token=test_config.authorization_info.valid_id_tag_2,
+                                              type=IdTokenTypeEnum.iso14443)),
+    )
+
+    # Authorize was accepted because of the correct group id token, transaction is started.
+    r: call_201.TransactionEventPayload = call_201.TransactionEventPayload(
+        **await wait_for_and_validate(
+            test_utility,
+            charge_point_v201,
+            "TransactionEvent",
+            {"eventType": "Started"}
+        )
+    )
+
+    transaction = TransactionType(**r.transaction_info)
+
+    # expect TransactionEvent with eventType 'Updated'
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Updated"}
+    )
+
+    # send request stop transaction
+    await charge_point_v201.request_stop_transaction_req(
+        transaction_id=transaction.transaction_id
+    )
+
+    # Which should be accepted.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "RequestStopTransaction",
+        call_result201.RequestStartTransactionPayload(
+            status=RequestStartStopStatusType.accepted
+        ),
+    )
+
+    # And the session should end.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Ended"}
+    )

--- a/tests/ocpp_tests/test_sets/ocpp201/reservations.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/reservations.py
@@ -338,6 +338,15 @@ async def test_reservation_connector_faulted(
     # Set evse in state 'faulted'
     test_controller.raise_error("MREC6UnderVoltage", 1)
 
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, 'Faulted', 1, 1
+        ),
+    )
+
     await asyncio.sleep(1)
 
     t = datetime.utcnow() + timedelta(minutes=10)

--- a/tests/ocpp_tests/test_sets/ocpp201/reservations.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/reservations.py
@@ -1,4 +1,3 @@
-import pytest_asyncio
 import pytest
 import logging
 from unittest.mock import ANY
@@ -12,14 +11,11 @@ from everest_test_utils import *
 
 from ocpp.v201.enums import (IdTokenType as IdTokenTypeEnum, ReserveNowStatusType, ConnectorStatusType,
                              OperationalStatusType, CancelReservationStatusType, SetVariableStatusType,
-                             RequestStartStopStatusType, AttributeType)
+                             RequestStartStopStatusType)
 from ocpp.v201.datatypes import *
 from ocpp.v201 import call as call_201
 from ocpp.v201 import call_result as call_result201
-from validations import (validate_standard_start_transaction,
-                         validate_standard_stop_transaction,
-                         validate_remote_start_stop_transaction,
-                         validate_status_notification_201)
+from validations import validate_remote_start_stop_transaction
 from ocpp.routing import on, create_route_map
 
 

--- a/tests/ocpp_tests/test_sets/ocpp201/reservations.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/reservations.py
@@ -106,8 +106,85 @@ async def test_reservation_local_start_tx(
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="There is a bug in the EVSE manager with setting an evse to occupied on plug in without "
-                         "checking if it is reserved. As soon as it is fixed, this test can be done")
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_reservation_local_start_tx_plugin_first(
+        test_config: OcppTestConfiguration,
+        charge_point_v201: ChargePoint201,
+        test_controller: TestController,
+        test_utility: TestUtility,
+):
+    """
+    Test making a reservation and start a transaction on the reserved evse id with the correct id token.
+    """
+    logging.info("######### test_reservation_local_start_tx #########")
+
+    t = datetime.utcnow() + timedelta(minutes=10)
+
+    await charge_point_v201.reserve_now_req(
+        id=0,
+        id_token=IdTokenType(id_token=test_config.authorization_info.valid_id_tag_1,
+                             type=IdTokenTypeEnum.iso14443),
+        expiry_date_time=t.isoformat(),
+        evse_id=1
+    )
+
+    # expect ReserveNow response with status accepted
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "ReserveNow",
+        call_result201.ReserveNowPayload(ReserveNowStatusType.accepted),
+    )
+
+    # expect StatusNotification with status reserved
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.reserved, 1, 1
+        ),
+    )
+
+    test_utility.messages.clear()
+
+    # start charging session
+    test_controller.plug_in()
+
+    await asyncio.sleep(2)
+
+    test_utility.messages.clear()
+
+    # swipe valid id tag that belongs to this reservation to authorize
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
+
+    # expect StatusNotification with status available (reservation is now used)
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call_201.StatusNotificationPayload(
+            ANY, ConnectorStatusType.occupied, 1, 1
+        ),
+    )
+
+    # expect TransactionEvent with event type Started and the reservation id.
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Started", "reservationId": 0}
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Updated"}
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.ocpp_version("ocpp2.0.1")
 async def test_reservation_plug_in_other_idtoken(
         test_config: OcppTestConfiguration,
@@ -167,7 +244,7 @@ async def test_reservation_plug_in_other_idtoken(
     test_utility.messages.clear()
 
     # swipe invalid id tag
-    test_controller.swipe(test_config.authorization_info.invalid_id_tag)
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_2)
 
     assert not await wait_for_and_validate(
         test_utility,
@@ -183,19 +260,6 @@ async def test_reservation_plug_in_other_idtoken(
 
     # swipe valid id tag to authorize
     test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
-
-    # expect StatusNotification with status available (reservation is now used)
-    assert await wait_for_and_validate(
-        test_utility,
-        charge_point_v201,
-        "StatusNotification",
-        call_201.StatusNotificationPayload(
-            ANY, ConnectorStatusType.available, 1, 1
-        ),
-    )
-
-    # start charging session
-    test_controller.plug_in()
 
     # expect TransactionEvent with event type Started and the reservation id.
     assert await wait_for_and_validate(

--- a/tests/ocpp_tests/test_sets/ocpp201/reservations.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/reservations.py
@@ -336,7 +336,7 @@ async def test_reservation_connector_faulted(
     logging.info("######### test_reservation_connector_faulted #########")
 
     # Set evse in state 'faulted'
-    test_controller.raise_error()
+    test_controller.raise_error("MREC6UnderVoltage", 1)
 
     await asyncio.sleep(1)
 
@@ -396,7 +396,7 @@ async def test_reservation_connector_faulted_after_reservation(
     )
 
     # Set evse in state 'faulted'
-    test_controller.raise_error(1)
+    test_controller.raise_error("MREC6UnderVoltage", 1)
 
     # This should result in the reservation being cancelled.
     assert await wait_for_and_validate(
@@ -847,7 +847,7 @@ async def test_reservation_faulted_state(
     """
     logging.info("######### test_reservation_faulted_state #########")
 
-    test_controller.raise_error(1)
+    test_controller.raise_error("MREC6UnderVoltage", 1)
 
     assert await wait_for_and_validate(
         test_utility,
@@ -879,7 +879,7 @@ async def test_reservation_faulted_state(
         call_result201.ReserveNowPayload(ReserveNowStatusType.faulted),
     )
 
-    test_controller.clear_error(1)
+    test_controller.clear_error("MREC6UnderVoltage", 1)
 
     test_utility.messages.clear()
 

--- a/types/reservation.yaml
+++ b/types/reservation.yaml
@@ -54,11 +54,15 @@ types:
         Expired: When the reservation expired before the reserved token was used for a session
         Cancelled: When the reservation was cancelled manually
         UsedToStartCharging: When the reservation ended because the reserved token was used for a session
+        GlobalReservationConnectorFree: When the reservation ended because there is a connector free and there are less
+                                        reservations than available evse's (reservation is still there but it is not
+                                        occupying the EVSE anymore).
     type: string
     enum:
       - Expired
       - Cancelled
       - UsedToStartCharging
+      - GlobalReservationConnectorFree
   ReservationEnd:
     description: Details on Reservation End
     type: object

--- a/types/reservation.yaml
+++ b/types/reservation.yaml
@@ -54,15 +54,15 @@ types:
         Expired: When the reservation expired before the reserved token was used for a session
         Cancelled: When the reservation was cancelled manually
         UsedToStartCharging: When the reservation ended because the reserved token was used for a session
-        GlobalReservationConnectorFree: When the reservation ended because there is a connector free and there are less
-                                        reservations than available evse's (reservation is still there but it is not
-                                        occupying the EVSE anymore).
+        GlobalReservationRequirementDropped: When the reservation ended for that specific EVSE because there is a
+                                             connector free and there are less reservations than available evse's
+                                             (reservation is still there but it is not occupying this EVSE anymore).
     type: string
     enum:
       - Expired
       - Cancelled
       - UsedToStartCharging
-      - GlobalReservationConnectorFree
+      - GlobalReservationRequirementDropped
   ReservationEnd:
     description: Details on Reservation End
     type: object


### PR DESCRIPTION
## Describe your changes

When there are as many reservations as evse's available, all available evse's must go to 'reserved'. And back to 'available' when there are more evse's than reservations.

Also, added unittests.

See other related pull requests:
https://github.com/EVerest/libocpp/pull/878
https://github.com/EVerest/everest-utils/pull/171

## Issue ticket number and link
#958 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

