### PR TITLE
Require replug in case of plug in timeout

### DIFF
--- a/modules/Auth/include/Connector.hpp
+++ b/modules/Auth/include/Connector.hpp
@@ -66,7 +66,12 @@ struct EVSEContext {
     }
 
     EVSEContext(int evse_id, int evse_index, const std::vector<Connector>& connectors) :
-        evse_id(evse_id), evse_index(evse_index), transaction_active(false), connectors(connectors), plugged_in(false) {
+        evse_id(evse_id),
+        evse_index(evse_index),
+        transaction_active(false),
+        connectors(connectors),
+        plugged_in(false),
+        plug_in_timeout(false) {
     }
 
     int32_t evse_id;
@@ -78,6 +83,8 @@ struct EVSEContext {
     std::vector<Connector> connectors;
     Everest::SteadyTimer timeout_timer;
     bool plugged_in;
+    bool plug_in_timeout; // indicates no authorization received within connection_timeout. Replug is required for this
+                          // EVSE to get authorization and start a transaction
 
     bool is_available();
     bool is_unavailable();

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -657,11 +657,11 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
                 [this, evse_id]() {
                     std::lock_guard<std::mutex> lk(this->event_mutex);
 
-                    EVLOG_info << "Plug In timeout for evse#" << evse_id;
+                    EVLOG_info << "Plug In timeout for evse#" << evse_id << ". Replug required for this EVSE";
                     this->withdraw_authorization_callback(this->evses.at(evse_id)->evse_index);
 
                     this->plug_in_queue.remove_if([evse_id](int value) { return value == evse_id; });
-                    this->evses.at(evse_id)->plugged_in = false;
+                    this->evses.at(evse_id)->plug_in_timeout = true;
                 },
                 std::chrono::seconds(this->connection_timeout));
         }
@@ -680,6 +680,7 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
         break;
     case SessionEventEnum::SessionFinished: {
         this->evses.at(evse_id)->plugged_in = false;
+        this->evses.at(evse_id)->plug_in_timeout = false;
         this->evses.at(evse_id)->identifier.reset();
         this->submit_event_for_connector(evse_id, connector_id, ConnectorEvent::SESSION_FINISHED);
         this->evses.at(evse_id)->timeout_timer.stop();

--- a/modules/Auth/lib/Connector.cpp
+++ b/modules/Auth/lib/Connector.cpp
@@ -40,6 +40,10 @@ std::string connector_state_to_string(const ConnectorState& state) {
 } // namespace conversions
 
 bool EVSEContext::is_available() {
+    if (this->plug_in_timeout) {
+        return false;
+    }
+
     bool occupied = false;
     bool available = false;
     for (const auto& connector : this->connectors) {


### PR DESCRIPTION
## Describe your changes
After a plug in timeout, a replug is required in order to get authorization and start a transaction at this EVSE. The Auth module now marks an EVSE where a plug in time out occured in order to not select it for a later authorization request

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

