### PR TITLE
Adding a few unit tests for the EvseV2G module

### DIFF
--- a/modules/EvseV2G/connection/tls_connection.cpp
+++ b/modules/EvseV2G/connection/tls_connection.cpp
@@ -61,9 +61,6 @@ void process_connection_thread(std::shared_ptr<tls::ServerConnection> con, struc
         const auto result = con->accept();
         switch (result) {
         case tls::Connection::result_t::success:
-
-            // TODO(james-ctc) v2g_ctx->tls_key_logging
-
             if (ctx->state == 0) {
                 const auto rv = ::v2g_handle_connection(connection.get());
                 dlog(DLOG_LEVEL_INFO, "v2g_dispatch_connection exited with %d", rv);

--- a/modules/EvseV2G/din_server.cpp
+++ b/modules/EvseV2G/din_server.cpp
@@ -69,14 +69,14 @@ static din_responseCodeType din_validate_state(int state, enum V2gMsgTypeId curr
                                                                          : din_responseCodeType_FAILED_SequenceError;
 }
 
+namespace utils {
 /*!
  * \brief din_validate_response_code This function checks if an external error has occurred (sequence error, user
  * abort)... ). \param din_response_code is a pointer to the current response code. The value will be modified if an
  * external error has occurred. \param conn the structure with the external error information. \return Returns the next
  * v2g-event.
  */
-static v2g_event din_validate_response_code(din_responseCodeType* const din_response_code,
-                                            struct v2g_connection const* conn) {
+v2g_event din_validate_response_code(din_responseCodeType* const din_response_code, struct v2g_connection const* conn) {
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
     din_responseCodeType response_code_tmp;
 
@@ -118,6 +118,7 @@ static v2g_event din_validate_response_code(din_responseCodeType* const din_resp
 
     return nextEvent;
 }
+} // namespace utils
 
 /*!
  * \brief publish_DIN_DcEvStatus This function is a helper function to publish EVStatusType.
@@ -295,6 +296,8 @@ static void publish_din_current_demand_req(struct v2g_context* ctx,
 //             Request Handling
 //=============================================
 
+namespace states {
+
 /*!
  * \brief handle_iso_session_setup This function handles the din_session_setup msg pair. It analyzes the request msg and
  * fills the response msg. The request and response msg based on the open V2G structures. This structures must be
@@ -302,7 +305,7 @@ static void publish_din_current_demand_req(struct v2g_context* ctx,
  * \param conn holds the structure with the V2G msg pair.
  * \return Returns the next V2G-event.
  */
-static enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
+enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
     struct din_SessionSetupReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.SessionSetupReq;
     struct din_SessionSetupResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.SessionSetupRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
@@ -348,7 +351,7 @@ static enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
     res->DateTimeNow = time(NULL);
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     conn->ctx->state = WAIT_FOR_SERVICEDISCOVERY; // [V2G-DC-438]
@@ -363,7 +366,7 @@ static enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
  * \param conn is the structure with the V2G msg pair.
  * \return Returns the next V2G-event.
  */
-static enum v2g_event handle_din_service_discovery(struct v2g_connection* conn) {
+enum v2g_event handle_din_service_discovery(struct v2g_connection* conn) {
     struct din_ServiceDiscoveryReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.ServiceDiscoveryReq;
     struct din_ServiceDiscoveryResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.ServiceDiscoveryRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
@@ -401,13 +404,15 @@ static enum v2g_event handle_din_service_discovery(struct v2g_connection* conn) 
     res->PaymentOptions.PaymentOption.arrayLen = 1;
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     conn->ctx->state = WAIT_FOR_PAYMENTSERVICESELECTION; // [V2G-DC-441]
 
     return nextEvent;
 }
+
+} // namespace states
 
 /*!
  * \brief handle_din_service_discovery This function handles the din service payment selection msg pair. It analyzes the
@@ -441,7 +446,7 @@ static enum v2g_event handle_din_service_payment_selection(struct v2g_connection
                                                                                    // shall be limited to 1)
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     conn->ctx->state = WAIT_FOR_AUTHORIZATION; // [V2G-DC-444]
@@ -456,7 +461,7 @@ static enum v2g_event handle_din_service_payment_selection(struct v2g_connection
  * \param conn is the structure with the V2G msg pair.
  * \return Returns the next V2G-event.
  */
-static enum v2g_event handle_din_contract_authentication(struct v2g_connection* conn) {
+enum v2g_event states::handle_din_contract_authentication(struct v2g_connection* conn) {
     struct din_ContractAuthenticationResType* res =
         &conn->exi_out.dinEXIDocument->V2G_Message.Body.ContractAuthenticationRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
@@ -468,7 +473,7 @@ static enum v2g_event handle_din_contract_authentication(struct v2g_connection* 
                               : din_EVSEProcessingType_Ongoing;
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     conn->ctx->state = (res->EVSEProcessing == din_EVSEProcessingType_Ongoing)
@@ -600,7 +605,7 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
     res->SASchedules_isUsed = (unsigned int)0;
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     if (res->EVSEProcessing == din_EVSEProcessingType_Finished) {
@@ -684,7 +689,7 @@ static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
                             : res->ResponseCode; // [V2G-DC-401]
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     if ((req->ReadyToChargeState == (int)1) && (V2G_CURRENT_DEMAND_MSG != conn->ctx->last_v2g_msg)) {
@@ -740,7 +745,7 @@ static enum v2g_event handle_din_cable_check(struct v2g_connection* conn) {
     }
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     if ((res->EVSEProcessing == din_EVSEProcessingType_Finished) &&
@@ -794,7 +799,7 @@ static enum v2g_event handle_din_pre_charge(struct v2g_connection* conn) {
     load_din_physical_value(&res->EVSEPresentVoltage, &conn->ctx->evse_v2g_data.evse_present_voltage);
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     conn->ctx->state = WAIT_FOR_PRECHARGE_POWERDELIVERY; // [V2G-DC-458]
@@ -848,7 +853,7 @@ static enum v2g_event handle_din_current_demand(struct v2g_connection* conn) {
     res->EVSEVoltageLimitAchieved = conn->ctx->evse_v2g_data.evse_voltage_limit_achieved;
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     conn->ctx->state = WAIT_FOR_CURRENTDEMAND_POWERDELIVERY; // [V2G-DC-465]
@@ -888,7 +893,7 @@ static enum v2g_event handle_din_welding_detection(struct v2g_connection* conn) 
     load_din_physical_value(&res->EVSEPresentVoltage, &conn->ctx->evse_v2g_data.evse_present_voltage);
 
     /* Check the current response code and check if no external error has occurred */
-    nextEvent = din_validate_response_code(&res->ResponseCode, conn);
+    nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Set next expected req msg */
     conn->ctx->state = WAIT_FOR_WELDINGDETECTION_SESSIONSTOP; // [V2G-DC-469]
@@ -910,7 +915,7 @@ static enum v2g_event handle_din_session_stop(struct v2g_connection* conn) {
     res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
 
     /* Check the current response code and check if no external error has occurred */
-    din_validate_response_code(&res->ResponseCode, conn);
+    utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Setuo dlink action */
     conn->dlink_action = MQTT_DLINK_ACTION_TERMINATE;
@@ -923,6 +928,8 @@ static enum v2g_event handle_din_session_stop(struct v2g_connection* conn) {
 }
 
 enum v2g_event din_handle_request(v2g_connection* conn) {
+    using namespace states;
+
     struct din_exiDocument* exi_in = conn->exi_in.dinEXIDocument;
     struct din_exiDocument* exi_out = conn->exi_out.dinEXIDocument;
     enum v2g_event next_v2g_event = V2G_EVENT_TERMINATE_CONNECTION; // ERROR_UNEXPECTED_REQUEST_MESSAGE;

--- a/modules/EvseV2G/din_server.hpp
+++ b/modules/EvseV2G/din_server.hpp
@@ -104,4 +104,17 @@ static const struct din_state din_states[] = {
  */
 enum v2g_event din_handle_request(v2g_connection* conn);
 
+namespace utils {
+enum v2g_event din_validate_response_code(din_responseCodeType* const din_response_code,
+                                          struct v2g_connection const* conn);
+} // namespace utils
+
+namespace states {
+
+enum v2g_event handle_din_session_setup(struct v2g_connection* conn);
+enum v2g_event handle_din_service_discovery(struct v2g_connection* conn);
+enum v2g_event handle_din_contract_authentication(struct v2g_connection* conn);
+
+} // namespace states
+
 #endif /* DIN_SERVER_HPP */

--- a/modules/EvseV2G/sdp.cpp
+++ b/modules/EvseV2G/sdp.cpp
@@ -36,16 +36,6 @@
 
 #define POLL_TIMEOUT 20
 
-enum sdp_security {
-    SDP_SECURITY_TLS = 0x00,
-    SDP_SECURITY_NONE = 0x10,
-};
-
-enum sdp_transport_protocol {
-    SDP_TRANSPORT_PROTOCOL_TCP = 0x00,
-    SDP_TRANSPORT_PROTOCOL_UDP = 0x10,
-};
-
 /* link-local multicast address ff02::1 aka ip6-allnodes */
 #define IN6ADDR_ALLNODES                                                                                               \
     { 0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 }
@@ -63,7 +53,7 @@ struct sdp_query {
 /*
  * Fills the SDP header into a given buffer
  */
-static int sdp_write_header(uint8_t* buffer, uint16_t payload_type, uint32_t payload_len) {
+int sdp_write_header(uint8_t* buffer, uint16_t payload_type, uint32_t payload_len) {
     int offset = 0;
 
     buffer[offset++] = SDP_VERSION;
@@ -82,7 +72,7 @@ static int sdp_write_header(uint8_t* buffer, uint16_t payload_type, uint32_t pay
     return offset;
 }
 
-static int sdp_validate_header(uint8_t* buffer, uint16_t expected_payload_type, uint32_t expected_payload_len) {
+int sdp_validate_header(uint8_t* buffer, uint16_t expected_payload_type, uint32_t expected_payload_len) {
     uint16_t payload_type;
     uint32_t payload_len;
 
@@ -134,7 +124,6 @@ int sdp_create_response(uint8_t* buffer, struct sockaddr_in6* addr, enum sdp_sec
 
     return offset;
 }
-
 /*
  * Sends a SDP response packet
  */

--- a/modules/EvseV2G/sdp.hpp
+++ b/modules/EvseV2G/sdp.hpp
@@ -6,6 +6,20 @@
 
 #include "v2g.hpp"
 
+enum sdp_security {
+    SDP_SECURITY_TLS = 0x00,
+    SDP_SECURITY_NONE = 0x10,
+};
+
+enum sdp_transport_protocol {
+    SDP_TRANSPORT_PROTOCOL_TCP = 0x00,
+    SDP_TRANSPORT_PROTOCOL_UDP = 0x10,
+};
+
+int sdp_write_header(uint8_t* buffer, uint16_t payload_type, uint32_t payload_len);
+int sdp_validate_header(uint8_t* buffer, uint16_t expected_payload_type, uint32_t expected_payload_len);
+int sdp_create_response(uint8_t* buffer, struct sockaddr_in6* addr, enum sdp_security security,
+                        enum sdp_transport_protocol proto);
 int sdp_init(struct v2g_context* v2g_ctx);
 int sdp_listen(struct v2g_context* v2g_ctx);
 

--- a/modules/EvseV2G/tests/CMakeLists.txt
+++ b/modules/EvseV2G/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 get_target_property(GENERATED_INCLUDE_DIR generate_cpp_files EVEREST_GENERATED_INCLUDE_DIR)
 find_package(libevent)
+find_package(OpenSSL 3)
 
 set(TLS_TEST_FILES
         alt_openssl-pki.conf
@@ -93,3 +94,111 @@ target_link_libraries(${V2G_MAIN_NAME} PRIVATE
 # runs fine locally, fails in CI
 add_test(${TLS_GTEST_NAME} ${TLS_GTEST_NAME})
 ev_register_test_target(${TLS_GTEST_NAME})
+
+
+set(DIN_SERVER_NAME din_server_test)
+add_executable(${DIN_SERVER_NAME})
+
+target_include_directories(${DIN_SERVER_NAME} PRIVATE
+    .. ../connection ../../../tests/include
+    ${GENERATED_INCLUDE_DIR}
+    ${CMAKE_BINARY_DIR}/generated/modules/${MODULE_NAME}
+    ${CMAKE_BINARY_DIR}/generated/include
+)
+
+target_compile_definitions(${DIN_SERVER_NAME} PRIVATE
+    -DUNIT_TEST
+    -DLIBEVSE_CRYPTO_SUPPLIER_OPENSSL
+)
+
+target_sources(${DIN_SERVER_NAME} PRIVATE
+    din_server_test.cpp
+    log.cpp
+    ../din_server.cpp
+    ../tools.cpp # TODO: Maybe mock this one
+)
+
+target_link_libraries(${DIN_SERVER_NAME}
+    PRIVATE
+        GTest::gtest_main
+        OpenSSL::SSL
+        OpenSSL::Crypto
+        cbv2g::din
+        cbv2g::iso2
+        cbv2g::tp
+        everest::framework
+        everest::evse_security
+        everest::tls
+)
+
+add_test(${DIN_SERVER_NAME} ${DIN_SERVER_NAME})
+ev_register_test_target(${DIN_SERVER_NAME})
+
+set(SDP_NAME sdp_test)
+add_executable(${SDP_NAME})
+target_include_directories(${SDP_NAME} PRIVATE
+    .. ../connection ../../../tests/include
+    ${GENERATED_INCLUDE_DIR}
+    ${CMAKE_BINARY_DIR}/generated/modules/${MODULE_NAME}
+    ${CMAKE_BINARY_DIR}/generated/include
+)
+
+target_compile_definitions(${SDP_NAME} PRIVATE
+    -DUNIT_TEST
+)
+
+target_sources(${SDP_NAME} PRIVATE
+    sdp_test.cpp
+    log.cpp
+    ../sdp.cpp
+)
+
+target_link_libraries(${SDP_NAME}
+    PRIVATE
+        GTest::gtest_main
+        cbv2g::tp
+        everest::framework
+        everest::tls
+)
+
+add_test(${SDP_NAME} ${SDP_NAME})
+ev_register_test_target(${SDP_NAME})
+
+set(V2GCTX_NAME v2g_ctx_test)
+add_executable(${V2GCTX_NAME})
+
+target_include_directories(${V2GCTX_NAME} PRIVATE
+    .. ../connection ../../../tests/include
+    ${GENERATED_INCLUDE_DIR}
+    ${CMAKE_BINARY_DIR}/generated/modules/${MODULE_NAME}
+    ${CMAKE_BINARY_DIR}/generated/include
+)
+
+target_compile_definitions(${V2GCTX_NAME} PRIVATE
+    -DUNIT_TEST
+    -DLIBEVSE_CRYPTO_SUPPLIER_OPENSSL
+)
+
+target_sources(${V2GCTX_NAME} PRIVATE
+    v2g_ctx_test.cpp
+    log.cpp
+    ../v2g_ctx.cpp
+    ../tools.cpp # TODO: Maybe mock this one
+)
+
+target_link_libraries(${V2GCTX_NAME}
+    PRIVATE
+        GTest::gtest_main
+        OpenSSL::SSL
+        OpenSSL::Crypto
+        cbv2g::din
+        cbv2g::iso2
+        cbv2g::tp
+        everest::framework
+        everest::evse_security
+        everest::tls
+        -levent -lpthread -levent_pthreads
+)
+
+add_test(${V2GCTX_NAME} ${V2GCTX_NAME})
+ev_register_test_target(${V2GCTX_NAME})

--- a/modules/EvseV2G/tests/ISO15118_chargerImplStub.hpp
+++ b/modules/EvseV2G/tests/ISO15118_chargerImplStub.hpp
@@ -5,6 +5,9 @@
 #define ISO15118_CHARGERIMPLSTUB_H_
 
 #include <iostream>
+#include <memory>
+
+#include "ModuleAdapterStub.hpp"
 
 #include <generated/interfaces/ISO15118_charger/Implementation.hpp>
 
@@ -12,8 +15,8 @@
 namespace module::stub {
 
 struct ISO15118_chargerImplStub : public ISO15118_chargerImplBase {
-public:
-    ISO15118_chargerImplStub() : ISO15118_chargerImplBase(nullptr, "EvseV2G"){};
+    ISO15118_chargerImplStub(ModuleAdapterStub& adapter) : ISO15118_chargerImplBase(&adapter, "EvseV2G"){};
+    ISO15118_chargerImplStub(ModuleAdapterStub* adapter) : ISO15118_chargerImplBase(adapter, "EvseV2G"){};
 
     virtual void init() {
     }

--- a/modules/EvseV2G/tests/din_server_test.cpp
+++ b/modules/EvseV2G/tests/din_server_test.cpp
@@ -1,0 +1,570 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include <din_server.hpp>
+
+#include <cstring>
+#include <gtest/gtest.h>
+
+#include "ISO15118_chargerImplStub.hpp"
+#include "cbv2g/din/din_msgDefDatatypes.h"
+#include "utest_log.hpp"
+#include "v2g.hpp"
+
+#include <memory>
+
+void publish_dc_ev_maximum_limits(struct v2g_context* ctx, const float& v2g_dc_ev_max_current_limit,
+                                  const unsigned int& v2g_dc_ev_max_current_limit_is_used,
+                                  const float& v2g_dc_ev_max_power_limit,
+                                  const unsigned int& v2g_dc_ev_max_power_limit_is_used,
+                                  const float& v2g_dc_ev_max_voltage_limit,
+                                  const unsigned int& v2g_dc_ev_max_voltage_limit_is_used) {
+}
+
+void stop_timer(struct event** event_timer, char const* const timer_name, struct v2g_context* ctx) {
+}
+
+void log_selected_energy_transfer_type(int selected_energy_transfer_mode) {
+}
+
+uint64_t v2g_session_id_from_exi(bool is_iso, void* exi_in) {
+    return 0;
+}
+
+void publish_dc_ev_target_voltage_current(struct v2g_context* ctx, const float& v2g_dc_ev_target_voltage,
+                                          const float& v2g_dc_ev_target_current) {
+}
+
+void publish_dc_ev_remaining_time(struct v2g_context* ctx, const float& v2g_dc_ev_remaining_time_to_full_soc,
+                                  const unsigned int& v2g_dc_ev_remaining_time_to_full_soc_is_used,
+                                  const float& v2g_dc_ev_remaining_time_to_bulk_soc,
+                                  const unsigned int& v2g_dc_ev_remaining_time_to_bulk_soc_is_used) {
+}
+
+namespace {
+class DinServerTest : public testing::Test {
+protected:
+    std::unique_ptr<v2g_connection> conn;
+    std::unique_ptr<v2g_context> ctx;
+    std::unique_ptr<din_exiDocument> exi_in;
+    std::unique_ptr<din_exiDocument> exi_out;
+
+    module::stub::ModuleAdapterStub adapter;
+    module::stub::ISO15118_chargerImplStub charger;
+
+    DinServerTest() : charger(adapter) {
+    }
+
+    void SetUp() override {
+        conn = std::make_unique<v2g_connection>();
+        ctx = std::make_unique<v2g_context>();
+        exi_in = std::make_unique<din_exiDocument>();
+        exi_out = std::make_unique<din_exiDocument>();
+
+        module::stub::clear_logs();
+        conn->ctx = ctx.get();
+        conn->ctx->p_charger = &charger;
+
+        conn->exi_in.dinEXIDocument = exi_in.get();
+        conn->exi_out.dinEXIDocument = exi_out.get();
+    }
+
+    void TearDown() override {
+    }
+};
+
+class DinServerTestValidateResponseCode
+    : public DinServerTest,
+      public testing::WithParamInterface<
+          std::tuple<int /*din_responseCodeType*/, bool, bool, bool, int /*V2gMsgTypeId*/, uint64_t, uint64_t, bool>> {
+};
+
+// For all test cases:
+// TODO: Define helper functions to set the conn and ctx variables
+
+// ----------------------------------------------------------------
+
+// Potential test for SessionSetup:
+// Bad Case:
+// Setting no EvseID -> A check should be added -> But a default value is in ctx provided.
+TEST_F(DinServerTest, session_setup_generating_new_session_id) {
+    // Setting up session_setup_req
+    auto& session_setup_req = exi_in->V2G_Message.Body.SessionSetupReq;
+    exi_in->V2G_Message.Body.SessionSetupReq_isUsed = true;
+    init_din_SessionSetupReqType(&session_setup_req);
+
+    const uint8_t evcc_id[8] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11};
+    memcpy(session_setup_req.EVCCID.bytes, evcc_id, sizeof(evcc_id));
+    session_setup_req.EVCCID.bytesLen = sizeof(evcc_id);
+
+    // Setting up conn
+    ctx->current_v2g_msg = V2G_SESSION_SETUP_MSG;
+    ctx->com_setup_timeout = nullptr;
+
+    ctx->evse_v2g_data.session_id = 0;
+    ctx->evse_v2g_data.date_time_now_is_used = 0;
+
+    ctx->ev_v2g_data.received_session_id = 0;
+
+    std::string evse_id = std::string("DE*PNX*TET1*234");
+    strcpy(reinterpret_cast<char*>(ctx->evse_v2g_data.evse_id.bytes), evse_id.data());
+    ctx->evse_v2g_data.evse_id.bytesLen = evse_id.size();
+
+    // Setting up session_setup_res
+    auto& session_setup_res = exi_out->V2G_Message.Body.SessionSetupRes;
+    exi_out->V2G_Message.Body.SessionSetupRes_isUsed = 1u;
+    init_din_SessionSetupResType(&session_setup_res);
+
+    EXPECT_EQ(states::handle_din_session_setup(conn.get()), V2G_EVENT_NO_EVENT);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_ERROR).size(), 0);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_INFO).size(), 3);
+
+    EXPECT_EQ(session_setup_res.DateTimeNow_isUsed, false);
+    // Checking if session id is generated
+    EXPECT_GT(ctx->evse_v2g_data.session_id, 0);
+    // Checking if evse id was set correctly
+    EXPECT_EQ(evse_id, std::string(reinterpret_cast<char*>(session_setup_res.EVSEID.bytes)));
+}
+
+TEST_F(DinServerTest, session_setup_old_session_id) {
+    // Setting up session_setup_req
+    auto& session_setup_req = exi_in->V2G_Message.Body.SessionSetupReq;
+    exi_in->V2G_Message.Body.SessionSetupReq_isUsed = true;
+    init_din_SessionSetupReqType(&session_setup_req);
+
+    const uint8_t evcc_id[8] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11};
+    memcpy(session_setup_req.EVCCID.bytes, evcc_id, sizeof(evcc_id));
+    session_setup_req.EVCCID.bytesLen = sizeof(evcc_id);
+
+    // Setting up conn
+    ctx->current_v2g_msg = V2G_SESSION_SETUP_MSG;
+    ctx->com_setup_timeout = nullptr;
+
+    ctx->evse_v2g_data.session_id = 4158610156;
+    ctx->evse_v2g_data.date_time_now_is_used = 0;
+
+    ctx->ev_v2g_data.received_session_id = 0;
+
+    std::string evse_id = std::string("DE*PNX*TET1*234");
+    strcpy(reinterpret_cast<char*>(ctx->evse_v2g_data.evse_id.bytes), evse_id.data());
+    ctx->evse_v2g_data.evse_id.bytesLen = evse_id.size();
+
+    // Setting up session_setup_res
+    auto& session_setup_res = exi_out->V2G_Message.Body.SessionSetupRes;
+    exi_out->V2G_Message.Body.SessionSetupRes_isUsed = 1u;
+    init_din_SessionSetupResType(&session_setup_res);
+
+    EXPECT_EQ(states::handle_din_session_setup(conn.get()), V2G_EVENT_NO_EVENT);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_ERROR).size(), 0);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_INFO).size(), 2);
+
+    EXPECT_EQ(session_setup_res.DateTimeNow_isUsed, false);
+    // Checking if session id is generated
+    EXPECT_EQ(ctx->evse_v2g_data.session_id, 4158610156);
+    // Checking if evse id was set correctly
+    EXPECT_EQ(evse_id, std::string(reinterpret_cast<char*>(session_setup_res.EVSEID.bytes)));
+}
+
+TEST_F(DinServerTest, session_setup_datetime_is_used) {
+    // Setting up session_setup_req
+    auto& session_setup_req = exi_in->V2G_Message.Body.SessionSetupReq;
+    exi_in->V2G_Message.Body.SessionSetupReq_isUsed = true;
+    init_din_SessionSetupReqType(&session_setup_req);
+
+    const uint8_t evcc_id[8] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11};
+    memcpy(session_setup_req.EVCCID.bytes, evcc_id, sizeof(evcc_id));
+    session_setup_req.EVCCID.bytesLen = sizeof(evcc_id);
+
+    // Setting up conn
+    ctx->current_v2g_msg = V2G_SESSION_SETUP_MSG;
+    ctx->com_setup_timeout = nullptr;
+
+    ctx->evse_v2g_data.session_id = 0;
+    ctx->evse_v2g_data.date_time_now_is_used = true;
+
+    ctx->ev_v2g_data.received_session_id = 0;
+
+    std::string evse_id = std::string("DE*PNX*TET1*234");
+    strcpy(reinterpret_cast<char*>(ctx->evse_v2g_data.evse_id.bytes), evse_id.data());
+    ctx->evse_v2g_data.evse_id.bytesLen = evse_id.size();
+
+    // Setting up session_setup_res
+    auto& session_setup_res = exi_out->V2G_Message.Body.SessionSetupRes;
+    exi_out->V2G_Message.Body.SessionSetupRes_isUsed = 1u;
+    init_din_SessionSetupResType(&session_setup_res);
+
+    EXPECT_EQ(states::handle_din_session_setup(conn.get()), V2G_EVENT_NO_EVENT);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_ERROR).size(), 0);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_INFO).size(), 3);
+
+    EXPECT_EQ(session_setup_res.DateTimeNow_isUsed, true);
+    EXPECT_GT(session_setup_res.DateTimeNow, 0);
+    // Checking if session id is generated
+    EXPECT_GT(ctx->evse_v2g_data.session_id, 0);
+    // Checking if evse id was set correctly
+    EXPECT_EQ(evse_id, std::string(reinterpret_cast<char*>(session_setup_res.EVSEID.bytes)));
+}
+
+TEST_F(DinServerTest, din_service_discovery_good_case) {
+
+    // TODO(sl): Maybe add this to check exi_out proberly
+    exi_out->V2G_Message.Body.ServiceDiscoveryRes_isUsed = true;
+    init_din_ServiceDiscoveryResType(&exi_out->V2G_Message.Body.ServiceDiscoveryRes);
+
+    // TODO: Setting the correct session_id + received_session_id via functions
+
+    EXPECT_EQ(states::handle_din_service_discovery(conn.get()), V2G_EVENT_NO_EVENT);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_ERROR).size(), 1);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_INFO).size(), 0);
+}
+
+TEST_F(DinServerTest, handle_din_contract_authentication_check_evse_processing_finished) {
+
+    ctx->com_setup_timeout = nullptr;
+
+    // TODO: set a prober session id
+    ctx->evse_v2g_data.session_id = 0;
+    ctx->evse_v2g_data.date_time_now_is_used = 0;
+
+    ctx->current_v2g_msg = V2G_AUTHORIZATION_MSG;
+    ctx->ev_v2g_data.received_session_id = 0;
+
+    ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = 0;
+    EXPECT_EQ(states::handle_din_contract_authentication(conn.get()), V2G_EVENT_NO_EVENT); // TODO
+
+    auto& res = exi_out->V2G_Message.Body.ContractAuthenticationRes;
+
+    // EXPECT_EQ(res.ResponseCode, din_responseCodeType_OK);
+    EXPECT_EQ(res.EVSEProcessing, din_EVSEProcessingType_Finished);
+    EXPECT_EQ(ctx->state, WAIT_FOR_CHARGEPARAMETERDISCOVERY);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_ERROR).size(), 1);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_INFO).size(), 0);
+}
+
+TEST_F(DinServerTest, handle_din_contract_authentication_check_evse_processing_ongoing) {
+
+    ctx->com_setup_timeout = nullptr;
+
+    // TODO: set a prober session id
+    ctx->evse_v2g_data.session_id = 0;
+    ctx->evse_v2g_data.date_time_now_is_used = 0;
+
+    ctx->current_v2g_msg = V2G_AUTHORIZATION_MSG;
+    ctx->ev_v2g_data.received_session_id = 0;
+
+    ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = 1;
+    EXPECT_EQ(states::handle_din_contract_authentication(conn.get()), V2G_EVENT_NO_EVENT); // TODO
+
+    auto& res = exi_out->V2G_Message.Body.ContractAuthenticationRes;
+
+    // EXPECT_EQ(res.ResponseCode, din_responseCodeType_OK);
+    EXPECT_EQ(res.EVSEProcessing, din_EVSEProcessingType_Ongoing);
+    EXPECT_EQ(ctx->state, WAIT_FOR_AUTHORIZATION);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_ERROR).size(), 1);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_INFO).size(), 0);
+}
+
+// if not otherwise specified, the following testcases are happy paths
+
+TEST_F(DinServerTest, din_validate_response_code_TERMINATE_CONNECTION) {
+
+    // which response code is actually irrelevant here and was picked at random
+    auto tmp = din_responseCodeType_FAILED_TariffSelectionInvalid;
+
+    // only this bool determines the outcome
+    ctx->is_connection_terminated = true;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_TERMINATE_CONNECTION);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_NO_EVENT_failed_response_FAILED) {
+
+    // which response code is actually irrelevant here and was picked at random
+    // FAILED code
+    auto tmp = din_responseCodeType_FAILED_ChallengeInvalid;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->terminate_connection_on_failed_response = false;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_NO_EVENT);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_NO_EVENT_failed_response_OK) {
+
+    // which response code is actually irrelevant here and was picked at random
+    // OK code
+    auto tmp = din_responseCodeType_OK;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->terminate_connection_on_failed_response = false;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_NO_EVENT);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_NO_EVENT_OK) {
+
+    // which response code is actually irrelevant here and was picked at random
+    // OK code
+    auto tmp = din_responseCodeType_OK;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = false; //||
+    ctx->intl_emergency_shutdown = false;
+
+    ctx->current_v2g_msg = V2G_SESSION_SETUP_MSG; // &&
+    ctx->evse_v2g_data.session_id = 1;
+    ctx->ev_v2g_data.received_session_id = 2;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_NO_EVENT);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_NO_EVENT_OK_bad_path_1) {
+
+    // OK code
+    auto tmp = din_responseCodeType_OK;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = true; //||
+    ctx->intl_emergency_shutdown = false;
+
+    ctx->current_v2g_msg = V2G_SESSION_SETUP_MSG; // &&
+    ctx->evse_v2g_data.session_id = 1;
+    ctx->ev_v2g_data.received_session_id = 2;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_NE(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_NO_EVENT);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_NO_EVENT_OK_bad_path_2) {
+
+    // OK code
+    auto tmp = din_responseCodeType_OK;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = false; //||
+    ctx->intl_emergency_shutdown = true;
+
+    ctx->current_v2g_msg = V2G_SESSION_SETUP_MSG; // &&
+    ctx->evse_v2g_data.session_id = 1;
+    ctx->ev_v2g_data.received_session_id = 2;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_NE(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_NO_EVENT);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_NO_EVENT_OK_bad_path_3) {
+
+    // OK code
+    auto tmp = din_responseCodeType_OK;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = false; //||
+    ctx->intl_emergency_shutdown = false;
+
+    ctx->current_v2g_msg = V2G_CERTIFICATE_INSTALLATION_MSG; // &&
+    ctx->evse_v2g_data.session_id = 1;
+    ctx->ev_v2g_data.received_session_id = 2;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_NE(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_NO_EVENT);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_NO_EVENT_OK_bad_path_4) {
+
+    // OK code
+    auto tmp = din_responseCodeType_OK;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = false; //||
+    ctx->intl_emergency_shutdown = true;
+
+    ctx->current_v2g_msg = V2G_SESSION_SETUP_MSG; // &&
+    ctx->evse_v2g_data.session_id = 6;
+    ctx->ev_v2g_data.received_session_id = 6;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_NE(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_NO_EVENT);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_SEND_AND_TERMINATE_1) {
+
+    auto tmp = din_responseCodeType_FAILED_WrongEnergyTransferType;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = true; //||
+    ctx->intl_emergency_shutdown = false;
+
+    ctx->current_v2g_msg = V2G_METERING_RECEIPT_MSG; // &&
+    ctx->evse_v2g_data.session_id = 6;
+    ctx->ev_v2g_data.received_session_id = 6;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_SEND_AND_TERMINATE);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_SEND_AND_TERMINATE_2) {
+
+    auto tmp = din_responseCodeType_FAILED_MeteringSignatureNotValid;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = false; //||
+    ctx->intl_emergency_shutdown = true;
+
+    ctx->current_v2g_msg = V2G_CHARGING_STATUS_MSG; // &&
+    ctx->evse_v2g_data.session_id = 1;
+    ctx->ev_v2g_data.received_session_id = 6;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_SEND_AND_TERMINATE);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_SEND_AND_TERMINATE_3) {
+
+    auto tmp = din_responseCodeType_OK_CertificateExpiresSoon;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = false; //||
+    ctx->intl_emergency_shutdown = false;
+
+    ctx->current_v2g_msg = V2G_UNKNOWN_MSG; // &&
+    ctx->evse_v2g_data.session_id = 1;
+    ctx->ev_v2g_data.received_session_id = 1;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_SEND_AND_TERMINATE);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_SEND_AND_TERMINATE_4) {
+
+    auto tmp = din_responseCodeType_OK_CertificateExpiresSoon;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = false; //||
+    ctx->intl_emergency_shutdown = false;
+
+    ctx->current_v2g_msg = V2G_UNKNOWN_MSG; // &&
+    ctx->evse_v2g_data.session_id = 1;
+    ctx->ev_v2g_data.received_session_id = 1;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_SEND_AND_TERMINATE);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_SEND_AND_TERMINATE_5) {
+
+    auto tmp = din_responseCodeType_OK_CertificateExpiresSoon;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = false; //||
+    ctx->intl_emergency_shutdown = false;
+
+    ctx->current_v2g_msg = V2G_CABLE_CHECK_MSG; // &&
+    ctx->evse_v2g_data.session_id = 1;
+    ctx->ev_v2g_data.received_session_id = 2;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_SEND_AND_TERMINATE);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_EVENT_SEND_AND_TERMINATE_6) {
+
+    auto tmp = din_responseCodeType_FAILED_SequenceError;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->stop_hlc = false; //||
+    ctx->intl_emergency_shutdown = false;
+
+    ctx->current_v2g_msg = V2G_SESSION_SETUP_MSG; // &&
+    ctx->evse_v2g_data.session_id = 1;
+    ctx->ev_v2g_data.received_session_id = 2;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_EQ(utils::din_validate_response_code(&tmp, conn.get()), V2G_EVENT_SEND_AND_TERMINATE);
+}
+TEST_F(DinServerTest, din_validate_response_code_V2G_DC_390) {
+    // The response message shall contain the ResponseCode “FAILED_SequenceError” if the
+    // SECC has received an unexpected request message.
+
+    auto given_response_code = din_responseCodeType_OK;
+    constexpr auto expected_response_code = din_responseCodeType_FAILED_SequenceError;
+    constexpr auto expected_response = V2G_EVENT_NO_EVENT;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->terminate_connection_on_failed_response = false;
+
+    ctx->current_v2g_msg = V2G_UNKNOWN_MSG;
+
+    EXPECT_EQ(utils::din_validate_response_code(&given_response_code, conn.get()), expected_response);
+    // given response code should change in the function call
+    EXPECT_EQ(given_response_code, expected_response_code);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_V2G_DC_391) {
+    // The response message shall contain the ResponseCode “FAILED_UnknownSession” if the
+    // SessionID in a request message does not match the SessionID provided by the SECC in the SessionSetupRes
+    // message.
+
+    auto given_response_code = din_responseCodeType_OK;
+    constexpr auto expected_response_code = din_responseCodeType_FAILED_UnknownSession;
+    constexpr auto expected_response = V2G_EVENT_NO_EVENT;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->terminate_connection_on_failed_response = false;
+    ctx->evse_v2g_data.session_id = 1234;
+    ctx->ev_v2g_data.received_session_id = 5678;
+
+    EXPECT_EQ(utils::din_validate_response_code(&given_response_code, conn.get()), expected_response);
+    // given response code should change in the function call
+    EXPECT_EQ(given_response_code, expected_response_code);
+}
+
+TEST_F(DinServerTest, din_validate_response_code_V2G_DC_665) {
+    // If the SECC receives a request message that it expects according to the message sequence
+    // specified in this chapter, and if the SECC cannot process this request message, e. g. due to
+    // errors in the message parameters or due to impeding conditions in the EVSE, the SECC
+    // shall:
+    // [1.] without any delay, carry out an “EVSE-initiated emergency shutdown” as specified in
+    // IEC 61851-23, which includes turning off the CP oscillator, if it is turned on,
+    // [2.] respond with the corresponding response message with parameter ResponseCode
+    // equal to “FAILED”, if possible, and
+    // [3.] close the TCP connection according to [V2G-DC-116].
+
+    auto given_response_code = din_responseCodeType_FAILED;
+    constexpr auto min_expected_response_code = din_responseCodeType_FAILED;
+    constexpr auto expected_response = V2G_EVENT_SEND_AND_TERMINATE;
+
+    ctx->is_connection_terminated = false;
+
+    ctx->terminate_connection_on_failed_response = true;
+
+    EXPECT_EQ(utils::din_validate_response_code(&given_response_code, conn.get()), expected_response);
+    EXPECT_GE(given_response_code, min_expected_response_code);
+}
+
+} // namespace

