### PR TITLE
Fix force unlock handling in EvseManager

### DIFF
--- a/config/config-sil-ocpp.yaml
+++ b/config/config-sil-ocpp.yaml
@@ -48,6 +48,9 @@ active_modules:
       store:
         - module_id: persistent_store
           implementation_id: main
+      connector_lock:
+        - module_id: yeti_driver_1
+          implementation_id: connector_lock
   evse_manager_2:
     module: EvseManager
     mapping:
@@ -78,6 +81,12 @@ active_modules:
       hlc:
         - module_id: iso15118_charger
           implementation_id: charger
+      store:
+        - module_id: persistent_store
+          implementation_id: main
+      connector_lock:
+        - module_id: yeti_driver_2
+          implementation_id: connector_lock
   yeti_driver_1:
     module: JsYetiSimulator
     mapping:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: refactor/unlock-connector-callback
+  git_tag: a26227aedea9c4cc61042c392f039a15097c2ca7
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -67,7 +67,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 6533694e8a25925985079bda33d5610f65c6d58f
+  git_tag: refactor/unlock-connector-callback
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -100,7 +100,10 @@ cmds:
         description: Specifies the ID of the connector that should be unlocked
         type: integer
     result:
-      description: Returns true if unlocking sequence was successfully executed
+      description: >-
+        Returns true if unlocking command was accepted, or false if it is not supported.
+        It does not reflect the success/failure of the actual unlocking.
+        If unlocking fails, the connector_lock interface shall raise an error asynchronously.
       type: boolean
   external_ready_to_start_charging:
     description: >-

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -467,6 +467,9 @@ bool evse_managerImpl::handle_external_ready_to_start_charging() {
 
 bool evse_managerImpl::handle_force_unlock(int& connector_id) {
     if (not mod->r_connector_lock.empty()) {
+        types::evse_manager::StopTransactionRequest request;
+        request.reason = types::evse_manager::StopTransactionReason::UnlockCommand;
+        mod->charger->cancel_transaction(request);
         mod->bsp->connector_force_unlock();
         return true;
     }

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -466,8 +466,11 @@ bool evse_managerImpl::handle_external_ready_to_start_charging() {
 }
 
 bool evse_managerImpl::handle_force_unlock(int& connector_id) {
-    mod->bsp->connector_force_unlock();
-    return true;
+    if (not mod->r_connector_lock.empty()) {
+        mod->bsp->connector_force_unlock();
+        return true;
+    }
+    return false;
 };
 
 } // namespace evse

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -542,9 +542,12 @@ void OCPP::ready() {
     this->charge_point->register_unlock_connector_callback([this](int32_t connector) {
         if (this->connector_evse_index_map.count(connector)) {
             EVLOG_info << "Executing unlock connector callback";
-            return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))->call_force_unlock(1);
+            // UnlockStatus::Failed is currently not supported by EVerest
+            return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))->call_force_unlock(1)
+                       ? ocpp::v16::UnlockStatus::Unlocked
+                       : ocpp::v16::UnlockStatus::NotSupported;
         } else {
-            return false;
+            return ocpp::v16::UnlockStatus::NotSupported;
         }
     });
 

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp.yaml
@@ -23,6 +23,9 @@ active_modules:
       powermeter_grid_side:
       - module_id: yeti_driver
         implementation_id: powermeter
+      connector_lock:
+      - module_id: yeti_driver
+        implementation_id: connector_lock
   yeti_driver:
     mapping:
       module:

--- a/tests/ocpp_tests/test_sets/ocpp16/california_pricing_ocpp16.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/california_pricing_ocpp16.py
@@ -850,6 +850,11 @@ class TestOcpp16CostAndPrice:
         # swipe id tag to finish transaction
         test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
 
