### PR TITLE
Ensure that "lib" is the CMAKE_INSTALL_LIBDIR in pugixml bazel dep

### DIFF
--- a/third-party/bazel/BUILD.pugixml.bazel
+++ b/third-party/bazel/BUILD.pugixml.bazel
@@ -8,6 +8,7 @@ filegroup(
 cmake(
     name = "libpugixml",
     cache_entries = {
+        "CMAKE_INSTALL_LIBDIR": "lib",
     },
     lib_source = "@pugixml//:all_srcs",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
If this is not set on some systems this might default to lib64 leading to bazel build errors like:

output 'external/pugixml/libpugixml/lib/libpugixml.a' was not created

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

