### PR TITLE
Feature/890 move reservations callbacks and handlers to new functional block

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: e52ac969095804144af4896af1984cedaf45a3f8
+  git_tag: feature/890-move-reservations-callbacks-and-handlers-to-new-functional-block
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: feature/890-move-reservations-callbacks-and-handlers-to-new-functional-block
+  git_tag: c66383782a32827920af80314165843deed63c98
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/tests/ocpp_tests/test_sets/ocpp201/reservations.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/reservations.py
@@ -629,7 +629,6 @@ async def test_reservation_connector_occupied(
     # start charging session
     test_controller.plug_in()
 
-    # TODO mz fix comments everywhere in this file!!!
     # expect StatusNotification with status occupied
     assert await wait_for_and_validate(
         test_utility,

--- a/tests/ocpp_tests/test_sets/ocpp201/reservations.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/reservations.py
@@ -15,7 +15,7 @@ from ocpp.v201.enums import (IdTokenType as IdTokenTypeEnum, ReserveNowStatusTyp
 from ocpp.v201.datatypes import *
 from ocpp.v201 import call as call_201
 from ocpp.v201 import call_result as call_result201
-from validations import validate_remote_start_stop_transaction
+from validations import (validate_remote_start_stop_transaction, wait_for_callerror_and_validate)
 from ocpp.routing import on, create_route_map
 
 
@@ -735,13 +735,9 @@ async def test_reservation_connector_rejected(
         evse_id=1
     )
 
-    # expect ReserveNow response with status rejected
-    assert await wait_for_and_validate(
-        test_utility,
-        charge_point_v201,
-        "ReserveNow",
-        call_result201.ReserveNowPayload(ReserveNowStatusType.rejected),
-    )
+    assert await wait_for_callerror_and_validate(test_utility,
+                                                 charge_point_v201,
+                                                 "NotImplemented")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes
Change test because behaviour of reservations slightly changed when reservations is not available ('NotImplemented' is returned when a ReserveNow request is performed from a CSMS).

This is now rebased on #958 and should be rebased to main before merging and merged after #958 .

## Issue ticket number and link


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

