### PR TITLE
RsPaymentTerminal: make all interfaces optional

### DIFF
--- a/modules/RsPaymentTerminal/manifest.yaml
+++ b/modules/RsPaymentTerminal/manifest.yaml
@@ -55,8 +55,12 @@ config:
 requires:
     session:
       interface: session_cost
+      min_connections: 0
+      max_connections: 1
     bank_session_token:
       interface: bank_session_token_provider
+      min_connections: 0
+      max_connections: 1
 provides:
   token_provider:
     interface: auth_token_provider


### PR DESCRIPTION
## Describe your changes

Currently there are no implementations for the bank_token_provider and session_cost. They are also not strictly needed for the payment terminal. If not provided the PT just works as a rfid card reader

