### PR TITLE
fix: correct csms_leaf_cert_directory default value in EvseSecurity

### DIFF
--- a/modules/EvseSecurity/manifest.yaml
+++ b/modules/EvseSecurity/manifest.yaml
@@ -21,7 +21,7 @@ config:
   csms_leaf_cert_directory:
     description: Directory where CSMS leaf certificates are stored. If relative will be prefixed with everest prefix + etc/everest/certs. Otherwise absolute file path is used.
     type: string
-    default: client/csms
+    default: ca/csms
   csms_leaf_key_directory:
     description: Directory where CSMS private keys are stored. If relative will be prefixed with everest prefix + etc/everest/certs. Otherwise absolute file path is used.
     type: string


### PR DESCRIPTION
## Describe your changes

This pull request fixes a bug that impeded me from connecting to a CSMS server with OCPP Profile 3.

```
The csms_leaf_cert_directory should point to the directory where CSMS
leaf certificates are stored. However, the current default value
(client/csms) does not reflect the actual location. The certificates
are placed in ca/csms by the script
Josev/iso15118/shared/pki/create_certs.sh.

The directory certs/ca/csms/ contains:
  - CPO_SUB_CA1.pem
  - CPO_SUB_CA1_LEAF.der
  - CPO_SUB_CA2.pem
  - CPO_SUB_CA2_LEAF.der

Meanwhile, certs/client/csms/ is used to store the private keys:
  - CPO_SUB_CA1.key
  - CPO_SUB_CA2.key

This commit updates the default value of csms_leaf_cert_directory in
EvseSecurity to ca/csms, to match the directory structure created by
the script.
```

## Issue ticket number and link
None

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

