### PR TITLE
Fix missing enum conversion for CertificateValidationResult::Expired

### DIFF
--- a/lib/staging/evse_security/CMakeLists.txt
+++ b/lib/staging/evse_security/CMakeLists.txt
@@ -13,6 +13,12 @@ target_include_directories(evse_security_conversions
     "$<TARGET_PROPERTY:generate_cpp_files,EVEREST_GENERATED_INCLUDE_DIR>"
 )
 
+target_compile_options(evse_security_conversions
+    PRIVATE
+        -Wimplicit-fallthrough
+        -Werror=switch-enum
+)
+
 add_dependencies(evse_security_conversions generate_cpp_files)
 
 target_link_libraries(evse_security_conversions
@@ -20,3 +26,4 @@ target_link_libraries(evse_security_conversions
         everest::evse_security
         everest::framework
 )
+

--- a/lib/staging/evse_security/conversions.cpp
+++ b/lib/staging/evse_security/conversions.cpp
@@ -328,9 +328,10 @@ types::evse_security::CertificateValidationResult to_everest(evse_security::Cert
         return types::evse_security::CertificateValidationResult::InvalidLeafSignature;
     case evse_security::CertificateValidationResult::InvalidChain:
         return types::evse_security::CertificateValidationResult::InvalidChain;
+    case evse_security::CertificateValidationResult::Expired:
+        return types::evse_security::CertificateValidationResult::Expired;
     case evse_security::CertificateValidationResult::Unknown:
         return types::evse_security::CertificateValidationResult::Unknown;
-        ;
     default:
         throw std::runtime_error("Could not convert evse_security::CertificateValidationResult to "
                                  "types::evse_security::CertificateValidationResult");


### PR DESCRIPTION
## Describe your changes
* Enabled -Werror=switch-enum for evse_security_conversions targt 
* Added missing enum value conversion for CertificateValidationResult

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

