### PR TITLE
Auth: Catch all exceptions while waiting for token validation and reject it instead of crashing

### DIFF
--- a/modules/Auth/Auth.cpp
+++ b/modules/Auth/Auth.cpp
@@ -73,7 +73,16 @@ void Auth::ready() {
     this->auth_handler->register_validate_token_callback([this](const ProvidedIdToken& provided_token) {
         std::vector<ValidationResult> validation_results;
         for (const auto& token_validator : this->r_token_validator) {
-            validation_results.push_back(token_validator->call_validate_token(provided_token));
+            try {
+                const auto result = token_validator->call_validate_token(provided_token);
+                validation_results.push_back(result);
+            // TODO: This is very broad catch, make it more narrow when the everest-framework error handling will be established
+            } catch (const std::exception& e) {
+                EVLOG_warning << "Exception during validating token: " << e.what();
+                ValidationResult validation_result;
+                validation_result.authorization_status = AuthorizationStatus::Unknown;
+                validation_results.push_back(validation_result);
+            }
         }
         return validation_results;
     });

--- a/modules/Auth/Auth.cpp
+++ b/modules/Auth/Auth.cpp
@@ -76,7 +76,8 @@ void Auth::ready() {
             try {
                 const auto result = token_validator->call_validate_token(provided_token);
                 validation_results.push_back(result);
-            // TODO: This is very broad catch, make it more narrow when the everest-framework error handling will be established
+                // TODO: This is very broad catch, make it more narrow when the everest-framework error handling will be
+                // established
             } catch (const std::exception& e) {
                 EVLOG_warning << "Exception during validating token: " << e.what();
                 ValidationResult validation_result;


### PR DESCRIPTION
## Describe your changes
Now instead of letting exceptions crash whole EVerest, we catch it and reject the token if any exception was raised by token_validator and/or everest
## Issue ticket number and link
https://github.com/EVerest/everest-core/issues/1024
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

