### PR TITLE
Fix race condition in test_c13

### DIFF
--- a/tests/ocpp_tests/test_sets/ocpp201/local_authorization_list.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/local_authorization_list.py
@@ -533,8 +533,19 @@ async def test_C13(
         },
     )
 
+    test_utility.messages.clear()
+
     test_controller.swipe(id_token_123.id_token)
     test_controller.plug_out()
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {
+            "eventType": "Ended"
+        },
+    )
 
     assert await wait_for_and_validate(
         test_utility,
@@ -547,6 +558,8 @@ async def test_C13(
     # Invalid token in local list may not be authorized
     # Check AuthList: Invalid, Cache: Valid
     # Expected result: No session started
+    test_utility.forbidden_actions.append("TransactionEvent")
+
     logging.info("disconnect the ws connection...")
     test_controller.disconnect_websocket()
 
@@ -559,9 +572,6 @@ async def test_C13(
 
     logging.info("connecting the ws connection")
     test_controller.connect_websocket()
-
-    test_utility.messages.clear()
-    test_utility.forbidden_actions.append("TransactionEvent")
 
     # wait for reconnect
     charge_point_v201 = await central_system_v201.wait_for_chargepoint(

--- a/tests/ocpp_tests/test_sets/ocpp201/local_authorization_list.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/local_authorization_list.py
@@ -554,6 +554,8 @@ async def test_C13(
         {"connectorStatus": "Available", "evseId": 1},
     )
 
+    test_utility.messages.clear()
+
     # C13.FR.01
     # Invalid token in local list may not be authorized
     # Check AuthList: Invalid, Cache: Valid


### PR DESCRIPTION
## Describe your changes
Fixed test case test_C13 by waiting for TransactionEvent(Ended) before disconnecting and adding it to forbidden messages. Otherwise it could happen that the TransactionEvent(Ended) could not be send before disconnecting and is then forbidden when reconnecting

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

