### PR TITLE
Evse15118D20: remove unused config parameter

### DIFF
--- a/modules/Evse15118D20/Evse15118D20.hpp
+++ b/modules/Evse15118D20/Evse15118D20.hpp
@@ -25,7 +25,6 @@ namespace module {
 
 struct Conf {
     std::string device;
-    std::string certificate_path;
     std::string logging_path;
     std::string tls_negotiation_strategy;
     bool enable_ssl_logging;

--- a/modules/Evse15118D20/manifest.yaml
+++ b/modules/Evse15118D20/manifest.yaml
@@ -7,10 +7,6 @@ config:
       link-local and a MAC addr will work
     type: string
     default: eth0
-  certificate_path:
-    description: Path to certificate directories
-    type: string
-    default: ""
   logging_path:
     description: Path to logging directory (will be created if non existent)
     type: string


### PR DESCRIPTION
Use of `certificate_path` was removed in https://github.com/EVerest/everest-core/commit/ffe208b28c18635046c01a4ccdc2abac4cd4bb3c with PR https://github.com/EVerest/everest-core/pull/1030.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

