### PR TITLE
Remove Javascript modules from OCPP integration test configs

### DIFF
--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-042_1.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-042_1.yaml
@@ -25,9 +25,9 @@ active_modules:
     config_module:
       connector_id: 1
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 1
       auto_enable: true

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-078.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-078.yaml
@@ -25,9 +25,9 @@ active_modules:
     config_module:
       connector_id: 1
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 1
       auto_enable: true

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-ocpp201-dir-bundles.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-ocpp201-dir-bundles.yaml
@@ -68,7 +68,7 @@ active_modules:
     config_module:
       connector_id: 2
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator_1:
     module: JsCarSimulator
     config_module:

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-ocpp201.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-ocpp201.yaml
@@ -72,9 +72,9 @@ active_modules:
     config_module:
       connector_id: 2
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator_1:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 1
       auto_enable: true
@@ -91,7 +91,7 @@ active_modules:
         - module_id: slac
           implementation_id: ev
   car_simulator_2:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 2
       auto_enable: true

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-security-profile-1.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-security-profile-1.yaml
@@ -25,9 +25,9 @@ active_modules:
     config_module:
       connector_id: 1
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 1
       auto_enable: true

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-security-profile-2.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-security-profile-2.yaml
@@ -25,9 +25,9 @@ active_modules:
     config_module:
       connector_id: 1
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 1
       auto_enable: true

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-iso no-tls.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-iso no-tls.yaml
@@ -47,9 +47,9 @@ active_modules:
     config_module:
       connector_id: 1
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator_1:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 1
       auto_enable: true

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-iso.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-iso.yaml
@@ -46,9 +46,9 @@ active_modules:
     config_module:
       connector_id: 1
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator_1:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 1
       auto_enable: true

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp-probe.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp-probe.yaml
@@ -25,9 +25,9 @@ active_modules:
     config_module:
       connector_id: 1
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 1
       auto_enable: true

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp.yaml
@@ -34,14 +34,14 @@ active_modules:
     config_module:
       connector_id: 1
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator:
-    module: JsEvManager
+    module: EvManager
     config_module:
-      connector_id: 1
       auto_enable: true
       auto_exec: false
       auto_exec_commands: sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 30;unplug
+      connector_id: 1
     connections:
       ev_board_support:
         - module_id: yeti_driver

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-two-connectors.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-two-connectors.yaml
@@ -74,9 +74,9 @@ active_modules:
     config_module:
       connector_id: 1
   slac:
-    module: JsSlacSimulator
+    module: SlacSimulator
   car_simulator_1:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 1
       auto_enable: true
@@ -93,7 +93,7 @@ active_modules:
         - module_id: slac
           implementation_id: ev
   car_simulator_2:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 2
       auto_enable: true

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-two-evse-dc.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-two-evse-dc.yaml
@@ -69,13 +69,13 @@ active_modules:
     config_module:
       connector_id: 1
   slac_1:
-    module: JsSlacSimulator
+    module: SlacSimulator
   powersupply_dc:
-    module: JsDCSupplySimulator
+    module: DCSupplySimulator
   imd:
-    module: JsIMDSimulator
+    module: IMDSimulator
   car_simulator_1:
-  module: JsEvManager
+  module: EvManager
   config_module:
     connector_id: 1
     auto_enable: true
@@ -92,7 +92,7 @@ active_modules:
       - module_id: slac
         implementation_id: ev
   car_simulator_2:
-    module: JsEvManager
+    module: EvManager
     config_module:
       connector_id: 2
       auto_enable: true


### PR DESCRIPTION

## Describe your changes
Replaced JsEvManager JsIMDMonitor and JsSlacSimulator with C++ versions in ocpp integration test configs

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

