### PR TITLE
feature: direct support for `__dump_gcov`

### DIFF
--- a/cmake/ev-project-bootstrap.cmake
+++ b/cmake/ev-project-bootstrap.cmake
@@ -1,6 +1,6 @@
 set_property(
     GLOBAL
-    PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION "0.4.0"
+    PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION "0.4.5"
 )
 
 # FIXME (aw): clean up this inclusion chain

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ ext-mbedtls:
 # everest-testing and ev-dev-tools
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
-  git_tag: v0.4.4
+  git_tag: feature/support_dump_gcov
 # linux_libnfc-nci for RFID
 libnfc-nci:
   git: https://github.com/EVerest/linux_libnfc-nci.git

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ ext-mbedtls:
 # everest-testing and ev-dev-tools
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
-  git_tag: feature/support_dump_gcov
+  git_tag: 54c4793d8494c2b66867c281e499c35a88c72624
 # linux_libnfc-nci for RFID
 libnfc-nci:
   git: https://github.com/EVerest/linux_libnfc-nci.git

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -86,7 +86,7 @@ ext-mbedtls:
 # everest-testing and ev-dev-tools
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
-  git_tag: 54c4793d8494c2b66867c281e499c35a88c72624
+  git_tag: 165f2c8acd7819e2c788f438d4f00a56dd030be0
 # linux_libnfc-nci for RFID
 libnfc-nci:
   git: https://github.com/EVerest/linux_libnfc-nci.git

--- a/lib/staging/helpers/CMakeLists.txt
+++ b/lib/staging/helpers/CMakeLists.txt
@@ -8,6 +8,15 @@ target_sources(everest_staging_helpers
         lib/helpers.cpp
 )
 
+if (EVEREST_CORE_BUILD_TESTING)
+    target_compile_definitions(everest_staging_helpers PUBLIC EVEREST_COVERAGE_ENABLED)
+
+    target_sources(everest_staging_helpers
+        PRIVATE
+            lib/coverage.cpp
+    )
+endif()
+
 target_include_directories(everest_staging_helpers
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/lib/staging/helpers/include/everest/staging/helpers/coverage.hpp
+++ b/lib/staging/helpers/include/everest/staging/helpers/coverage.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace everest::helpers {
+    void install_signal_handlers_for_gcov();
+}

--- a/lib/staging/helpers/include/everest/staging/helpers/coverage.hpp
+++ b/lib/staging/helpers/include/everest/staging/helpers/coverage.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
 namespace everest::helpers {
-    void install_signal_handlers_for_gcov();
+
+void install_signal_handlers_for_gcov();
+
 }

--- a/lib/staging/helpers/lib/coverage.cpp
+++ b/lib/staging/helpers/lib/coverage.cpp
@@ -1,0 +1,38 @@
+#include <everest/staging/helpers/coverage.hpp>
+
+#include <atomic>
+
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+extern "C" void __gcov_dump();
+
+namespace {
+
+static std::atomic_flag going_to_terminate = ATOMIC_FLAG_INIT;
+
+void terminate_handler(int signal) {
+    if (going_to_terminate.test_and_set()) {
+        return;
+    }
+
+    __gcov_dump();
+
+    _exit(EXIT_FAILURE);
+};
+
+} // namespace
+
+namespace everest::helpers {
+
+void install_signal_handlers_for_gcov() {
+    struct sigaction action {};
+    action.sa_handler = &terminate_handler;
+    // action.sa_mask should be zero, so no blocked signals within the signal handler
+    // action.sa_flags should be fine with being zero
+    sigaction(SIGINT, &action, nullptr);
+    sigaction(SIGTERM, &action, nullptr);
+}
+
+} // namespace everest::helpers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,10 @@ foreach(type MODULES LIBRARIES)
 
     foreach(target ${targets})
         append_coverage_compiler_flags_to_target(${target})
+
+        if (type STREQUAL "MODULES")
+            target_link_libraries(${target} PRIVATE everest::staging::helpers)
+        endif()
     endforeach()
 endforeach()
 


### PR DESCRIPTION
- the previous implementation for dumping gcov statistics wasn't robust enough
- now, `__dump_gcov` is called directly from the signal handler and then `_exit` is called - this guarantees dumping of gcov statistics and immidiate module exit

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