+        # expect StopTransaction.req
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StopTransaction",
+                                           call.StopTransactionPayload(0, "", 1, Reason.local),
+                                           validate_standard_stop_transaction)
+        
         # expect StatusNotification with status finishing
         assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StatusNotification",
                                            call.StatusNotificationPayload(1, ChargePointErrorCode.no_error,
@@ -860,13 +865,7 @@ class TestOcpp16CostAndPrice:
                                            call.MeterValuesPayload(1, meter_value=[{'sampledValue': [
                                                {'context': 'Other', 'format': 'Raw', 'location': 'Outlet',
                                                 'measurand': 'Energy.Active.Import.Register', 'unit': 'Wh',
-                                                'value': '1.00'}], 'timestamp': timestamp[:-9] + 'Z'}],
-                                                                   transaction_id=1))
-
-        # expect StopTransaction.req
-        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StopTransaction",
-                                           call.StopTransactionPayload(0, "", 1, Reason.local),
-                                           validate_standard_stop_transaction)
+                                                'value': '1.00'}], 'timestamp': timestamp[:-9] + 'Z'}]))
 
         test_controller.plug_out()
 

--- a/tests/ocpp_tests/test_sets/ocpp16/california_pricing_ocpp16.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/california_pricing_ocpp16.py
@@ -854,7 +854,7 @@ class TestOcpp16CostAndPrice:
         assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StopTransaction",
                                            call.StopTransactionPayload(0, "", 1, Reason.local),
                                            validate_standard_stop_transaction)
-        
+
         # expect StatusNotification with status finishing
         assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StatusNotification",
                                            call.StatusNotificationPayload(1, ChargePointErrorCode.no_error,

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -707,16 +707,6 @@ async def test_005_1_ev_side_disconnect(
 
     test_utility.messages.clear()
 
-    # expect StatusNotification with status finishing
-    assert await wait_for_and_validate(
-        test_utility,
-        charge_point_v16,
-        "StatusNotification",
-        call.StatusNotificationPayload(
-            1, ChargePointErrorCode.no_error, ChargePointStatus.finishing
-        ),
-    )
-
     # expect StopTransaction.req
     assert await wait_for_and_validate(
         test_utility,
@@ -813,16 +803,6 @@ async def test_ev_side_disconnect(
     test_utility.messages.clear()
 
     test_controller.plug_out()
-
-    # expect StatusNotification with status finishing
-    assert await wait_for_and_validate(
-        test_utility,
-        charge_point_v16,
-        "StatusNotification",
-        call.StatusNotificationPayload(
-            1, ChargePointErrorCode.no_error, ChargePointStatus.finishing
-        ),
-    )
 
     # expect StopTransaction.req
     assert await wait_for_and_validate(
@@ -2015,9 +1995,10 @@ async def test_unlock_connector_no_charging_no_fixed_cable(
         call_result.UnlockConnectorPayload(UnlockStatus.unlocked),
     )
 
-
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-two-connectors.yaml") # this config has no connector_lock configured
+)
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="EVerest SIL currently does not support this")
 async def test_unlock_connector_no_charging_fixed_cable(
     charge_point_v16: ChargePoint16, test_utility: TestUtility
 ):
@@ -2121,8 +2102,10 @@ async def test_unlock_connector_with_charging_session_no_fixed_cable(
     )
 
 
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-two-connectors.yaml") # this config has no connector_lock configured
+)
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="EVerest SIL currently does not support this")
 async def test_unlock_connector_with_charging_session_fixed_cable(
     test_config: OcppTestConfiguration,
     charge_point_v16: ChargePoint16,


### PR DESCRIPTION
## Describe your changes
Currently the `EvseManager` always responds with `true` to a `force_unlock` command. This PR changes that it responds with `true` only if the connector lock requirement is fullfilled. It will respond with `false` if the connector lock requirement is not fullfilled. 

In addition, the force_unlock command will attempt to stop a transaction (if active) before executing the unlock command at the bsp.

The OCPP module has been adapted to these changes and the changes required by the PR mentioned below.

## Issue ticket number and link
Companion PR in libocpp: https://github.com/EVerest/libocpp/pull/1006

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

