### PR TITLE
Bump everest-framework dependency to 0.20.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,7 +4,7 @@
 ---
 everest-framework:
   git: https://github.com/EVerest/everest-framework.git
-  git_tag: 7a87814e7618b8b4b3c67b776d86fd390164c917
+  git_tag: v0.20.2
   options: [
     "BUILD_TESTING OFF",
     "everest-framework_USE_PYTHON_VENV ${PROJECT_NAME}_USE_PYTHON_VENV",

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,7 +4,7 @@
 ---
 everest-framework:
   git: https://github.com/EVerest/everest-framework.git
-  git_tag: v0.20.1
+  git_tag: 7a87814e7618b8b4b3c67b776d86fd390164c917
   options: [
     "BUILD_TESTING OFF",
     "everest-framework_USE_PYTHON_VENV ${PROJECT_NAME}_USE_PYTHON_VENV",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -547,7 +547,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "everestrs"
 version = "0.20.2"
-source = "git+https://github.com/everest/everest-framework.git?rev=7a87814e7618b8b4b3c67b776d86fd390164c917#7a87814e7618b8b4b3c67b776d86fd390164c917"
+source = "git+https://github.com/everest/everest-framework.git?tag=v0.20.2#bf8899cf67d014a2908aedbecfe0768eb4c28737"
 dependencies = [
  "clap",
  "cxx",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "everestrs-build"
 version = "0.20.1"
-source = "git+https://github.com/everest/everest-framework.git?rev=7a87814e7618b8b4b3c67b776d86fd390164c917#7a87814e7618b8b4b3c67b776d86fd390164c917"
+source = "git+https://github.com/everest/everest-framework.git?tag=v0.20.2#bf8899cf67d014a2908aedbecfe0768eb4c28737"
 dependencies = [
  "anyhow",
  "argh",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -420,9 +420,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cxx"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc894913dccfed0f84106062c284fa021c3ba70cb1d78797d6f5165d4492e45"
+checksum = "3956d60afa98653c5a57f60d7056edd513bfe0307ef6fb06f6167400c3884459"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d2cb64a95b4b5a381971482235c4db2e0208302a962acdbe314db03cbbe2fb"
+checksum = "0f01e92ab4ce9fd4d16e3bb11b158d98cbdcca803c1417aa43130a6526fbf208"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -447,15 +447,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f797b0206463c9c2a68ed605ab28892cca784f1ef066050f4942e3de26ad885"
+checksum = "8c41cbfab344869e70998b388923f7d1266588f56c8ca284abf259b1c1ffc695"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79010a2093848e65a3e0f7062d3f02fb2ef27f866416dfe436fccfa73d3bb59"
+checksum = "88d82a2f759f0ad3eae43b96604efd42b1d4729a35a6f2dc7bdb797ae25d9284"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -546,8 +546,8 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "everestrs"
-version = "0.20.1"
-source = "git+https://github.com/everest/everest-framework.git?tag=v0.20.1#18c71c45d2052d5cfb00828177071056bc456cc5"
+version = "0.20.2"
+source = "git+https://github.com/everest/everest-framework.git?rev=7a87814e7618b8b4b3c67b776d86fd390164c917#7a87814e7618b8b4b3c67b776d86fd390164c917"
 dependencies = [
  "clap",
  "cxx",
@@ -562,7 +562,7 @@ dependencies = [
 [[package]]
 name = "everestrs-build"
 version = "0.20.1"
-source = "git+https://github.com/everest/everest-framework.git?tag=v0.20.1#18c71c45d2052d5cfb00828177071056bc456cc5"
+source = "git+https://github.com/everest/everest-framework.git?rev=7a87814e7618b8b4b3c67b776d86fd390164c917#7a87814e7618b8b4b3c67b776d86fd390164c917"
 dependencies = [
  "anyhow",
  "argh",

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -8,5 +8,5 @@ members = [
 ]
 
 [workspace.dependencies]
-everestrs = { git = "https://github.com/everest/everest-framework.git", rev = "7a87814e7618b8b4b3c67b776d86fd390164c917" }
-everestrs-build = { git = "https://github.com/everest/everest-framework.git", rev = "7a87814e7618b8b4b3c67b776d86fd390164c917" }
+everestrs = { git = "https://github.com/everest/everest-framework.git", tag = "v0.20.2" }
+everestrs-build = { git = "https://github.com/everest/everest-framework.git", tag = "v0.20.2" }

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -8,5 +8,5 @@ members = [
 ]
 
 [workspace.dependencies]
-everestrs = { git = "https://github.com/everest/everest-framework.git", tag = "v0.20.1" }
-everestrs-build = { git = "https://github.com/everest/everest-framework.git", tag = "v0.20.1" }
+everestrs = { git = "https://github.com/everest/everest-framework.git", rev = "7a87814e7618b8b4b3c67b776d86fd390164c917" }
+everestrs-build = { git = "https://github.com/everest/everest-framework.git", rev = "7a87814e7618b8b4b3c67b776d86fd390164c917" }


### PR DESCRIPTION
This fixes:
- a configuration parsing bug for Python modules
- optional connections for Rust modules

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

