### PR TITLE
Rename v201 to v2 for OCPP modules

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: refactor/rename-v201-to-v2
+  git_tag: 04059e2cb6ea34029b661b6803dce49727ea65c3
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.23.0
+  git_tag: refactor/rename-v201-to-v2
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/lib/staging/ocpp/ocpp_conversions.cpp
+++ b/lib/staging/ocpp/ocpp_conversions.cpp
@@ -6,91 +6,89 @@
 
 namespace ocpp_conversions {
 types::display_message::MessagePriorityEnum
-to_everest_display_message_priority(const ocpp::v201::MessagePriorityEnum& priority) {
+to_everest_display_message_priority(const ocpp::v2::MessagePriorityEnum& priority) {
     switch (priority) {
-    case ocpp::v201::MessagePriorityEnum::AlwaysFront:
+    case ocpp::v2::MessagePriorityEnum::AlwaysFront:
         return types::display_message::MessagePriorityEnum::AlwaysFront;
-    case ocpp::v201::MessagePriorityEnum::InFront:
+    case ocpp::v2::MessagePriorityEnum::InFront:
         return types::display_message::MessagePriorityEnum::InFront;
-    case ocpp::v201::MessagePriorityEnum::NormalCycle:
+    case ocpp::v2::MessagePriorityEnum::NormalCycle:
         return types::display_message::MessagePriorityEnum::NormalCycle;
     }
     throw std::out_of_range(
-        "Could not convert ocpp::v201::MessagePriorityEnum to types::display_message::MessagePriorityEnum");
+        "Could not convert ocpp::v2::MessagePriorityEnum to types::display_message::MessagePriorityEnum");
 }
 
-ocpp::v201::MessagePriorityEnum
+ocpp::v2::MessagePriorityEnum
 to_ocpp_201_message_priority(const types::display_message::MessagePriorityEnum& priority) {
     switch (priority) {
     case types::display_message::MessagePriorityEnum::AlwaysFront:
-        return ocpp::v201::MessagePriorityEnum::AlwaysFront;
+        return ocpp::v2::MessagePriorityEnum::AlwaysFront;
     case types::display_message::MessagePriorityEnum::InFront:
-        return ocpp::v201::MessagePriorityEnum::InFront;
+        return ocpp::v2::MessagePriorityEnum::InFront;
     case types::display_message::MessagePriorityEnum::NormalCycle:
-        return ocpp::v201::MessagePriorityEnum::NormalCycle;
+        return ocpp::v2::MessagePriorityEnum::NormalCycle;
     }
     throw std::out_of_range(
-        "Could not convert types::display_message::MessagePriorityEnum to ocpp::v201::MessagePriorityEnum");
+        "Could not convert types::display_message::MessagePriorityEnum to ocpp::v2::MessagePriorityEnum");
 }
 
