### PR TITLE
cmake: install missed cmake file

### DIFF
--- a/cmake/everest-generate.cmake
+++ b/cmake/everest-generate.cmake
@@ -736,6 +736,7 @@ function(ev_install_project)
             ${EV_CORE_CMAKE_SCRIPT_DIR}/ev-cli.cmake
             ${EV_CORE_CMAKE_SCRIPT_DIR}/project-config.cmake.in
             ${EV_CORE_CMAKE_SCRIPT_DIR}/ev-project-bootstrap.cmake
+            ${EV_CORE_CMAKE_SCRIPT_DIR}/ev-targets.cmake
             ${EV_CORE_CMAKE_SCRIPT_DIR}/config-run-script.cmake
             ${EV_CORE_CMAKE_SCRIPT_DIR}/config-run-nodered-script.cmake
         DESTINATION


### PR DESCRIPTION
This file was added in commit e5d840863aa245534d22a2746aeec5bf691fdb47 (PR https://github.com/EVerest/everest-core/pull/1004), but forgotten to install, despite being referenced by other installed files.

This fixes non-EDM builds of modules in separate repos, such as done when adding them in additional Yocto layers.

## Describe your changes

Add an install directive for the new file.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

