### PR TITLE
PN532TokenProvider: drop unused config 'timeout'

### DIFF
--- a/modules/PN532TokenProvider/main/auth_token_providerImpl.hpp
+++ b/modules/PN532TokenProvider/main/auth_token_providerImpl.hpp
@@ -23,7 +23,6 @@ namespace main {
 struct Conf {
     std::string serial_port;
     int baud_rate;
-    double timeout;
     int read_timeout;
     bool debug;
 };

--- a/modules/PN532TokenProvider/manifest.yaml
+++ b/modules/PN532TokenProvider/manifest.yaml
@@ -14,12 +14,6 @@ provides:
         minimum: 9600
         maximum: 230400
         default: 115200
-      timeout:
-        description: Time a new token is valid (in s)
-        type: number
-        minimum: 0
-        maximum: 120
-        default: 30
       read_timeout:
         description: Time between subsequent card reads (in s)
         type: integer


### PR DESCRIPTION
## Describe your changes

The variable is not used anymore, so can be dropped.

## Issue ticket number and link

 - n/a -

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
