### PR TITLE
Refactored mutex locking in Auth module

### DIFF
--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -253,7 +253,7 @@ private:
     bool any_parent_id_present(const std::vector<int>& evse_ids);
     bool equals_master_pass_group_id(const std::optional<types::authorization::IdToken> parent_id_token);
 
-    TokenHandlingResult handle_token(const ProvidedIdToken& provided_token);
+    TokenHandlingResult handle_token(const ProvidedIdToken& provided_token, std::unique_lock<std::mutex>& lk);
 
     /**
      * @brief Method selects an evse based on the configured selection algorithm. It might block until an event
@@ -262,7 +262,7 @@ private:
      * @param selected_evses
      * @return int
      */
-    int select_evse(const std::vector<int>& selected_evses);
+    int select_evse(const std::vector<int>& selected_evses, std::unique_lock<std::mutex>& lk);
 
     int get_latest_plugin(const std::vector<int>& evse_ids);
     void notify_evse(int evse_id, const ProvidedIdToken& provided_token, const ValidationResult& validation_result);

--- a/modules/Auth/lib/Connector.cpp
+++ b/modules/Auth/lib/Connector.cpp
@@ -44,6 +44,11 @@ bool EVSEContext::is_available() {
         return false;
     }
 
+    // if an identifier is present, an EVSE is not considered available
+    if (this->identifier.has_value()) {
+        return false;
+    }
+
     bool occupied = false;
     bool available = false;
     for (const auto& connector : this->connectors) {

--- a/tests/ocpp_tests/test_sets/ocpp16/authorization_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/authorization_tests.py
@@ -616,6 +616,7 @@ async def test_authorization_cache_entry_1(
         validate_standard_stop_transaction,
     )
 
+    test_utility.messages.clear()
     test_controller.plug_out()
 
     # expect StatusNotification with status finishing
@@ -740,6 +741,7 @@ async def test_authorization_cache_entry_1(
         ),
     )
 
+    test_utility.messages.clear()
     # swipe card
     test_controller.swipe(test_config.authorization_info.valid_id_tag_2)
 


### PR DESCRIPTION
## Describe your changes
* Passing a std::unique_lock to be able to use it inside a wait_for inside select_evse. Before this change, authorization could've been provided to the same EVSE for parallel authorization requests. With this change, this is not possible anymore 
* Adding a check in the Connector so that an EVSE that already has an identifier assigned is not considered available

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