-types::display_message::MessageStateEnum to_everest_display_message_state(const ocpp::v201::MessageStateEnum& state) {
+types::display_message::MessageStateEnum to_everest_display_message_state(const ocpp::v2::MessageStateEnum& state) {
     switch (state) {
-    case ocpp::v201::MessageStateEnum::Charging:
+    case ocpp::v2::MessageStateEnum::Charging:
         return types::display_message::MessageStateEnum::Charging;
-    case ocpp::v201::MessageStateEnum::Faulted:
+    case ocpp::v2::MessageStateEnum::Faulted:
         return types::display_message::MessageStateEnum::Faulted;
-    case ocpp::v201::MessageStateEnum::Idle:
+    case ocpp::v2::MessageStateEnum::Idle:
         return types::display_message::MessageStateEnum::Idle;
-    case ocpp::v201::MessageStateEnum::Unavailable:
+    case ocpp::v2::MessageStateEnum::Unavailable:
         return types::display_message::MessageStateEnum::Unavailable;
     }
-    throw std::out_of_range(
-        "Could not convert ocpp::v201::MessageStateEnum to types::display_message::MessageStateEnum");
+    throw std::out_of_range("Could not convert ocpp::v2::MessageStateEnum to types::display_message::MessageStateEnum");
 }
 
-ocpp::v201::MessageStateEnum to_ocpp_201_display_message_state(const types::display_message::MessageStateEnum& state) {
+ocpp::v2::MessageStateEnum to_ocpp_201_display_message_state(const types::display_message::MessageStateEnum& state) {
     switch (state) {
     case types::display_message::MessageStateEnum::Charging:
-        return ocpp::v201::MessageStateEnum::Charging;
+        return ocpp::v2::MessageStateEnum::Charging;
     case types::display_message::MessageStateEnum::Faulted:
-        return ocpp::v201::MessageStateEnum::Faulted;
+        return ocpp::v2::MessageStateEnum::Faulted;
     case types::display_message::MessageStateEnum::Idle:
-        return ocpp::v201::MessageStateEnum::Idle;
+        return ocpp::v2::MessageStateEnum::Idle;
     case types::display_message::MessageStateEnum::Unavailable:
-        return ocpp::v201::MessageStateEnum::Unavailable;
+        return ocpp::v2::MessageStateEnum::Unavailable;
     }
-    throw std::out_of_range(
-        "Could not convert types::display_message::MessageStateEnum to ocpp::v201::MessageStateEnum");
+    throw std::out_of_range("Could not convert types::display_message::MessageStateEnum to ocpp::v2::MessageStateEnum");
 }
 
 types::display_message::MessageFormat
-to_everest_display_message_format(const ocpp::v201::MessageFormatEnum& message_format) {
+to_everest_display_message_format(const ocpp::v2::MessageFormatEnum& message_format) {
     switch (message_format) {
-    case ocpp::v201::MessageFormatEnum::ASCII:
+    case ocpp::v2::MessageFormatEnum::ASCII:
         return types::display_message::MessageFormat::ASCII;
-    case ocpp::v201::MessageFormatEnum::HTML:
+    case ocpp::v2::MessageFormatEnum::HTML:
         return types::display_message::MessageFormat::HTML;
-    case ocpp::v201::MessageFormatEnum::URI:
+    case ocpp::v2::MessageFormatEnum::URI:
         return types::display_message::MessageFormat::URI;
-    case ocpp::v201::MessageFormatEnum::UTF8:
+    case ocpp::v2::MessageFormatEnum::UTF8:
         return types::display_message::MessageFormat::UTF8;
     }
-    throw std::out_of_range("Could not convert ocpp::v201::MessageFormat to types::display_message::MessageFormatEnum");
+    throw std::out_of_range("Could not convert ocpp::v2::MessageFormat to types::display_message::MessageFormatEnum");
 }
 
-ocpp::v201::MessageFormatEnum to_ocpp_201_message_format_enum(const types::display_message::MessageFormat& format) {
+ocpp::v2::MessageFormatEnum to_ocpp_201_message_format_enum(const types::display_message::MessageFormat& format) {
     switch (format) {
     case types::display_message::MessageFormat::ASCII:
-        return ocpp::v201::MessageFormatEnum::ASCII;
+        return ocpp::v2::MessageFormatEnum::ASCII;
     case types::display_message::MessageFormat::HTML:
-        return ocpp::v201::MessageFormatEnum::HTML;
+        return ocpp::v2::MessageFormatEnum::HTML;
     case types::display_message::MessageFormat::URI:
-        return ocpp::v201::MessageFormatEnum::URI;
+        return ocpp::v2::MessageFormatEnum::URI;
     case types::display_message::MessageFormat::UTF8:
-        return ocpp::v201::MessageFormatEnum::UTF8;
+        return ocpp::v2::MessageFormatEnum::UTF8;
     }
 
-    throw std::out_of_range("Could not convert types::display_message::MessageFormat to ocpp::v201::MessageFormatEnum");
+    throw std::out_of_range("Could not convert types::display_message::MessageFormat to ocpp::v2::MessageFormatEnum");
 }
 
 ocpp::IdentifierType to_ocpp_identifiertype_enum(const types::display_message::Identifier_type identifier_type) {

--- a/lib/staging/ocpp/ocpp_conversions.hpp
+++ b/lib/staging/ocpp/ocpp_conversions.hpp
@@ -5,19 +5,18 @@
 #include <generated/types/reservation.hpp>
 #include <generated/types/session_cost.hpp>
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/ocpp_enums.hpp>
+#include <ocpp/v2/ocpp_enums.hpp>
 
 namespace ocpp_conversions {
 types::display_message::MessagePriorityEnum
-to_everest_display_message_priority(const ocpp::v201::MessagePriorityEnum& priority);
-ocpp::v201::MessagePriorityEnum
-to_ocpp_201_message_priority(const types::display_message::MessagePriorityEnum& priority);
-types::display_message::MessageStateEnum to_everest_display_message_state(const ocpp::v201::MessageStateEnum& state);
-ocpp::v201::MessageStateEnum to_ocpp_201_display_message_state(const types::display_message::MessageStateEnum& state);
+to_everest_display_message_priority(const ocpp::v2::MessagePriorityEnum& priority);
+ocpp::v2::MessagePriorityEnum to_ocpp_201_message_priority(const types::display_message::MessagePriorityEnum& priority);
+types::display_message::MessageStateEnum to_everest_display_message_state(const ocpp::v2::MessageStateEnum& state);
+ocpp::v2::MessageStateEnum to_ocpp_201_display_message_state(const types::display_message::MessageStateEnum& state);
 
 types::display_message::MessageFormat
-to_everest_display_message_format(const ocpp::v201::MessageFormatEnum& message_format);
-ocpp::v201::MessageFormatEnum to_ocpp_201_message_format_enum(const types::display_message::MessageFormat& format);
+to_everest_display_message_format(const ocpp::v2::MessageFormatEnum& message_format);
+ocpp::v2::MessageFormatEnum to_ocpp_201_message_format_enum(const types::display_message::MessageFormat& format);
 
 ocpp::IdentifierType to_ocpp_identifiertype_enum(const types::display_message::Identifier_type identifier_type);
 types::display_message::Identifier_type to_everest_identifier_type_enum(const ocpp::IdentifierType identifier_type);

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -783,8 +783,8 @@ void OCPP::ready() {
         [this](bool is_connected) { this->p_ocpp_generic->publish_is_connected(is_connected); });
 
     this->charge_point->register_get_15118_ev_certificate_response_callback(
-        [this](const int32_t connector_id, const ocpp::v201::Get15118EVCertificateResponse& certificate_response,
-               const ocpp::v201::CertificateActionEnum& certificate_action) {
+        [this](const int32_t connector_id, const ocpp::v2::Get15118EVCertificateResponse& certificate_response,
+               const ocpp::v2::CertificateActionEnum& certificate_action) {
             types::iso15118::ResponseExiStreamStatus response;
             response.status = conversions::to_everest_iso15118_status(certificate_response.status);
             response.certificate_action = conversions::to_everest_certificate_action_enum(certificate_action);

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -44,7 +44,7 @@
 #include <ocpp/common/types.hpp>
 #include <ocpp/v16/charge_point.hpp>
 #include <ocpp/v16/types.hpp>
-#include <ocpp/v201/ocpp_types.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
 
 using EvseConnectorMap = std::map<int32_t, std::map<int32_t, int32_t>>;
 using ClearedErrorId = std::string;

--- a/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
@@ -4,7 +4,7 @@
 #include <conversions.hpp>
 #include <ocpp/common/types.hpp>
 #include <ocpp/v16/ocpp_enums.hpp>
-#include <ocpp/v201/ocpp_types.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
 
 namespace module {
 namespace auth_validator {
@@ -29,18 +29,18 @@ types::authorization::ValidationResult
 auth_token_validatorImpl::validate_pnc_request(const types::authorization::ProvidedIdToken& provided_token) {
 
     // preparing payload for data_transfer_pnc_authorize
-    std::optional<std::vector<ocpp::v201::OCSPRequestData>> iso15118_certificate_hash_data_opt;
+    std::optional<std::vector<ocpp::v2::OCSPRequestData>> iso15118_certificate_hash_data_opt;
     if (provided_token.iso15118CertificateHashData.has_value()) {
-        std::vector<ocpp::v201::OCSPRequestData> iso15118_certificate_hash_data;
+        std::vector<ocpp::v2::OCSPRequestData> iso15118_certificate_hash_data;
         for (const auto& certificate_hash_data : provided_token.iso15118CertificateHashData.value()) {
-            ocpp::v201::OCSPRequestData v201_certificate_hash_data;
-            v201_certificate_hash_data.hashAlgorithm =
+            ocpp::v2::OCSPRequestData v2_certificate_hash_data;
+            v2_certificate_hash_data.hashAlgorithm =
                 conversions::to_ocpp_hash_algorithm_enum(certificate_hash_data.hashAlgorithm);
-            v201_certificate_hash_data.issuerKeyHash = certificate_hash_data.issuerKeyHash;
-            v201_certificate_hash_data.issuerNameHash = certificate_hash_data.issuerNameHash;
-            v201_certificate_hash_data.responderURL = certificate_hash_data.responderURL;
-            v201_certificate_hash_data.serialNumber = certificate_hash_data.serialNumber;
-            iso15118_certificate_hash_data.push_back(v201_certificate_hash_data);
+            v2_certificate_hash_data.issuerKeyHash = certificate_hash_data.issuerKeyHash;
+            v2_certificate_hash_data.issuerNameHash = certificate_hash_data.issuerNameHash;
+            v2_certificate_hash_data.responderURL = certificate_hash_data.responderURL;
+            v2_certificate_hash_data.serialNumber = certificate_hash_data.serialNumber;
+            iso15118_certificate_hash_data.push_back(v2_certificate_hash_data);
         }
         iso15118_certificate_hash_data_opt.emplace(iso15118_certificate_hash_data);
     }

--- a/modules/OCPP/conversions.cpp
+++ b/modules/OCPP/conversions.cpp
@@ -106,15 +106,15 @@ ocpp::v16::Reason to_ocpp_reason(const types::evse_manager::StopTransactionReaso
     throw std::out_of_range("Could not convert types::evse_manager::StopTransactionReason to ocpp::v16::Reason");
 }
 
-ocpp::v201::CertificateActionEnum to_ocpp_certificate_action_enum(const types::iso15118::CertificateActionEnum action) {
+ocpp::v2::CertificateActionEnum to_ocpp_certificate_action_enum(const types::iso15118::CertificateActionEnum action) {
     switch (action) {
     case types::iso15118::CertificateActionEnum::Install:
-        return ocpp::v201::CertificateActionEnum::Install;
+        return ocpp::v2::CertificateActionEnum::Install;
     case types::iso15118::CertificateActionEnum::Update:
-        return ocpp::v201::CertificateActionEnum::Update;
+        return ocpp::v2::CertificateActionEnum::Update;
     }
     throw std::out_of_range(
-        "Could not convert types::iso15118::CertificateActionEnum to ocpp::v201::CertificateActionEnum");
+        "Could not convert types::iso15118::CertificateActionEnum to ocpp::v2::CertificateActionEnum");
 }
 
 ocpp::v16::ReservationStatus to_ocpp_reservation_status(const types::reservation::ReservationResult result) {
@@ -255,14 +255,14 @@ std::vector<ocpp::Temperature> to_ocpp_temperatures(const std::vector<types::tem
     return ocpp_temperatures;
 }
 
-ocpp::v201::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118::HashAlgorithm hash_algorithm) {
+ocpp::v2::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118::HashAlgorithm hash_algorithm) {
     switch (hash_algorithm) {
     case types::iso15118::HashAlgorithm::SHA256:
-        return ocpp::v201::HashAlgorithmEnum::SHA256;
+        return ocpp::v2::HashAlgorithmEnum::SHA256;
     case types::iso15118::HashAlgorithm::SHA384:
-        return ocpp::v201::HashAlgorithmEnum::SHA384;
+        return ocpp::v2::HashAlgorithmEnum::SHA384;
     case types::iso15118::HashAlgorithm::SHA512:
-        return ocpp::v201::HashAlgorithmEnum::SHA512;
+        return ocpp::v2::HashAlgorithmEnum::SHA512;
     }
     throw std::out_of_range("Could not convert types::iso15118::HashAlgorithm to ocpp::v16::HashAlgorithmEnumType");
 }
@@ -305,48 +305,48 @@ types::system::ResetType to_everest_reset_type(const ocpp::v16::ResetType type) 
     throw std::out_of_range("Could not convert ocpp::v16::ResetType to types::system::ResetType");
 }
 
-types::iso15118::Status to_everest_iso15118_status(const ocpp::v201::Iso15118EVCertificateStatusEnum status) {
+types::iso15118::Status to_everest_iso15118_status(const ocpp::v2::Iso15118EVCertificateStatusEnum status) {
     switch (status) {
-    case ocpp::v201::Iso15118EVCertificateStatusEnum::Accepted:
+    case ocpp::v2::Iso15118EVCertificateStatusEnum::Accepted:
         return types::iso15118::Status::Accepted;
-    case ocpp::v201::Iso15118EVCertificateStatusEnum::Failed:
+    case ocpp::v2::Iso15118EVCertificateStatusEnum::Failed:
         return types::iso15118::Status::Failed;
     }
-    throw std::out_of_range("Could not convert ocpp::v201::Iso15118EVCertificateStatusEnum to types::iso15118::Status");
+    throw std::out_of_range("Could not convert ocpp::v2::Iso15118EVCertificateStatusEnum to types::iso15118::Status");
 }
 
 types::iso15118::CertificateActionEnum
-to_everest_certificate_action_enum(const ocpp::v201::CertificateActionEnum action) {
+to_everest_certificate_action_enum(const ocpp::v2::CertificateActionEnum action) {
     switch (action) {
-    case ocpp::v201::CertificateActionEnum::Install:
+    case ocpp::v2::CertificateActionEnum::Install:
         return types::iso15118::CertificateActionEnum::Install;
-    case ocpp::v201::CertificateActionEnum::Update:
+    case ocpp::v2::CertificateActionEnum::Update:
         return types::iso15118::CertificateActionEnum::Update;
     }
     throw std::out_of_range(
-        "Could not convert ocpp::v201::CertificateActionEnum to types::iso15118::CertificateActionEnum");
+        "Could not convert ocpp::v2::CertificateActionEnum to types::iso15118::CertificateActionEnum");
 }
 
 types::authorization::CertificateStatus
-to_everest_certificate_status(const ocpp::v201::AuthorizeCertificateStatusEnum status) {
+to_everest_certificate_status(const ocpp::v2::AuthorizeCertificateStatusEnum status) {
     switch (status) {
-    case ocpp::v201::AuthorizeCertificateStatusEnum::Accepted:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::Accepted:
         return types::authorization::CertificateStatus::Accepted;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::SignatureError:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::SignatureError:
         return types::authorization::CertificateStatus::SignatureError;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::CertificateExpired:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::CertificateExpired:
         return types::authorization::CertificateStatus::CertificateExpired;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::CertificateRevoked:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::CertificateRevoked:
         return types::authorization::CertificateStatus::CertificateRevoked;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::NoCertificateAvailable:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::NoCertificateAvailable:
         return types::authorization::CertificateStatus::NoCertificateAvailable;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::CertChainError:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::CertChainError:
         return types::authorization::CertificateStatus::CertChainError;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::ContractCancelled:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::ContractCancelled:
         return types::authorization::CertificateStatus::ContractCancelled;
     }
     throw std::out_of_range(
-        "Could not convert ocpp::v201::AuthorizeCertificateStatusEnum to types::authorization::CertificateStatus");
+        "Could not convert ocpp::v2::AuthorizeCertificateStatusEnum to types::authorization::CertificateStatus");
 }
 
 types::authorization::AuthorizationStatus to_everest_authorization_status(const ocpp::v16::AuthorizationStatus status) {
@@ -367,31 +367,31 @@ types::authorization::AuthorizationStatus to_everest_authorization_status(const 
 }
 
 types::authorization::AuthorizationStatus
-to_everest_authorization_status(const ocpp::v201::AuthorizationStatusEnum status) {
+to_everest_authorization_status(const ocpp::v2::AuthorizationStatusEnum status) {
     switch (status) {
-    case ocpp::v201::AuthorizationStatusEnum::Accepted:
+    case ocpp::v2::AuthorizationStatusEnum::Accepted:
         return types::authorization::AuthorizationStatus::Accepted;
-    case ocpp::v201::AuthorizationStatusEnum::Blocked:
+    case ocpp::v2::AuthorizationStatusEnum::Blocked:
         return types::authorization::AuthorizationStatus::Blocked;
-    case ocpp::v201::AuthorizationStatusEnum::ConcurrentTx:
+    case ocpp::v2::AuthorizationStatusEnum::ConcurrentTx:
         return types::authorization::AuthorizationStatus::ConcurrentTx;
-    case ocpp::v201::AuthorizationStatusEnum::Expired:
+    case ocpp::v2::AuthorizationStatusEnum::Expired:
         return types::authorization::AuthorizationStatus::Expired;
-    case ocpp::v201::AuthorizationStatusEnum::Invalid:
+    case ocpp::v2::AuthorizationStatusEnum::Invalid:
         return types::authorization::AuthorizationStatus::Invalid;
-    case ocpp::v201::AuthorizationStatusEnum::NoCredit:
+    case ocpp::v2::AuthorizationStatusEnum::NoCredit:
         return types::authorization::AuthorizationStatus::NoCredit;
-    case ocpp::v201::AuthorizationStatusEnum::NotAllowedTypeEVSE:
+    case ocpp::v2::AuthorizationStatusEnum::NotAllowedTypeEVSE:
         return types::authorization::AuthorizationStatus::NotAllowedTypeEVSE;
-    case ocpp::v201::AuthorizationStatusEnum::NotAtThisLocation:
+    case ocpp::v2::AuthorizationStatusEnum::NotAtThisLocation:
         return types::authorization::AuthorizationStatus::NotAtThisLocation;
-    case ocpp::v201::AuthorizationStatusEnum::NotAtThisTime:
+    case ocpp::v2::AuthorizationStatusEnum::NotAtThisTime:
         return types::authorization::AuthorizationStatus::NotAtThisTime;
-    case ocpp::v201::AuthorizationStatusEnum::Unknown:
+    case ocpp::v2::AuthorizationStatusEnum::Unknown:
         return types::authorization::AuthorizationStatus::Unknown;
     }
     throw std::out_of_range(
-        "Could not convert ocpp::v201::AuthorizationStatusEnum to types::authorization::AuthorizationStatus");
+        "Could not convert ocpp::v2::AuthorizationStatusEnum to types::authorization::AuthorizationStatus");
 }
 
 types::ocpp::ChargingSchedulePeriod
@@ -440,7 +440,7 @@ to_everest_registration_status(const ocpp::v16::RegistrationStatus& registration
     case ocpp::v16::RegistrationStatus::Rejected:
         return types::ocpp::RegistrationStatus::Rejected;
     }
-    throw std::out_of_range("Could not convert ocpp::v201::RegistrationStatus to types::ocpp::RegistrationStatus");
+    throw std::out_of_range("Could not convert ocpp::v2::RegistrationStatus to types::ocpp::RegistrationStatus");
 }
 
 ocpp::v16::DataTransferStatus

--- a/modules/OCPP/conversions.hpp
+++ b/modules/OCPP/conversions.hpp
@@ -17,8 +17,8 @@
 #include <ocpp/v16/messages/LogStatusNotification.hpp>
 #include <ocpp/v16/messages/ReserveNow.hpp>
 #include <ocpp/v16/messages/StopTransaction.hpp>
-#include <ocpp/v201/messages/DeleteCertificate.hpp>
-#include <ocpp/v201/messages/Get15118EVCertificate.hpp>
+#include <ocpp/v2/messages/DeleteCertificate.hpp>
+#include <ocpp/v2/messages/Get15118EVCertificate.hpp>
 
 namespace module {
 namespace conversions {
@@ -37,8 +37,8 @@ ocpp::v16::DataTransferStatus to_ocpp_data_transfer_status(const types::ocpp::Da
 ocpp::v16::Reason to_ocpp_reason(const types::evse_manager::StopTransactionReason reason);
 
 /// \brief Converts a given types::iso15118::CertificateActionEnum \p action to a
-/// ocpp::v201::CertificateActionEnum.
-ocpp::v201::CertificateActionEnum to_ocpp_certificate_action_enum(const types::iso15118::CertificateActionEnum action);
+/// ocpp::v2::CertificateActionEnum.
+ocpp::v2::CertificateActionEnum to_ocpp_certificate_action_enum(const types::iso15118::CertificateActionEnum action);
 
 /// \brief Converts a given types::reservation::ReservationResult \p result to a ocpp::v16::ReservationStatus.
 ocpp::v16::ReservationStatus to_ocpp_reservation_status(const types::reservation::ReservationResult result);
@@ -55,7 +55,7 @@ to_ocpp_update_firmware_status_enum_type(const types::system::UpdateFirmwareResp
 /// ocpp::v16::HashAlgorithmEnumType.
 ocpp::v16::HashAlgorithmEnumType to_ocpp_hash_algorithm_enum_type(const types::iso15118::HashAlgorithm hash_algorithm);
 
-/// \brief  Converts a given types::iso15118::Status \p status to a ocpp::v201::Iso15118EVCertificateStatusEnum.
+/// \brief  Converts a given types::iso15118::Status \p status to a ocpp::v2::Iso15118EVCertificateStatusEnum.
 ocpp::v16::BootReasonEnum to_ocpp_boot_reason_enum(const types::system::BootReason reason);
 
 /// \brief  Converts a given types::powermeter::Powermeter \p powermeter to a ocpp::Powermeter
@@ -64,8 +64,8 @@ ocpp::Powermeter to_ocpp_power_meter(const types::powermeter::Powermeter& powerm
 /// \brief Converts a given vector of types::temperature::Temperature \p powermeter to a vector of ocpp::Temperature
 std::vector<ocpp::Temperature> to_ocpp_temperatures(const std::vector<types::temperature::Temperature>& temperatures);
 
-/// \brief Converts a given types::iso15118::HashAlgorithm \p hash_algorithm to a ocpp::v201::HashAlgorithmEnum.
-ocpp::v201::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118::HashAlgorithm hash_algorithm);
+/// \brief Converts a given types::iso15118::HashAlgorithm \p hash_algorithm to a ocpp::v2::HashAlgorithmEnum.
+ocpp::v2::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118::HashAlgorithm hash_algorithm);
 
 /// \brief Converts a given ocpp::v16::Reason \p reason to a types::evse_manager::StopTransactionReason.
 types::evse_manager::StopTransactionReason to_everest_stop_transaction_reason(const ocpp::v16::Reason reason);
@@ -73,26 +73,25 @@ types::evse_manager::StopTransactionReason to_everest_stop_transaction_reason(co
 /// \brief Converts a given ocpp::v16::ResetType \p type to a types::system::ResetType.
 types::system::ResetType to_everest_reset_type(const ocpp::v16::ResetType type);
 
-/// \brief Converts a given ocpp::v201::Iso15118EVCertificateStatusEnum \p status to a types::iso15118::Status.
-types::iso15118::Status to_everest_iso15118_status(const ocpp::v201::Iso15118EVCertificateStatusEnum status);
+/// \brief Converts a given ocpp::v2::Iso15118EVCertificateStatusEnum \p status to a types::iso15118::Status.
+types::iso15118::Status to_everest_iso15118_status(const ocpp::v2::Iso15118EVCertificateStatusEnum status);
 
-/// \brief Converts a given ocpp::v201::CertificateActionEnum \p action to a
+/// \brief Converts a given ocpp::v2::CertificateActionEnum \p action to a
 /// types::iso15118::CertificateActionEnum.
-types::iso15118::CertificateActionEnum
-to_everest_certificate_action_enum(const ocpp::v201::CertificateActionEnum action);
+types::iso15118::CertificateActionEnum to_everest_certificate_action_enum(const ocpp::v2::CertificateActionEnum action);
 
-/// \brief Converts a given ocpp::v201::AuthorizeCertificateStatusEnum \p status to a
+/// \brief Converts a given ocpp::v2::AuthorizeCertificateStatusEnum \p status to a
 /// types::authorization::CertificateStatus.
 types::authorization::CertificateStatus
-to_everest_certificate_status(const ocpp::v201::AuthorizeCertificateStatusEnum status);
+to_everest_certificate_status(const ocpp::v2::AuthorizeCertificateStatusEnum status);
 
 /// \brief Converts a given ocpp::v16::AuthorizationStatus \p status to a types::authorization::AuthorizationStatus.
 types::authorization::AuthorizationStatus to_everest_authorization_status(const ocpp::v16::AuthorizationStatus status);
 
-/// \brief Converts a given ocpp::v201::AuthorizationStatusEnum \p status to a
+/// \brief Converts a given ocpp::v2::AuthorizationStatusEnum \p status to a
 /// types::authorization::AuthorizationStatus.
 types::authorization::AuthorizationStatus
-to_everest_authorization_status(const ocpp::v201::AuthorizationStatusEnum status);
+to_everest_authorization_status(const ocpp::v2::AuthorizationStatusEnum status);
 
 /// \brief Convert ocpp::v16::EnhancedChargingSchedulePeriod to types::ocpp::ChargingSchedulePeriod
 types::ocpp::ChargingSchedulePeriod

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -21,31 +21,31 @@ const std::string CERTS_DIR = "certs";
 
 namespace fs = std::filesystem;
 
-TxEvent get_tx_event(const ocpp::v201::ReasonEnum reason) {
+TxEvent get_tx_event(const ocpp::v2::ReasonEnum reason) {
     switch (reason) {
-    case ocpp::v201::ReasonEnum::DeAuthorized:
-    case ocpp::v201::ReasonEnum::Remote:
-    case ocpp::v201::ReasonEnum::Local:
-    case ocpp::v201::ReasonEnum::MasterPass:
-    case ocpp::v201::ReasonEnum::StoppedByEV:
+    case ocpp::v2::ReasonEnum::DeAuthorized:
+    case ocpp::v2::ReasonEnum::Remote:
+    case ocpp::v2::ReasonEnum::Local:
+    case ocpp::v2::ReasonEnum::MasterPass:
+    case ocpp::v2::ReasonEnum::StoppedByEV:
         return TxEvent::DEAUTHORIZED;
-    case ocpp::v201::ReasonEnum::EVDisconnected:
+    case ocpp::v2::ReasonEnum::EVDisconnected:
         return TxEvent::EV_DISCONNECTED;
-    case ocpp::v201::ReasonEnum::ImmediateReset:
+    case ocpp::v2::ReasonEnum::ImmediateReset:
         return TxEvent::IMMEDIATE_RESET;
     // FIXME(kai): these reasons definitely do not all map to NONE
-    case ocpp::v201::ReasonEnum::EmergencyStop:
-    case ocpp::v201::ReasonEnum::EnergyLimitReached:
-    case ocpp::v201::ReasonEnum::GroundFault:
-    case ocpp::v201::ReasonEnum::LocalOutOfCredit:
-    case ocpp::v201::ReasonEnum::Other:
-    case ocpp::v201::ReasonEnum::OvercurrentFault:
-    case ocpp::v201::ReasonEnum::PowerLoss:
-    case ocpp::v201::ReasonEnum::PowerQuality:
-    case ocpp::v201::ReasonEnum::Reboot:
-    case ocpp::v201::ReasonEnum::SOCLimitReached:
-    case ocpp::v201::ReasonEnum::TimeLimitReached:
-    case ocpp::v201::ReasonEnum::Timeout:
+    case ocpp::v2::ReasonEnum::EmergencyStop:
+    case ocpp::v2::ReasonEnum::EnergyLimitReached:
+    case ocpp::v2::ReasonEnum::GroundFault:
+    case ocpp::v2::ReasonEnum::LocalOutOfCredit:
+    case ocpp::v2::ReasonEnum::Other:
+    case ocpp::v2::ReasonEnum::OvercurrentFault:
+    case ocpp::v2::ReasonEnum::PowerLoss:
+    case ocpp::v2::ReasonEnum::PowerQuality:
+    case ocpp::v2::ReasonEnum::Reboot:
+    case ocpp::v2::ReasonEnum::SOCLimitReached:
+    case ocpp::v2::ReasonEnum::TimeLimitReached:
+    case ocpp::v2::ReasonEnum::Timeout:
         return TxEvent::NONE;
     }
     return TxEvent::NONE;
@@ -81,48 +81,48 @@ std::set<TxStartStopPoint> get_tx_start_stop_points(const std::string& tx_start_
     return tx_start_stop_points;
 }
 
-ocpp::v201::TriggerReasonEnum stop_reason_to_trigger_reason_enum(const ocpp::v201::ReasonEnum& stop_reason) {
+ocpp::v2::TriggerReasonEnum stop_reason_to_trigger_reason_enum(const ocpp::v2::ReasonEnum& stop_reason) {
     switch (stop_reason) {
-    case ocpp::v201::ReasonEnum::DeAuthorized:
-        return ocpp::v201::TriggerReasonEnum::Deauthorized;
-    case ocpp::v201::ReasonEnum::EmergencyStop:
-        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
-    case ocpp::v201::ReasonEnum::EnergyLimitReached:
-        return ocpp::v201::TriggerReasonEnum::EnergyLimitReached;
-    case ocpp::v201::ReasonEnum::EVDisconnected:
-        return ocpp::v201::TriggerReasonEnum::EVCommunicationLost;
-    case ocpp::v201::ReasonEnum::GroundFault:
-        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
-    case ocpp::v201::ReasonEnum::ImmediateReset:
-        return ocpp::v201::TriggerReasonEnum::ResetCommand;
-    case ocpp::v201::ReasonEnum::Local:
-        return ocpp::v201::TriggerReasonEnum::StopAuthorized;
-    case ocpp::v201::ReasonEnum::LocalOutOfCredit:
-        return ocpp::v201::TriggerReasonEnum::ChargingStateChanged;
-    case ocpp::v201::ReasonEnum::MasterPass:
-        return ocpp::v201::TriggerReasonEnum::StopAuthorized;
-    case ocpp::v201::ReasonEnum::Other:
-        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
-    case ocpp::v201::ReasonEnum::OvercurrentFault:
-        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
-    case ocpp::v201::ReasonEnum::PowerLoss:
-        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
-    case ocpp::v201::ReasonEnum::PowerQuality:
-        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
-    case ocpp::v201::ReasonEnum::Reboot:
-        return ocpp::v201::TriggerReasonEnum::ResetCommand;
-    case ocpp::v201::ReasonEnum::Remote:
-        return ocpp::v201::TriggerReasonEnum::RemoteStop;
-    case ocpp::v201::ReasonEnum::SOCLimitReached:
-        return ocpp::v201::TriggerReasonEnum::EnergyLimitReached;
-    case ocpp::v201::ReasonEnum::StoppedByEV:
-        return ocpp::v201::TriggerReasonEnum::StopAuthorized;
-    case ocpp::v201::ReasonEnum::TimeLimitReached:
-        return ocpp::v201::TriggerReasonEnum::TimeLimitReached;
-    case ocpp::v201::ReasonEnum::Timeout:
-        return ocpp::v201::TriggerReasonEnum::EVConnectTimeout;
+    case ocpp::v2::ReasonEnum::DeAuthorized:
+        return ocpp::v2::TriggerReasonEnum::Deauthorized;
+    case ocpp::v2::ReasonEnum::EmergencyStop:
+        return ocpp::v2::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v2::ReasonEnum::EnergyLimitReached:
+        return ocpp::v2::TriggerReasonEnum::EnergyLimitReached;
+    case ocpp::v2::ReasonEnum::EVDisconnected:
+        return ocpp::v2::TriggerReasonEnum::EVCommunicationLost;
+    case ocpp::v2::ReasonEnum::GroundFault:
+        return ocpp::v2::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v2::ReasonEnum::ImmediateReset:
+        return ocpp::v2::TriggerReasonEnum::ResetCommand;
+    case ocpp::v2::ReasonEnum::Local:
+        return ocpp::v2::TriggerReasonEnum::StopAuthorized;
+    case ocpp::v2::ReasonEnum::LocalOutOfCredit:
+        return ocpp::v2::TriggerReasonEnum::ChargingStateChanged;
+    case ocpp::v2::ReasonEnum::MasterPass:
+        return ocpp::v2::TriggerReasonEnum::StopAuthorized;
+    case ocpp::v2::ReasonEnum::Other:
+        return ocpp::v2::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v2::ReasonEnum::OvercurrentFault:
+        return ocpp::v2::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v2::ReasonEnum::PowerLoss:
+        return ocpp::v2::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v2::ReasonEnum::PowerQuality:
+        return ocpp::v2::TriggerReasonEnum::AbnormalCondition;
+    case ocpp::v2::ReasonEnum::Reboot:
+        return ocpp::v2::TriggerReasonEnum::ResetCommand;
+    case ocpp::v2::ReasonEnum::Remote:
+        return ocpp::v2::TriggerReasonEnum::RemoteStop;
+    case ocpp::v2::ReasonEnum::SOCLimitReached:
+        return ocpp::v2::TriggerReasonEnum::EnergyLimitReached;
+    case ocpp::v2::ReasonEnum::StoppedByEV:
+        return ocpp::v2::TriggerReasonEnum::StopAuthorized;
+    case ocpp::v2::ReasonEnum::TimeLimitReached:
+        return ocpp::v2::TriggerReasonEnum::TimeLimitReached;
+    case ocpp::v2::ReasonEnum::Timeout:
+        return ocpp::v2::TriggerReasonEnum::EVConnectTimeout;
     default:
-        return ocpp::v201::TriggerReasonEnum::AbnormalCondition;
+        return ocpp::v2::TriggerReasonEnum::AbnormalCondition;
     }
 }
 
@@ -233,7 +233,7 @@ get_signed_meter_value(const types::evse_manager::SessionEvent& session_event) {
     return std::nullopt;
 }
 
-std::optional<ocpp::v201::IdToken> get_authorized_id_token(const types::evse_manager::SessionEvent& session_event) {
+std::optional<ocpp::v2::IdToken> get_authorized_id_token(const types::evse_manager::SessionEvent& session_event) {
     const auto event_type = session_event.event;
     if (event_type == types::evse_manager::SessionEventEnum::SessionStarted) {
         if (!session_event.session_started.has_value()) {
@@ -253,13 +253,13 @@ std::optional<ocpp::v201::IdToken> get_authorized_id_token(const types::evse_man
     return std::nullopt;
 }
 
-ocpp::v201::ChargingRateUnitEnum get_unit_or_default(const std::string& unit_string) {
+ocpp::v2::ChargingRateUnitEnum get_unit_or_default(const std::string& unit_string) {
     try {
-        return ocpp::v201::conversions::string_to_charging_rate_unit_enum(unit_string);
+        return ocpp::v2::conversions::string_to_charging_rate_unit_enum(unit_string);
     } catch (const std::out_of_range& e) {
         EVLOG_warning << "RequestCompositeScheduleUnit configured incorrectly with: " << unit_string
                       << ". Defaulting to using Amps.";
-        return ocpp::v201::ChargingRateUnitEnum::A;
+        return ocpp::v2::ChargingRateUnitEnum::A;
     }
 }
 
@@ -343,9 +343,9 @@ void OCPP201::ready() {
         }
     }
 
-    ocpp::v201::Callbacks callbacks;
+    ocpp::v2::Callbacks callbacks;
     callbacks.is_reset_allowed_callback = [this](const std::optional<const int32_t> evse_id,
-                                                 const ocpp::v201::ResetEnum& type) {
+                                                 const ocpp::v2::ResetEnum& type) {
         if (evse_id.has_value()) {
             return false; // Reset of EVSE is currently not supported
         }
@@ -357,13 +357,13 @@ void OCPP201::ready() {
             return false;
         }
     };
-    callbacks.reset_callback = [this](const std::optional<const int32_t> evse_id, const ocpp::v201::ResetEnum& type) {
+    callbacks.reset_callback = [this](const std::optional<const int32_t> evse_id, const ocpp::v2::ResetEnum& type) {
         if (evse_id.has_value()) {
             EVLOG_warning << "Reset of EVSE is currently not supported";
             return;
         }
 
-        bool scheduled = type == ocpp::v201::ResetEnum::OnIdle;
+        bool scheduled = type == ocpp::v2::ResetEnum::OnIdle;
 
         try {
             this->r_system->call_reset(types::system::ResetType::NotSpecified, scheduled);
@@ -374,8 +374,8 @@ void OCPP201::ready() {
     };
 
     callbacks.connector_effective_operative_status_changed_callback =
-        [this](const int32_t evse_id, const int32_t connector_id, const ocpp::v201::OperationalStatusEnum new_status) {
-            if (new_status == ocpp::v201::OperationalStatusEnum::Operative) {
+        [this](const int32_t evse_id, const int32_t connector_id, const ocpp::v2::OperationalStatusEnum new_status) {
+            if (new_status == ocpp::v2::OperationalStatusEnum::Operative) {
                 if (this->r_evse_manager.at(evse_id - 1)
                         ->call_enable_disable(connector_id, {types::evse_manager::Enable_source::CSMS,
                                                              types::evse_manager::Enable_state::Enable, 5000})) {
@@ -390,7 +390,7 @@ void OCPP201::ready() {
             }
         };
 
-    callbacks.remote_start_transaction_callback = [this](const ocpp::v201::RequestStartTransactionRequest& request,
+    callbacks.remote_start_transaction_callback = [this](const ocpp::v2::RequestStartTransactionRequest& request,
                                                          const bool authorize_remote_start) {
         types::authorization::ProvidedIdToken provided_token;
         provided_token.id_token = conversions::to_everest_id_token(request.idToken);
@@ -406,20 +406,20 @@ void OCPP201::ready() {
             provided_token.connectors = std::vector<int32_t>{request.evseId.value()};
         }
         this->p_auth_provider->publish_provided_token(provided_token);
-        return ocpp::v201::RequestStartStopStatusEnum::Accepted;
+        return ocpp::v2::RequestStartStopStatusEnum::Accepted;
     };
 
-    callbacks.stop_transaction_callback = [this](const int32_t evse_id, const ocpp::v201::ReasonEnum& stop_reason) {
+    callbacks.stop_transaction_callback = [this](const int32_t evse_id, const ocpp::v2::ReasonEnum& stop_reason) {
         if (evse_id <= 0 or evse_id > this->r_evse_manager.size()) {
-            return ocpp::v201::RequestStartStopStatusEnum::Rejected;
+            return ocpp::v2::RequestStartStopStatusEnum::Rejected;
         }
 
         types::evse_manager::StopTransactionRequest req;
         req.reason = conversions::to_everest_stop_transaction_reason(stop_reason);
 
         return this->r_evse_manager.at(evse_id - 1)->call_stop_transaction(req)
-                   ? ocpp::v201::RequestStartStopStatusEnum::Accepted
-                   : ocpp::v201::RequestStartStopStatusEnum::Rejected;
+                   ? ocpp::v2::RequestStartStopStatusEnum::Accepted
+                   : ocpp::v2::RequestStartStopStatusEnum::Rejected;
     };
 
     callbacks.pause_charging_callback = [this](const int32_t evse_id) {
@@ -430,21 +430,21 @@ void OCPP201::ready() {
 
     callbacks.unlock_connector_callback = [this](const int32_t evse_id, const int32_t connector_id) {
         // FIXME: This needs to properly handle different connectors
-        ocpp::v201::UnlockConnectorResponse response;
+        ocpp::v2::UnlockConnectorResponse response;
         if (evse_id > 0 && evse_id <= this->r_evse_manager.size()) {
             if (this->r_evse_manager.at(evse_id - 1)->call_force_unlock(connector_id)) {
-                response.status = ocpp::v201::UnlockStatusEnum::Unlocked;
+                response.status = ocpp::v2::UnlockStatusEnum::Unlocked;
             } else {
-                response.status = ocpp::v201::UnlockStatusEnum::UnlockFailed;
+                response.status = ocpp::v2::UnlockStatusEnum::UnlockFailed;
             }
         } else {
-            response.status = ocpp::v201::UnlockStatusEnum::UnknownConnector;
+            response.status = ocpp::v2::UnlockStatusEnum::UnknownConnector;
         }
 
         return response;
     };
 
-    callbacks.get_log_request_callback = [this](const ocpp::v201::GetLogRequest& request) {
+    callbacks.get_log_request_callback = [this](const ocpp::v2::GetLogRequest& request) {
         const auto response = this->r_system->call_upload_logs(conversions::to_everest_upload_logs_request(request));
         return conversions::to_ocpp_get_log_response(response);
     };
@@ -468,13 +468,13 @@ void OCPP201::ready() {
         return ocpp_conversions::to_ocpp_reservation_check_status(reservation_status);
     };
 
-    callbacks.update_firmware_request_callback = [this](const ocpp::v201::UpdateFirmwareRequest& request) {
+    callbacks.update_firmware_request_callback = [this](const ocpp::v2::UpdateFirmwareRequest& request) {
         const auto response =
             this->r_system->call_update_firmware(conversions::to_everest_firmware_update_request(request));
         return conversions::to_ocpp_update_firmware_response(response);
     };
 
-    callbacks.variable_changed_callback = [this](const ocpp::v201::SetVariableData& set_variable_data) {
+    callbacks.variable_changed_callback = [this](const ocpp::v2::SetVariableData& set_variable_data) {
         if (set_variable_data.component.name == "TxCtrlr" and
             set_variable_data.variable.name == "EVConnectionTimeOut") {
             try {
@@ -507,24 +507,22 @@ void OCPP201::ready() {
     };
 
     callbacks.validate_network_profile_callback =
-        [this](const int32_t configuration_slot,
-               const ocpp::v201::NetworkConnectionProfile& network_connection_profile) {
+        [this](const int32_t configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile) {
             auto ws_uri = ocpp::uri(network_connection_profile.ocppCsmsUrl.get());
 
             if (ws_uri.get_valid()) {
-                return ocpp::v201::SetNetworkProfileStatusEnum::Accepted;
+                return ocpp::v2::SetNetworkProfileStatusEnum::Accepted;
             } else {
-                return ocpp::v201::SetNetworkProfileStatusEnum::Rejected;
+                return ocpp::v2::SetNetworkProfileStatusEnum::Rejected;
             }
             // TODO(piet): Add further validation of the NetworkConnectionProfile
         };
 
     callbacks.configure_network_connection_profile_callback =
-        [this](const int32_t configuration_slot,
-               const ocpp::v201::NetworkConnectionProfile& network_connection_profile) {
-            std::promise<ocpp::v201::ConfigNetworkResult> promise;
-            std::future<ocpp::v201::ConfigNetworkResult> future = promise.get_future();
-            ocpp::v201::ConfigNetworkResult result;
+        [this](const int32_t configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile) {
+            std::promise<ocpp::v2::ConfigNetworkResult> promise;
+            std::future<ocpp::v2::ConfigNetworkResult> future = promise.get_future();
+            ocpp::v2::ConfigNetworkResult result;
             result.success = true;
             promise.set_value(result);
             return future;
@@ -535,14 +533,14 @@ void OCPP201::ready() {
         this->r_system->call_allow_firmware_installation();
     };
 
-    callbacks.transaction_event_callback = [this](const ocpp::v201::TransactionEventRequest& transaction_event) {
+    callbacks.transaction_event_callback = [this](const ocpp::v2::TransactionEventRequest& transaction_event) {
         const auto ocpp_transaction_event = conversions::to_everest_ocpp_transaction_event(transaction_event);
         this->p_ocpp_generic->publish_ocpp_transaction_event(ocpp_transaction_event);
     };
 
     callbacks.transaction_event_response_callback =
-        [this](const ocpp::v201::TransactionEventRequest& transaction_event,
-               const ocpp::v201::TransactionEventResponse& transaction_event_response) {
+        [this](const ocpp::v2::TransactionEventRequest& transaction_event,
+               const ocpp::v2::TransactionEventResponse& transaction_event_response) {
             auto ocpp_transaction_event = conversions::to_everest_ocpp_transaction_event(transaction_event);
             auto ocpp_transaction_event_response =
                 conversions::to_everest_transaction_event_response(transaction_event_response);
@@ -551,17 +549,17 @@ void OCPP201::ready() {
         };
 
     callbacks.boot_notification_callback =
-        [this](const ocpp::v201::BootNotificationResponse& boot_notification_response) {
+        [this](const ocpp::v2::BootNotificationResponse& boot_notification_response) {
             const auto everest_boot_notification_response =
                 conversions::to_everest_boot_notification_response(boot_notification_response);
             this->p_ocpp_generic->publish_boot_notification_response(everest_boot_notification_response);
         };
 
     callbacks.set_display_message_callback =
-        [this](const std::vector<ocpp::DisplayMessage>& messages) -> ocpp::v201::SetDisplayMessageResponse {
-        ocpp::v201::SetDisplayMessageResponse response;
+        [this](const std::vector<ocpp::DisplayMessage>& messages) -> ocpp::v2::SetDisplayMessageResponse {
+        ocpp::v2::SetDisplayMessageResponse response;
         if (this->r_display_message.empty()) {
-            response.status = ocpp::v201::DisplayMessageStatusEnum::Rejected;
+            response.status = ocpp::v2::DisplayMessageStatusEnum::Rejected;
             return response;
         }
 
@@ -579,7 +577,7 @@ void OCPP201::ready() {
     };
 
     callbacks.get_display_message_callback =
-        [this](const ocpp::v201::GetDisplayMessagesRequest& request) -> std::vector<ocpp::DisplayMessage> {
+        [this](const ocpp::v2::GetDisplayMessagesRequest& request) -> std::vector<ocpp::DisplayMessage> {
         if (this->r_display_message.empty()) {
             return {};
         }
@@ -602,10 +600,10 @@ void OCPP201::ready() {
     };
 
     callbacks.clear_display_message_callback =
-        [this](const ocpp::v201::ClearDisplayMessageRequest& request) -> ocpp::v201::ClearDisplayMessageResponse {
+        [this](const ocpp::v2::ClearDisplayMessageRequest& request) -> ocpp::v2::ClearDisplayMessageResponse {
         if (this->r_display_message.empty()) {
-            ocpp::v201::ClearDisplayMessageResponse response;
-            response.status = ocpp::v201::ClearMessageStatusEnum::Unknown;
+            ocpp::v2::ClearDisplayMessageResponse response;
+            response.status = ocpp::v2::ClearMessageStatusEnum::Unknown;
             return response;
         }
 
@@ -635,12 +633,12 @@ void OCPP201::ready() {
     }
 
     if (!this->r_data_transfer.empty()) {
-        callbacks.data_transfer_callback = [this](const ocpp::v201::DataTransferRequest& request) {
+        callbacks.data_transfer_callback = [this](const ocpp::v2::DataTransferRequest& request) {
             types::ocpp::DataTransferRequest data_transfer_request =
                 conversions::to_everest_data_transfer_request(request);
             types::ocpp::DataTransferResponse data_transfer_response =
                 this->r_data_transfer.at(0)->call_data_transfer(data_transfer_request);
-            ocpp::v201::DataTransferResponse response =
+            ocpp::v2::DataTransferResponse response =
                 conversions::to_ocpp_data_transfer_response(data_transfer_response);
             return response;
         };
@@ -648,7 +646,7 @@ void OCPP201::ready() {
 
     callbacks.connection_state_changed_callback =
         [this](const bool is_connected, const int /*configuration_slot*/,
-               const ocpp::v201::NetworkConnectionProfile& /*network_connection_profile*/) {
+               const ocpp::v2::NetworkConnectionProfile& /*network_connection_profile*/) {
             this->p_ocpp_generic->publish_is_connected(is_connected);
         };
 
@@ -681,11 +679,11 @@ void OCPP201::ready() {
     };
 
     callbacks.reserve_now_callback =
-        [this](const ocpp::v201::ReserveNowRequest& request) -> ocpp::v201::ReserveNowStatusEnum {
-        ocpp::v201::ReserveNowResponse response;
+        [this](const ocpp::v2::ReserveNowRequest& request) -> ocpp::v2::ReserveNowStatusEnum {
+        ocpp::v2::ReserveNowResponse response;
         if (this->r_reservation.empty() || this->r_reservation.at(0) == nullptr) {
             EVLOG_info << "Reservation rejected because the interface r_reservation is a nullptr";
-            return ocpp::v201::ReserveNowStatusEnum::Rejected;
+            return ocpp::v2::ReserveNowStatusEnum::Rejected;
         }
 
         types::reservation::Reservation reservation;
@@ -706,7 +704,6 @@ void OCPP201::ready() {
 
     callbacks.cancel_reservation_callback = [this](const int32_t reservation_id) -> bool {
         EVLOG_debug << "Received cancel reservation request for reservation id " << reservation_id;
-        ocpp::v201::CancelReservationResponse response;
         if (this->r_reservation.empty() || this->r_reservation.at(0) == nullptr) {
             return false;
         }
@@ -720,7 +717,7 @@ void OCPP201::ready() {
     std::unique_ptr<module::device_model::ComposedDeviceModelStorage> device_model_storage =
         std::make_unique<module::device_model::ComposedDeviceModelStorage>(
             device_model_database_path, true, device_model_database_migration_path, device_model_config_path);
-    this->charge_point = std::make_unique<ocpp::v201::ChargePoint>(
+    this->charge_point = std::make_unique<ocpp::v2::ChargePoint>(
         evse_connector_structure, std::move(device_model_storage), this->ocpp_share_path.string(),
         this->config.CoreDatabasePath, sql_init_path.string(), this->config.MessageLogPath,
         std::make_shared<EvseSecurity>(*this->r_security), callbacks);
@@ -754,17 +751,15 @@ void OCPP201::ready() {
     }
 
     const auto ev_connection_timeout_request_value_response = this->charge_point->request_value<int32_t>(
-        ocpp::v201::Component{"TxCtrlr"}, ocpp::v201::Variable{"EVConnectionTimeOut"},
-        ocpp::v201::AttributeEnum::Actual);
-    if (ev_connection_timeout_request_value_response.status == ocpp::v201::GetVariableStatusEnum::Accepted and
+        ocpp::v2::Component{"TxCtrlr"}, ocpp::v2::Variable{"EVConnectionTimeOut"}, ocpp::v2::AttributeEnum::Actual);
+    if (ev_connection_timeout_request_value_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         ev_connection_timeout_request_value_response.value.has_value()) {
         this->r_auth->call_set_connection_timeout(ev_connection_timeout_request_value_response.value.value());
     }
 
     const auto master_pass_group_id_response = this->charge_point->request_value<std::string>(
-        ocpp::v201::Component{"AuthCtrlr"}, ocpp::v201::Variable{"MasterPassGroupId"},
-        ocpp::v201::AttributeEnum::Actual);
-    if (master_pass_group_id_response.status == ocpp::v201::GetVariableStatusEnum::Accepted and
+        ocpp::v2::Component{"AuthCtrlr"}, ocpp::v2::Variable{"MasterPassGroupId"}, ocpp::v2::AttributeEnum::Actual);
+    if (master_pass_group_id_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         master_pass_group_id_response.value.has_value()) {
         this->r_auth->call_set_master_pass_group_id(master_pass_group_id_response.value.value());
     }
@@ -783,8 +778,8 @@ void OCPP201::ready() {
     std::set<TxStartStopPoint> tx_stop_points;
 
     const auto tx_start_point_request_value_response = this->charge_point->request_value<std::string>(
-        ocpp::v201::Component{"TxCtrlr"}, ocpp::v201::Variable{"TxStartPoint"}, ocpp::v201::AttributeEnum::Actual);
-    if (tx_start_point_request_value_response.status == ocpp::v201::GetVariableStatusEnum::Accepted and
+        ocpp::v2::Component{"TxCtrlr"}, ocpp::v2::Variable{"TxStartPoint"}, ocpp::v2::AttributeEnum::Actual);
+    if (tx_start_point_request_value_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         tx_start_point_request_value_response.value.has_value()) {
         auto tx_start_point_csl =
             tx_start_point_request_value_response.value.value(); // contains comma seperated list of TxStartPoints
@@ -797,8 +792,8 @@ void OCPP201::ready() {
     }
 
     const auto tx_stop_point_request_value_response = this->charge_point->request_value<std::string>(
-        ocpp::v201::Component{"TxCtrlr"}, ocpp::v201::Variable{"TxStopPoint"}, ocpp::v201::AttributeEnum::Actual);
-    if (tx_stop_point_request_value_response.status == ocpp::v201::GetVariableStatusEnum::Accepted and
+        ocpp::v2::Component{"TxCtrlr"}, ocpp::v2::Variable{"TxStopPoint"}, ocpp::v2::AttributeEnum::Actual);
+    if (tx_stop_point_request_value_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         tx_stop_point_request_value_response.value.has_value()) {
         auto tx_stop_point_csl =
             tx_stop_point_request_value_response.value.value(); // contains comma seperated list of TxStartPoints
@@ -821,11 +816,11 @@ void OCPP201::ready() {
 
         evse->subscribe_powermeter([this, evse_id](const types::powermeter::Powermeter& power_meter) {
             auto meter_value = conversions::to_ocpp_meter_value(
-                power_meter, ocpp::v201::ReadingContextEnum::Sample_Periodic, power_meter.signed_meter_value);
+                power_meter, ocpp::v2::ReadingContextEnum::Sample_Periodic, power_meter.signed_meter_value);
             if (this->evse_soc_map[evse_id].has_value()) {
                 auto sampled_soc_value = conversions::to_ocpp_sampled_value(
-                    ocpp::v201::ReadingContextEnum::Sample_Periodic, ocpp::v201::MeasurandEnum::SoC, "Percent",
-                    std::nullopt, ocpp::v201::LocationEnum::EV);
+                    ocpp::v2::ReadingContextEnum::Sample_Periodic, ocpp::v2::MeasurandEnum::SoC, "Percent",
+                    std::nullopt, ocpp::v2::LocationEnum::EV);
                 sampled_soc_value.value = this->evse_soc_map[evse_id].value();
                 meter_value.sampledValue.push_back(sampled_soc_value);
             }
@@ -1014,7 +1009,7 @@ void OCPP201::process_tx_event_effect(const int32_t evse_id, const TxEventEffect
     if (tx_event_effect == TxEventEffect::START_TRANSACTION) {
         transaction_data->started = true;
         transaction_data->meter_value = conversions::to_ocpp_meter_value(
-            get_meter_value(session_event), ocpp::v201::ReadingContextEnum::Transaction_Begin,
+            get_meter_value(session_event), ocpp::v2::ReadingContextEnum::Transaction_Begin,
             get_signed_meter_value(session_event));
         this->charge_point->on_transaction_started(
             evse_id, transaction_data->connector_id, transaction_data->session_id, transaction_data->timestamp,
@@ -1022,9 +1017,9 @@ void OCPP201::process_tx_event_effect(const int32_t evse_id, const TxEventEffect
             transaction_data->group_id_token, transaction_data->reservation_id, transaction_data->remote_start_id,
             transaction_data->charging_state);
     } else if (tx_event_effect == TxEventEffect::STOP_TRANSACTION) {
-        transaction_data->meter_value = conversions::to_ocpp_meter_value(
-            get_meter_value(session_event), ocpp::v201::ReadingContextEnum::Transaction_End,
-            get_signed_meter_value(session_event));
+        transaction_data->meter_value = conversions::to_ocpp_meter_value(get_meter_value(session_event),
+                                                                         ocpp::v2::ReadingContextEnum::Transaction_End,
+                                                                         get_signed_meter_value(session_event));
         this->charge_point->on_transaction_finished(evse_id, transaction_data->timestamp, transaction_data->meter_value,
                                                     transaction_data->stop_reason, transaction_data->trigger_reason,
                                                     transaction_data->id_token, std::nullopt,
@@ -1041,16 +1036,16 @@ void OCPP201::process_session_started(const int32_t evse_id, const int32_t conne
 
     const auto session_started = session_event.session_started.value();
 
-    std::optional<ocpp::v201::IdToken> id_token = std::nullopt;
-    std::optional<ocpp::v201::IdToken> group_id_token = std::nullopt;
+    std::optional<ocpp::v2::IdToken> id_token = std::nullopt;
+    std::optional<ocpp::v2::IdToken> group_id_token = std::nullopt;
     std::optional<int32_t> remote_start_id = std::nullopt;
-    auto charging_state = ocpp::v201::ChargingStateEnum::Idle;
-    auto trigger_reason = ocpp::v201::TriggerReasonEnum::Authorized;
+    auto charging_state = ocpp::v2::ChargingStateEnum::Idle;
+    auto trigger_reason = ocpp::v2::TriggerReasonEnum::Authorized;
     auto tx_event = TxEvent::AUTHORIZED;
     if (session_started.reason == types::evse_manager::StartSessionReason::EVConnected) {
         tx_event = TxEvent::EV_CONNECTED;
-        trigger_reason = ocpp::v201::TriggerReasonEnum::CablePluggedIn;
-        charging_state = ocpp::v201::ChargingStateEnum::EVConnected;
+        trigger_reason = ocpp::v2::TriggerReasonEnum::CablePluggedIn;
+        charging_state = ocpp::v2::ChargingStateEnum::EVConnected;
     } else if (!session_started.id_tag.has_value()) {
         EVLOG_warning << "Session started with reason Authorized, but no id_tag provided as part of the "
                          "session event";
@@ -1061,7 +1056,7 @@ void OCPP201::process_session_started(const int32_t evse_id, const int32_t conne
             group_id_token = conversions::to_ocpp_id_token(session_started.id_tag.value().parent_id_token.value());
         }
         if (session_started.id_tag.value().authorization_type == types::authorization::AuthorizationType::OCPP) {
-            trigger_reason = ocpp::v201::TriggerReasonEnum::RemoteStart;
+            trigger_reason = ocpp::v2::TriggerReasonEnum::RemoteStart;
         }
     }
     const auto timestamp = ocpp_conversions::to_ocpp_datetime_or_now(session_event.timestamp);
@@ -1088,9 +1083,9 @@ void OCPP201::process_session_finished(const int32_t evse_id, const int32_t conn
     this->evse_soc_map[evse_id].reset();
     auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
     if (transaction_data != nullptr) {
-        transaction_data->charging_state = ocpp::v201::ChargingStateEnum::Idle;
-        transaction_data->stop_reason = ocpp::v201::ReasonEnum::EVDisconnected;
-        transaction_data->trigger_reason = ocpp::v201::TriggerReasonEnum::EVCommunicationLost;
+        transaction_data->charging_state = ocpp::v2::ChargingStateEnum::Idle;
+        transaction_data->stop_reason = ocpp::v2::ReasonEnum::EVDisconnected;
+        transaction_data->trigger_reason = ocpp::v2::TriggerReasonEnum::EVCommunicationLost;
     }
     const auto tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::EV_DISCONNECTED);
     this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
@@ -1119,7 +1114,7 @@ void OCPP201::process_transaction_started(const int32_t evse_id, const int32_t c
     // at this point we dont know if the TransactionStarted event was triggered because of an Authorization or EV Plug
     // in event. We assume cable has been plugged in first and then authorized and update if other order was applied
     auto tx_event = TxEvent::AUTHORIZED;
-    auto trigger_reason = ocpp::v201::TriggerReasonEnum::Authorized;
+    auto trigger_reason = ocpp::v2::TriggerReasonEnum::Authorized;
     const auto transaction_started = session_event.transaction_started.value();
     if (transaction_started.reservation_id.has_value()) {
         transaction_data->reservation_id = transaction_started.reservation_id;
@@ -1128,23 +1123,23 @@ void OCPP201::process_transaction_started(const int32_t evse_id, const int32_t c
     const auto id_token = conversions::to_ocpp_id_token(transaction_started.id_tag.id_token);
     transaction_data->id_token = id_token;
 
-    std::optional<ocpp::v201::IdToken> group_id_token = std::nullopt;
+    std::optional<ocpp::v2::IdToken> group_id_token = std::nullopt;
     if (transaction_started.id_tag.parent_id_token.has_value()) {
         transaction_data->group_id_token =
             conversions::to_ocpp_id_token(transaction_started.id_tag.parent_id_token.value());
     }
 
     // if session started reason was Authorized, Transaction is started because of EV plug in event
-    if (transaction_data->trigger_reason == ocpp::v201::TriggerReasonEnum::Authorized or
-        transaction_data->trigger_reason == ocpp::v201::TriggerReasonEnum::RemoteStart) {
-        trigger_reason = ocpp::v201::TriggerReasonEnum::CablePluggedIn;
-        transaction_data->charging_state = ocpp::v201::ChargingStateEnum::EVConnected;
+    if (transaction_data->trigger_reason == ocpp::v2::TriggerReasonEnum::Authorized or
+        transaction_data->trigger_reason == ocpp::v2::TriggerReasonEnum::RemoteStart) {
+        trigger_reason = ocpp::v2::TriggerReasonEnum::CablePluggedIn;
+        transaction_data->charging_state = ocpp::v2::ChargingStateEnum::EVConnected;
         this->charge_point->on_session_started(evse_id, connector_id);
         tx_event = TxEvent::EV_CONNECTED;
     }
 
     if (transaction_started.id_tag.authorization_type == types::authorization::AuthorizationType::OCPP) {
-        trigger_reason = ocpp::v201::TriggerReasonEnum::RemoteStart;
+        trigger_reason = ocpp::v2::TriggerReasonEnum::RemoteStart;
     }
 
     transaction_data->trigger_reason = trigger_reason;
@@ -1159,27 +1154,27 @@ void OCPP201::process_transaction_finished(const int32_t evse_id, const int32_t 
     }
     const auto transaction_finished = session_event.transaction_finished.value();
     auto tx_event = TxEvent::NONE;
-    auto reason = ocpp::v201::ReasonEnum::Other;
+    auto reason = ocpp::v2::ReasonEnum::Other;
     if (transaction_finished.reason.has_value()) {
         reason = conversions::to_ocpp_reason(transaction_finished.reason.value());
         tx_event = get_tx_event(reason);
     }
     auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
     if (transaction_data != nullptr) {
-        std::optional<ocpp::v201::IdToken> id_token = std::nullopt;
+        std::optional<ocpp::v2::IdToken> id_token = std::nullopt;
         if (transaction_finished.id_tag.has_value()) {
             id_token = conversions::to_ocpp_id_token(transaction_finished.id_tag.value().id_token);
         }
 
         // this is required to report the correct charging_state within a TransactionEvent(Ended) message
         auto charging_state = transaction_data->charging_state;
-        if (reason == ocpp::v201::ReasonEnum::EVDisconnected) {
-            charging_state = ocpp::v201::ChargingStateEnum::Idle;
-        } else if (reason == ocpp::v201::ReasonEnum::ImmediateReset &&
-                   charging_state != ocpp::v201::ChargingStateEnum::Idle) {
-            charging_state = ocpp::v201::ChargingStateEnum::EVConnected;
+        if (reason == ocpp::v2::ReasonEnum::EVDisconnected) {
+            charging_state = ocpp::v2::ChargingStateEnum::Idle;
+        } else if (reason == ocpp::v2::ReasonEnum::ImmediateReset &&
+                   charging_state != ocpp::v2::ChargingStateEnum::Idle) {
+            charging_state = ocpp::v2::ChargingStateEnum::EVConnected;
         } else if (tx_event == TxEvent::DEAUTHORIZED) {
-            charging_state = ocpp::v201::ChargingStateEnum::EVConnected;
+            charging_state = ocpp::v2::ChargingStateEnum::EVConnected;
         }
         transaction_data->trigger_reason = stop_reason_to_trigger_reason_enum(reason);
         transaction_data->stop_reason = reason;
@@ -1192,12 +1187,12 @@ void OCPP201::process_transaction_finished(const int32_t evse_id, const int32_t 
     this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
 
     if (tx_event == TxEvent::DEAUTHORIZED) {
-        if (reason == ocpp::v201::ReasonEnum::Remote) {
-            this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::EVConnected,
-                                                          ocpp::v201::TriggerReasonEnum::RemoteStop);
+        if (reason == ocpp::v2::ReasonEnum::Remote) {
+            this->charge_point->on_charging_state_changed(evse_id, ocpp::v2::ChargingStateEnum::EVConnected,
+                                                          ocpp::v2::TriggerReasonEnum::RemoteStop);
         } else {
-            this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::EVConnected,
-                                                          ocpp::v201::TriggerReasonEnum::StopAuthorized);
+            this->charge_point->on_charging_state_changed(evse_id, ocpp::v2::ChargingStateEnum::EVConnected,
+                                                          ocpp::v2::TriggerReasonEnum::StopAuthorized);
         }
     } else {
         // TODO(piet): If StopTxOnEVSideDisconnect is false, authorization shall still be present. This cannot only be
@@ -1215,51 +1210,50 @@ void OCPP201::process_charging_started(const int32_t evse_id, const int32_t conn
                                        const types::evse_manager::SessionEvent& session_event) {
     auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
     if (transaction_data != nullptr) {
-        transaction_data->trigger_reason = ocpp::v201::TriggerReasonEnum::ChargingStateChanged;
-        transaction_data->charging_state = ocpp::v201::ChargingStateEnum::Charging;
+        transaction_data->trigger_reason = ocpp::v2::TriggerReasonEnum::ChargingStateChanged;
+        transaction_data->charging_state = ocpp::v2::ChargingStateEnum::Charging;
     }
     const auto tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::ENERGY_TRANSFER_STARTED);
     this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
-    this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::Charging);
+    this->charge_point->on_charging_state_changed(evse_id, ocpp::v2::ChargingStateEnum::Charging);
 }
 
 void OCPP201::process_charging_resumed(const int32_t evse_id, const int32_t connector_id,
                                        const types::evse_manager::SessionEvent& session_event) {
     auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
     if (transaction_data != nullptr) {
-        transaction_data->charging_state = ocpp::v201::ChargingStateEnum::Charging;
+        transaction_data->charging_state = ocpp::v2::ChargingStateEnum::Charging;
     }
-    this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::Charging);
+    this->charge_point->on_charging_state_changed(evse_id, ocpp::v2::ChargingStateEnum::Charging);
 }
 
 void OCPP201::process_charging_paused_ev(const int32_t evse_id, const int32_t connector_id,
                                          const types::evse_manager::SessionEvent& session_event) {
     auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
     if (transaction_data != nullptr) {
-        transaction_data->charging_state = ocpp::v201::ChargingStateEnum::SuspendedEV;
-        transaction_data->trigger_reason = ocpp::v201::TriggerReasonEnum::ChargingStateChanged;
-        transaction_data->stop_reason = ocpp::v201::ReasonEnum::StoppedByEV;
+        transaction_data->charging_state = ocpp::v2::ChargingStateEnum::SuspendedEV;
+        transaction_data->trigger_reason = ocpp::v2::TriggerReasonEnum::ChargingStateChanged;
+        transaction_data->stop_reason = ocpp::v2::ReasonEnum::StoppedByEV;
     }
     const auto tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::ENERGY_TRANSFER_STOPPED);
     this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
-    this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::SuspendedEV);
+    this->charge_point->on_charging_state_changed(evse_id, ocpp::v2::ChargingStateEnum::SuspendedEV);
 }
 
 void OCPP201::process_charging_paused_evse(const int32_t evse_id, const int32_t connector_id,
                                            const types::evse_manager::SessionEvent& session_event) {
     auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
-    auto trigger_reason = ocpp::v201::TriggerReasonEnum::ChargingStateChanged;
+    auto trigger_reason = ocpp::v2::TriggerReasonEnum::ChargingStateChanged;
     if (transaction_data != nullptr) {
-        transaction_data->charging_state = ocpp::v201::ChargingStateEnum::SuspendedEVSE;
-        if (transaction_data->stop_reason == ocpp::v201::ReasonEnum::Remote) {
-            trigger_reason = ocpp::v201::TriggerReasonEnum::RemoteStop;
-            transaction_data->trigger_reason = ocpp::v201::TriggerReasonEnum::ChargingStateChanged;
+        transaction_data->charging_state = ocpp::v2::ChargingStateEnum::SuspendedEVSE;
+        if (transaction_data->stop_reason == ocpp::v2::ReasonEnum::Remote) {
+            trigger_reason = ocpp::v2::TriggerReasonEnum::RemoteStop;
+            transaction_data->trigger_reason = ocpp::v2::TriggerReasonEnum::ChargingStateChanged;
         }
     }
     const auto tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::ENERGY_TRANSFER_STOPPED);
     this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
-    this->charge_point->on_charging_state_changed(evse_id, ocpp::v201::ChargingStateEnum::SuspendedEVSE,
-                                                  trigger_reason);
+    this->charge_point->on_charging_state_changed(evse_id, ocpp::v2::ChargingStateEnum::SuspendedEVSE, trigger_reason);
 }
 
 void OCPP201::process_enabled(const int32_t evse_id, const int32_t connector_id,
@@ -1281,7 +1275,7 @@ void OCPP201::process_deauthorized(const int32_t evse_id, const int32_t connecto
                                    const types::evse_manager::SessionEvent& session_event) {
     auto transaction_data = this->transaction_handler->get_transaction_data(evse_id);
     if (transaction_data != nullptr) {
-        transaction_data->trigger_reason = ocpp::v201::TriggerReasonEnum::StopAuthorized;
+        transaction_data->trigger_reason = ocpp::v2::TriggerReasonEnum::StopAuthorized;
     }
     const auto tx_event_effect = this->transaction_handler->submit_event(evse_id, TxEvent::DEAUTHORIZED);
     this->process_tx_event_effect(evse_id, tx_event_effect, session_event);
@@ -1295,12 +1289,12 @@ void OCPP201::process_reservation_end(const int32_t evse_id, const int32_t conne
     this->charge_point->on_reservation_cleared(evse_id, connector_id);
 }
 
-void OCPP201::publish_charging_schedules(const std::vector<ocpp::v201::CompositeSchedule>& composite_schedules) {
+void OCPP201::publish_charging_schedules(const std::vector<ocpp::v2::CompositeSchedule>& composite_schedules) {
     const auto everest_schedules = conversions::to_everest_charging_schedules(composite_schedules);
     this->p_ocpp_generic->publish_charging_schedules(everest_schedules);
 }
 
-void OCPP201::set_external_limits(const std::vector<ocpp::v201::CompositeSchedule>& composite_schedules) {
+void OCPP201::set_external_limits(const std::vector<ocpp::v2::CompositeSchedule>& composite_schedules) {
     const auto start_time = ocpp::DateTime();
 
     // iterate over all schedules reported by the libocpp to create ExternalLimits
@@ -1321,7 +1315,7 @@ void OCPP201::set_external_limits(const std::vector<ocpp::v201::CompositeSchedul
             types::energy::LimitsReq limits_req;
             const auto timestamp = start_time.to_time_point() + std::chrono::seconds(period.startPeriod);
             schedule_req_entry.timestamp = ocpp::DateTime(timestamp).to_rfc3339();
-            if (composite_schedule.chargingRateUnit == ocpp::v201::ChargingRateUnitEnum::A) {
+            if (composite_schedule.chargingRateUnit == ocpp::v2::ChargingRateUnitEnum::A) {
                 limits_req.ac_max_current_A = period.limit;
                 if (period.numberPhases.has_value()) {
                     limits_req.ac_max_phase_count = period.numberPhases.value();

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -32,7 +32,7 @@
 // insert your custom include headers here
 #include <tuple>
 
-#include <ocpp/v201/charge_point.hpp>
+#include <ocpp/v2/charge_point.hpp>
 #include <transaction_handler.hpp>
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
@@ -103,7 +103,7 @@ public:
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     // insert your public definitions here
-    std::unique_ptr<ocpp::v201::ChargePoint> charge_point;
+    std::unique_ptr<ocpp::v2::ChargePoint> charge_point;
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:
@@ -164,10 +164,10 @@ private:
     void process_reservation_end(const int32_t evse_id, const int32_t connector_id);
 
     /// \brief This function publishes the given \p composite_schedules via the ocpp interface
-    void publish_charging_schedules(const std::vector<ocpp::v201::CompositeSchedule>& composite_schedules);
+    void publish_charging_schedules(const std::vector<ocpp::v2::CompositeSchedule>& composite_schedules);
 
     /// \brief This function applies given \p composite_schedules for each connected evse_energy_sink
-    void set_external_limits(const std::vector<ocpp::v201::CompositeSchedule>& composite_schedules);
+    void set_external_limits(const std::vector<ocpp::v2::CompositeSchedule>& composite_schedules);
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/OCPP201/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/OCPP201/auth_validator/auth_token_validatorImpl.cpp
@@ -3,7 +3,7 @@
 
 #include <conversions.hpp>
 #include <generated/interfaces/ISO15118_charger/Implementation.hpp>
-#include <ocpp/v201/messages/Authorize.hpp>
+#include <ocpp/v2/messages/Authorize.hpp>
 
 #include "auth_token_validatorImpl.hpp"
 
@@ -23,7 +23,7 @@ auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedId
     if (provided_token.certificate.has_value()) {
         certificate_opt.emplace(provided_token.certificate.value());
     }
-    std::optional<std::vector<ocpp::v201::OCSPRequestData>> ocsp_request_data_opt;
+    std::optional<std::vector<ocpp::v2::OCSPRequestData>> ocsp_request_data_opt;
     if (provided_token.iso15118CertificateHashData.has_value()) {
         ocsp_request_data_opt =
             conversions::to_ocpp_ocsp_request_data_vector(provided_token.iso15118CertificateHashData.value());

--- a/modules/OCPP201/conversions.cpp
+++ b/modules/OCPP201/conversions.cpp
@@ -7,58 +7,58 @@
 
 namespace module {
 namespace conversions {
-ocpp::v201::FirmwareStatusEnum to_ocpp_firmware_status_enum(const types::system::FirmwareUpdateStatusEnum status) {
+ocpp::v2::FirmwareStatusEnum to_ocpp_firmware_status_enum(const types::system::FirmwareUpdateStatusEnum status) {
     switch (status) {
     case types::system::FirmwareUpdateStatusEnum::Downloaded:
-        return ocpp::v201::FirmwareStatusEnum::Downloaded;
+        return ocpp::v2::FirmwareStatusEnum::Downloaded;
     case types::system::FirmwareUpdateStatusEnum::DownloadFailed:
-        return ocpp::v201::FirmwareStatusEnum::DownloadFailed;
+        return ocpp::v2::FirmwareStatusEnum::DownloadFailed;
     case types::system::FirmwareUpdateStatusEnum::Downloading:
-        return ocpp::v201::FirmwareStatusEnum::Downloading;
+        return ocpp::v2::FirmwareStatusEnum::Downloading;
     case types::system::FirmwareUpdateStatusEnum::DownloadScheduled:
-        return ocpp::v201::FirmwareStatusEnum::DownloadScheduled;
+        return ocpp::v2::FirmwareStatusEnum::DownloadScheduled;
     case types::system::FirmwareUpdateStatusEnum::DownloadPaused:
-        return ocpp::v201::FirmwareStatusEnum::DownloadPaused;
+        return ocpp::v2::FirmwareStatusEnum::DownloadPaused;
     case types::system::FirmwareUpdateStatusEnum::Idle:
-        return ocpp::v201::FirmwareStatusEnum::Idle;
+        return ocpp::v2::FirmwareStatusEnum::Idle;
     case types::system::FirmwareUpdateStatusEnum::InstallationFailed:
-        return ocpp::v201::FirmwareStatusEnum::InstallationFailed;
+        return ocpp::v2::FirmwareStatusEnum::InstallationFailed;
     case types::system::FirmwareUpdateStatusEnum::Installing:
-        return ocpp::v201::FirmwareStatusEnum::Installing;
+        return ocpp::v2::FirmwareStatusEnum::Installing;
     case types::system::FirmwareUpdateStatusEnum::Installed:
-        return ocpp::v201::FirmwareStatusEnum::Installed;
+        return ocpp::v2::FirmwareStatusEnum::Installed;
     case types::system::FirmwareUpdateStatusEnum::InstallRebooting:
-        return ocpp::v201::FirmwareStatusEnum::InstallRebooting;
+        return ocpp::v2::FirmwareStatusEnum::InstallRebooting;
     case types::system::FirmwareUpdateStatusEnum::InstallScheduled:
-        return ocpp::v201::FirmwareStatusEnum::InstallScheduled;
+        return ocpp::v2::FirmwareStatusEnum::InstallScheduled;
     case types::system::FirmwareUpdateStatusEnum::InstallVerificationFailed:
-        return ocpp::v201::FirmwareStatusEnum::InstallVerificationFailed;
+        return ocpp::v2::FirmwareStatusEnum::InstallVerificationFailed;
     case types::system::FirmwareUpdateStatusEnum::InvalidSignature:
-        return ocpp::v201::FirmwareStatusEnum::InvalidSignature;
+        return ocpp::v2::FirmwareStatusEnum::InvalidSignature;
     case types::system::FirmwareUpdateStatusEnum::SignatureVerified:
-        return ocpp::v201::FirmwareStatusEnum::SignatureVerified;
+        return ocpp::v2::FirmwareStatusEnum::SignatureVerified;
     }
     throw std::out_of_range("Could not convert FirmwareUpdateStatusEnum to FirmwareStatusEnum");
 }
 
-ocpp::v201::DataTransferStatusEnum to_ocpp_data_transfer_status_enum(types::ocpp::DataTransferStatus status) {
+ocpp::v2::DataTransferStatusEnum to_ocpp_data_transfer_status_enum(types::ocpp::DataTransferStatus status) {
     switch (status) {
     case types::ocpp::DataTransferStatus::Accepted:
-        return ocpp::v201::DataTransferStatusEnum::Accepted;
+        return ocpp::v2::DataTransferStatusEnum::Accepted;
     case types::ocpp::DataTransferStatus::Rejected:
-        return ocpp::v201::DataTransferStatusEnum::Rejected;
+        return ocpp::v2::DataTransferStatusEnum::Rejected;
     case types::ocpp::DataTransferStatus::UnknownMessageId:
-        return ocpp::v201::DataTransferStatusEnum::UnknownMessageId;
+        return ocpp::v2::DataTransferStatusEnum::UnknownMessageId;
     case types::ocpp::DataTransferStatus::UnknownVendorId:
-        return ocpp::v201::DataTransferStatusEnum::UnknownVendorId;
+        return ocpp::v2::DataTransferStatusEnum::UnknownVendorId;
     case types::ocpp::DataTransferStatus::Offline:
-        return ocpp::v201::DataTransferStatusEnum::UnknownVendorId;
+        return ocpp::v2::DataTransferStatusEnum::UnknownVendorId;
     }
-    return ocpp::v201::DataTransferStatusEnum::UnknownVendorId;
+    return ocpp::v2::DataTransferStatusEnum::UnknownVendorId;
 }
 
-ocpp::v201::DataTransferRequest to_ocpp_data_transfer_request(types::ocpp::DataTransferRequest request) {
-    ocpp::v201::DataTransferRequest ocpp_request;
+ocpp::v2::DataTransferRequest to_ocpp_data_transfer_request(types::ocpp::DataTransferRequest request) {
+    ocpp::v2::DataTransferRequest ocpp_request;
     ocpp_request.vendorId = request.vendor_id;
     if (request.message_id.has_value()) {
         ocpp_request.messageId = request.message_id.value();
@@ -89,8 +89,8 @@ ocpp::v201::DataTransferRequest to_ocpp_data_transfer_request(types::ocpp::DataT
     return ocpp_request;
 }
 
-ocpp::v201::DataTransferResponse to_ocpp_data_transfer_response(types::ocpp::DataTransferResponse response) {
-    ocpp::v201::DataTransferResponse ocpp_response;
+ocpp::v2::DataTransferResponse to_ocpp_data_transfer_response(types::ocpp::DataTransferResponse response) {
+    ocpp::v2::DataTransferResponse ocpp_response;
     ocpp_response.status = conversions::to_ocpp_data_transfer_status_enum(response.status);
     if (response.data.has_value()) {
         ocpp_response.data = json::parse(response.data.value());
@@ -107,12 +107,12 @@ ocpp::v201::DataTransferResponse to_ocpp_data_transfer_response(types::ocpp::Dat
     return ocpp_response;
 }
 
-ocpp::v201::SampledValue to_ocpp_sampled_value(const ocpp::v201::ReadingContextEnum& reading_context,
-                                               const ocpp::v201::MeasurandEnum& measurand, const std::string& unit,
-                                               const std::optional<ocpp::v201::PhaseEnum> phase,
-                                               ocpp::v201::LocationEnum location) {
-    ocpp::v201::SampledValue sampled_value;
-    ocpp::v201::UnitOfMeasure unit_of_measure;
+ocpp::v2::SampledValue to_ocpp_sampled_value(const ocpp::v2::ReadingContextEnum& reading_context,
+                                             const ocpp::v2::MeasurandEnum& measurand, const std::string& unit,
+                                             const std::optional<ocpp::v2::PhaseEnum> phase,
+                                             ocpp::v2::LocationEnum location) {
+    ocpp::v2::SampledValue sampled_value;
+    ocpp::v2::UnitOfMeasure unit_of_measure;
     sampled_value.context = reading_context;
     sampled_value.location = location;
     sampled_value.measurand = measurand;
@@ -122,9 +122,8 @@ ocpp::v201::SampledValue to_ocpp_sampled_value(const ocpp::v201::ReadingContextE
     return sampled_value;
 }
 
-ocpp::v201::SignedMeterValue
-to_ocpp_signed_meter_value(const types::units_signed::SignedMeterValue& signed_meter_value) {
-    ocpp::v201::SignedMeterValue ocpp_signed_meter_value;
+ocpp::v2::SignedMeterValue to_ocpp_signed_meter_value(const types::units_signed::SignedMeterValue& signed_meter_value) {
+    ocpp::v2::SignedMeterValue ocpp_signed_meter_value;
     ocpp_signed_meter_value.signedMeterData = signed_meter_value.signed_meter_data;
     ocpp_signed_meter_value.signingMethod = signed_meter_value.signing_method;
     ocpp_signed_meter_value.encodingMethod = signed_meter_value.encoding_method;
@@ -133,18 +132,18 @@ to_ocpp_signed_meter_value(const types::units_signed::SignedMeterValue& signed_m
     return ocpp_signed_meter_value;
 }
 
-ocpp::v201::MeterValue
+ocpp::v2::MeterValue
 to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
-                    const ocpp::v201::ReadingContextEnum& reading_context,
+                    const ocpp::v2::ReadingContextEnum& reading_context,
                     const std::optional<types::units_signed::SignedMeterValue> signed_meter_value) {
-    ocpp::v201::MeterValue meter_value;
+    ocpp::v2::MeterValue meter_value;
     meter_value.timestamp = ocpp_conversions::to_ocpp_datetime_or_now(power_meter.timestamp);
 
     bool energy_Wh_import_signed_total_added = false;
     // individual signed meter values can be provided by the power_meter itself
 
-    ocpp::v201::SampledValue sampled_value = to_ocpp_sampled_value(
-        reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register, "Wh", std::nullopt);
+    ocpp::v2::SampledValue sampled_value = to_ocpp_sampled_value(
+        reading_context, ocpp::v2::MeasurandEnum::Energy_Active_Import_Register, "Wh", std::nullopt);
 
     // Energy.Active.Import.Register
     if (power_meter.energy_Wh_import_signed.has_value()) {
@@ -162,7 +161,7 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
         // just one global signed_meter_value is present signed_meter_value is intended for OCMF style blobs of signed
         // meter value reports during transaction start or end
         // This is interpreted as Energy.Active.Import.Register
-        sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
+        sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Energy_Active_Import_Register,
                                               "Wh", std::nullopt);
         sampled_value.value = power_meter.energy_Wh_import.total;
         // add signedMeterValue if present
@@ -173,8 +172,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
     }
 
     if (power_meter.energy_Wh_import.L1.has_value()) {
-        sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
-                                              "Wh", ocpp::v201::PhaseEnum::L1);
+        sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Energy_Active_Import_Register,
+                                              "Wh", ocpp::v2::PhaseEnum::L1);
         sampled_value.value = power_meter.energy_Wh_import.L1.value();
         if (power_meter.energy_Wh_import_signed.has_value()) {
             const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
@@ -185,8 +184,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
         meter_value.sampledValue.push_back(sampled_value);
     }
     if (power_meter.energy_Wh_import.L2.has_value()) {
-        sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
-                                              "Wh", ocpp::v201::PhaseEnum::L2);
+        sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Energy_Active_Import_Register,
+                                              "Wh", ocpp::v2::PhaseEnum::L2);
         sampled_value.value = power_meter.energy_Wh_import.L2.value();
         if (power_meter.energy_Wh_import_signed.has_value()) {
             const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
@@ -197,8 +196,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
         meter_value.sampledValue.push_back(sampled_value);
     }
     if (power_meter.energy_Wh_import.L3.has_value()) {
-        sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Import_Register,
-                                              "Wh", ocpp::v201::PhaseEnum::L3);
+        sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Energy_Active_Import_Register,
+                                              "Wh", ocpp::v2::PhaseEnum::L3);
         sampled_value.value = power_meter.energy_Wh_import.L3.value();
         if (power_meter.energy_Wh_import_signed.has_value()) {
             const auto& energy_Wh_import_signed = power_meter.energy_Wh_import_signed.value();
@@ -212,7 +211,7 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
     // Energy.Active.Export.Register
     if (power_meter.energy_Wh_export.has_value()) {
         auto sampled_value = to_ocpp_sampled_value(
-            reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register, "Wh", std::nullopt);
+            reading_context, ocpp::v2::MeasurandEnum::Energy_Active_Export_Register, "Wh", std::nullopt);
         sampled_value.value = power_meter.energy_Wh_export.value().total;
         if (power_meter.energy_Wh_export_signed.has_value()) {
             const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
@@ -222,9 +221,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
         }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.energy_Wh_export.value().L1.has_value()) {
-            sampled_value =
-                to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register, "Wh",
-                                      ocpp::v201::PhaseEnum::L1);
+            sampled_value = to_ocpp_sampled_value(
+                reading_context, ocpp::v2::MeasurandEnum::Energy_Active_Export_Register, "Wh", ocpp::v2::PhaseEnum::L1);
             sampled_value.value = power_meter.energy_Wh_export.value().L1.value();
             if (power_meter.energy_Wh_export_signed.has_value()) {
                 const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
@@ -235,9 +233,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.energy_Wh_export.value().L2.has_value()) {
-            sampled_value =
-                to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register, "Wh",
-                                      ocpp::v201::PhaseEnum::L2);
+            sampled_value = to_ocpp_sampled_value(
+                reading_context, ocpp::v2::MeasurandEnum::Energy_Active_Export_Register, "Wh", ocpp::v2::PhaseEnum::L2);
             sampled_value.value = power_meter.energy_Wh_export.value().L2.value();
             if (power_meter.energy_Wh_export_signed.has_value()) {
                 const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
@@ -248,9 +245,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.energy_Wh_export.value().L3.has_value()) {
-            sampled_value =
-                to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Energy_Active_Export_Register, "Wh",
-                                      ocpp::v201::PhaseEnum::L3);
+            sampled_value = to_ocpp_sampled_value(
+                reading_context, ocpp::v2::MeasurandEnum::Energy_Active_Export_Register, "Wh", ocpp::v2::PhaseEnum::L3);
             sampled_value.value = power_meter.energy_Wh_export.value().L3.value();
             if (power_meter.energy_Wh_export_signed.has_value()) {
                 const auto& energy_Wh_export_signed = power_meter.energy_Wh_export_signed.value();
@@ -265,7 +261,7 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
     // Power.Active.Import
     if (power_meter.power_W.has_value()) {
         auto sampled_value =
-            to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W", std::nullopt);
+            to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Power_Active_Import, "W", std::nullopt);
         sampled_value.value = power_meter.power_W.value().total;
         if (power_meter.power_W_signed.has_value()) {
             const auto& power_W_signed = power_meter.power_W_signed.value();
@@ -275,8 +271,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
         }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.power_W.value().L1.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
-                                                  ocpp::v201::PhaseEnum::L1);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Power_Active_Import, "W",
+                                                  ocpp::v2::PhaseEnum::L1);
             sampled_value.value = power_meter.power_W.value().L1.value();
             if (power_meter.power_W_signed.has_value()) {
                 const auto& power_W_signed = power_meter.power_W_signed.value();
@@ -287,8 +283,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.power_W.value().L2.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
-                                                  ocpp::v201::PhaseEnum::L2);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Power_Active_Import, "W",
+                                                  ocpp::v2::PhaseEnum::L2);
             sampled_value.value = power_meter.power_W.value().L2.value();
             if (power_meter.power_W_signed.has_value()) {
                 const auto& power_W_signed = power_meter.power_W_signed.value();
@@ -299,8 +295,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.power_W.value().L3.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Active_Import, "W",
-                                                  ocpp::v201::PhaseEnum::L3);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Power_Active_Import, "W",
+                                                  ocpp::v2::PhaseEnum::L3);
             sampled_value.value = power_meter.power_W.value().L3.value();
             if (power_meter.power_W_signed.has_value()) {
                 const auto& power_W_signed = power_meter.power_W_signed.value();
@@ -314,8 +310,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
 
     // Power.Reactive.Import
     if (power_meter.VAR.has_value()) {
-        auto sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import,
-                                                   "var", std::nullopt);
+        auto sampled_value =
+            to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Power_Reactive_Import, "var", std::nullopt);
         sampled_value.value = power_meter.VAR.value().total;
         if (power_meter.VAR_signed.has_value()) {
             const auto& VAR_signed = power_meter.VAR_signed.value();
@@ -325,8 +321,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
         }
         meter_value.sampledValue.push_back(sampled_value);
         if (power_meter.VAR.value().L1.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import,
-                                                  "var", ocpp::v201::PhaseEnum::L1);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Power_Reactive_Import,
+                                                  "var", ocpp::v2::PhaseEnum::L1);
             sampled_value.value = power_meter.VAR.value().L1.value();
             if (power_meter.VAR_signed.has_value()) {
                 const auto& VAR_signed = power_meter.VAR_signed.value();
@@ -337,8 +333,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.VAR.value().L2.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import,
-                                                  "var", ocpp::v201::PhaseEnum::L2);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Power_Reactive_Import,
+                                                  "var", ocpp::v2::PhaseEnum::L2);
             sampled_value.value = power_meter.VAR.value().L2.value();
             if (power_meter.VAR_signed.has_value()) {
                 const auto& VAR_signed = power_meter.VAR_signed.value();
@@ -349,8 +345,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.VAR.value().L3.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Power_Reactive_Import,
-                                                  "var", ocpp::v201::PhaseEnum::L3);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Power_Reactive_Import,
+                                                  "var", ocpp::v2::PhaseEnum::L3);
             sampled_value.value = power_meter.VAR.value().L3.value();
             if (power_meter.VAR_signed.has_value()) {
                 const auto& VAR_signed = power_meter.VAR_signed.value();
@@ -365,10 +361,10 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
     // Current.Import
     if (power_meter.current_A.has_value()) {
         auto sampled_value =
-            to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A", std::nullopt);
+            to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Current_Import, "A", std::nullopt);
         if (power_meter.current_A.value().L1.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
-                                                  ocpp::v201::PhaseEnum::L1);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Current_Import, "A",
+                                                  ocpp::v2::PhaseEnum::L1);
             sampled_value.value = power_meter.current_A.value().L1.value();
             if (power_meter.current_A_signed.has_value()) {
                 const auto& current_A_signed = power_meter.current_A_signed.value();
@@ -379,8 +375,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().L2.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
-                                                  ocpp::v201::PhaseEnum::L2);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Current_Import, "A",
+                                                  ocpp::v2::PhaseEnum::L2);
             sampled_value.value = power_meter.current_A.value().L2.value();
             if (power_meter.current_A_signed.has_value()) {
                 const auto& current_A_signed = power_meter.current_A_signed.value();
@@ -391,8 +387,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().L3.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
-                                                  ocpp::v201::PhaseEnum::L3);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Current_Import, "A",
+                                                  ocpp::v2::PhaseEnum::L3);
             sampled_value.value = power_meter.current_A.value().L3.value();
             if (power_meter.current_A_signed.has_value()) {
                 const auto& current_A_signed = power_meter.current_A_signed.value();
@@ -404,7 +400,7 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
         }
         if (power_meter.current_A.value().DC.has_value()) {
             sampled_value =
-                to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A", std::nullopt);
+                to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Current_Import, "A", std::nullopt);
             sampled_value.value = power_meter.current_A.value().DC.value();
             if (power_meter.current_A_signed.has_value()) {
                 const auto& current_A_signed = power_meter.current_A_signed.value();
@@ -415,8 +411,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.current_A.value().N.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Current_Import, "A",
-                                                  ocpp::v201::PhaseEnum::N);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Current_Import, "A",
+                                                  ocpp::v2::PhaseEnum::N);
             sampled_value.value = power_meter.current_A.value().N.value();
             if (power_meter.current_A_signed.has_value()) {
                 const auto& current_A_signed = power_meter.current_A_signed.value();
@@ -431,8 +427,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
     // Voltage
     if (power_meter.voltage_V.has_value()) {
         if (power_meter.voltage_V.value().L1.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
-                                                  ocpp::v201::PhaseEnum::L1_N);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Voltage, "V",
+                                                  ocpp::v2::PhaseEnum::L1_N);
             sampled_value.value = power_meter.voltage_V.value().L1.value();
             if (power_meter.voltage_V_signed.has_value()) {
                 const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
@@ -443,8 +439,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().L2.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
-                                                  ocpp::v201::PhaseEnum::L2_N);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Voltage, "V",
+                                                  ocpp::v2::PhaseEnum::L2_N);
             sampled_value.value = power_meter.voltage_V.value().L2.value();
             if (power_meter.voltage_V_signed.has_value()) {
                 const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
@@ -455,8 +451,8 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().L3.has_value()) {
-            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V",
-                                                  ocpp::v201::PhaseEnum::L3_N);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Voltage, "V",
+                                                  ocpp::v2::PhaseEnum::L3_N);
             sampled_value.value = power_meter.voltage_V.value().L3.value();
             if (power_meter.voltage_V_signed.has_value()) {
                 const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
@@ -467,8 +463,7 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
             meter_value.sampledValue.push_back(sampled_value);
         }
         if (power_meter.voltage_V.value().DC.has_value()) {
-            sampled_value =
-                to_ocpp_sampled_value(reading_context, ocpp::v201::MeasurandEnum::Voltage, "V", std::nullopt);
+            sampled_value = to_ocpp_sampled_value(reading_context, ocpp::v2::MeasurandEnum::Voltage, "V", std::nullopt);
             sampled_value.value = power_meter.voltage_V.value().DC.value();
             if (power_meter.voltage_V_signed.has_value()) {
                 const auto& voltage_V_signed = power_meter.voltage_V_signed.value();
@@ -482,168 +477,168 @@ to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
     return meter_value;
 }
 
-ocpp::v201::LogStatusEnum to_ocpp_log_status_enum(types::system::UploadLogsStatus log_status) {
+ocpp::v2::LogStatusEnum to_ocpp_log_status_enum(types::system::UploadLogsStatus log_status) {
     switch (log_status) {
     case types::system::UploadLogsStatus::Accepted:
-        return ocpp::v201::LogStatusEnum::Accepted;
+        return ocpp::v2::LogStatusEnum::Accepted;
     case types::system::UploadLogsStatus::Rejected:
-        return ocpp::v201::LogStatusEnum::Rejected;
+        return ocpp::v2::LogStatusEnum::Rejected;
     case types::system::UploadLogsStatus::AcceptedCanceled:
-        return ocpp::v201::LogStatusEnum::AcceptedCanceled;
+        return ocpp::v2::LogStatusEnum::AcceptedCanceled;
     }
     throw std::runtime_error("Could not convert UploadLogsStatus");
 }
 
-ocpp::v201::GetLogResponse to_ocpp_get_log_response(const types::system::UploadLogsResponse& response) {
-    ocpp::v201::GetLogResponse _response;
+ocpp::v2::GetLogResponse to_ocpp_get_log_response(const types::system::UploadLogsResponse& response) {
+    ocpp::v2::GetLogResponse _response;
     _response.status = to_ocpp_log_status_enum(response.upload_logs_status);
     _response.filename = response.file_name;
     return _response;
 }
 
-ocpp::v201::UpdateFirmwareStatusEnum
+ocpp::v2::UpdateFirmwareStatusEnum
 to_ocpp_update_firmware_status_enum(const types::system::UpdateFirmwareResponse& response) {
     switch (response) {
     case types::system::UpdateFirmwareResponse::Accepted:
-        return ocpp::v201::UpdateFirmwareStatusEnum::Accepted;
+        return ocpp::v2::UpdateFirmwareStatusEnum::Accepted;
     case types::system::UpdateFirmwareResponse::Rejected:
-        return ocpp::v201::UpdateFirmwareStatusEnum::Rejected;
+        return ocpp::v2::UpdateFirmwareStatusEnum::Rejected;
     case types::system::UpdateFirmwareResponse::AcceptedCanceled:
-        return ocpp::v201::UpdateFirmwareStatusEnum::AcceptedCanceled;
+        return ocpp::v2::UpdateFirmwareStatusEnum::AcceptedCanceled;
     case types::system::UpdateFirmwareResponse::InvalidCertificate:
-        return ocpp::v201::UpdateFirmwareStatusEnum::InvalidCertificate;
+        return ocpp::v2::UpdateFirmwareStatusEnum::InvalidCertificate;
     case types::system::UpdateFirmwareResponse::RevokedCertificate:
-        return ocpp::v201::UpdateFirmwareStatusEnum::RevokedCertificate;
+        return ocpp::v2::UpdateFirmwareStatusEnum::RevokedCertificate;
     }
     throw std::runtime_error("Could not convert UpdateFirmwareResponse");
 }
 
-ocpp::v201::UpdateFirmwareResponse
+ocpp::v2::UpdateFirmwareResponse
 to_ocpp_update_firmware_response(const types::system::UpdateFirmwareResponse& response) {
-    ocpp::v201::UpdateFirmwareResponse _response;
+    ocpp::v2::UpdateFirmwareResponse _response;
     _response.status = conversions::to_ocpp_update_firmware_status_enum(response);
     return _response;
 }
 
-ocpp::v201::UploadLogStatusEnum to_ocpp_upload_logs_status_enum(types::system::LogStatusEnum status) {
+ocpp::v2::UploadLogStatusEnum to_ocpp_upload_logs_status_enum(types::system::LogStatusEnum status) {
     switch (status) {
     case types::system::LogStatusEnum::BadMessage:
-        return ocpp::v201::UploadLogStatusEnum::BadMessage;
+        return ocpp::v2::UploadLogStatusEnum::BadMessage;
     case types::system::LogStatusEnum::Idle:
-        return ocpp::v201::UploadLogStatusEnum::Idle;
+        return ocpp::v2::UploadLogStatusEnum::Idle;
     case types::system::LogStatusEnum::NotSupportedOperation:
-        return ocpp::v201::UploadLogStatusEnum::NotSupportedOperation;
+        return ocpp::v2::UploadLogStatusEnum::NotSupportedOperation;
     case types::system::LogStatusEnum::PermissionDenied:
-        return ocpp::v201::UploadLogStatusEnum::PermissionDenied;
+        return ocpp::v2::UploadLogStatusEnum::PermissionDenied;
     case types::system::LogStatusEnum::Uploaded:
-        return ocpp::v201::UploadLogStatusEnum::Uploaded;
+        return ocpp::v2::UploadLogStatusEnum::Uploaded;
     case types::system::LogStatusEnum::UploadFailure:
-        return ocpp::v201::UploadLogStatusEnum::UploadFailure;
+        return ocpp::v2::UploadLogStatusEnum::UploadFailure;
     case types::system::LogStatusEnum::Uploading:
-        return ocpp::v201::UploadLogStatusEnum::Uploading;
+        return ocpp::v2::UploadLogStatusEnum::Uploading;
     case types::system::LogStatusEnum::AcceptedCanceled:
-        return ocpp::v201::UploadLogStatusEnum::AcceptedCanceled;
+        return ocpp::v2::UploadLogStatusEnum::AcceptedCanceled;
     }
     throw std::runtime_error("Could not convert UploadLogStatusEnum");
 }
 
-ocpp::v201::BootReasonEnum to_ocpp_boot_reason(types::system::BootReason reason) {
+ocpp::v2::BootReasonEnum to_ocpp_boot_reason(types::system::BootReason reason) {
     switch (reason) {
     case types::system::BootReason::ApplicationReset:
-        return ocpp::v201::BootReasonEnum::ApplicationReset;
+        return ocpp::v2::BootReasonEnum::ApplicationReset;
     case types::system::BootReason::FirmwareUpdate:
-        return ocpp::v201::BootReasonEnum::FirmwareUpdate;
+        return ocpp::v2::BootReasonEnum::FirmwareUpdate;
     case types::system::BootReason::LocalReset:
-        return ocpp::v201::BootReasonEnum::LocalReset;
+        return ocpp::v2::BootReasonEnum::LocalReset;
     case types::system::BootReason::PowerUp:
-        return ocpp::v201::BootReasonEnum::PowerUp;
+        return ocpp::v2::BootReasonEnum::PowerUp;
     case types::system::BootReason::RemoteReset:
-        return ocpp::v201::BootReasonEnum::RemoteReset;
+        return ocpp::v2::BootReasonEnum::RemoteReset;
     case types::system::BootReason::ScheduledReset:
-        return ocpp::v201::BootReasonEnum::ScheduledReset;
+        return ocpp::v2::BootReasonEnum::ScheduledReset;
     case types::system::BootReason::Triggered:
-        return ocpp::v201::BootReasonEnum::Triggered;
+        return ocpp::v2::BootReasonEnum::Triggered;
     case types::system::BootReason::Unknown:
-        return ocpp::v201::BootReasonEnum::Unknown;
+        return ocpp::v2::BootReasonEnum::Unknown;
     case types::system::BootReason::Watchdog:
-        return ocpp::v201::BootReasonEnum::Watchdog;
+        return ocpp::v2::BootReasonEnum::Watchdog;
     }
     throw std::runtime_error("Could not convert BootReasonEnum");
 }
 
-ocpp::v201::ReasonEnum to_ocpp_reason(types::evse_manager::StopTransactionReason reason) {
+ocpp::v2::ReasonEnum to_ocpp_reason(types::evse_manager::StopTransactionReason reason) {
     switch (reason) {
     case types::evse_manager::StopTransactionReason::DeAuthorized:
-        return ocpp::v201::ReasonEnum::DeAuthorized;
+        return ocpp::v2::ReasonEnum::DeAuthorized;
     case types::evse_manager::StopTransactionReason::EmergencyStop:
-        return ocpp::v201::ReasonEnum::EmergencyStop;
+        return ocpp::v2::ReasonEnum::EmergencyStop;
     case types::evse_manager::StopTransactionReason::EnergyLimitReached:
-        return ocpp::v201::ReasonEnum::EnergyLimitReached;
+        return ocpp::v2::ReasonEnum::EnergyLimitReached;
     case types::evse_manager::StopTransactionReason::EVDisconnected:
-        return ocpp::v201::ReasonEnum::EVDisconnected;
+        return ocpp::v2::ReasonEnum::EVDisconnected;
     case types::evse_manager::StopTransactionReason::GroundFault:
-        return ocpp::v201::ReasonEnum::GroundFault;
+        return ocpp::v2::ReasonEnum::GroundFault;
     case types::evse_manager::StopTransactionReason::HardReset:
-        return ocpp::v201::ReasonEnum::ImmediateReset;
+        return ocpp::v2::ReasonEnum::ImmediateReset;
     case types::evse_manager::StopTransactionReason::Local:
-        return ocpp::v201::ReasonEnum::Local;
+        return ocpp::v2::ReasonEnum::Local;
     case types::evse_manager::StopTransactionReason::LocalOutOfCredit:
-        return ocpp::v201::ReasonEnum::LocalOutOfCredit;
+        return ocpp::v2::ReasonEnum::LocalOutOfCredit;
     case types::evse_manager::StopTransactionReason::MasterPass:
-        return ocpp::v201::ReasonEnum::MasterPass;
+        return ocpp::v2::ReasonEnum::MasterPass;
     case types::evse_manager::StopTransactionReason::Other:
-        return ocpp::v201::ReasonEnum::Other;
+        return ocpp::v2::ReasonEnum::Other;
     case types::evse_manager::StopTransactionReason::OvercurrentFault:
-        return ocpp::v201::ReasonEnum::OvercurrentFault;
+        return ocpp::v2::ReasonEnum::OvercurrentFault;
     case types::evse_manager::StopTransactionReason::PowerLoss:
-        return ocpp::v201::ReasonEnum::PowerLoss;
+        return ocpp::v2::ReasonEnum::PowerLoss;
     case types::evse_manager::StopTransactionReason::PowerQuality:
-        return ocpp::v201::ReasonEnum::PowerQuality;
+        return ocpp::v2::ReasonEnum::PowerQuality;
     case types::evse_manager::StopTransactionReason::Reboot:
-        return ocpp::v201::ReasonEnum::Reboot;
+        return ocpp::v2::ReasonEnum::Reboot;
     case types::evse_manager::StopTransactionReason::Remote:
-        return ocpp::v201::ReasonEnum::Remote;
+        return ocpp::v2::ReasonEnum::Remote;
     case types::evse_manager::StopTransactionReason::SOCLimitReached:
-        return ocpp::v201::ReasonEnum::SOCLimitReached;
+        return ocpp::v2::ReasonEnum::SOCLimitReached;
     case types::evse_manager::StopTransactionReason::StoppedByEV:
-        return ocpp::v201::ReasonEnum::StoppedByEV;
+        return ocpp::v2::ReasonEnum::StoppedByEV;
     case types::evse_manager::StopTransactionReason::TimeLimitReached:
-        return ocpp::v201::ReasonEnum::TimeLimitReached;
+        return ocpp::v2::ReasonEnum::TimeLimitReached;
     case types::evse_manager::StopTransactionReason::Timeout:
-        return ocpp::v201::ReasonEnum::Timeout;
+        return ocpp::v2::ReasonEnum::Timeout;
     case types::evse_manager::StopTransactionReason::SoftReset:
     case types::evse_manager::StopTransactionReason::UnlockCommand:
-        return ocpp::v201::ReasonEnum::Other;
+        return ocpp::v2::ReasonEnum::Other;
     }
-    return ocpp::v201::ReasonEnum::Other;
+    return ocpp::v2::ReasonEnum::Other;
 }
 
-ocpp::v201::IdTokenEnum to_ocpp_id_token_enum(types::authorization::IdTokenType id_token_type) {
+ocpp::v2::IdTokenEnum to_ocpp_id_token_enum(types::authorization::IdTokenType id_token_type) {
     switch (id_token_type) {
     case types::authorization::IdTokenType::Central:
-        return ocpp::v201::IdTokenEnum::Central;
+        return ocpp::v2::IdTokenEnum::Central;
     case types::authorization::IdTokenType::eMAID:
-        return ocpp::v201::IdTokenEnum::eMAID;
+        return ocpp::v2::IdTokenEnum::eMAID;
     case types::authorization::IdTokenType::MacAddress:
-        return ocpp::v201::IdTokenEnum::MacAddress;
+        return ocpp::v2::IdTokenEnum::MacAddress;
     case types::authorization::IdTokenType::ISO14443:
-        return ocpp::v201::IdTokenEnum::ISO14443;
+        return ocpp::v2::IdTokenEnum::ISO14443;
     case types::authorization::IdTokenType::ISO15693:
-        return ocpp::v201::IdTokenEnum::ISO15693;
+        return ocpp::v2::IdTokenEnum::ISO15693;
     case types::authorization::IdTokenType::KeyCode:
-        return ocpp::v201::IdTokenEnum::KeyCode;
+        return ocpp::v2::IdTokenEnum::KeyCode;
     case types::authorization::IdTokenType::Local:
-        return ocpp::v201::IdTokenEnum::Local;
+        return ocpp::v2::IdTokenEnum::Local;
     case types::authorization::IdTokenType::NoAuthorization:
-        return ocpp::v201::IdTokenEnum::NoAuthorization;
+        return ocpp::v2::IdTokenEnum::NoAuthorization;
     }
     throw std::runtime_error("Could not convert IdTokenEnum");
 }
 
-ocpp::v201::IdToken to_ocpp_id_token(const types::authorization::IdToken& id_token) {
-    ocpp::v201::IdToken ocpp_id_token = {id_token.value, to_ocpp_id_token_enum(id_token.type)};
+ocpp::v2::IdToken to_ocpp_id_token(const types::authorization::IdToken& id_token) {
+    ocpp::v2::IdToken ocpp_id_token = {id_token.value, to_ocpp_id_token_enum(id_token.type)};
     if (id_token.additional_info.has_value()) {
-        std::vector<ocpp::v201::AdditionalInfo> ocpp_additional_info;
+        std::vector<ocpp::v2::AdditionalInfo> ocpp_additional_info;
         const auto& additional_info = id_token.additional_info.value();
         for (const auto& entry : additional_info) {
             ocpp_additional_info.push_back({entry.value, entry.type});
@@ -653,68 +648,66 @@ ocpp::v201::IdToken to_ocpp_id_token(const types::authorization::IdToken& id_tok
     return ocpp_id_token;
 }
 
-ocpp::v201::CertificateActionEnum
-to_ocpp_certificate_action_enum(const types::iso15118::CertificateActionEnum& action) {
+ocpp::v2::CertificateActionEnum to_ocpp_certificate_action_enum(const types::iso15118::CertificateActionEnum& action) {
     switch (action) {
     case types::iso15118::CertificateActionEnum::Install:
-        return ocpp::v201::CertificateActionEnum::Install;
+        return ocpp::v2::CertificateActionEnum::Install;
     case types::iso15118::CertificateActionEnum::Update:
-        return ocpp::v201::CertificateActionEnum::Update;
+        return ocpp::v2::CertificateActionEnum::Update;
     }
     throw std::out_of_range("Could not convert CertificateActionEnum"); // this should never happen
 }
 
-types::evse_manager::StopTransactionReason
-to_everest_stop_transaction_reason(const ocpp::v201::ReasonEnum& stop_reason) {
+types::evse_manager::StopTransactionReason to_everest_stop_transaction_reason(const ocpp::v2::ReasonEnum& stop_reason) {
     switch (stop_reason) {
-    case ocpp::v201::ReasonEnum::DeAuthorized:
+    case ocpp::v2::ReasonEnum::DeAuthorized:
         return types::evse_manager::StopTransactionReason::DeAuthorized;
-    case ocpp::v201::ReasonEnum::EmergencyStop:
+    case ocpp::v2::ReasonEnum::EmergencyStop:
         return types::evse_manager::StopTransactionReason::EmergencyStop;
-    case ocpp::v201::ReasonEnum::EnergyLimitReached:
+    case ocpp::v2::ReasonEnum::EnergyLimitReached:
         return types::evse_manager::StopTransactionReason::EnergyLimitReached;
-    case ocpp::v201::ReasonEnum::EVDisconnected:
+    case ocpp::v2::ReasonEnum::EVDisconnected:
         return types::evse_manager::StopTransactionReason::EVDisconnected;
-    case ocpp::v201::ReasonEnum::GroundFault:
+    case ocpp::v2::ReasonEnum::GroundFault:
         return types::evse_manager::StopTransactionReason::GroundFault;
-    case ocpp::v201::ReasonEnum::ImmediateReset:
+    case ocpp::v2::ReasonEnum::ImmediateReset:
         return types::evse_manager::StopTransactionReason::HardReset;
-    case ocpp::v201::ReasonEnum::Local:
+    case ocpp::v2::ReasonEnum::Local:
         return types::evse_manager::StopTransactionReason::Local;
-    case ocpp::v201::ReasonEnum::LocalOutOfCredit:
+    case ocpp::v2::ReasonEnum::LocalOutOfCredit:
         return types::evse_manager::StopTransactionReason::LocalOutOfCredit;
-    case ocpp::v201::ReasonEnum::MasterPass:
+    case ocpp::v2::ReasonEnum::MasterPass:
         return types::evse_manager::StopTransactionReason::MasterPass;
-    case ocpp::v201::ReasonEnum::Other:
+    case ocpp::v2::ReasonEnum::Other:
         return types::evse_manager::StopTransactionReason::Other;
-    case ocpp::v201::ReasonEnum::OvercurrentFault:
+    case ocpp::v2::ReasonEnum::OvercurrentFault:
         return types::evse_manager::StopTransactionReason::OvercurrentFault;
-    case ocpp::v201::ReasonEnum::PowerLoss:
+    case ocpp::v2::ReasonEnum::PowerLoss:
         return types::evse_manager::StopTransactionReason::PowerLoss;
-    case ocpp::v201::ReasonEnum::PowerQuality:
+    case ocpp::v2::ReasonEnum::PowerQuality:
         return types::evse_manager::StopTransactionReason::PowerQuality;
-    case ocpp::v201::ReasonEnum::Reboot:
+    case ocpp::v2::ReasonEnum::Reboot:
         return types::evse_manager::StopTransactionReason::Reboot;
-    case ocpp::v201::ReasonEnum::Remote:
+    case ocpp::v2::ReasonEnum::Remote:
         return types::evse_manager::StopTransactionReason::Remote;
-    case ocpp::v201::ReasonEnum::SOCLimitReached:
+    case ocpp::v2::ReasonEnum::SOCLimitReached:
         return types::evse_manager::StopTransactionReason::SOCLimitReached;
-    case ocpp::v201::ReasonEnum::StoppedByEV:
+    case ocpp::v2::ReasonEnum::StoppedByEV:
         return types::evse_manager::StopTransactionReason::StoppedByEV;
-    case ocpp::v201::ReasonEnum::TimeLimitReached:
+    case ocpp::v2::ReasonEnum::TimeLimitReached:
         return types::evse_manager::StopTransactionReason::TimeLimitReached;
-    case ocpp::v201::ReasonEnum::Timeout:
+    case ocpp::v2::ReasonEnum::Timeout:
         return types::evse_manager::StopTransactionReason::Timeout;
     }
     return types::evse_manager::StopTransactionReason::Other;
 }
 
-std::vector<ocpp::v201::OCSPRequestData> to_ocpp_ocsp_request_data_vector(
+std::vector<ocpp::v2::OCSPRequestData> to_ocpp_ocsp_request_data_vector(
     const std::vector<types::iso15118::CertificateHashDataInfo>& certificate_hash_data_info) {
-    std::vector<ocpp::v201::OCSPRequestData> ocsp_request_data_list;
+    std::vector<ocpp::v2::OCSPRequestData> ocsp_request_data_list;
 
     for (const auto& certificate_hash_data : certificate_hash_data_info) {
-        ocpp::v201::OCSPRequestData ocsp_request_data;
+        ocpp::v2::OCSPRequestData ocsp_request_data;
         ocsp_request_data.hashAlgorithm = conversions::to_ocpp_hash_algorithm_enum(certificate_hash_data.hashAlgorithm);
         ocsp_request_data.issuerKeyHash = certificate_hash_data.issuerKeyHash;
         ocsp_request_data.issuerNameHash = certificate_hash_data.issuerNameHash;
@@ -725,23 +718,23 @@ std::vector<ocpp::v201::OCSPRequestData> to_ocpp_ocsp_request_data_vector(
     return ocsp_request_data_list;
 }
 
-ocpp::v201::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118::HashAlgorithm hash_algorithm) {
+ocpp::v2::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118::HashAlgorithm hash_algorithm) {
     switch (hash_algorithm) {
     case types::iso15118::HashAlgorithm::SHA256:
-        return ocpp::v201::HashAlgorithmEnum::SHA256;
+        return ocpp::v2::HashAlgorithmEnum::SHA256;
     case types::iso15118::HashAlgorithm::SHA384:
-        return ocpp::v201::HashAlgorithmEnum::SHA384;
+        return ocpp::v2::HashAlgorithmEnum::SHA384;
     case types::iso15118::HashAlgorithm::SHA512:
-        return ocpp::v201::HashAlgorithmEnum::SHA512;
+        return ocpp::v2::HashAlgorithmEnum::SHA512;
     }
-    throw std::out_of_range("Could not convert types::iso15118::HashAlgorithm to ocpp::v201::HashAlgorithmEnum");
+    throw std::out_of_range("Could not convert types::iso15118::HashAlgorithm to ocpp::v2::HashAlgorithmEnum");
 }
 
-std::vector<ocpp::v201::GetVariableData>
+std::vector<ocpp::v2::GetVariableData>
 to_ocpp_get_variable_data_vector(const std::vector<types::ocpp::GetVariableRequest>& get_variable_request_vector) {
-    std::vector<ocpp::v201::GetVariableData> ocpp_get_variable_data_vector;
+    std::vector<ocpp::v2::GetVariableData> ocpp_get_variable_data_vector;
     for (const auto& get_variable_request : get_variable_request_vector) {
-        ocpp::v201::GetVariableData get_variable_data;
+        ocpp::v2::GetVariableData get_variable_data;
         get_variable_data.component = to_ocpp_component(get_variable_request.component_variable.component);
         get_variable_data.variable = to_ocpp_variable(get_variable_request.component_variable.variable);
         if (get_variable_request.attribute_type.has_value()) {
@@ -752,11 +745,11 @@ to_ocpp_get_variable_data_vector(const std::vector<types::ocpp::GetVariableReque
     return ocpp_get_variable_data_vector;
 }
 
-std::vector<ocpp::v201::SetVariableData>
+std::vector<ocpp::v2::SetVariableData>
 to_ocpp_set_variable_data_vector(const std::vector<types::ocpp::SetVariableRequest>& set_variable_request_vector) {
-    std::vector<ocpp::v201::SetVariableData> ocpp_set_variable_data_vector;
+    std::vector<ocpp::v2::SetVariableData> ocpp_set_variable_data_vector;
     for (const auto& set_variable_request : set_variable_request_vector) {
-        ocpp::v201::SetVariableData set_variable_data;
+        ocpp::v2::SetVariableData set_variable_data;
         set_variable_data.component = to_ocpp_component(set_variable_request.component_variable.component);
         set_variable_data.variable = to_ocpp_variable(set_variable_request.component_variable.variable);
         if (set_variable_request.attribute_type.has_value()) {
@@ -773,8 +766,8 @@ to_ocpp_set_variable_data_vector(const std::vector<types::ocpp::SetVariableReque
     return ocpp_set_variable_data_vector;
 }
 
-ocpp::v201::Component to_ocpp_component(const types::ocpp::Component& component) {
-    ocpp::v201::Component _component;
+ocpp::v2::Component to_ocpp_component(const types::ocpp::Component& component) {
+    ocpp::v2::Component _component;
     _component.name = component.name;
     if (component.evse.has_value()) {
         _component.evse = to_ocpp_evse(component.evse.value());
@@ -785,8 +778,8 @@ ocpp::v201::Component to_ocpp_component(const types::ocpp::Component& component)
     return _component;
 }
 
-ocpp::v201::Variable to_ocpp_variable(const types::ocpp::Variable& variable) {
-    ocpp::v201::Variable _variable;
+ocpp::v2::Variable to_ocpp_variable(const types::ocpp::Variable& variable) {
+    ocpp::v2::Variable _variable;
     _variable.name = variable.name;
     if (variable.instance.has_value()) {
         _variable.instance = variable.instance.value();
@@ -794,8 +787,8 @@ ocpp::v201::Variable to_ocpp_variable(const types::ocpp::Variable& variable) {
     return _variable;
 }
 
-ocpp::v201::EVSE to_ocpp_evse(const types::ocpp::EVSE& evse) {
-    ocpp::v201::EVSE _evse;
+ocpp::v2::EVSE to_ocpp_evse(const types::ocpp::EVSE& evse) {
+    ocpp::v2::EVSE _evse;
     _evse.id = evse.id;
     if (evse.connector_id.has_value()) {
         _evse.connectorId = evse.connector_id.value();
@@ -803,53 +796,53 @@ ocpp::v201::EVSE to_ocpp_evse(const types::ocpp::EVSE& evse) {
     return _evse;
 }
 
-ocpp::v201::AttributeEnum to_ocpp_attribute_enum(const types::ocpp::AttributeEnum attribute_enum) {
+ocpp::v2::AttributeEnum to_ocpp_attribute_enum(const types::ocpp::AttributeEnum attribute_enum) {
     switch (attribute_enum) {
     case types::ocpp::AttributeEnum::Actual:
-        return ocpp::v201::AttributeEnum::Actual;
+        return ocpp::v2::AttributeEnum::Actual;
     case types::ocpp::AttributeEnum::Target:
-        return ocpp::v201::AttributeEnum::Target;
+        return ocpp::v2::AttributeEnum::Target;
     case types::ocpp::AttributeEnum::MinSet:
-        return ocpp::v201::AttributeEnum::MinSet;
+        return ocpp::v2::AttributeEnum::MinSet;
     case types::ocpp::AttributeEnum::MaxSet:
-        return ocpp::v201::AttributeEnum::MaxSet;
+        return ocpp::v2::AttributeEnum::MaxSet;
     }
     throw std::out_of_range("Could not convert AttributeEnum");
 }
 
-ocpp::v201::Get15118EVCertificateRequest
+ocpp::v2::Get15118EVCertificateRequest
 to_ocpp_get_15118_certificate_request(const types::iso15118::RequestExiStreamSchema& request) {
-    ocpp::v201::Get15118EVCertificateRequest _request;
+    ocpp::v2::Get15118EVCertificateRequest _request;
     _request.iso15118SchemaVersion = request.iso15118_schema_version;
     _request.exiRequest = request.exi_request;
     _request.action = conversions::to_ocpp_certificate_action_enum(request.certificate_action);
     return _request;
 }
 
-ocpp::v201::ReserveNowStatusEnum to_ocpp_reservation_status(const types::reservation::ReservationResult result) {
+ocpp::v2::ReserveNowStatusEnum to_ocpp_reservation_status(const types::reservation::ReservationResult result) {
     switch (result) {
     case types::reservation::ReservationResult::Accepted:
-        return ocpp::v201::ReserveNowStatusEnum::Accepted;
+        return ocpp::v2::ReserveNowStatusEnum::Accepted;
     case types::reservation::ReservationResult::Faulted:
-        return ocpp::v201::ReserveNowStatusEnum::Faulted;
+        return ocpp::v2::ReserveNowStatusEnum::Faulted;
     case types::reservation::ReservationResult::Occupied:
-        return ocpp::v201::ReserveNowStatusEnum::Occupied;
+        return ocpp::v2::ReserveNowStatusEnum::Occupied;
     case types::reservation::ReservationResult::Rejected:
-        return ocpp::v201::ReserveNowStatusEnum::Rejected;
+        return ocpp::v2::ReserveNowStatusEnum::Rejected;
     case types::reservation::ReservationResult::Unavailable:
-        return ocpp::v201::ReserveNowStatusEnum::Unavailable;
+        return ocpp::v2::ReserveNowStatusEnum::Unavailable;
     }
 
     throw std::out_of_range("Could not convert ReservationResult");
 }
 
-ocpp::v201::ReservationUpdateStatusEnum
+ocpp::v2::ReservationUpdateStatusEnum
 to_ocpp_reservation_update_status_enum(const types::reservation::Reservation_status status) {
     switch (status) {
     case types::reservation::Reservation_status::Expired:
-        return ocpp::v201::ReservationUpdateStatusEnum::Expired;
+        return ocpp::v2::ReservationUpdateStatusEnum::Expired;
     case types::reservation::Reservation_status::Removed:
-        return ocpp::v201::ReservationUpdateStatusEnum::Removed;
+        return ocpp::v2::ReservationUpdateStatusEnum::Removed;
 
     case types::reservation::Reservation_status::Cancelled:
     case types::reservation::Reservation_status::Placed:
@@ -861,7 +854,7 @@ to_ocpp_reservation_update_status_enum(const types::reservation::Reservation_sta
     throw std::out_of_range("Could not convert ReservationUpdateStatus");
 }
 
-types::system::UploadLogsRequest to_everest_upload_logs_request(const ocpp::v201::GetLogRequest& request) {
+types::system::UploadLogsRequest to_everest_upload_logs_request(const ocpp::v2::GetLogRequest& request) {
     types::system::UploadLogsRequest _request;
     _request.location = request.log.remoteLocation.get();
     _request.retries = request.retries;
@@ -873,13 +866,13 @@ types::system::UploadLogsRequest to_everest_upload_logs_request(const ocpp::v201
     if (request.log.latestTimestamp.has_value()) {
         _request.latest_timestamp = request.log.latestTimestamp.value().to_rfc3339();
     }
-    _request.type = ocpp::v201::conversions::log_enum_to_string(request.logType);
+    _request.type = ocpp::v2::conversions::log_enum_to_string(request.logType);
     _request.request_id = request.requestId;
     return _request;
 }
 
 types::system::FirmwareUpdateRequest
-to_everest_firmware_update_request(const ocpp::v201::UpdateFirmwareRequest& request) {
+to_everest_firmware_update_request(const ocpp::v2::UpdateFirmwareRequest& request) {
     types::system::FirmwareUpdateRequest _request;
     _request.request_id = request.requestId;
     _request.location = request.firmware.location.get();
@@ -898,31 +891,31 @@ to_everest_firmware_update_request(const ocpp::v201::UpdateFirmwareRequest& requ
     return _request;
 }
 
-types::iso15118::Status to_everest_iso15118_status(const ocpp::v201::Iso15118EVCertificateStatusEnum& status) {
+types::iso15118::Status to_everest_iso15118_status(const ocpp::v2::Iso15118EVCertificateStatusEnum& status) {
     switch (status) {
-    case ocpp::v201::Iso15118EVCertificateStatusEnum::Accepted:
+    case ocpp::v2::Iso15118EVCertificateStatusEnum::Accepted:
         return types::iso15118::Status::Accepted;
-    case ocpp::v201::Iso15118EVCertificateStatusEnum::Failed:
+    case ocpp::v2::Iso15118EVCertificateStatusEnum::Failed:
         return types::iso15118::Status::Failed;
     }
     throw std::out_of_range("Could not convert Iso15118EVCertificateStatusEnum"); // this should never happen
 }
 
-types::ocpp::DataTransferStatus to_everest_data_transfer_status(ocpp::v201::DataTransferStatusEnum status) {
+types::ocpp::DataTransferStatus to_everest_data_transfer_status(ocpp::v2::DataTransferStatusEnum status) {
     switch (status) {
-    case ocpp::v201::DataTransferStatusEnum::Accepted:
+    case ocpp::v2::DataTransferStatusEnum::Accepted:
         return types::ocpp::DataTransferStatus::Accepted;
-    case ocpp::v201::DataTransferStatusEnum::Rejected:
+    case ocpp::v2::DataTransferStatusEnum::Rejected:
         return types::ocpp::DataTransferStatus::Rejected;
-    case ocpp::v201::DataTransferStatusEnum::UnknownMessageId:
+    case ocpp::v2::DataTransferStatusEnum::UnknownMessageId:
         return types::ocpp::DataTransferStatus::UnknownMessageId;
-    case ocpp::v201::DataTransferStatusEnum::UnknownVendorId:
+    case ocpp::v2::DataTransferStatusEnum::UnknownVendorId:
         return types::ocpp::DataTransferStatus::UnknownVendorId;
     }
     return types::ocpp::DataTransferStatus::UnknownVendorId;
 }
 
-types::ocpp::DataTransferRequest to_everest_data_transfer_request(ocpp::v201::DataTransferRequest request) {
+types::ocpp::DataTransferRequest to_everest_data_transfer_request(ocpp::v2::DataTransferRequest request) {
     types::ocpp::DataTransferRequest data_transfer_request;
     data_transfer_request.vendor_id = request.vendorId.get();
     if (request.messageId.has_value()) {
@@ -939,7 +932,7 @@ types::ocpp::DataTransferRequest to_everest_data_transfer_request(ocpp::v201::Da
     return data_transfer_request;
 }
 
-types::ocpp::DataTransferResponse to_everest_data_transfer_response(ocpp::v201::DataTransferResponse response) {
+types::ocpp::DataTransferResponse to_everest_data_transfer_response(ocpp::v2::DataTransferResponse response) {
     types::ocpp::DataTransferResponse everest_response;
     everest_response.status = conversions::to_everest_data_transfer_status(response.status);
     if (response.data.has_value()) {
@@ -953,7 +946,7 @@ types::ocpp::DataTransferResponse to_everest_data_transfer_response(ocpp::v201::
     return everest_response;
 }
 
-types::authorization::ValidationResult to_everest_validation_result(const ocpp::v201::AuthorizeResponse& response) {
+types::authorization::ValidationResult to_everest_validation_result(const ocpp::v2::AuthorizeResponse& response) {
     types::authorization::ValidationResult validation_result;
 
     validation_result.authorization_status = to_everest_authorization_status(response.idTokenInfo.status);
@@ -998,56 +991,56 @@ types::authorization::ValidationResult to_everest_validation_result(const ocpp::
 }
 
 types::authorization::AuthorizationStatus
-to_everest_authorization_status(const ocpp::v201::AuthorizationStatusEnum status) {
+to_everest_authorization_status(const ocpp::v2::AuthorizationStatusEnum status) {
     switch (status) {
-    case ocpp::v201::AuthorizationStatusEnum::Accepted:
+    case ocpp::v2::AuthorizationStatusEnum::Accepted:
         return types::authorization::AuthorizationStatus::Accepted;
-    case ocpp::v201::AuthorizationStatusEnum::Blocked:
+    case ocpp::v2::AuthorizationStatusEnum::Blocked:
         return types::authorization::AuthorizationStatus::Blocked;
-    case ocpp::v201::AuthorizationStatusEnum::ConcurrentTx:
+    case ocpp::v2::AuthorizationStatusEnum::ConcurrentTx:
         return types::authorization::AuthorizationStatus::ConcurrentTx;
-    case ocpp::v201::AuthorizationStatusEnum::Expired:
+    case ocpp::v2::AuthorizationStatusEnum::Expired:
         return types::authorization::AuthorizationStatus::Expired;
-    case ocpp::v201::AuthorizationStatusEnum::Invalid:
+    case ocpp::v2::AuthorizationStatusEnum::Invalid:
         return types::authorization::AuthorizationStatus::Invalid;
-    case ocpp::v201::AuthorizationStatusEnum::NoCredit:
+    case ocpp::v2::AuthorizationStatusEnum::NoCredit:
         return types::authorization::AuthorizationStatus::NoCredit;
-    case ocpp::v201::AuthorizationStatusEnum::NotAllowedTypeEVSE:
+    case ocpp::v2::AuthorizationStatusEnum::NotAllowedTypeEVSE:
         return types::authorization::AuthorizationStatus::NotAllowedTypeEVSE;
-    case ocpp::v201::AuthorizationStatusEnum::NotAtThisLocation:
+    case ocpp::v2::AuthorizationStatusEnum::NotAtThisLocation:
         return types::authorization::AuthorizationStatus::NotAtThisLocation;
-    case ocpp::v201::AuthorizationStatusEnum::NotAtThisTime:
+    case ocpp::v2::AuthorizationStatusEnum::NotAtThisTime:
         return types::authorization::AuthorizationStatus::NotAtThisTime;
-    case ocpp::v201::AuthorizationStatusEnum::Unknown:
+    case ocpp::v2::AuthorizationStatusEnum::Unknown:
         return types::authorization::AuthorizationStatus::Unknown;
     }
     throw std::out_of_range(
-        "Could not convert ocpp::v201::AuthorizationStatusEnum to types::authorization::AuthorizationStatus");
+        "Could not convert ocpp::v2::AuthorizationStatusEnum to types::authorization::AuthorizationStatus");
 }
 
-types::authorization::IdTokenType to_everest_id_token_type(const ocpp::v201::IdTokenEnum& type) {
+types::authorization::IdTokenType to_everest_id_token_type(const ocpp::v2::IdTokenEnum& type) {
     switch (type) {
-    case ocpp::v201::IdTokenEnum::Central:
+    case ocpp::v2::IdTokenEnum::Central:
         return types::authorization::IdTokenType::Central;
-    case ocpp::v201::IdTokenEnum::eMAID:
+    case ocpp::v2::IdTokenEnum::eMAID:
         return types::authorization::IdTokenType::eMAID;
-    case ocpp::v201::IdTokenEnum::ISO14443:
+    case ocpp::v2::IdTokenEnum::ISO14443:
         return types::authorization::IdTokenType::ISO14443;
-    case ocpp::v201::IdTokenEnum::ISO15693:
+    case ocpp::v2::IdTokenEnum::ISO15693:
         return types::authorization::IdTokenType::ISO15693;
-    case ocpp::v201::IdTokenEnum::KeyCode:
+    case ocpp::v2::IdTokenEnum::KeyCode:
         return types::authorization::IdTokenType::KeyCode;
-    case ocpp::v201::IdTokenEnum::Local:
+    case ocpp::v2::IdTokenEnum::Local:
         return types::authorization::IdTokenType::Local;
-    case ocpp::v201::IdTokenEnum::MacAddress:
+    case ocpp::v2::IdTokenEnum::MacAddress:
         return types::authorization::IdTokenType::MacAddress;
-    case ocpp::v201::IdTokenEnum::NoAuthorization:
+    case ocpp::v2::IdTokenEnum::NoAuthorization:
         return types::authorization::IdTokenType::NoAuthorization;
     }
-    throw std::out_of_range("Could not convert ocpp::v201::IdTokenEnum to types::authorization::IdTokenType");
+    throw std::out_of_range("Could not convert ocpp::v2::IdTokenEnum to types::authorization::IdTokenType");
 }
 
-types::authorization::IdToken to_everest_id_token(const ocpp::v201::IdToken& id_token) {
+types::authorization::IdToken to_everest_id_token(const ocpp::v2::IdToken& id_token) {
     types::authorization::IdToken _id_token;
     _id_token.value = id_token.idToken.get();
     _id_token.type = to_everest_id_token_type(id_token.type);
@@ -1055,38 +1048,38 @@ types::authorization::IdToken to_everest_id_token(const ocpp::v201::IdToken& id_
 }
 
 types::authorization::CertificateStatus
-to_everest_certificate_status(const ocpp::v201::AuthorizeCertificateStatusEnum status) {
+to_everest_certificate_status(const ocpp::v2::AuthorizeCertificateStatusEnum status) {
     switch (status) {
-    case ocpp::v201::AuthorizeCertificateStatusEnum::Accepted:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::Accepted:
         return types::authorization::CertificateStatus::Accepted;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::SignatureError:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::SignatureError:
         return types::authorization::CertificateStatus::SignatureError;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::CertificateExpired:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::CertificateExpired:
         return types::authorization::CertificateStatus::CertificateExpired;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::CertificateRevoked:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::CertificateRevoked:
         return types::authorization::CertificateStatus::CertificateRevoked;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::NoCertificateAvailable:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::NoCertificateAvailable:
         return types::authorization::CertificateStatus::NoCertificateAvailable;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::CertChainError:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::CertChainError:
         return types::authorization::CertificateStatus::CertChainError;
-    case ocpp::v201::AuthorizeCertificateStatusEnum::ContractCancelled:
+    case ocpp::v2::AuthorizeCertificateStatusEnum::ContractCancelled:
         return types::authorization::CertificateStatus::ContractCancelled;
     }
-    throw std::out_of_range("Could not convert ocpp::v201::AuthorizeCertificateStatusEnum to "
+    throw std::out_of_range("Could not convert ocpp::v2::AuthorizeCertificateStatusEnum to "
                             "types::authorization::CertificateStatus");
 }
 
 types::ocpp::OcppTransactionEvent
-to_everest_ocpp_transaction_event(const ocpp::v201::TransactionEventRequest& transaction_event) {
+to_everest_ocpp_transaction_event(const ocpp::v2::TransactionEventRequest& transaction_event) {
     types::ocpp::OcppTransactionEvent ocpp_transaction_event;
     switch (transaction_event.eventType) {
-    case ocpp::v201::TransactionEventEnum::Started:
+    case ocpp::v2::TransactionEventEnum::Started:
         ocpp_transaction_event.transaction_event = types::ocpp::TransactionEvent::Started;
         break;
-    case ocpp::v201::TransactionEventEnum::Updated:
+    case ocpp::v2::TransactionEventEnum::Updated:
         ocpp_transaction_event.transaction_event = types::ocpp::TransactionEvent::Updated;
         break;
-    case ocpp::v201::TransactionEventEnum::Ended:
+    case ocpp::v2::TransactionEventEnum::Ended:
         ocpp_transaction_event.transaction_event = types::ocpp::TransactionEvent::Ended;
         break;
     }
@@ -1100,21 +1093,21 @@ to_everest_ocpp_transaction_event(const ocpp::v201::TransactionEventRequest& tra
     return ocpp_transaction_event;
 }
 
-types::display_message::MessageFormat to_everest_message_format(const ocpp::v201::MessageFormatEnum& message_format) {
+types::display_message::MessageFormat to_everest_message_format(const ocpp::v2::MessageFormatEnum& message_format) {
     switch (message_format) {
-    case ocpp::v201::MessageFormatEnum::ASCII:
+    case ocpp::v2::MessageFormatEnum::ASCII:
         return types::display_message::MessageFormat::ASCII;
-    case ocpp::v201::MessageFormatEnum::HTML:
+    case ocpp::v2::MessageFormatEnum::HTML:
         return types::display_message::MessageFormat::HTML;
-    case ocpp::v201::MessageFormatEnum::URI:
+    case ocpp::v2::MessageFormatEnum::URI:
         return types::display_message::MessageFormat::URI;
-    case ocpp::v201::MessageFormatEnum::UTF8:
+    case ocpp::v2::MessageFormatEnum::UTF8:
         return types::display_message::MessageFormat::UTF8;
     }
-    throw std::out_of_range("Could not convert ocpp::v201::MessageFormatEnum to types::ocpp::MessageFormat");
+    throw std::out_of_range("Could not convert ocpp::v2::MessageFormatEnum to types::ocpp::MessageFormat");
 }
 
-types::display_message::MessageContent to_everest_message_content(const ocpp::v201::MessageContent& message_content) {
+types::display_message::MessageContent to_everest_message_content(const ocpp::v2::MessageContent& message_content) {
     types::display_message::MessageContent everest_message_content;
     everest_message_content.format = to_everest_message_format(message_content.format);
     everest_message_content.content = message_content.content;
@@ -1123,7 +1116,7 @@ types::display_message::MessageContent to_everest_message_content(const ocpp::v2
 }
 
 types::ocpp::OcppTransactionEventResponse
-to_everest_transaction_event_response(const ocpp::v201::TransactionEventResponse& transaction_event_response) {
+to_everest_transaction_event_response(const ocpp::v2::TransactionEventResponse& transaction_event_response) {
     types::ocpp::OcppTransactionEventResponse everest_transaction_event_response;
 
     everest_transaction_event_response.total_cost = transaction_event_response.totalCost;
@@ -1137,7 +1130,7 @@ to_everest_transaction_event_response(const ocpp::v201::TransactionEventResponse
 }
 
 types::ocpp::BootNotificationResponse
-to_everest_boot_notification_response(const ocpp::v201::BootNotificationResponse& boot_notification_response) {
+to_everest_boot_notification_response(const ocpp::v2::BootNotificationResponse& boot_notification_response) {
     types::ocpp::BootNotificationResponse everest_boot_notification_response;
     everest_boot_notification_response.status = to_everest_registration_status(boot_notification_response.status);
     everest_boot_notification_response.current_time = boot_notification_response.currentTime.to_rfc3339();
@@ -1150,19 +1143,19 @@ to_everest_boot_notification_response(const ocpp::v201::BootNotificationResponse
 }
 
 types::ocpp::RegistrationStatus
-to_everest_registration_status(const ocpp::v201::RegistrationStatusEnum& registration_status) {
+to_everest_registration_status(const ocpp::v2::RegistrationStatusEnum& registration_status) {
     switch (registration_status) {
-    case ocpp::v201::RegistrationStatusEnum::Accepted:
+    case ocpp::v2::RegistrationStatusEnum::Accepted:
         return types::ocpp::RegistrationStatus::Accepted;
-    case ocpp::v201::RegistrationStatusEnum::Pending:
+    case ocpp::v2::RegistrationStatusEnum::Pending:
         return types::ocpp::RegistrationStatus::Pending;
-    case ocpp::v201::RegistrationStatusEnum::Rejected:
+    case ocpp::v2::RegistrationStatusEnum::Rejected:
         return types::ocpp::RegistrationStatus::Rejected;
     }
-    throw std::out_of_range("Could not convert ocpp::v201::RegistrationStatusEnum to types::ocpp::RegistrationStatus");
+    throw std::out_of_range("Could not convert ocpp::v2::RegistrationStatusEnum to types::ocpp::RegistrationStatus");
 }
 
-types::ocpp::StatusInfoType to_everest_status_info_type(const ocpp::v201::StatusInfo& status_info) {
+types::ocpp::StatusInfoType to_everest_status_info_type(const ocpp::v2::StatusInfo& status_info) {
     types::ocpp::StatusInfoType everest_status_info;
     everest_status_info.reason_code = status_info.reasonCode;
     everest_status_info.additional_info = status_info.additionalInfo;
@@ -1170,7 +1163,7 @@ types::ocpp::StatusInfoType to_everest_status_info_type(const ocpp::v201::Status
 }
 
 std::vector<types::ocpp::GetVariableResult>
-to_everest_get_variable_result_vector(const std::vector<ocpp::v201::GetVariableResult>& get_variable_result_vector) {
+to_everest_get_variable_result_vector(const std::vector<ocpp::v2::GetVariableResult>& get_variable_result_vector) {
     std::vector<types::ocpp::GetVariableResult> response;
     for (const auto& get_variable_result : get_variable_result_vector) {
         types::ocpp::GetVariableResult _get_variable_result;
@@ -1190,7 +1183,7 @@ to_everest_get_variable_result_vector(const std::vector<ocpp::v201::GetVariableR
 }
 
 std::vector<types::ocpp::SetVariableResult>
-to_everest_set_variable_result_vector(const std::vector<ocpp::v201::SetVariableResult>& set_variable_result_vector) {
+to_everest_set_variable_result_vector(const std::vector<ocpp::v2::SetVariableResult>& set_variable_result_vector) {
     std::vector<types::ocpp::SetVariableResult> response;
     for (const auto& set_variable_result : set_variable_result_vector) {
         types::ocpp::SetVariableResult _set_variable_result;
@@ -1207,7 +1200,7 @@ to_everest_set_variable_result_vector(const std::vector<ocpp::v201::SetVariableR
     return response;
 }
 
-types::ocpp::Component to_everest_component(const ocpp::v201::Component& component) {
+types::ocpp::Component to_everest_component(const ocpp::v2::Component& component) {
     types::ocpp::Component _component;
     _component.name = component.name;
     if (component.evse.has_value()) {
@@ -1219,7 +1212,7 @@ types::ocpp::Component to_everest_component(const ocpp::v201::Component& compone
     return _component;
 }
 
-types::ocpp::Variable to_everest_variable(const ocpp::v201::Variable& variable) {
+types::ocpp::Variable to_everest_variable(const ocpp::v2::Variable& variable) {
     types::ocpp::Variable _variable;
     _variable.name = variable.name;
     if (variable.instance.has_value()) {
@@ -1228,7 +1221,7 @@ types::ocpp::Variable to_everest_variable(const ocpp::v201::Variable& variable) 
     return _variable;
 }
 
-types::ocpp::EVSE to_everest_evse(const ocpp::v201::EVSE& evse) {
+types::ocpp::EVSE to_everest_evse(const ocpp::v2::EVSE& evse) {
     types::ocpp::EVSE _evse;
     _evse.id = evse.id;
     if (evse.connectorId.has_value()) {
@@ -1237,58 +1230,58 @@ types::ocpp::EVSE to_everest_evse(const ocpp::v201::EVSE& evse) {
     return _evse;
 }
 
-types::ocpp::AttributeEnum to_everest_attribute_enum(const ocpp::v201::AttributeEnum attribute_enum) {
+types::ocpp::AttributeEnum to_everest_attribute_enum(const ocpp::v2::AttributeEnum attribute_enum) {
     switch (attribute_enum) {
-    case ocpp::v201::AttributeEnum::Actual:
+    case ocpp::v2::AttributeEnum::Actual:
         return types::ocpp::AttributeEnum::Actual;
-    case ocpp::v201::AttributeEnum::Target:
+    case ocpp::v2::AttributeEnum::Target:
         return types::ocpp::AttributeEnum::Target;
-    case ocpp::v201::AttributeEnum::MinSet:
+    case ocpp::v2::AttributeEnum::MinSet:
         return types::ocpp::AttributeEnum::MinSet;
-    case ocpp::v201::AttributeEnum::MaxSet:
+    case ocpp::v2::AttributeEnum::MaxSet:
         return types::ocpp::AttributeEnum::MaxSet;
     }
     throw std::out_of_range("Could not convert AttributeEnum");
 }
 
 types::ocpp::GetVariableStatusEnumType
-to_everest_get_variable_status_enum_type(const ocpp::v201::GetVariableStatusEnum get_variable_status) {
+to_everest_get_variable_status_enum_type(const ocpp::v2::GetVariableStatusEnum get_variable_status) {
     switch (get_variable_status) {
-    case ocpp::v201::GetVariableStatusEnum::Accepted:
+    case ocpp::v2::GetVariableStatusEnum::Accepted:
         return types::ocpp::GetVariableStatusEnumType::Accepted;
-    case ocpp::v201::GetVariableStatusEnum::Rejected:
+    case ocpp::v2::GetVariableStatusEnum::Rejected:
         return types::ocpp::GetVariableStatusEnumType::Rejected;
-    case ocpp::v201::GetVariableStatusEnum::UnknownComponent:
+    case ocpp::v2::GetVariableStatusEnum::UnknownComponent:
         return types::ocpp::GetVariableStatusEnumType::UnknownComponent;
-    case ocpp::v201::GetVariableStatusEnum::UnknownVariable:
+    case ocpp::v2::GetVariableStatusEnum::UnknownVariable:
         return types::ocpp::GetVariableStatusEnumType::UnknownVariable;
-    case ocpp::v201::GetVariableStatusEnum::NotSupportedAttributeType:
+    case ocpp::v2::GetVariableStatusEnum::NotSupportedAttributeType:
         return types::ocpp::GetVariableStatusEnumType::NotSupportedAttributeType;
     }
     throw std::out_of_range("Could not convert GetVariableStatusEnumType");
 }
 
 types::ocpp::SetVariableStatusEnumType
-to_everest_set_variable_status_enum_type(const ocpp::v201::SetVariableStatusEnum set_variable_status) {
+to_everest_set_variable_status_enum_type(const ocpp::v2::SetVariableStatusEnum set_variable_status) {
     switch (set_variable_status) {
-    case ocpp::v201::SetVariableStatusEnum::Accepted:
+    case ocpp::v2::SetVariableStatusEnum::Accepted:
         return types::ocpp::SetVariableStatusEnumType::Accepted;
-    case ocpp::v201::SetVariableStatusEnum::Rejected:
+    case ocpp::v2::SetVariableStatusEnum::Rejected:
         return types::ocpp::SetVariableStatusEnumType::Rejected;
-    case ocpp::v201::SetVariableStatusEnum::UnknownComponent:
+    case ocpp::v2::SetVariableStatusEnum::UnknownComponent:
         return types::ocpp::SetVariableStatusEnumType::UnknownComponent;
-    case ocpp::v201::SetVariableStatusEnum::UnknownVariable:
+    case ocpp::v2::SetVariableStatusEnum::UnknownVariable:
         return types::ocpp::SetVariableStatusEnumType::UnknownVariable;
-    case ocpp::v201::SetVariableStatusEnum::NotSupportedAttributeType:
+    case ocpp::v2::SetVariableStatusEnum::NotSupportedAttributeType:
         return types::ocpp::SetVariableStatusEnumType::NotSupportedAttributeType;
-    case ocpp::v201::SetVariableStatusEnum::RebootRequired:
+    case ocpp::v2::SetVariableStatusEnum::RebootRequired:
         return types::ocpp::SetVariableStatusEnumType::RebootRequired;
     }
     throw std::out_of_range("Could not convert GetVariableStatusEnumType");
 }
 
 types::ocpp::ChargingSchedules
-to_everest_charging_schedules(const std::vector<ocpp::v201::CompositeSchedule>& composite_schedules) {
+to_everest_charging_schedules(const std::vector<ocpp::v2::CompositeSchedule>& composite_schedules) {
     types::ocpp::ChargingSchedules charging_schedules;
     for (const auto& composite_schedule : composite_schedules) {
         charging_schedules.schedules.push_back(conversions::to_everest_charging_schedule(composite_schedule));
@@ -1296,11 +1289,11 @@ to_everest_charging_schedules(const std::vector<ocpp::v201::CompositeSchedule>& 
     return charging_schedules;
 }
 
-types::ocpp::ChargingSchedule to_everest_charging_schedule(const ocpp::v201::CompositeSchedule& composite_schedule) {
+types::ocpp::ChargingSchedule to_everest_charging_schedule(const ocpp::v2::CompositeSchedule& composite_schedule) {
     types::ocpp::ChargingSchedule charging_schedule;
     charging_schedule.evse = composite_schedule.evseId;
     charging_schedule.charging_rate_unit =
-        ocpp::v201::conversions::charging_rate_unit_enum_to_string(composite_schedule.chargingRateUnit);
+        ocpp::v2::conversions::charging_rate_unit_enum_to_string(composite_schedule.chargingRateUnit);
     charging_schedule.evse = composite_schedule.evseId;
     charging_schedule.duration = composite_schedule.duration;
     charging_schedule.start_schedule = composite_schedule.scheduleStart.to_rfc3339();
@@ -1313,7 +1306,7 @@ types::ocpp::ChargingSchedule to_everest_charging_schedule(const ocpp::v201::Com
 }
 
 types::ocpp::ChargingSchedulePeriod
-to_everest_charging_schedule_period(const ocpp::v201::ChargingSchedulePeriod& period) {
+to_everest_charging_schedule_period(const ocpp::v2::ChargingSchedulePeriod& period) {
     types::ocpp::ChargingSchedulePeriod _period;
     _period.start_period = period.startPeriod;
     _period.limit = period.limit;
@@ -1322,32 +1315,32 @@ to_everest_charging_schedule_period(const ocpp::v201::ChargingSchedulePeriod& pe
     return _period;
 }
 
-ocpp::v201::DisplayMessageStatusEnum
+ocpp::v2::DisplayMessageStatusEnum
 to_ocpp_display_message_status_enum(const types::display_message::DisplayMessageStatusEnum& from) {
     switch (from) {
     case types::display_message::DisplayMessageStatusEnum::Accepted:
-        return ocpp::v201::DisplayMessageStatusEnum::Accepted;
+        return ocpp::v2::DisplayMessageStatusEnum::Accepted;
     case types::display_message::DisplayMessageStatusEnum::NotSupportedMessageFormat:
-        return ocpp::v201::DisplayMessageStatusEnum::NotSupportedMessageFormat;
+        return ocpp::v2::DisplayMessageStatusEnum::NotSupportedMessageFormat;
     case types::display_message::DisplayMessageStatusEnum::Rejected:
-        return ocpp::v201::DisplayMessageStatusEnum::Rejected;
+        return ocpp::v2::DisplayMessageStatusEnum::Rejected;
     case types::display_message::DisplayMessageStatusEnum::NotSupportedPriority:
-        return ocpp::v201::DisplayMessageStatusEnum::NotSupportedPriority;
+        return ocpp::v2::DisplayMessageStatusEnum::NotSupportedPriority;
     case types::display_message::DisplayMessageStatusEnum::NotSupportedState:
-        return ocpp::v201::DisplayMessageStatusEnum::NotSupportedState;
+        return ocpp::v2::DisplayMessageStatusEnum::NotSupportedState;
     case types::display_message::DisplayMessageStatusEnum::UnknownTransaction:
-        return ocpp::v201::DisplayMessageStatusEnum::UnknownTransaction;
+        return ocpp::v2::DisplayMessageStatusEnum::UnknownTransaction;
     }
 
     throw std::out_of_range("Could not convert DisplayMessageStatusEnum");
 }
 
-ocpp::v201::SetDisplayMessageResponse
+ocpp::v2::SetDisplayMessageResponse
 to_ocpp_set_display_message_response(const types::display_message::SetDisplayMessageResponse& response) {
-    ocpp::v201::SetDisplayMessageResponse ocpp_response;
+    ocpp::v2::SetDisplayMessageResponse ocpp_response;
     ocpp_response.status = to_ocpp_display_message_status_enum(response.status);
     if (response.status_info.has_value()) {
-        ocpp_response.statusInfo = ocpp::v201::StatusInfo();
+        ocpp_response.statusInfo = ocpp::v2::StatusInfo();
         ocpp_response.statusInfo.value().additionalInfo = response.status_info.value();
     }
 
@@ -1355,13 +1348,13 @@ to_ocpp_set_display_message_response(const types::display_message::SetDisplayMes
 }
 
 types::display_message::MessagePriorityEnum
-to_everest_display_message_priority_enum(const ocpp::v201::MessagePriorityEnum& priority) {
+to_everest_display_message_priority_enum(const ocpp::v2::MessagePriorityEnum& priority) {
     switch (priority) {
-    case ocpp::v201::MessagePriorityEnum::AlwaysFront:
+    case ocpp::v2::MessagePriorityEnum::AlwaysFront:
         return types::display_message::MessagePriorityEnum::AlwaysFront;
-    case ocpp::v201::MessagePriorityEnum::InFront:
+    case ocpp::v2::MessagePriorityEnum::InFront:
         return types::display_message::MessagePriorityEnum::InFront;
-    case ocpp::v201::MessagePriorityEnum::NormalCycle:
+    case ocpp::v2::MessagePriorityEnum::NormalCycle:
         return types::display_message::MessagePriorityEnum::NormalCycle;
     }
 
@@ -1369,15 +1362,15 @@ to_everest_display_message_priority_enum(const ocpp::v201::MessagePriorityEnum& 
 }
 
 types::display_message::MessageStateEnum
-to_everest_display_message_state_enum(const ocpp::v201::MessageStateEnum& message_state) {
+to_everest_display_message_state_enum(const ocpp::v2::MessageStateEnum& message_state) {
     switch (message_state) {
-    case ocpp::v201::MessageStateEnum::Charging:
+    case ocpp::v2::MessageStateEnum::Charging:
         return types::display_message::MessageStateEnum::Charging;
-    case ocpp::v201::MessageStateEnum::Faulted:
+    case ocpp::v2::MessageStateEnum::Faulted:
         return types::display_message::MessageStateEnum::Faulted;
-    case ocpp::v201::MessageStateEnum::Idle:
+    case ocpp::v2::MessageStateEnum::Idle:
         return types::display_message::MessageStateEnum::Idle;
-    case ocpp::v201::MessageStateEnum::Unavailable:
+    case ocpp::v2::MessageStateEnum::Unavailable:
         return types::display_message::MessageStateEnum::Unavailable;
     }
 
@@ -1385,7 +1378,7 @@ to_everest_display_message_state_enum(const ocpp::v201::MessageStateEnum& messag
 }
 
 types::display_message::GetDisplayMessageRequest
-to_everest_display_message_request(const ocpp::v201::GetDisplayMessagesRequest& request) {
+to_everest_display_message_request(const ocpp::v2::GetDisplayMessagesRequest& request) {
     types::display_message::GetDisplayMessageRequest result_request;
     result_request.id = request.id;
     if (request.priority.has_value()) {
@@ -1399,81 +1392,81 @@ to_everest_display_message_request(const ocpp::v201::GetDisplayMessagesRequest& 
 }
 
 types::display_message::ClearDisplayMessageRequest
-to_everest_clear_display_message_request(const ocpp::v201::ClearDisplayMessageRequest& request) {
+to_everest_clear_display_message_request(const ocpp::v2::ClearDisplayMessageRequest& request) {
     types::display_message::ClearDisplayMessageRequest result_request;
     result_request.id = request.id;
     return result_request;
 }
 
-ocpp::v201::ClearMessageStatusEnum
+ocpp::v2::ClearMessageStatusEnum
 to_ocpp_clear_message_response_enum(const types::display_message::ClearMessageResponseEnum& response_enum) {
     switch (response_enum) {
     case types::display_message::ClearMessageResponseEnum::Accepted:
-        return ocpp::v201::ClearMessageStatusEnum::Accepted;
+        return ocpp::v2::ClearMessageStatusEnum::Accepted;
     case types::display_message::ClearMessageResponseEnum::Unknown:
-        return ocpp::v201::ClearMessageStatusEnum::Unknown;
+        return ocpp::v2::ClearMessageStatusEnum::Unknown;
     }
 
     throw std::out_of_range("Could not convert ClearMessageResponseEnum");
 }
 
-ocpp::v201::ClearDisplayMessageResponse
+ocpp::v2::ClearDisplayMessageResponse
 to_ocpp_clear_display_message_response(const types::display_message::ClearDisplayMessageResponse& response) {
-    ocpp::v201::ClearDisplayMessageResponse result_response;
+    ocpp::v2::ClearDisplayMessageResponse result_response;
     result_response.status = to_ocpp_clear_message_response_enum(response.status);
     if (response.status_info.has_value()) {
-        result_response.statusInfo = ocpp::v201::StatusInfo();
+        result_response.statusInfo = ocpp::v2::StatusInfo();
         result_response.statusInfo.value().additionalInfo = response.status_info.value();
     }
 
     return result_response;
 }
 
-types::evse_manager::ConnectorTypeEnum to_everest_connector_type_enum(const ocpp::v201::ConnectorEnum& connector_type) {
+types::evse_manager::ConnectorTypeEnum to_everest_connector_type_enum(const ocpp::v2::ConnectorEnum& connector_type) {
     switch (connector_type) {
-    case ocpp::v201::ConnectorEnum::cCCS1:
+    case ocpp::v2::ConnectorEnum::cCCS1:
         return types::evse_manager::ConnectorTypeEnum::cCCS1;
-    case ocpp::v201::ConnectorEnum::cCCS2:
+    case ocpp::v2::ConnectorEnum::cCCS2:
         return types::evse_manager::ConnectorTypeEnum::cCCS2;
-    case ocpp::v201::ConnectorEnum::cG105:
+    case ocpp::v2::ConnectorEnum::cG105:
         return types::evse_manager::ConnectorTypeEnum::cG105;
-    case ocpp::v201::ConnectorEnum::cTesla:
+    case ocpp::v2::ConnectorEnum::cTesla:
         return types::evse_manager::ConnectorTypeEnum::cTesla;
-    case ocpp::v201::ConnectorEnum::cType1:
+    case ocpp::v2::ConnectorEnum::cType1:
         return types::evse_manager::ConnectorTypeEnum::cType1;
-    case ocpp::v201::ConnectorEnum::cType2:
+    case ocpp::v2::ConnectorEnum::cType2:
         return types::evse_manager::ConnectorTypeEnum::cType2;
-    case ocpp::v201::ConnectorEnum::s309_1P_16A:
+    case ocpp::v2::ConnectorEnum::s309_1P_16A:
         return types::evse_manager::ConnectorTypeEnum::s309_1P_16A;
-    case ocpp::v201::ConnectorEnum::s309_1P_32A:
+    case ocpp::v2::ConnectorEnum::s309_1P_32A:
         return types::evse_manager::ConnectorTypeEnum::s309_1P_32A;
-    case ocpp::v201::ConnectorEnum::s309_3P_16A:
+    case ocpp::v2::ConnectorEnum::s309_3P_16A:
         return types::evse_manager::ConnectorTypeEnum::s309_3P_16A;
-    case ocpp::v201::ConnectorEnum::s309_3P_32A:
+    case ocpp::v2::ConnectorEnum::s309_3P_32A:
         return types::evse_manager::ConnectorTypeEnum::s309_3P_32A;
-    case ocpp::v201::ConnectorEnum::sBS1361:
+    case ocpp::v2::ConnectorEnum::sBS1361:
         return types::evse_manager::ConnectorTypeEnum::sBS1361;
-    case ocpp::v201::ConnectorEnum::sCEE_7_7:
+    case ocpp::v2::ConnectorEnum::sCEE_7_7:
         return types::evse_manager::ConnectorTypeEnum::sCEE_7_7;
-    case ocpp::v201::ConnectorEnum::sType2:
+    case ocpp::v2::ConnectorEnum::sType2:
         return types::evse_manager::ConnectorTypeEnum::sType2;
-    case ocpp::v201::ConnectorEnum::sType3:
+    case ocpp::v2::ConnectorEnum::sType3:
         return types::evse_manager::ConnectorTypeEnum::sType3;
-    case ocpp::v201::ConnectorEnum::Other1PhMax16A:
+    case ocpp::v2::ConnectorEnum::Other1PhMax16A:
         return types::evse_manager::ConnectorTypeEnum::Other1PhMax16A;
-    case ocpp::v201::ConnectorEnum::Other1PhOver16A:
+    case ocpp::v2::ConnectorEnum::Other1PhOver16A:
         return types::evse_manager::ConnectorTypeEnum::Other1PhOver16A;
-    case ocpp::v201::ConnectorEnum::Other3Ph:
+    case ocpp::v2::ConnectorEnum::Other3Ph:
         return types::evse_manager::ConnectorTypeEnum::Other3Ph;
-    case ocpp::v201::ConnectorEnum::Pan:
+    case ocpp::v2::ConnectorEnum::Pan:
         return types::evse_manager::ConnectorTypeEnum::Pan;
-    case ocpp::v201::ConnectorEnum::wInductive:
+    case ocpp::v2::ConnectorEnum::wInductive:
         return types::evse_manager::ConnectorTypeEnum::wInductive;
-    case ocpp::v201::ConnectorEnum::wResonant:
+    case ocpp::v2::ConnectorEnum::wResonant:
         return types::evse_manager::ConnectorTypeEnum::wResonant;
-    case ocpp::v201::ConnectorEnum::Undetermined:
+    case ocpp::v2::ConnectorEnum::Undetermined:
         return types::evse_manager::ConnectorTypeEnum::Undetermined;
-    case ocpp::v201::ConnectorEnum::Unknown:
+    case ocpp::v2::ConnectorEnum::Unknown:
         return types::evse_manager::ConnectorTypeEnum::Unknown;
     }
 

--- a/modules/OCPP201/conversions.hpp
+++ b/modules/OCPP201/conversions.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
-#ifndef OCPP_V201_CONVERSIONS_HPP
-#define OCPP_V201_CONVERSIONS_HPP
+#ifndef OCPP_V2_CONVERSIONS_HPP
+#define OCPP_V2_CONVERSIONS_HPP
 
 #include <generated/types/evse_manager.hpp>
 #include <generated/types/iso15118.hpp>
@@ -9,273 +9,268 @@
 #include <generated/types/reservation.hpp>
 #include <generated/types/system.hpp>
 
-#include <ocpp/v201/messages/Authorize.hpp>
-#include <ocpp/v201/messages/BootNotification.hpp>
-#include <ocpp/v201/messages/ClearDisplayMessage.hpp>
-#include <ocpp/v201/messages/DataTransfer.hpp>
-#include <ocpp/v201/messages/FirmwareStatusNotification.hpp>
-#include <ocpp/v201/messages/Get15118EVCertificate.hpp>
-#include <ocpp/v201/messages/GetDisplayMessages.hpp>
-#include <ocpp/v201/messages/GetLog.hpp>
-#include <ocpp/v201/messages/SetDisplayMessage.hpp>
-#include <ocpp/v201/messages/TransactionEvent.hpp>
-#include <ocpp/v201/messages/UpdateFirmware.hpp>
+#include <ocpp/v2/messages/Authorize.hpp>
+#include <ocpp/v2/messages/BootNotification.hpp>
+#include <ocpp/v2/messages/ClearDisplayMessage.hpp>
+#include <ocpp/v2/messages/DataTransfer.hpp>
+#include <ocpp/v2/messages/FirmwareStatusNotification.hpp>
+#include <ocpp/v2/messages/Get15118EVCertificate.hpp>
+#include <ocpp/v2/messages/GetDisplayMessages.hpp>
+#include <ocpp/v2/messages/GetLog.hpp>
+#include <ocpp/v2/messages/SetDisplayMessage.hpp>
+#include <ocpp/v2/messages/TransactionEvent.hpp>
+#include <ocpp/v2/messages/UpdateFirmware.hpp>
 
 namespace module {
 namespace conversions {
-/// \brief Converts a given types::system::FirmwareUpdateStatusEnum \p status to a ocpp::v201::FirmwareStatusEnum.
-ocpp::v201::FirmwareStatusEnum to_ocpp_firmware_status_enum(const types::system::FirmwareUpdateStatusEnum status);
+/// \brief Converts a given types::system::FirmwareUpdateStatusEnum \p status to a ocpp::v2::FirmwareStatusEnum.
+ocpp::v2::FirmwareStatusEnum to_ocpp_firmware_status_enum(const types::system::FirmwareUpdateStatusEnum status);
 
-/// \brief Converts a given types::ocpp::DataTransferStatus \p status to a ocpp::v201::DataTransferStatusEnum.
-ocpp::v201::DataTransferStatusEnum to_ocpp_data_transfer_status_enum(types::ocpp::DataTransferStatus status);
+/// \brief Converts a given types::ocpp::DataTransferStatus \p status to a ocpp::v2::DataTransferStatusEnum.
+ocpp::v2::DataTransferStatusEnum to_ocpp_data_transfer_status_enum(types::ocpp::DataTransferStatus status);
 
-/// \brief Converts a given types::ocpp::DataTransferRequest \p status to a ocpp::v201::DataTransferRequest.
-ocpp::v201::DataTransferRequest to_ocpp_data_transfer_request(types::ocpp::DataTransferRequest request);
+/// \brief Converts a given types::ocpp::DataTransferRequest \p status to a ocpp::v2::DataTransferRequest.
+ocpp::v2::DataTransferRequest to_ocpp_data_transfer_request(types::ocpp::DataTransferRequest request);
 
-/// \brief Converts a given types::ocpp::DataTransferResponse \p status to a ocpp::v201::DataTransferResponse.
-ocpp::v201::DataTransferResponse to_ocpp_data_transfer_response(types::ocpp::DataTransferResponse response);
+/// \brief Converts a given types::ocpp::DataTransferResponse \p status to a ocpp::v2::DataTransferResponse.
+ocpp::v2::DataTransferResponse to_ocpp_data_transfer_response(types::ocpp::DataTransferResponse response);
 
-/// \brief Converts the provided parameters to an ocpp::v201::SampledValue.
-ocpp::v201::SampledValue to_ocpp_sampled_value(const ocpp::v201::ReadingContextEnum& reading_context,
-                                               const ocpp::v201::MeasurandEnum& measurand, const std::string& unit,
-                                               const std::optional<ocpp::v201::PhaseEnum> phase,
-                                               ocpp::v201::LocationEnum location = ocpp::v201::LocationEnum::Outlet);
+/// \brief Converts the provided parameters to an ocpp::v2::SampledValue.
+ocpp::v2::SampledValue to_ocpp_sampled_value(const ocpp::v2::ReadingContextEnum& reading_context,
+                                             const ocpp::v2::MeasurandEnum& measurand, const std::string& unit,
+                                             const std::optional<ocpp::v2::PhaseEnum> phase,
+                                             ocpp::v2::LocationEnum location = ocpp::v2::LocationEnum::Outlet);
 
 /// \brief Converts the given types::units_signed::SignedMeterValue \p signed_meter_value  to an
-/// ocpp::v201::SignedMeterValue.
-ocpp::v201::SignedMeterValue
-to_ocpp_signed_meter_value(const types::units_signed::SignedMeterValue& signed_meter_value);
+/// ocpp::v2::SignedMeterValue.
+ocpp::v2::SignedMeterValue to_ocpp_signed_meter_value(const types::units_signed::SignedMeterValue& signed_meter_value);
 
-/// \brief Converts the provided parameters to an ocpp::v201::MeterValue.
-ocpp::v201::MeterValue
-to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
-                    const ocpp::v201::ReadingContextEnum& reading_context,
-                    const std::optional<types::units_signed::SignedMeterValue> signed_meter_value);
+/// \brief Converts the provided parameters to an ocpp::v2::MeterValue.
+ocpp::v2::MeterValue to_ocpp_meter_value(const types::powermeter::Powermeter& power_meter,
+                                         const ocpp::v2::ReadingContextEnum& reading_context,
+                                         const std::optional<types::units_signed::SignedMeterValue> signed_meter_value);
 
-/// \brief Converts a given types::system::UploadLogsStatus \p log_status to an ocpp::v201::LogStatusEnum.
-ocpp::v201::LogStatusEnum to_ocpp_log_status_enum(types::system::UploadLogsStatus log_status);
+/// \brief Converts a given types::system::UploadLogsStatus \p log_status to an ocpp::v2::LogStatusEnum.
+ocpp::v2::LogStatusEnum to_ocpp_log_status_enum(types::system::UploadLogsStatus log_status);
 
-/// \brief Converts a given types::system::UploadLogsResponse \p response to an ocpp::v201::GetLogResponse.
-ocpp::v201::GetLogResponse to_ocpp_get_log_response(const types::system::UploadLogsResponse& response);
+/// \brief Converts a given types::system::UploadLogsResponse \p response to an ocpp::v2::GetLogResponse.
+ocpp::v2::GetLogResponse to_ocpp_get_log_response(const types::system::UploadLogsResponse& response);
 
 /// \brief Converts a given types::system::UpdateFirmwareResponse \p response to an
-/// ocpp::v201::UpdateFirmwareStatusEnum.
-ocpp::v201::UpdateFirmwareStatusEnum
+/// ocpp::v2::UpdateFirmwareStatusEnum.
+ocpp::v2::UpdateFirmwareStatusEnum
 to_ocpp_update_firmware_status_enum(const types::system::UpdateFirmwareResponse& response);
 
-/// \brief Converts a given types::system::UpdateFirmwareResponse \p response to an ocpp::v201::UpdateFirmwareResponse.
-ocpp::v201::UpdateFirmwareResponse
+/// \brief Converts a given types::system::UpdateFirmwareResponse \p response to an ocpp::v2::UpdateFirmwareResponse.
+ocpp::v2::UpdateFirmwareResponse
 to_ocpp_update_firmware_response(const types::system::UpdateFirmwareResponse& response);
 
-/// \brief Converts a given types::system::LogStatusEnum \p status to an ocpp::v201::UploadLogStatusEnum.
-ocpp::v201::UploadLogStatusEnum to_ocpp_upload_logs_status_enum(types::system::LogStatusEnum status);
+/// \brief Converts a given types::system::LogStatusEnum \p status to an ocpp::v2::UploadLogStatusEnum.
+ocpp::v2::UploadLogStatusEnum to_ocpp_upload_logs_status_enum(types::system::LogStatusEnum status);
 
-/// \brief Converts a given types::system::BootReason \p reason to an ocpp::v201::BootReasonEnum.
-ocpp::v201::BootReasonEnum to_ocpp_boot_reason(types::system::BootReason reason);
+/// \brief Converts a given types::system::BootReason \p reason to an ocpp::v2::BootReasonEnum.
+ocpp::v2::BootReasonEnum to_ocpp_boot_reason(types::system::BootReason reason);
 
-/// \brief Converts a given types::evse_manager::StopTransactionReason \p reason to an ocpp::v201::ReasonEnum.
-ocpp::v201::ReasonEnum to_ocpp_reason(types::evse_manager::StopTransactionReason reason);
+/// \brief Converts a given types::evse_manager::StopTransactionReason \p reason to an ocpp::v2::ReasonEnum.
+ocpp::v2::ReasonEnum to_ocpp_reason(types::evse_manager::StopTransactionReason reason);
 
-/// \brief Converts a given types::authorization::IdTokenType \p id_token_type to an ocpp::v201::IdTokenEnum.
-ocpp::v201::IdTokenEnum to_ocpp_id_token_enum(types::authorization::IdTokenType id_token_type);
+/// \brief Converts a given types::authorization::IdTokenType \p id_token_type to an ocpp::v2::IdTokenEnum.
+ocpp::v2::IdTokenEnum to_ocpp_id_token_enum(types::authorization::IdTokenType id_token_type);
 
-/// \brief Converts a given types::authorization::IdToken \p id_token to an ocpp::v201::IdToken.
-ocpp::v201::IdToken to_ocpp_id_token(const types::authorization::IdToken& id_token);
+/// \brief Converts a given types::authorization::IdToken \p id_token to an ocpp::v2::IdToken.
+ocpp::v2::IdToken to_ocpp_id_token(const types::authorization::IdToken& id_token);
 
 /// \brief Converts a given types::iso15118::CertificateActionEnum \p action to an
-/// ocpp::v201::CertificateActionEnum.
-ocpp::v201::CertificateActionEnum to_ocpp_certificate_action_enum(const types::iso15118::CertificateActionEnum& action);
+/// ocpp::v2::CertificateActionEnum.
+ocpp::v2::CertificateActionEnum to_ocpp_certificate_action_enum(const types::iso15118::CertificateActionEnum& action);
 
 /// \brief Converts a vector of types::iso15118::CertificateHashDataInfo to a vector of
-/// ocpp::v201::OCSPRequestData.
-std::vector<ocpp::v201::OCSPRequestData> to_ocpp_ocsp_request_data_vector(
+/// ocpp::v2::OCSPRequestData.
+std::vector<ocpp::v2::OCSPRequestData> to_ocpp_ocsp_request_data_vector(
     const std::vector<types::iso15118::CertificateHashDataInfo>& certificate_hash_data_info);
 
 /// \brief Converts a given types::iso15118::HashAlgorithm \p hash_algorithm to an
-/// ocpp::v201::HashAlgorithmEnum.
-ocpp::v201::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118::HashAlgorithm hash_algorithm);
+/// ocpp::v2::HashAlgorithmEnum.
+ocpp::v2::HashAlgorithmEnum to_ocpp_hash_algorithm_enum(const types::iso15118::HashAlgorithm hash_algorithm);
 
 /// \brief Converts a given types::ocpp::GetVariableRequest \p get_variable_request_vector to an
-/// std::vector<ocpp::v201::GetVariableData>
-std::vector<ocpp::v201::GetVariableData>
+/// std::vector<ocpp::v2::GetVariableData>
+std::vector<ocpp::v2::GetVariableData>
 to_ocpp_get_variable_data_vector(const std::vector<types::ocpp::GetVariableRequest>& get_variable_request_vector);
 
 /// \brief Converts a given types::ocpp::SetVariableRequest \p set_variable_request_vector to an
-/// std::vector<ocpp::v201::SetVariableData>
-std::vector<ocpp::v201::SetVariableData>
+/// std::vector<ocpp::v2::SetVariableData>
+std::vector<ocpp::v2::SetVariableData>
 to_ocpp_set_variable_data_vector(const std::vector<types::ocpp::SetVariableRequest>& set_variable_request_vector);
 
-/// \brief Converts a given types::ocpp::Component \p component to a ocpp::v201::Component
-ocpp::v201::Component to_ocpp_component(const types::ocpp::Component& component);
+/// \brief Converts a given types::ocpp::Component \p component to a ocpp::v2::Component
+ocpp::v2::Component to_ocpp_component(const types::ocpp::Component& component);
 
-/// \brief Converts a given types::ocpp::Variable \p variable to a ocpp::v201::Variable
-ocpp::v201::Variable to_ocpp_variable(const types::ocpp::Variable& variable);
+/// \brief Converts a given types::ocpp::Variable \p variable to a ocpp::v2::Variable
+ocpp::v2::Variable to_ocpp_variable(const types::ocpp::Variable& variable);
 
-/// \brief Converts a given types::ocpp::EVSE \p evse to a ocpp::v201::EVSE
-ocpp::v201::EVSE to_ocpp_evse(const types::ocpp::EVSE& evse);
+/// \brief Converts a given types::ocpp::EVSE \p evse to a ocpp::v2::EVSE
+ocpp::v2::EVSE to_ocpp_evse(const types::ocpp::EVSE& evse);
 
-/// \brief Converts a given types::ocpp::AttributeEnum to ocpp::v201::AttributeEnum
-ocpp::v201::AttributeEnum to_ocpp_attribute_enum(const types::ocpp::AttributeEnum attribute_enum);
+/// \brief Converts a given types::ocpp::AttributeEnum to ocpp::v2::AttributeEnum
+ocpp::v2::AttributeEnum to_ocpp_attribute_enum(const types::ocpp::AttributeEnum attribute_enum);
 
 /// \brief Converts a given types::types::iso15118::RequestExiStreamSchema to
-/// ocpp::v201::Get15118EVCertificateRequest
-ocpp::v201::Get15118EVCertificateRequest
+/// ocpp::v2::Get15118EVCertificateRequest
+ocpp::v2::Get15118EVCertificateRequest
 to_ocpp_get_15118_certificate_request(const types::iso15118::RequestExiStreamSchema& request);
 
-/// \brief Converts a given types::reservation::ReservationResult to ocpp::v201::ReserveNowStatusEnum
-ocpp::v201::ReserveNowStatusEnum to_ocpp_reservation_status(const types::reservation::ReservationResult result);
+/// \brief Converts a given types::reservation::ReservationResult to ocpp::v2::ReserveNowStatusEnum
+ocpp::v2::ReserveNowStatusEnum to_ocpp_reservation_status(const types::reservation::ReservationResult result);
 
-/// \brief Converts a given types::reservation::Reservation_status to ocpp::v201::ReservationUpdateStatusEnum
-/// \warning This function can throw when there is no existing ocpp::v201::ReservationUpdateStatusEnum that is equal to
+/// \brief Converts a given types::reservation::Reservation_status to ocpp::v2::ReservationUpdateStatusEnum
+/// \warning This function can throw when there is no existing ocpp::v2::ReservationUpdateStatusEnum that is equal to
 ///          types::reservation::Reservation_status.
-ocpp::v201::ReservationUpdateStatusEnum
+ocpp::v2::ReservationUpdateStatusEnum
 to_ocpp_reservation_update_status_enum(const types::reservation::Reservation_status status);
 
-/// \brief Converts a given ocpp::v201::ReasonEnum \p stop_reason to a types::evse_manager::StopTransactionReason.
-types::evse_manager::StopTransactionReason
-to_everest_stop_transaction_reason(const ocpp::v201::ReasonEnum& stop_reason);
+/// \brief Converts a given ocpp::v2::ReasonEnum \p stop_reason to a types::evse_manager::StopTransactionReason.
+types::evse_manager::StopTransactionReason to_everest_stop_transaction_reason(const ocpp::v2::ReasonEnum& stop_reason);
 
-/// \brief Converts a given ocpp::v201::GetLogRequest \p request to a types::system::UploadLogsRequest.
-types::system::UploadLogsRequest to_everest_upload_logs_request(const ocpp::v201::GetLogRequest& request);
+/// \brief Converts a given ocpp::v2::GetLogRequest \p request to a types::system::UploadLogsRequest.
+types::system::UploadLogsRequest to_everest_upload_logs_request(const ocpp::v2::GetLogRequest& request);
 
-/// \brief Converts a given ocpp::v201::UpdateFirmwareRequest \p request to a types::system::FirmwareUpdateRequest.
-types::system::FirmwareUpdateRequest
-to_everest_firmware_update_request(const ocpp::v201::UpdateFirmwareRequest& request);
+/// \brief Converts a given ocpp::v2::UpdateFirmwareRequest \p request to a types::system::FirmwareUpdateRequest.
+types::system::FirmwareUpdateRequest to_everest_firmware_update_request(const ocpp::v2::UpdateFirmwareRequest& request);
 
-/// \brief Converts a given ocpp::v201::Iso15118EVCertificateStatusEnum \p status to a types::iso15118::Status.
-types::iso15118::Status to_everest_iso15118_status(const ocpp::v201::Iso15118EVCertificateStatusEnum& status);
+/// \brief Converts a given ocpp::v2::Iso15118EVCertificateStatusEnum \p status to a types::iso15118::Status.
+types::iso15118::Status to_everest_iso15118_status(const ocpp::v2::Iso15118EVCertificateStatusEnum& status);
 
-/// \brief Converts a given ocpp::v201::DataTransferStatusEnum \p status to a types::ocpp::DataTransferStatus.
-types::ocpp::DataTransferStatus to_everest_data_transfer_status(ocpp::v201::DataTransferStatusEnum status);
+/// \brief Converts a given ocpp::v2::DataTransferStatusEnum \p status to a types::ocpp::DataTransferStatus.
+types::ocpp::DataTransferStatus to_everest_data_transfer_status(ocpp::v2::DataTransferStatusEnum status);
 
-/// \brief Converts a given ocpp::v201::DataTransferRequest \p status to a types::ocpp::DataTransferRequest.
-types::ocpp::DataTransferRequest to_everest_data_transfer_request(ocpp::v201::DataTransferRequest request);
+/// \brief Converts a given ocpp::v2::DataTransferRequest \p status to a types::ocpp::DataTransferRequest.
+types::ocpp::DataTransferRequest to_everest_data_transfer_request(ocpp::v2::DataTransferRequest request);
 
-/// \brief Converts a given ocpp::v201::DataTransferResponse \p status to a types::ocpp::DataTransferResponse.
-types::ocpp::DataTransferResponse to_everest_data_transfer_response(ocpp::v201::DataTransferResponse response);
+/// \brief Converts a given ocpp::v2::DataTransferResponse \p status to a types::ocpp::DataTransferResponse.
+types::ocpp::DataTransferResponse to_everest_data_transfer_response(ocpp::v2::DataTransferResponse response);
 
-/// \brief Converts a given ocpp::v201::AuthorizeResponse \p response to a types::authorization::ValidationResult.
-types::authorization::ValidationResult to_everest_validation_result(const ocpp::v201::AuthorizeResponse& response);
+/// \brief Converts a given ocpp::v2::AuthorizeResponse \p response to a types::authorization::ValidationResult.
+types::authorization::ValidationResult to_everest_validation_result(const ocpp::v2::AuthorizeResponse& response);
 
-/// \brief Converts a given ocpp::v201::AuthorizationStatusEnum \p status to a
+/// \brief Converts a given ocpp::v2::AuthorizationStatusEnum \p status to a
 /// types::authorization::AuthorizationStatus.
 types::authorization::AuthorizationStatus
-to_everest_authorization_status(const ocpp::v201::AuthorizationStatusEnum status);
+to_everest_authorization_status(const ocpp::v2::AuthorizationStatusEnum status);
 
-/// \brief Converts a given ocpp::v201::IdTokenEnum \p type to a types::authorization::IdTokenType.
-types::authorization::IdTokenType to_everest_id_token_type(const ocpp::v201::IdTokenEnum& type);
+/// \brief Converts a given ocpp::v2::IdTokenEnum \p type to a types::authorization::IdTokenType.
+types::authorization::IdTokenType to_everest_id_token_type(const ocpp::v2::IdTokenEnum& type);
 
-/// \brief Converts a given ocpp::v201::IdToken \p id_token to a types::authorization::IdToken.
-types::authorization::IdToken to_everest_id_token(const ocpp::v201::IdToken& id_token);
+/// \brief Converts a given ocpp::v2::IdToken \p id_token to a types::authorization::IdToken.
+types::authorization::IdToken to_everest_id_token(const ocpp::v2::IdToken& id_token);
 
-/// \brief Converts a given ocpp::v201::AuthorizeCertificateStatusEnum \p status to a
+/// \brief Converts a given ocpp::v2::AuthorizeCertificateStatusEnum \p status to a
 /// types::authorization::CertificateStatus.
 types::authorization::CertificateStatus
-to_everest_certificate_status(const ocpp::v201::AuthorizeCertificateStatusEnum status);
+to_everest_certificate_status(const ocpp::v2::AuthorizeCertificateStatusEnum status);
 
-/// \brief Converts a given ocpp::v201::TransactionEventRequest \p transaction_event to a
+/// \brief Converts a given ocpp::v2::TransactionEventRequest \p transaction_event to a
 /// types::ocpp::OcppTransactionEvent.
 types::ocpp::OcppTransactionEvent
-to_everest_ocpp_transaction_event(const ocpp::v201::TransactionEventRequest& transaction_event);
+to_everest_ocpp_transaction_event(const ocpp::v2::TransactionEventRequest& transaction_event);
 
-/// \brief Converts a given ocpp::v201::MessageFormat \p message_format to a
+/// \brief Converts a given ocpp::v2::MessageFormat \p message_format to a
 /// types::ocpp::MessageFormat
-types::display_message::MessageFormat to_everest_message_format(const ocpp::v201::MessageFormatEnum& message_format);
+types::display_message::MessageFormat to_everest_message_format(const ocpp::v2::MessageFormatEnum& message_format);
 
-/// \brief Converts a given ocpp::v201::MessageContent \p message_content to a
+/// \brief Converts a given ocpp::v2::MessageContent \p message_content to a
 /// types::ocpp::MessageContent
-types::display_message::MessageContent to_everest_message_content(const ocpp::v201::MessageContent& message_content);
+types::display_message::MessageContent to_everest_message_content(const ocpp::v2::MessageContent& message_content);
 
-/// \brief Converts a given ocpp::v201::TransactionEventResponse \p transaction_event_response to a
+/// \brief Converts a given ocpp::v2::TransactionEventResponse \p transaction_event_response to a
 /// types::ocpp::OcppTransactionEventResponse
 types::ocpp::OcppTransactionEventResponse
-to_everest_transaction_event_response(const ocpp::v201::TransactionEventResponse& transaction_event_response);
+to_everest_transaction_event_response(const ocpp::v2::TransactionEventResponse& transaction_event_response);
 
-/// \brief Converts a given ocpp::v201::BootNotificationResponse \p boot_notification_response to a
+/// \brief Converts a given ocpp::v2::BootNotificationResponse \p boot_notification_response to a
 /// types::ocpp::BootNotificationResponse
 types::ocpp::BootNotificationResponse
-to_everest_boot_notification_response(const ocpp::v201::BootNotificationResponse& boot_notification_response);
+to_everest_boot_notification_response(const ocpp::v2::BootNotificationResponse& boot_notification_response);
 
-/// \brief Converts a given ocpp::v201::RegistrationStatusEnum \p registration_status to a
+/// \brief Converts a given ocpp::v2::RegistrationStatusEnum \p registration_status to a
 /// types::ocpp::RegistrationStatus
 types::ocpp::RegistrationStatus
-to_everest_registration_status(const ocpp::v201::RegistrationStatusEnum& registration_status);
+to_everest_registration_status(const ocpp::v2::RegistrationStatusEnum& registration_status);
 
-/// \brief Converts a given ocpp::v201::StatusInfo \p status_info to a
+/// \brief Converts a given ocpp::v2::StatusInfo \p status_info to a
 /// types::ocpp::StatusInfoType
-types::ocpp::StatusInfoType to_everest_status_info_type(const ocpp::v201::StatusInfo& status_info);
+types::ocpp::StatusInfoType to_everest_status_info_type(const ocpp::v2::StatusInfo& status_info);
 
-/// \brief Converts a given ocpp::v201::GetVariableResult \p get_variable_result_vector to a
+/// \brief Converts a given ocpp::v2::GetVariableResult \p get_variable_result_vector to a
 /// std::vector<types::ocpp::GetVariableResult>
 std::vector<types::ocpp::GetVariableResult>
-to_everest_get_variable_result_vector(const std::vector<ocpp::v201::GetVariableResult>& get_variable_result_vector);
+to_everest_get_variable_result_vector(const std::vector<ocpp::v2::GetVariableResult>& get_variable_result_vector);
 
-/// \brief Converts a given ocpp::v201::SetVariableResult \p set_variable_result_vector to a
+/// \brief Converts a given ocpp::v2::SetVariableResult \p set_variable_result_vector to a
 /// std::vector<types::ocpp::SetVariableResult>
 std::vector<types::ocpp::SetVariableResult>
-to_everest_set_variable_result_vector(const std::vector<ocpp::v201::SetVariableResult>& set_variable_result_vector);
+to_everest_set_variable_result_vector(const std::vector<ocpp::v2::SetVariableResult>& set_variable_result_vector);
 
-/// \brief Converts a given ocpp::v201::Component \p component to a types::ocpp::Component.
-types::ocpp::Component to_everest_component(const ocpp::v201::Component& component);
+/// \brief Converts a given ocpp::v2::Component \p component to a types::ocpp::Component.
+types::ocpp::Component to_everest_component(const ocpp::v2::Component& component);
 
-/// \brief Converts a given ocpp::v201::Variable \p variable to a types::ocpp::Variable.
-types::ocpp::Variable to_everest_variable(const ocpp::v201::Variable& variable);
+/// \brief Converts a given ocpp::v2::Variable \p variable to a types::ocpp::Variable.
+types::ocpp::Variable to_everest_variable(const ocpp::v2::Variable& variable);
 
-/// \brief Converts a given ocpp::v201::EVSE \p evse to a types::ocpp::EVSE.
-types::ocpp::EVSE to_everest_evse(const ocpp::v201::EVSE& evse);
+/// \brief Converts a given ocpp::v2::EVSE \p evse to a types::ocpp::EVSE.
+types::ocpp::EVSE to_everest_evse(const ocpp::v2::EVSE& evse);
 
-/// \brief Converts a given ocpp::v201::AttributeEnum \p attribute_enum to a types::ocpp::AttributeEnum.
-types::ocpp::AttributeEnum to_everest_attribute_enum(const ocpp::v201::AttributeEnum attribute_enum);
+/// \brief Converts a given ocpp::v2::AttributeEnum \p attribute_enum to a types::ocpp::AttributeEnum.
+types::ocpp::AttributeEnum to_everest_attribute_enum(const ocpp::v2::AttributeEnum attribute_enum);
 
-/// \brief Converts a given ocpp::v201::GetVariableStatusEnum \p get_variable_status to a
+/// \brief Converts a given ocpp::v2::GetVariableStatusEnum \p get_variable_status to a
 /// types::ocpp::GetVariableStatusEnumType
 types::ocpp::GetVariableStatusEnumType
-to_everest_get_variable_status_enum_type(const ocpp::v201::GetVariableStatusEnum get_variable_status);
+to_everest_get_variable_status_enum_type(const ocpp::v2::GetVariableStatusEnum get_variable_status);
 
-/// \brief Converts a given ocpp::v201::SetVariableStatusEnum \p set_variable_status to a
+/// \brief Converts a given ocpp::v2::SetVariableStatusEnum \p set_variable_status to a
 /// types::ocpp::SetVariableStatusEnumType
 types::ocpp::SetVariableStatusEnumType
-to_everest_set_variable_status_enum_type(const ocpp::v201::SetVariableStatusEnum set_variable_status);
+to_everest_set_variable_status_enum_type(const ocpp::v2::SetVariableStatusEnum set_variable_status);
 
-/// \brief Converts a given vector of ocpp::v201::CompositeSchedule \p composite_schedules to a
+/// \brief Converts a given vector of ocpp::v2::CompositeSchedule \p composite_schedules to a
 /// types::ocpp::ChargingSchedules
 types::ocpp::ChargingSchedules
-to_everest_charging_schedules(const std::vector<ocpp::v201::CompositeSchedule>& composite_schedules);
+to_everest_charging_schedules(const std::vector<ocpp::v2::CompositeSchedule>& composite_schedules);
 
-/// \brief Converts a given ocpp::v201::CompositeSchedule \p composite_schedule to a types::ocpp::ChargingSchedule
-types::ocpp::ChargingSchedule to_everest_charging_schedule(const ocpp::v201::CompositeSchedule& composite_schedule);
+/// \brief Converts a given ocpp::v2::CompositeSchedule \p composite_schedule to a types::ocpp::ChargingSchedule
+types::ocpp::ChargingSchedule to_everest_charging_schedule(const ocpp::v2::CompositeSchedule& composite_schedule);
 
-/// \brief Converst a given ocpp::v201::ChargingSchedulePeriod \p period to a types::ocpp::ChargingSchedulePeriod
-types::ocpp::ChargingSchedulePeriod
-to_everest_charging_schedule_period(const ocpp::v201::ChargingSchedulePeriod& period);
+/// \brief Converst a given ocpp::v2::ChargingSchedulePeriod \p period to a types::ocpp::ChargingSchedulePeriod
+types::ocpp::ChargingSchedulePeriod to_everest_charging_schedule_period(const ocpp::v2::ChargingSchedulePeriod& period);
 
-ocpp::v201::DisplayMessageStatusEnum
+ocpp::v2::DisplayMessageStatusEnum
 to_ocpp_display_message_status_enum(const types::display_message::DisplayMessageStatusEnum& from);
 
-ocpp::v201::SetDisplayMessageResponse
+ocpp::v2::SetDisplayMessageResponse
 to_ocpp_set_display_message_response(const types::display_message::SetDisplayMessageResponse& response);
 
 types::display_message::MessagePriorityEnum
-to_everest_display_message_priority_enum(const ocpp::v201::MessagePriorityEnum& priority);
+to_everest_display_message_priority_enum(const ocpp::v2::MessagePriorityEnum& priority);
 types::display_message::MessageStateEnum
-to_everest_display_message_state_enum(const ocpp::v201::MessageStateEnum& message_state);
+to_everest_display_message_state_enum(const ocpp::v2::MessageStateEnum& message_state);
 
 types::display_message::GetDisplayMessageRequest
-to_everest_display_message_request(const ocpp::v201::GetDisplayMessagesRequest& request);
+to_everest_display_message_request(const ocpp::v2::GetDisplayMessagesRequest& request);
 
 types::display_message::ClearDisplayMessageRequest
-to_everest_clear_display_message_request(const ocpp::v201::ClearDisplayMessageRequest& request);
+to_everest_clear_display_message_request(const ocpp::v2::ClearDisplayMessageRequest& request);
 
-ocpp::v201::ClearMessageStatusEnum
+ocpp::v2::ClearMessageStatusEnum
 to_ocpp_clear_message_response_enum(const types::display_message::ClearMessageResponseEnum& response_enum);
 
-ocpp::v201::ClearDisplayMessageResponse
+ocpp::v2::ClearDisplayMessageResponse
 to_ocpp_clear_display_message_response(const types::display_message::ClearDisplayMessageResponse& response);
 
-/// \brief Convert a given ocpp::v201::ConnectorEnum connector type to a types::evse_manager::ConnectorTypeEnum
-types::evse_manager::ConnectorTypeEnum to_everest_connector_type_enum(const ocpp::v201::ConnectorEnum& connector_type);
+/// \brief Convert a given ocpp::v2::ConnectorEnum connector type to a types::evse_manager::ConnectorTypeEnum
+types::evse_manager::ConnectorTypeEnum to_everest_connector_type_enum(const ocpp::v2::ConnectorEnum& connector_type);
 
 } // namespace conversions
 } // namespace module
 
-#endif // OCPP_V201_CONVERSIONS_HPP
+#endif // OCPP_V2_CONVERSIONS_HPP

--- a/modules/OCPP201/data_transfer/ocpp_data_transferImpl.cpp
+++ b/modules/OCPP201/data_transfer/ocpp_data_transferImpl.cpp
@@ -16,7 +16,7 @@ void ocpp_data_transferImpl::ready() {
 
 types::ocpp::DataTransferResponse
 ocpp_data_transferImpl::handle_data_transfer(types::ocpp::DataTransferRequest& request) {
-    ocpp::v201::DataTransferRequest ocpp_request = conversions::to_ocpp_data_transfer_request(request);
+    ocpp::v2::DataTransferRequest ocpp_request = conversions::to_ocpp_data_transfer_request(request);
     auto ocpp_response = mod->charge_point->data_transfer_req(ocpp_request);
 
     types::ocpp::DataTransferResponse response;

--- a/modules/OCPP201/device_model/composed_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.cpp
@@ -11,23 +11,23 @@ ComposedDeviceModelStorage::ComposedDeviceModelStorage(const std::string& libocp
                                                        const std::string& device_model_migration_path,
                                                        const std::string& device_model_config_path) :
     everest_device_model_storage(std::make_unique<EverestDeviceModelStorage>()),
-    libocpp_device_model_storage(std::make_unique<ocpp::v201::DeviceModelStorageSqlite>(
+    libocpp_device_model_storage(std::make_unique<ocpp::v2::DeviceModelStorageSqlite>(
         libocpp_device_model_storage_address, device_model_migration_path, device_model_config_path,
         libocpp_initialize_device_model)),
     device_model_map(get_device_model()) {
 }
 
-ocpp::v201::DeviceModelMap ComposedDeviceModelStorage::get_device_model() {
-    ocpp::v201::DeviceModelMap everest_dm = everest_device_model_storage->get_device_model();
-    ocpp::v201::DeviceModelMap libocpp_dm = libocpp_device_model_storage->get_device_model();
+ocpp::v2::DeviceModelMap ComposedDeviceModelStorage::get_device_model() {
+    ocpp::v2::DeviceModelMap everest_dm = everest_device_model_storage->get_device_model();
+    ocpp::v2::DeviceModelMap libocpp_dm = libocpp_device_model_storage->get_device_model();
     everest_dm.merge(libocpp_dm);
     return everest_dm;
 }
 
-std::optional<ocpp::v201::VariableAttribute>
-ComposedDeviceModelStorage::get_variable_attribute(const ocpp::v201::Component& component_id,
-                                                   const ocpp::v201::Variable& variable_id,
-                                                   const ocpp::v201::AttributeEnum& attribute_enum) {
+std::optional<ocpp::v2::VariableAttribute>
+ComposedDeviceModelStorage::get_variable_attribute(const ocpp::v2::Component& component_id,
+                                                   const ocpp::v2::Variable& variable_id,
+                                                   const ocpp::v2::AttributeEnum& attribute_enum) {
     if (get_variable_source(component_id, variable_id) == VARIABLE_SOURCE_OCPP) {
         return libocpp_device_model_storage->get_variable_attribute(component_id, variable_id, attribute_enum);
     }
@@ -35,10 +35,10 @@ ComposedDeviceModelStorage::get_variable_attribute(const ocpp::v201::Component& 
     return everest_device_model_storage->get_variable_attribute(component_id, variable_id, attribute_enum);
 }
 
-std::vector<ocpp::v201::VariableAttribute>
-ComposedDeviceModelStorage::get_variable_attributes(const ocpp::v201::Component& component_id,
-                                                    const ocpp::v201::Variable& variable_id,
-                                                    const std::optional<ocpp::v201::AttributeEnum>& attribute_enum) {
+std::vector<ocpp::v2::VariableAttribute>
+ComposedDeviceModelStorage::get_variable_attributes(const ocpp::v2::Component& component_id,
+                                                    const ocpp::v2::Variable& variable_id,
+                                                    const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) {
     if (get_variable_source(component_id, variable_id) == VARIABLE_SOURCE_OCPP) {
         return libocpp_device_model_storage->get_variable_attributes(component_id, variable_id, attribute_enum);
     }
@@ -46,9 +46,9 @@ ComposedDeviceModelStorage::get_variable_attributes(const ocpp::v201::Component&
     return everest_device_model_storage->get_variable_attributes(component_id, variable_id, attribute_enum);
 }
 
-bool ComposedDeviceModelStorage::set_variable_attribute_value(const ocpp::v201::Component& component_id,
-                                                              const ocpp::v201::Variable& variable_id,
-                                                              const ocpp::v201::AttributeEnum& attribute_enum,
+bool ComposedDeviceModelStorage::set_variable_attribute_value(const ocpp::v2::Component& component_id,
+                                                              const ocpp::v2::Variable& variable_id,
+                                                              const ocpp::v2::AttributeEnum& attribute_enum,
                                                               const std::string& value, const std::string& source) {
     if (get_variable_source(component_id, variable_id) == VARIABLE_SOURCE_OCPP) {
         return libocpp_device_model_storage->set_variable_attribute_value(component_id, variable_id, attribute_enum,
@@ -58,9 +58,9 @@ bool ComposedDeviceModelStorage::set_variable_attribute_value(const ocpp::v201::
                                                                       source);
 }
 
-std::optional<ocpp::v201::VariableMonitoringMeta>
-ComposedDeviceModelStorage::set_monitoring_data(const ocpp::v201::SetMonitoringData& data,
-                                                const ocpp::v201::VariableMonitorType type) {
+std::optional<ocpp::v2::VariableMonitoringMeta>
+ComposedDeviceModelStorage::set_monitoring_data(const ocpp::v2::SetMonitoringData& data,
+                                                const ocpp::v2::VariableMonitorType type) {
     return libocpp_device_model_storage->set_monitoring_data(data, type);
 }
 
@@ -69,10 +69,10 @@ bool ComposedDeviceModelStorage::update_monitoring_reference(const int32_t monit
     return libocpp_device_model_storage->update_monitoring_reference(monitor_id, reference_value);
 }
 
-std::vector<ocpp::v201::VariableMonitoringMeta>
-ComposedDeviceModelStorage::get_monitoring_data(const std::vector<ocpp::v201::MonitoringCriterionEnum>& criteria,
-                                                const ocpp::v201::Component& component_id,
-                                                const ocpp::v201::Variable& variable_id) {
+std::vector<ocpp::v2::VariableMonitoringMeta>
+ComposedDeviceModelStorage::get_monitoring_data(const std::vector<ocpp::v2::MonitoringCriterionEnum>& criteria,
+                                                const ocpp::v2::Component& component_id,
+                                                const ocpp::v2::Variable& variable_id) {
     if (get_variable_source(component_id, variable_id) == VARIABLE_SOURCE_OCPP) {
         return libocpp_device_model_storage->get_monitoring_data(criteria, component_id, variable_id);
     }
@@ -80,8 +80,8 @@ ComposedDeviceModelStorage::get_monitoring_data(const std::vector<ocpp::v201::Mo
     return everest_device_model_storage->get_monitoring_data(criteria, component_id, variable_id);
 }
 
-ocpp::v201::ClearMonitoringStatusEnum ComposedDeviceModelStorage::clear_variable_monitor(int monitor_id,
-                                                                                         bool allow_protected) {
+ocpp::v2::ClearMonitoringStatusEnum ComposedDeviceModelStorage::clear_variable_monitor(int monitor_id,
+                                                                                       bool allow_protected) {
     return libocpp_device_model_storage->clear_variable_monitor(monitor_id, allow_protected);
 }
 
@@ -94,14 +94,13 @@ void ComposedDeviceModelStorage::check_integrity() {
     libocpp_device_model_storage->check_integrity();
 }
 
-std::string
-module::device_model::ComposedDeviceModelStorage::get_variable_source(const ocpp::v201::Component& component,
-                                                                      const ocpp::v201::Variable& variable) {
+std::string module::device_model::ComposedDeviceModelStorage::get_variable_source(const ocpp::v2::Component& component,
+                                                                                  const ocpp::v2::Variable& variable) {
     std::optional<std::string> variable_source = device_model_map[component][variable].source;
     if (variable_source.has_value() && variable_source.value() != VARIABLE_SOURCE_OCPP) {
         // For now, this just throws because we only have the libocpp source. When the config service is
         // implemented, this should not throw.
-        throw ocpp::v201::DeviceModelError("Source is not 'OCPP', not sure what to do");
+        throw ocpp::v2::DeviceModelError("Source is not 'OCPP', not sure what to do");
     }
 
     return VARIABLE_SOURCE_OCPP;

--- a/modules/OCPP201/device_model/composed_device_model_storage.hpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.hpp
@@ -4,15 +4,15 @@
 #pragma once
 
 #include <device_model/everest_device_model_storage.hpp>
-#include <ocpp/v201/device_model_storage_interface.hpp>
-#include <ocpp/v201/device_model_storage_sqlite.hpp>
+#include <ocpp/v2/device_model_storage_interface.hpp>
+#include <ocpp/v2/device_model_storage_sqlite.hpp>
 
 namespace module::device_model {
-class ComposedDeviceModelStorage : public ocpp::v201::DeviceModelStorageInterface {
+class ComposedDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
 private: // Members
     std::unique_ptr<EverestDeviceModelStorage> everest_device_model_storage;
-    std::unique_ptr<ocpp::v201::DeviceModelStorageSqlite> libocpp_device_model_storage;
-    ocpp::v201::DeviceModelMap device_model_map;
+    std::unique_ptr<ocpp::v2::DeviceModelStorageSqlite> libocpp_device_model_storage;
+    ocpp::v2::DeviceModelMap device_model_map;
 
 public:
     ComposedDeviceModelStorage(const std::string& libocpp_device_model_storage_address,
@@ -20,24 +20,24 @@ public:
                                const std::string& device_model_migration_path,
                                const std::string& device_model_config_path);
     virtual ~ComposedDeviceModelStorage() override = default;
-    virtual ocpp::v201::DeviceModelMap get_device_model() override;
-    virtual std::optional<ocpp::v201::VariableAttribute>
-    get_variable_attribute(const ocpp::v201::Component& component_id, const ocpp::v201::Variable& variable_id,
-                           const ocpp::v201::AttributeEnum& attribute_enum) override;
-    virtual std::vector<ocpp::v201::VariableAttribute>
-    get_variable_attributes(const ocpp::v201::Component& component_id, const ocpp::v201::Variable& variable_id,
-                            const std::optional<ocpp::v201::AttributeEnum>& attribute_enum) override;
-    virtual bool set_variable_attribute_value(const ocpp::v201::Component& component_id,
-                                              const ocpp::v201::Variable& variable_id,
-                                              const ocpp::v201::AttributeEnum& attribute_enum, const std::string& value,
+    virtual ocpp::v2::DeviceModelMap get_device_model() override;
+    virtual std::optional<ocpp::v2::VariableAttribute>
+    get_variable_attribute(const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
+                           const ocpp::v2::AttributeEnum& attribute_enum) override;
+    virtual std::vector<ocpp::v2::VariableAttribute>
+    get_variable_attributes(const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
+                            const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) override;
+    virtual bool set_variable_attribute_value(const ocpp::v2::Component& component_id,
+                                              const ocpp::v2::Variable& variable_id,
+                                              const ocpp::v2::AttributeEnum& attribute_enum, const std::string& value,
                                               const std::string& source) override;
-    virtual std::optional<ocpp::v201::VariableMonitoringMeta>
-    set_monitoring_data(const ocpp::v201::SetMonitoringData& data, const ocpp::v201::VariableMonitorType type) override;
+    virtual std::optional<ocpp::v2::VariableMonitoringMeta>
+    set_monitoring_data(const ocpp::v2::SetMonitoringData& data, const ocpp::v2::VariableMonitorType type) override;
     virtual bool update_monitoring_reference(const int32_t monitor_id, const std::string& reference_value) override;
-    virtual std::vector<ocpp::v201::VariableMonitoringMeta>
-    get_monitoring_data(const std::vector<ocpp::v201::MonitoringCriterionEnum>& criteria,
-                        const ocpp::v201::Component& component_id, const ocpp::v201::Variable& variable_id) override;
-    virtual ocpp::v201::ClearMonitoringStatusEnum clear_variable_monitor(int monitor_id, bool allow_protected) override;
+    virtual std::vector<ocpp::v2::VariableMonitoringMeta>
+    get_monitoring_data(const std::vector<ocpp::v2::MonitoringCriterionEnum>& criteria,
+                        const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id) override;
+    virtual ocpp::v2::ClearMonitoringStatusEnum clear_variable_monitor(int monitor_id, bool allow_protected) override;
     virtual int32_t clear_custom_variable_monitors() override;
     virtual void check_integrity() override;
 
@@ -49,6 +49,6 @@ private: // Functions
          /// \return The variable source. Defaults to 'OCPP'.
          /// \throws DeviceModelError    When source is something else than 'OCPP' (not implemented yet)
          ///
-    std::string get_variable_source(const ocpp::v201::Component& component, const ocpp::v201::Variable& variable);
+    std::string get_variable_source(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable);
 };
 } // namespace module::device_model

--- a/modules/OCPP201/device_model/everest_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/everest_device_model_storage.cpp
@@ -4,35 +4,35 @@
 #include <device_model/everest_device_model_storage.hpp>
 
 namespace module::device_model {
-ocpp::v201::DeviceModelMap EverestDeviceModelStorage::get_device_model() {
+ocpp::v2::DeviceModelMap EverestDeviceModelStorage::get_device_model() {
     return {};
 }
 
-std::optional<ocpp::v201::VariableAttribute>
-EverestDeviceModelStorage::get_variable_attribute(const ocpp::v201::Component& /*component_id*/,
-                                                  const ocpp::v201::Variable& /*variable_id*/,
-                                                  const ocpp::v201::AttributeEnum& /*attribute_enum*/) {
+std::optional<ocpp::v2::VariableAttribute>
+EverestDeviceModelStorage::get_variable_attribute(const ocpp::v2::Component& /*component_id*/,
+                                                  const ocpp::v2::Variable& /*variable_id*/,
+                                                  const ocpp::v2::AttributeEnum& /*attribute_enum*/) {
     return std::nullopt;
 }
 
-std::vector<ocpp::v201::VariableAttribute>
-EverestDeviceModelStorage::get_variable_attributes(const ocpp::v201::Component& /*component_id*/,
-                                                   const ocpp::v201::Variable& /*variable_id*/,
-                                                   const std::optional<ocpp::v201::AttributeEnum>& /*attribute_enum*/) {
+std::vector<ocpp::v2::VariableAttribute>
+EverestDeviceModelStorage::get_variable_attributes(const ocpp::v2::Component& /*component_id*/,
+                                                   const ocpp::v2::Variable& /*variable_id*/,
+                                                   const std::optional<ocpp::v2::AttributeEnum>& /*attribute_enum*/) {
     return {};
 }
 
-bool EverestDeviceModelStorage::set_variable_attribute_value(const ocpp::v201::Component& /*component_id*/,
-                                                             const ocpp::v201::Variable& /*variable_id*/,
-                                                             const ocpp::v201::AttributeEnum& /*attribute_enum*/,
+bool EverestDeviceModelStorage::set_variable_attribute_value(const ocpp::v2::Component& /*component_id*/,
+                                                             const ocpp::v2::Variable& /*variable_id*/,
+                                                             const ocpp::v2::AttributeEnum& /*attribute_enum*/,
                                                              const std::string& /*value*/,
                                                              const std::string& /*source*/) {
     return false;
 }
 
-std::optional<ocpp::v201::VariableMonitoringMeta>
-EverestDeviceModelStorage::set_monitoring_data(const ocpp::v201::SetMonitoringData& /*data*/,
-                                               const ocpp::v201::VariableMonitorType /*type*/) {
+std::optional<ocpp::v2::VariableMonitoringMeta>
+EverestDeviceModelStorage::set_monitoring_data(const ocpp::v2::SetMonitoringData& /*data*/,
+                                               const ocpp::v2::VariableMonitorType /*type*/) {
     return std::nullopt;
 }
 
@@ -41,16 +41,16 @@ bool EverestDeviceModelStorage::update_monitoring_reference(const int32_t /*moni
     return false;
 }
 
-std::vector<ocpp::v201::VariableMonitoringMeta>
-EverestDeviceModelStorage::get_monitoring_data(const std::vector<ocpp::v201::MonitoringCriterionEnum>& /*criteria*/,
-                                               const ocpp::v201::Component& /*component_id*/,
-                                               const ocpp::v201::Variable& /*variable_id*/) {
+std::vector<ocpp::v2::VariableMonitoringMeta>
+EverestDeviceModelStorage::get_monitoring_data(const std::vector<ocpp::v2::MonitoringCriterionEnum>& /*criteria*/,
+                                               const ocpp::v2::Component& /*component_id*/,
+                                               const ocpp::v2::Variable& /*variable_id*/) {
     return {};
 }
 
-ocpp::v201::ClearMonitoringStatusEnum EverestDeviceModelStorage::clear_variable_monitor(int /*monitor_id*/,
-                                                                                        bool /*allow_protected*/) {
-    return ocpp::v201::ClearMonitoringStatusEnum::NotFound;
+ocpp::v2::ClearMonitoringStatusEnum EverestDeviceModelStorage::clear_variable_monitor(int /*monitor_id*/,
+                                                                                      bool /*allow_protected*/) {
+    return ocpp::v2::ClearMonitoringStatusEnum::NotFound;
 }
 
 int32_t EverestDeviceModelStorage::clear_custom_variable_monitors() {

--- a/modules/OCPP201/device_model/everest_device_model_storage.hpp
+++ b/modules/OCPP201/device_model/everest_device_model_storage.hpp
@@ -3,30 +3,30 @@
 
 #pragma once
 
-#include <ocpp/v201/device_model_storage_interface.hpp>
+#include <ocpp/v2/device_model_storage_interface.hpp>
 
 namespace module::device_model {
-class EverestDeviceModelStorage : public ocpp::v201::DeviceModelStorageInterface {
+class EverestDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
 public:
     virtual ~EverestDeviceModelStorage() override = default;
-    virtual ocpp::v201::DeviceModelMap get_device_model() override;
-    virtual std::optional<ocpp::v201::VariableAttribute>
-    get_variable_attribute(const ocpp::v201::Component& component_id, const ocpp::v201::Variable& variable_id,
-                           const ocpp::v201::AttributeEnum& attribute_enum) override;
-    virtual std::vector<ocpp::v201::VariableAttribute>
-    get_variable_attributes(const ocpp::v201::Component& component_id, const ocpp::v201::Variable& variable_id,
-                            const std::optional<ocpp::v201::AttributeEnum>& attribute_enum) override;
-    virtual bool set_variable_attribute_value(const ocpp::v201::Component& component_id,
-                                              const ocpp::v201::Variable& variable_id,
-                                              const ocpp::v201::AttributeEnum& attribute_enum, const std::string& value,
+    virtual ocpp::v2::DeviceModelMap get_device_model() override;
+    virtual std::optional<ocpp::v2::VariableAttribute>
+    get_variable_attribute(const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
+                           const ocpp::v2::AttributeEnum& attribute_enum) override;
+    virtual std::vector<ocpp::v2::VariableAttribute>
+    get_variable_attributes(const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
+                            const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) override;
+    virtual bool set_variable_attribute_value(const ocpp::v2::Component& component_id,
+                                              const ocpp::v2::Variable& variable_id,
+                                              const ocpp::v2::AttributeEnum& attribute_enum, const std::string& value,
                                               const std::string& source) override;
-    virtual std::optional<ocpp::v201::VariableMonitoringMeta>
-    set_monitoring_data(const ocpp::v201::SetMonitoringData& data, const ocpp::v201::VariableMonitorType type) override;
+    virtual std::optional<ocpp::v2::VariableMonitoringMeta>
+    set_monitoring_data(const ocpp::v2::SetMonitoringData& data, const ocpp::v2::VariableMonitorType type) override;
     virtual bool update_monitoring_reference(const int32_t monitor_id, const std::string& reference_value) override;
-    virtual std::vector<ocpp::v201::VariableMonitoringMeta>
-    get_monitoring_data(const std::vector<ocpp::v201::MonitoringCriterionEnum>& criteria,
-                        const ocpp::v201::Component& component_id, const ocpp::v201::Variable& variable_id) override;
-    virtual ocpp::v201::ClearMonitoringStatusEnum clear_variable_monitor(int monitor_id, bool allow_protected) override;
+    virtual std::vector<ocpp::v2::VariableMonitoringMeta>
+    get_monitoring_data(const std::vector<ocpp::v2::MonitoringCriterionEnum>& criteria,
+                        const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id) override;
+    virtual ocpp::v2::ClearMonitoringStatusEnum clear_variable_monitor(int monitor_id, bool allow_protected) override;
     virtual int32_t clear_custom_variable_monitors() override;
     virtual void check_integrity() override;
 };

--- a/modules/OCPP201/doc.rst
+++ b/modules/OCPP201/doc.rst
@@ -23,7 +23,7 @@ parameter **DeviceModelConfigPath**. It shall point to the directory where the c
 * standardized
 * custom
 
-The `device model setup from libocpp <https://github.com/EVerest/libocpp/tree/main/config/v201/component_config>`_ serves as a good example. 
+The `device model setup from libocpp <https://github.com/EVerest/libocpp/tree/main/config/v2/component_config>`_ serves as a good example. 
 The split between the directories only has semantic reasons. The **standardized** directory usually does not need to be modified since it contains
 standardized components and variables that the specification refers to in its functional requirements. The **custom** directory is meant to be used
 for components that are custom for your specific charging station. Especially the number of EVSE and Connector components, as well as their

--- a/modules/OCPP201/error_handling.hpp
+++ b/modules/OCPP201/error_handling.hpp
@@ -3,7 +3,7 @@
 #ifndef OCPP201_ERROR_HANDLING_HPP
 #define OCPP201_ERROR_HANDLING_HPP
 
-#include <ocpp/v201/ocpp_types.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
 #include <ocpp_conversions.hpp>
 #include <utils/error.hpp>
 
@@ -40,12 +40,12 @@ const auto CONNECTOR_COMPONENT_NAME = "Connector";
 const auto PROBLEM_VARIABLE_NAME = "Problem";
 
 /// \brief Derives the EventData from the given \p error, \p cleared and \p event_id parameters
-ocpp::v201::EventData get_event_data(const Everest::error::Error& error, const bool cleared, const int32_t event_id) {
-    ocpp::v201::EventData event_data;
+ocpp::v2::EventData get_event_data(const Everest::error::Error& error, const bool cleared, const int32_t event_id) {
+    ocpp::v2::EventData event_data;
     event_data.eventId = event_id; // This can theoretically conflict with eventIds generated in libocpp (e.g.
                                    // for monitoring events), but the spec does not strictly forbid that
     event_data.timestamp = ocpp::DateTime(error.timestamp);
-    event_data.trigger = ocpp::v201::EventTriggerEnum::Alerting;
+    event_data.trigger = ocpp::v2::EventTriggerEnum::Alerting;
     event_data.cause = std::nullopt; // TODO: use caused_by when available within error object
     event_data.actualValue = cleared ? "false" : "true";
 
@@ -59,7 +59,7 @@ ocpp::v201::EventData get_event_data(const Everest::error::Error& error, const b
     event_data.cleared = cleared;
     event_data.transactionId = std::nullopt;        // TODO: Do we need to set this here?
     event_data.variableMonitoringId = std::nullopt; // We dont need to set this for HardwiredNotification
-    event_data.eventNotificationType = ocpp::v201::EventNotificationEnum::HardWiredNotification;
+    event_data.eventNotificationType = ocpp::v2::EventNotificationEnum::HardWiredNotification;
 
     // TODO: choose proper component
     const auto evse_id = error.origin.mapping.has_value() ? error.origin.mapping.value().evse : 0;
@@ -68,11 +68,11 @@ ocpp::v201::EventData get_event_data(const Everest::error::Error& error, const b
         event_data.component = {CHARGING_STATION_COMPONENT_NAME}; // TODO: use origin of error for mapping to component?
     } else if (not error.origin.mapping.value().connector.has_value()) {
         // component is EVSE
-        ocpp::v201::EVSE evse = {evse_id};
+        ocpp::v2::EVSE evse = {evse_id};
         event_data.component = {EVSE_COMPONENT_NAME, std::nullopt, evse};
     } else {
         // component is Connector
-        ocpp::v201::EVSE evse = {evse_id, std::nullopt, error.origin.mapping.value().connector.value()};
+        ocpp::v2::EVSE evse = {evse_id, std::nullopt, error.origin.mapping.value().connector.value()};
         event_data.component = {CONNECTOR_COMPONENT_NAME, std::nullopt, evse};
     }
     event_data.variable = {PROBLEM_VARIABLE_NAME}; // TODO: use type of error for mapping to variable?

--- a/modules/OCPP201/ocpp_generic/ocppImpl.cpp
+++ b/modules/OCPP201/ocpp_generic/ocppImpl.cpp
@@ -43,7 +43,7 @@ std::vector<types::ocpp::SetVariableResult>
 ocppImpl::handle_set_variables(std::vector<types::ocpp::SetVariableRequest>& requests, std::string& source) {
     const auto _requests = conversions::to_ocpp_set_variable_data_vector(requests);
     const auto response_map = this->mod->charge_point->set_variables(_requests, source);
-    std::vector<ocpp::v201::SetVariableResult> response;
+    std::vector<ocpp::v2::SetVariableResult> response;
     for (const auto& [set_variable_data, set_variable_result] : response_map) {
         response.push_back(set_variable_result);
     }

--- a/modules/OCPP201/tests/transaction_handler_tests.cpp
+++ b/modules/OCPP201/tests/transaction_handler_tests.cpp
@@ -17,8 +17,8 @@ protected:
     }
 
     std::shared_ptr<TransactionData> transaction_data() {
-        return std::make_shared<TransactionData>(1, "123", ocpp::DateTime(), ocpp::v201::TriggerReasonEnum::Authorized,
-                                                 ocpp::v201::ChargingStateEnum::Idle);
+        return std::make_shared<TransactionData>(1, "123", ocpp::DateTime(), ocpp::v2::TriggerReasonEnum::Authorized,
+                                                 ocpp::v2::ChargingStateEnum::Idle);
     }
 };
 

--- a/modules/OCPP201/transaction_handler.hpp
+++ b/modules/OCPP201/transaction_handler.hpp
@@ -10,7 +10,7 @@
 #include <set>
 #include <vector>
 
-#include <ocpp/v201/ocpp_types.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
 
 namespace module {
 
@@ -142,18 +142,18 @@ struct TransactionData {
     int32_t connector_id;
     std::string session_id;
     ocpp::DateTime timestamp;
-    ocpp::v201::TriggerReasonEnum trigger_reason;
-    ocpp::v201::MeterValue meter_value;
-    ocpp::v201::ChargingStateEnum charging_state;
-    ocpp::v201::ReasonEnum stop_reason = ocpp::v201::ReasonEnum::Other;
-    std::optional<ocpp::v201::IdToken> id_token;
-    std::optional<ocpp::v201::IdToken> group_id_token;
+    ocpp::v2::TriggerReasonEnum trigger_reason;
+    ocpp::v2::MeterValue meter_value;
+    ocpp::v2::ChargingStateEnum charging_state;
+    ocpp::v2::ReasonEnum stop_reason = ocpp::v2::ReasonEnum::Other;
+    std::optional<ocpp::v2::IdToken> id_token;
+    std::optional<ocpp::v2::IdToken> group_id_token;
     std::optional<int32_t> reservation_id;
     std::optional<int32_t> remote_start_id;
 
     TransactionData(const int32_t connector_id, const std::string& session_id, const ocpp::DateTime timestamp,
-                    const ocpp::v201::TriggerReasonEnum trigger_reason,
-                    const ocpp::v201::ChargingStateEnum charging_state) :
+                    const ocpp::v2::TriggerReasonEnum trigger_reason,
+                    const ocpp::v2::ChargingStateEnum charging_state) :
         connector_id(connector_id),
         session_id(session_id),
         timestamp(timestamp),


### PR DESCRIPTION

## Describe your changes
This PR addresses the renaming changes in libocpp from v201 to v2 / V201 to V2. All occurances have been renamed according to the changes in libocpp.

## Issue ticket number and link
[Companion PR in libocpp](https://github.com/EVerest/libocpp/pull/991)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

