### PR TITLE
Reservation Handling in EvseManager

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: bug/ocpp16-reservation-inoperative-multiple-state-change
+  git_tag: 6533694e8a25925985079bda33d5610f65c6d58f
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 04059e2cb6ea34029b661b6803dce49727ea65c3
+  git_tag: bug/ocpp16-reservation-inoperative-multiple-state-change
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -602,6 +602,10 @@ void AuthHandler::call_reservation_cancelled(const int32_t reservation_id,
     }
 
     this->reservation_cancelled_callback(evse_id, reservation_id, reason, send_reservation_update);
+
+    // If this was a global reservation or there are global reservations which made evse's go to reserved because of
+    // this reservation, they should be cancelled.
+    this->check_evse_reserved_and_send_updates();
 }
 
 void AuthHandler::handle_permanent_fault_raised(const int evse_id, const int32_t connector_id) {
@@ -734,7 +738,7 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
     // When reservation is started or ended, check if the number of reservations match the number of evses and
     // send 'reserved' notifications to the evse manager accordingly if needed.
     if (check_reservations) {
-        check_evse_reserved_and_send_updates();
+        this->check_evse_reserved_and_send_updates();
     }
 }
 

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -832,10 +832,6 @@ void EvseManager::ready() {
     error_handling->signal_error.connect([this](bool prevents_charging) { cancel_reservation(true); });
 
     charger->signal_simple_event.connect([this](types::evse_manager::SessionEventEnum s) {
-        // Cancel reservations if charger is disabled
-        if (s == types::evse_manager::SessionEventEnum::Disabled) {
-            cancel_reservation(true);
-        }
         if (s == types::evse_manager::SessionEventEnum::SessionFinished) {
             // Reset EV information on Session start and end
             ev_info = types::evse_manager::EVInfo();

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -419,6 +419,11 @@ void evse_managerImpl::handle_authorize_response(types::authorization::ProvidedI
 };
 
 void evse_managerImpl::handle_withdraw_authorization() {
+    // reservation_id might have been stored when reserved id token has been authorized, but timed out, so
+    //  we can consider the reservation as consumed
+    if (mod->charger->get_authorized_eim() and mod->is_reserved()) {
+        mod->cancel_reservation(true);
+    }
     this->mod->charger->deauthorize();
 };
 


### PR DESCRIPTION

## Describe your changes
Changed reservation handling in EvseManager:
* Signaling reservation end after Signaling Disabled event. This allows OCPPs state machine to move from
**Reserved->Unavailable** instead of **Reserved->Available->Unavailable**
* Fixed issue that reservation was cancelled on every SessionFinished event

## Conflicting requirements of OCPP2.0.1 and OCPP1.6

OCPP2.0.1 and OCPP1.6 use a shared implementation of the Reservation handling (implemented by the Auth module). We identified conflicting requirements between OCPP2.0.1 and OCPP1.6:
OCPP1.6 requires: 
> A reservation SHALL be terminated on the Charge Point when either (1) a transaction is started

OCPP2.0.1 requires:
> H03.FR.09 When an idToken or groupIdToken is presented that matches a reservation, Charging Station SHALL consider the reservation to be used (consumed)

This means, for OCPP1.6 a reservation is consumed/terminated when a transaction starts (Authorization present + EV plugged in) while in OCPP2.0.1 valid authorization is sufficient (e.g. swipe reserved RFID without EV plugin) to consume/terminate the reservation. 

Since the handling of the reservations is mainly implemented in the EvseManager and the Auth module (which are unaware of the OCPP version) and not in libocpp, this can't be solved properly for both versions at the same time.

For now and with these changes, the requirement of OCPP1.6 is applied and therefore  H03.FR.09 of OCPP2.0.1 is violated.

## Issue ticket number and link
[Companion PR in libocpp](https://github.com/EVerest/libocpp/pull/998)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

