### PR TITLE
Adding proper tls 1.3 support for d20 in Evse15118D20 and PyEvJosev

### DIFF
--- a/config/certs/.gitignore
+++ b/config/certs/.gitignore
@@ -10,4 +10,5 @@
 !mf
 !mo
 !oem
+!vehicle
 !v2g

--- a/config/certs/ca/vehicle/.gitignore
+++ b/config/certs/ca/vehicle/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/certs/client/vehicle/.gitignore
+++ b/config/certs/client/vehicle/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/config/config-sil-dc-d20.yaml
+++ b/config/config-sil-dc-d20.yaml
@@ -15,6 +15,7 @@ active_modules:
       supported_ISO15118_2: false
       supported_ISO15118_20_DC: true
       tls_active: true
+      enable_tls_1_3: true
   evse_manager:
     module: EvseManager
     config_module:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -72,7 +72,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: ff3efe50c41ac2c40ef24d61ea03ec5b7709704a
+  git_tag: 2025.2.0
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT AND EVEREST_DEPENDENCY_ENABLED_JOSEV"
 # mbedtls
 ext-mbedtls:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -72,7 +72,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: 2024.10.0
+  git_tag: ff3efe50c41ac2c40ef24d61ea03ec5b7709704a
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT AND EVEREST_DEPENDENCY_ENABLED_JOSEV"
 # mbedtls
 ext-mbedtls:

--- a/modules/Evse15118D20/Evse15118D20.hpp
+++ b/modules/Evse15118D20/Evse15118D20.hpp
@@ -27,8 +27,10 @@ struct Conf {
     std::string device;
     std::string logging_path;
     std::string tls_negotiation_strategy;
+    bool enforce_tls_1_3;
     bool enable_ssl_logging;
     bool enable_tls_key_logging;
+    std::string tls_key_logging_path;
     bool enable_sdp_server;
     bool supported_dynamic_mode;
     bool supported_mobility_needs_mode_provided_by_secc;

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -271,19 +271,22 @@ void ISO15118_chargerImpl::ready() {
         EVLOG_AND_THROW(Everest::EverestConfigError("V2G certificate not found"));
     }
 
+    const auto v2g_root_cert_path = mod->r_security->call_get_verify_file(types::evse_security::CaCertificateType::V2G);
+    const auto mo_root_cert_path = mod->r_security->call_get_verify_file(types::evse_security::CaCertificateType::MO);
+
     const iso15118::TbdConfig tbd_config = {
         {
             iso15118::config::CertificateBackend::EVEREST_LAYOUT,
             {},                                 ///< config_string
             path_chain,                         ///< path_certificate_chain
             certificate_info.key,               ///< path_certificate_key
-            certificate_info.password,          ///< private_key_password
-            {},                                 ///< path_certificate_v2g_root
-            {},                                 ///< path_certificate_mo_root
+            certificate_info.password,          ///< private_key_password                              
+            v2g_root_cert_path,                 ///< path_certificate_v2g_root
+            mo_root_cert_path,                  ///< path_certificate_mo_root
             mod->config.enable_ssl_logging,     ///< enable_ssl_logging
             mod->config.enable_tls_key_logging, ///< enable_tls_key_logging
-            false,                              ///< enforce_tls_1_3
-            {}                                  ///< tls_key_logging_path
+            mod->config.enforce_tls_1_3,        ///< enforce_tls_1_3
+            mod->config.tls_key_logging_path,   ///< tls_key_logging_path
         },
         mod->config.device,
         convert_tls_negotiation_strategy(mod->config.tls_negotiation_strategy),

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -280,7 +280,7 @@ void ISO15118_chargerImpl::ready() {
             {},                                 ///< config_string
             path_chain,                         ///< path_certificate_chain
             certificate_info.key,               ///< path_certificate_key
-            certificate_info.password,          ///< private_key_password                              
+            certificate_info.password,          ///< private_key_password
             v2g_root_cert_path,                 ///< path_certificate_v2g_root
             mo_root_cert_path,                  ///< path_certificate_mo_root
             mod->config.enable_ssl_logging,     ///< enable_ssl_logging

--- a/modules/Evse15118D20/manifest.yaml
+++ b/modules/Evse15118D20/manifest.yaml
@@ -20,7 +20,7 @@ config:
       - ENFORCE_NO_TLS
     default: ACCEPT_CLIENT_OFFER  
   enforce_tls_1_3:
-    description: Enforcing tls version 1.3 if the ev and secc supports tls
+    description: Enforcing tls version 1.3. Only applies if tls_negotiation_strategy is ENFORCE_TLS.
     type: boolean
     default: false
   enable_ssl_logging:

--- a/modules/Evse15118D20/manifest.yaml
+++ b/modules/Evse15118D20/manifest.yaml
@@ -19,6 +19,10 @@ config:
       - ENFORCE_TLS
       - ENFORCE_NO_TLS
     default: ACCEPT_CLIENT_OFFER  
+  enforce_tls_1_3:
+    description: Enforcing tls version 1.3 if the ev and secc supports tls
+    type: boolean
+    default: false
   enable_ssl_logging:
     description: Verbosely log the ssl/tls connection
     type: boolean
@@ -30,6 +34,11 @@ config:
       simulation purpose only
     type: boolean
     default: false
+  tls_key_logging_path:
+    description:  >-
+      Output directory for the TLS key log file
+    type: string
+    default: /tmp
   enable_sdp_server:
     description: >-
       Enable the built-in SDP server

--- a/modules/PyEvJosev/manifest.yaml
+++ b/modules/PyEvJosev/manifest.yaml
@@ -36,6 +36,10 @@ config:
       And any existing contract certificate will also be overwritten.
     type: boolean
     default: false
+  enable_tls_1_3:
+    description: The EVCC will enable TLS version 1.3
+    type: boolean
+    default: false
 provides:  
   ev:
     interface: ISO15118_ev

--- a/modules/PyEvJosev/module.py
+++ b/modules/PyEvJosev/module.py
@@ -16,7 +16,7 @@ from iso15118.evcc.controller.simulator import SimEVController
 from iso15118.evcc.evcc_config import EVCCConfig
 from iso15118.evcc.everest import context as JOSEV_CONTEXT
 from iso15118.shared.exificient_exi_codec import ExificientEXICodec
-from iso15118.shared.settings import set_PKI_PATH
+from iso15118.shared.settings import set_PKI_PATH, enable_tls_1_3
 
 from utilities import (
     setup_everest_logging,
@@ -58,6 +58,9 @@ class PyEVJosevModule():
 
         etc_certs_path = m.info.paths.etc / EVEREST_CERTS_SUB_DIR
         set_PKI_PATH(str(etc_certs_path.resolve()))
+
+        if self._setup.configs.module['enable_tls_1_3'] == True:
+            enable_tls_1_3()
 
         # setup publishing callback
         def publish_callback(variable_name: str, value: any):


### PR DESCRIPTION
## Describe your changes
See title.
~Adding PR from libiso15118: https://github.com/EVerest/libiso15118/pull/86~ merged
~Adding PR from Josev: https://github.com/EVerest/ext-switchev-iso15118/pull/36~ merged

## Issue ticket number and link
In libiso15118 there was previously only rudimentary TLS 1.3 support. Although only TLS1.3 is actually predefined in ISO15118-20. 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

