### PR TITLE
Replace deprecated boost::asio::io_service with boost::asio::io_context

### DIFF
--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -50,11 +50,11 @@ private: // Members
     std::set<int32_t> last_reserved_status;
 
     /// \brief worker for the timers.
-    boost::shared_ptr<boost::asio::io_service::work> work;
-    /// \brief io_service for the worker for the timers.
-    boost::asio::io_service io_service;
+    boost::shared_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work;
+    /// \brief io_context for the worker for the timers.
+    boost::asio::io_context io_context;
     /// \brief io service thread for the timers.
-    std::thread io_service_thread;
+    std::thread io_context_thread;
 
 public:
     ///

--- a/modules/Auth/include/ReservationHandler.hpp
+++ b/modules/Auth/include/ReservationHandler.hpp
@@ -53,7 +53,7 @@ private: // Members
     boost::shared_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work;
     /// \brief io_context for the worker for the timers.
     boost::asio::io_context io_context;
-    /// \brief io service thread for the timers.
+    /// \brief io context thread for the timers.
     std::thread io_context_thread;
 
 public:


### PR DESCRIPTION
## Describe your changes

`boost::asio::io_service` and `boost::asio::io_service::work` is removed in boost version `1.78`.
Replace with `boost::asio::io_context` and `executor_work_guard<boost::asio::io_context::executor_type>`
Requires boost version >= `1.66`

## Issue ticket number and link

Closes https://github.com/EVerest/everest-core/issues/1072

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

