### PR TITLE
Use CSV for output tags of docker meta action in OCPP-tests

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -61,6 +61,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.BUILD_KIT_IMAGE_NAME }}
+          sep-tags: ","
       - name: Set output tag
         id: buildkit_tag
         shell: python3 {0}


### PR DESCRIPTION
This has already been fixed in the reusable workflow ( https://github.com/EVerest/everest-ci/pull/71 ) but this doesn't automatically apply here

(this fixes the scheduled build for main)

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