--- a/modules/EvseV2G/tests/evse_securityIntfStub.hpp
+++ b/modules/EvseV2G/tests/evse_securityIntfStub.hpp
@@ -17,13 +17,19 @@
 //-----------------------------------------------------------------------------
 namespace module::stub {
 
-class evse_securityIntfStub : public ModuleAdapterStub, public evse_securityIntf {
+class evse_securityIntfStub : public evse_securityIntf {
 private:
     std::map<const std::string, Result (evse_securityIntfStub::*)(const Requirement& req, const Parameters& args)>
         functions;
 
 public:
-    evse_securityIntfStub() : evse_securityIntf(this, Requirement{"", 0}, "EvseSecurity", std::nullopt) {
+    evse_securityIntfStub(ModuleAdapterStub* adapter) :
+        evse_securityIntf(adapter, Requirement{"", 0}, "EvseSecurity", std::nullopt) {
+        functions["get_verify_file"] = &evse_securityIntfStub::get_verify_file;
+        functions["get_leaf_certificate_info"] = &evse_securityIntfStub::get_leaf_certificate_info;
+    }
+    evse_securityIntfStub(ModuleAdapterStub& adapter) :
+        evse_securityIntf(&adapter, Requirement{"", 0}, "EvseSecurity", std::nullopt) {
         functions["get_verify_file"] = &evse_securityIntfStub::get_verify_file;
         functions["get_leaf_certificate_info"] = &evse_securityIntfStub::get_leaf_certificate_info;
     }

--- a/modules/EvseV2G/tests/log.cpp
+++ b/modules/EvseV2G/tests/log.cpp
@@ -1,16 +1,45 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
-#include "log.hpp"
+#include "utest_log.hpp"
 
 #include <cstdarg>
 #include <cstdio>
 
+#include <algorithm>
+#include <array>
+#include <map>
+
+namespace {
+std::map<dloglevel_t, std::vector<std::string>> logged_events;
+
+void add_log(dloglevel_t loglevel, const std::string& event) {
+    logged_events[loglevel].push_back(event);
+}
+} // namespace
+
+namespace module::stub {
+std::vector<std::string>& get_logs(dloglevel_t loglevel) {
+    return logged_events[loglevel];
+}
+
+void clear_logs() {
+    logged_events.clear();
+}
+
+} // namespace module::stub
+
 void dlog_func(const dloglevel_t loglevel, const char* filename, const int linenumber, const char* functionname,
                const char* format, ...) {
     va_list ap;
+    std::array<char, 256> buffer;
     va_start(ap, format);
-    (void)std::vfprintf(stderr, format, ap);
+    std::size_t len = std::vsnprintf(buffer.data(), buffer.size(), format, ap);
     va_end(ap);
-    (void)std::fprintf(stderr, "\n");
+    if (len > 0) {
+        auto s_len = std::min(len, buffer.size());
+        std::string event{buffer.data(), s_len};
+        (void)std::fprintf(stderr, "log: %s\n", event.c_str());
+        add_log(loglevel, event);
+    }
 }

--- a/modules/EvseV2G/tests/sdp_test.cpp
+++ b/modules/EvseV2G/tests/sdp_test.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include <gtest/gtest.h>
+#include <sdp.hpp>
+
+namespace {
+
+class SdpTest : public testing::Test {
+protected:
+    SdpTest() {
+    }
+};
+
+TEST_F(SdpTest, sdp_write_header) {
+    uint8_t buffer[20];
+    uint16_t payload_type = 0x9001;
+    uint32_t length = 367;
+
+    EXPECT_EQ(sdp_write_header(buffer, payload_type, length), 8);
+
+    EXPECT_EQ(buffer[0], 0x01);
+    EXPECT_EQ(buffer[1], 0xFE);
+    EXPECT_EQ(buffer[2], 0x90);
+    EXPECT_EQ(buffer[3], 0x01);
+    EXPECT_EQ(buffer[4], 0x00);
+    EXPECT_EQ(buffer[5], 0x00);
+    EXPECT_EQ(buffer[6], 0x01);
+    EXPECT_EQ(buffer[7], 0x6F);
+}
+
+} // namespace

--- a/modules/EvseV2G/tests/utest_log.hpp
+++ b/modules/EvseV2G/tests/utest_log.hpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <log.hpp>
+
+#include <string>
+#include <vector>
+
+namespace module::stub {
+std::vector<std::string>& get_logs(dloglevel_t loglevel);
+void clear_logs();
+
+} // namespace module::stub

--- a/modules/EvseV2G/tests/v2g_ctx_test.cpp
+++ b/modules/EvseV2G/tests/v2g_ctx_test.cpp
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include <memory>
+#include <v2g_ctx.hpp>
+
+#include "ISO15118_chargerImplStub.hpp"
+#include "ModuleAdapterStub.hpp"
+#include "evse_securityIntfStub.hpp"
+#include "utest_log.hpp"
+#include "v2g.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct v2g_contextDeleter {
+    void operator()(v2g_context* ptr) const {
+        v2g_ctx_free(ptr);
+    };
+};
+
+class V2gCtxTest : public testing::Test {
+protected:
+    std::unique_ptr<v2g_context, v2g_contextDeleter> ctx;
+    module::stub::QuietModuleAdapterStub adapter;
+    module::stub::ISO15118_chargerImplStub charger;
+    module::stub::evse_securityIntfStub security;
+
+    V2gCtxTest() : charger(adapter), security(adapter) {
+    }
+
+    void v2g_ctx_init_charging_state_cleared() {
+        // checks try to match the order is v2g.hpp
+
+        EXPECT_EQ(ctx->com_setup_timeout, nullptr);
+
+        EXPECT_EQ(ctx->last_v2g_msg, V2G_UNKNOWN_MSG);
+        EXPECT_EQ(ctx->current_v2g_msg, V2G_UNKNOWN_MSG);
+        EXPECT_EQ(ctx->state, 0);
+
+        // not changed
+        // is_dc_charger
+        // debugMode
+        // supported_protocols
+
+        EXPECT_EQ(ctx->selected_protocol, V2G_UNKNOWN_PROTOCOL);
+        EXPECT_FALSE(ctx->intl_emergency_shutdown);
+        EXPECT_FALSE(ctx->stop_hlc);
+
+        // ctx->is_connection_terminated is updated rather than cleared
+
+        // not changed
+        // terminate_connection_on_failed_response
+        // contactor_is_closed
+
+        // many items in session not reset
+        EXPECT_FALSE(ctx->session.renegotiation_required);
+        EXPECT_FALSE(ctx->session.is_charging);
+    }
+
+    void SetUp() override {
+        auto ptr = v2g_ctx_create(&charger, &security);
+        ctx = std::unique_ptr<v2g_context, v2g_contextDeleter>(ptr, v2g_contextDeleter());
+        module::stub::clear_logs();
+    }
+
+    void TearDown() override {
+    }
+};
+
+TEST(RunFirst, v2g_ctx_init_charging_values) {
+    // must not be part of V2gCtxTest
+    // V2gCtxTest::SetUp() creates the v2g_context which would be the 1st
+    // call to v2g_ctx_init_charging_values()
+
+    // only called from v2g_ctx_init_charging_session()
+    // which is called from v2g_ctx_create()
+
+    // note v2g_ctx_init_charging_values() has a static bool so it
+    // performs different tidyup after the first time it is called
+
+    v2g_context ctx;
+    ctx.evse_v2g_data.charge_service.FreeService = 9;
+    v2g_ctx_init_charging_values(&ctx);
+    EXPECT_EQ(ctx.evse_v2g_data.charge_service.FreeService, 0);
+    ctx.evse_v2g_data.charge_service.FreeService = 10;
+    v2g_ctx_init_charging_values(&ctx);
+    EXPECT_EQ(ctx.evse_v2g_data.charge_service.FreeService, 10);
+
+    // reset back to a valid value as it will never be reset
+    ctx.evse_v2g_data.charge_service.FreeService = 0;
+}
+
+TEST_F(V2gCtxTest, v2g_ctx_init_charging_stateTrue) {
+    // called on session start in v2g_handle_connection()
+
+    ctx->com_setup_timeout = nullptr; // does not appear to ever be set
+    ctx->last_v2g_msg = V2G_CABLE_CHECK_MSG;
+    ctx->current_v2g_msg = V2G_CHARGE_PARAMETER_DISCOVERY_MSG;
+    ctx->state = 10;
+    ctx->selected_protocol = V2G_PROTO_DIN70121;
+    ctx->intl_emergency_shutdown = true;
+    ctx->stop_hlc = true;
+    ctx->session.renegotiation_required = true;
+    ctx->session.is_charging = true;
+
+    v2g_ctx_init_charging_state(ctx.get(), true);
+
+    v2g_ctx_init_charging_state_cleared();
+    EXPECT_TRUE(ctx->is_connection_terminated);
+}
+
+TEST_F(V2gCtxTest, v2g_ctx_init_charging_stateFalse) {
+    // called on session end in v2g_handle_connection()
+
+    ctx->com_setup_timeout = nullptr; // does not appear to ever be set
+    ctx->last_v2g_msg = V2G_CABLE_CHECK_MSG;
+    ctx->current_v2g_msg = V2G_CHARGE_PARAMETER_DISCOVERY_MSG;
+    ctx->state = 10;
+    ctx->selected_protocol = V2G_PROTO_DIN70121;
+    ctx->intl_emergency_shutdown = true;
+    ctx->stop_hlc = true;
+    ctx->session.renegotiation_required = true;
+    ctx->session.is_charging = true;
+
+    v2g_ctx_init_charging_state(ctx.get(), false);
+
+    v2g_ctx_init_charging_state_cleared();
+    EXPECT_FALSE(ctx->is_connection_terminated);
+}
+
+#if 0
+// v2g_ctx_init_charging_session() is a trivial implementation
+TEST_F(V2gCtxTest, v2g_ctx_init_charging_sessionTrue) {
+    // called in connection_teardown()
+    // calls v2g_ctx_init_charging_state
+    // calls v2g_ctx_init_charging_values
+}
+
+TEST_F(V2gCtxTest, v2g_ctx_init_charging_sessionFalse) {
+    // called in connection_teardown()
+    // calls v2g_ctx_init_charging_state
+    // calls v2g_ctx_init_charging_values
+}
+#endif
+
+TEST(valgrind, memcheck) {
+    GTEST_SKIP() << "pthreads result in valgrind reporting errors";
+    /*
+     * v2g_ctx_free() doesn't stop or wait for threads to finish (no join)
+     * hence there is access to free'd memory reported.
+     *
+     * ==2136== LEAK SUMMARY:
+     * ==2136==    definitely lost: 0 bytes in 0 blocks
+     * ==2136==    indirectly lost: 0 bytes in 0 blocks
+     * ==2136==      possibly lost: 304 bytes in 1 blocks
+     * ==2136==    still reachable: 80 bytes in 2 blocks
+     * ==2136==         suppressed: 0 bytes in 0 blocks
+     */
+
+    // run via valgrind to ensure that malloc/free are working
+    module::stub::QuietModuleAdapterStub adapter;
+    module::stub::ISO15118_chargerImplStub charger(adapter);
+    module::stub::evse_securityIntfStub security(adapter);
+    auto ptr = v2g_ctx_create(&charger, &security);
+    v2g_ctx_free(ptr);
+}
+
+} // namespace

--- a/modules/EvseV2G/tests/v2g_main.cpp
+++ b/modules/EvseV2G/tests/v2g_main.cpp
@@ -18,6 +18,7 @@
 #include <unistd.h>
 
 #include "ISO15118_chargerImplStub.hpp"
+#include "ModuleAdapterStub.hpp"
 #include "evse_securityIntfStub.hpp"
 
 #include <connection.hpp>
@@ -79,6 +80,9 @@ void parse_options(int argc, char** argv) {
 
 // EvseSecurity "implementation"
 struct EvseSecurity : public module::stub::evse_securityIntfStub {
+    EvseSecurity(module::stub::ModuleAdapterStub& adapter) : module::stub::evse_securityIntfStub(&adapter) {
+    }
+
     Result get_verify_file(const Requirement& req, const Parameters& args) override {
         return "client_root_cert.pem";
     }
@@ -119,8 +123,9 @@ int main(int argc, char** argv) {
     parse_options(argc, argv);
 
     tls::Server tls_server;
-    module::stub::ISO15118_chargerImplStub charger;
-    EvseSecurity security;
+    module::stub::ModuleAdapterStub adapter;
+    module::stub::ISO15118_chargerImplStub charger(adapter);
+    EvseSecurity security(adapter);
 
     auto* ctx = v2g_ctx_create(&charger, &security);
     if (ctx == nullptr) {

--- a/tests/include/ModuleAdapterStub.hpp
+++ b/tests/include/ModuleAdapterStub.hpp
@@ -6,6 +6,7 @@
 
 #include <framework/ModuleAdapter.hpp>
 
+#include <optional>
 #include <utils/error/error_database_map.hpp>
 #include <utils/error/error_factory.hpp>
 #include <utils/error/error_manager_impl.hpp>
@@ -31,16 +32,22 @@ struct ModuleAdapterStub : public Everest::ModuleAdapter {
             return this->get_error_state_monitor_impl_fn(str);
         };
         get_error_factory = [this](const std::string& str) { return this->get_error_factory_fn(str); };
-        this->get_error_manager_req = [this](const Requirement& req) { return this->get_error_manager_req_fn(req); };
+        get_error_manager_req = [this](const Requirement& req) { return this->get_error_manager_req_fn(req); };
         get_error_state_monitor_req = [this](const Requirement& req) {
             return this->get_error_state_monitor_req_fn(req);
         };
+        get_global_error_manager = [this]() { return this->get_global_error_manager_fn(); };
+        get_global_error_state_monitor = [this]() { return this->get_global_error_state_monitor_fn(); };
         ext_mqtt_publish = [this](const std::string& s1, const std::string& s2) { this->ext_mqtt_publish_fn(s1, s2); };
         ext_mqtt_subscribe = [this](const std::string& str, StringHandler sh) {
             return this->ext_mqtt_subscribe_fn(str, sh);
         };
+        ext_mqtt_subscribe_pair = [this](const std::string& topic, const StringPairHandler& handler) {
+            return this->ext_mqtt_subscribe_pair_fn(topic, handler);
+        };
         telemetry_publish = [this](const std::string& s1, const std::string& s2, const std::string& s3,
                                    const Everest::TelemetryMap& tm) { this->telemetry_publish_fn(s1, s2, s3, tm); };
+        get_mapping = [this]() { return this->get_mapping_fn(); };
     }
 
     virtual Result call_fn(const Requirement&, const std::string&, Parameters) {
@@ -66,6 +73,14 @@ struct ModuleAdapterStub : public Everest::ModuleAdapter {
         return std::make_shared<Everest::error::ErrorStateMonitor>(
             std::make_shared<Everest::error::ErrorDatabaseMap>());
     }
+    virtual std::shared_ptr<Everest::error::ErrorManagerReqGlobal> get_global_error_manager_fn() {
+        std::printf("get_global_error_manager_fn\n");
+        return {};
+    }
+    virtual std::shared_ptr<Everest::error::ErrorStateMonitor> get_global_error_state_monitor_fn() {
+        std::printf("get_global_error_state_monitor_fn\n");
+        return {};
+    }
     virtual std::shared_ptr<Everest::error::ErrorFactory> get_error_factory_fn(const std::string&) {
         std::printf("get_error_factory_fn\n");
         return std::make_shared<Everest::error::ErrorFactory>(std::make_shared<Everest::error::ErrorTypeMap>());
@@ -90,9 +105,73 @@ struct ModuleAdapterStub : public Everest::ModuleAdapter {
         std::printf("ext_mqtt_subscribe_fn\n");
         return nullptr;
     }
+    virtual std::function<void()> ext_mqtt_subscribe_pair_fn(const std::string& topic,
+                                                             const StringPairHandler& handler) {
+        std::printf("ext_mqtt_subscribe_pair_fn\n");
+        return {};
+    }
     virtual void telemetry_publish_fn(const std::string&, const std::string&, const std::string&,
                                       const Everest::TelemetryMap&) {
         std::printf("telemetry_publish_fn\n");
+    }
+    virtual std::optional<ModuleTierMappings> get_mapping_fn() {
+        std::printf("get_mapping_fn\n");
+        return {};
+    }
+};
+
+struct QuietModuleAdapterStub : public ModuleAdapterStub {
+    Result call_fn(const Requirement&, const std::string&, Parameters) override {
+        return {};
+    }
+    void publish_fn(const std::string&, const std::string&, Value) override {
+    }
+    void subscribe_fn(const Requirement&, const std::string& fn, ValueCallback) override {
+    }
+    std::shared_ptr<Everest::error::ErrorManagerImpl> get_error_manager_impl_fn(const std::string&) override {
+        return std::make_shared<Everest::error::ErrorManagerImpl>(
+            std::make_shared<Everest::error::ErrorTypeMap>(), std::make_shared<Everest::error::ErrorDatabaseMap>(),
+            std::list<Everest::error::ErrorType>(), [](const Everest::error::Error&) {},
+            [](const Everest::error::Error&) {});
+    }
+    std::shared_ptr<Everest::error::ErrorStateMonitor> get_error_state_monitor_impl_fn(const std::string&) override {
+        return std::make_shared<Everest::error::ErrorStateMonitor>(
+            std::make_shared<Everest::error::ErrorDatabaseMap>());
+    }
+    std::shared_ptr<Everest::error::ErrorManagerReqGlobal> get_global_error_manager_fn() override {
+        return {};
+    }
+    std::shared_ptr<Everest::error::ErrorStateMonitor> get_global_error_state_monitor_fn() override {
+        return {};
+    }
+    std::shared_ptr<Everest::error::ErrorFactory> get_error_factory_fn(const std::string&) override {
+        return std::make_shared<Everest::error::ErrorFactory>(std::make_shared<Everest::error::ErrorTypeMap>());
+    }
+    std::shared_ptr<Everest::error::ErrorManagerReq> get_error_manager_req_fn(const Requirement&) override {
+        return std::make_shared<Everest::error::ErrorManagerReq>(
+            std::make_shared<Everest::error::ErrorTypeMap>(), std::make_shared<Everest::error::ErrorDatabaseMap>(),
+            std::list<Everest::error::ErrorType>(),
+            [](const Everest::error::ErrorType&, const Everest::error::ErrorCallback&,
+               const Everest::error::ErrorCallback&) { std::printf("subscribe_error\n"); });
+    }
+    std::shared_ptr<Everest::error::ErrorStateMonitor> get_error_state_monitor_req_fn(const Requirement&) override {
+        return std::make_shared<Everest::error::ErrorStateMonitor>(
+            Everest::error::ErrorStateMonitor(std::make_shared<Everest::error::ErrorDatabaseMap>()));
+    }
+    void ext_mqtt_publish_fn(const std::string&, const std::string&) override {
+    }
+    std::function<void()> ext_mqtt_subscribe_fn(const std::string&, StringHandler) override {
+        return nullptr;
+    }
+    std::function<void()> ext_mqtt_subscribe_pair_fn(const std::string& topic,
+                                                     const StringPairHandler& handler) override {
+        return {};
+    }
+    void telemetry_publish_fn(const std::string&, const std::string&, const std::string&,
+                              const Everest::TelemetryMap&) override {
+    }
+    std::optional<ModuleTierMappings> get_mapping_fn() override {
+        return {};
     }
 };
 


### PR DESCRIPTION
## Describe your changes
Adding a few unit tests for the EvseV2G module. This should serve as a starting point for further tests.

## Issue ticket number and link
The EvseV2G module has hardly any unit tests. Nevertheless, it should be possible to test certain parts of the code, such as the DIN/ISO-2 state machine, using unit tests. The first task was to find out how easy or difficult it is to add unit tests for the DIN state machine.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

