### PR TITLE
Fixing bad_optional access in EvseManager

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1177,7 +1177,7 @@ void EvseManager::setup_v2h_mode() {
     types::energy::ExternalLimits external_limits;
     types::energy::ScheduleReqEntry target_entry;
     target_entry.timestamp = timestamp;
-    target_entry.limits_to_leaves.total_power_W = powersupply_capabilities.max_import_power_W.value();
+    target_entry.limits_to_leaves.total_power_W = powersupply_capabilities.max_import_power_W.value_or(0);
 
     types::energy::ScheduleReqEntry zero_entry;
     zero_entry.timestamp = timestamp;


### PR DESCRIPTION
EvseManger crashed with bad_optional access, if the optional values in the capabilities of a power supply DC are not set.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

