### PR TITLE
Adding ISO15118-20 pause/resume feature

### DIFF
--- a/config/nodered/config-sil-dc-bpt-flow.json
+++ b/config/nodered/config-sil-dc-bpt-flow.json
@@ -1789,7 +1789,7 @@
         "options": [
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
                 "type": "str"
             }
         ],
@@ -1859,7 +1859,7 @@
         "once": true,
         "onceDelay": "1",
         "topic": "sim_commands",
-        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
+        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
         "payloadType": "str",
         "x": 150,
         "y": 1180,

--- a/config/nodered/config-sil-dc-flow.json
+++ b/config/nodered/config-sil-dc-flow.json
@@ -1789,7 +1789,7 @@
         "options": [
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
                 "type": "str"
             }
         ],
@@ -1859,7 +1859,7 @@
         "once": true,
         "onceDelay": "1",
         "topic": "sim_commands",
-        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
+        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
         "payloadType": "str",
         "x": 150,
         "y": 1180,

--- a/config/nodered/config-sil-energy-management-flow.json
+++ b/config/nodered/config-sil-energy-management-flow.json
@@ -1792,12 +1792,12 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
                 "type": "str"
             },
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
                 "type": "str"
             }
         ],

--- a/config/nodered/config-sil-flow.json
+++ b/config/nodered/config-sil-flow.json
@@ -1856,7 +1856,7 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             }
         ],

--- a/config/nodered/config-sil-two-evse-flow.json
+++ b/config/nodered/config-sil-two-evse-flow.json
@@ -2136,12 +2136,12 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             },
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000;",
                 "type": "str"
             }
         ],

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -47,7 +47,7 @@ libcbv2g:
 # libiso15118
 libiso15118:
   git: https://github.com/EVerest/libiso15118.git
-  git_tag: v0.5.2
+  git_tag: v0.6.0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBISO15118"
 
 # LEM DCBM 400/600, IsabellenhuetteIemDcr modules
@@ -84,7 +84,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: 2025.2.0
+  git_tag: 2025.5.0
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT AND EVEREST_DEPENDENCY_ENABLED_JOSEV"
 # everest-testing and ev-dev-tools
 everest-utils:

--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -113,6 +113,12 @@ cmds:
       stop:
         description: Set to true when to stop, set to false when to continue
         type: boolean
+  pause_charging:
+    description: Pause the charging process (only in ISO15118-20)
+    arguments:
+      pause:
+        description: Set to true when to pause, set to false when to continue
+        type: boolean
 # Update physical values
   update_ac_max_current:
     description: Update the maximum allowed line current restriction per phase. Call at least once during start up.

--- a/interfaces/ISO15118_ev.yaml
+++ b/interfaces/ISO15118_ev.yaml
@@ -54,3 +54,6 @@ vars:
   DC_PowerOn:
     description: The ev wants to close the dc contactors
     type: 'null'
+  pause_from_charger:
+    description: The charger wants to pause the session (only d20)
+    type: 'null'

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
@@ -55,6 +55,10 @@ void ISO15118_chargerImpl::handle_stop_charging(bool& stop) {
     // your code for cmd stop_charging goes here
 }
 
+void ISO15118_chargerImpl::handle_pause_charging(bool& pause) {
+    // your code for cmd pause_charging goes here
+}
+
 void ISO15118_chargerImpl::handle_update_ac_max_current(double& max_current) {
     // your code for cmd update_ac_max_current goes here
 }

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
@@ -47,6 +47,7 @@ protected:
     virtual void handle_cable_check_finished(bool& status) override;
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
+    virtual void handle_pause_charging(bool& pause) override;
     virtual void handle_update_ac_max_current(double& max_current) override;
     virtual void handle_update_dc_maximum_limits(types::iso15118::DcEvseMaximumLimits& maximum_limits) override;
     virtual void handle_update_dc_minimum_limits(types::iso15118::DcEvseMinimumLimits& minimum_limits) override;

--- a/modules/EvManager/main/car_simulation.cpp
+++ b/modules/EvManager/main/car_simulation.cpp
@@ -209,6 +209,7 @@ bool CarSimulation::iso_start_v2g_session(const CmdArguments& arguments, bool th
     const auto& energy_mode = arguments[0];
 
     if (energy_mode == constants::AC) {
+        sim_data.energy_mode = EnergyMode::AC;
         if (three_phases == false) {
             r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::AC_single_phase_core);
         } else {
@@ -216,6 +217,7 @@ bool CarSimulation::iso_start_v2g_session(const CmdArguments& arguments, bool th
         }
     } else if (energy_mode == constants::DC) {
         r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::DC_extended);
+        sim_data.energy_mode = EnergyMode::DC;
     } else {
         return false;
     }
@@ -261,11 +263,39 @@ bool CarSimulation::iso_wait_for_stop(const CmdArguments& arguments, size_t loop
         sim_data.sleep_ticks_left.reset();
         return true;
     }
+
+    if (sim_data.iso_d20_paused) {
+
+        const auto cmds =
+            std::array<std::string, 2>{"pause;iso_wait_v2g_session_stopped;sleep 2;iso_wait_pwm_is_running;",
+                                       "iso_wait_pwr_ready;iso_wait_for_stop 36000"};
+
+        EVLOG_info << "Charger wants to pause the session";
+        r_ev_board_support->call_allow_power_on(false);
+
+        // NOTE(sl): Change when the Energymode has more then 2 values
+        const std::string energy_mode = (sim_data.energy_mode == EnergyMode::AC) ? "AC" : "DC";
+        const std::string iso_start_v2g_session = "iso_start_v2g_session " + energy_mode + ";";
+
+        auto& modify_session_cmds = sim_data.modify_charging_session_cmds.emplace();
+
+        modify_session_cmds = cmds[0];
+        modify_session_cmds += iso_start_v2g_session;
+        modify_session_cmds += cmds[1];
+
+        sim_data.iso_pwr_ready = false;
+        sim_data.sleep_ticks_left.reset();
+        sim_data.iso_d20_paused = false;
+
+        // NOTE(sl): return false, otherwise the simulation will end too early before the session cmds can be adjusted
+        return false;
+    }
     return false;
 }
 
 bool CarSimulation::iso_wait_v2g_session_stopped(const CmdArguments& arguments) {
     if (sim_data.v2g_finished) {
+        sim_data.v2g_finished = false;
         return true;
     }
     return false;

--- a/modules/EvManager/main/car_simulation.hpp
+++ b/modules/EvManager/main/car_simulation.hpp
@@ -28,6 +28,10 @@ public:
         return sim_data.state;
     }
 
+    std::optional<std::string>& get_modify_charging_session_cmds() {
+        return sim_data.modify_charging_session_cmds;
+    }
+
     void set_state(SimState state) {
         sim_data.state = state;
     }
@@ -62,6 +66,10 @@ public:
 
     void set_iso_stopped(bool iso_stopped) {
         sim_data.iso_stopped = iso_stopped;
+    }
+
+    void set_iso_d20_paused(bool iso_d20_paused) {
+        sim_data.iso_d20_paused = iso_d20_paused;
     }
 
     void set_v2g_finished(bool v2g_finished) {

--- a/modules/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EvManager/main/car_simulatorImpl.cpp
@@ -111,6 +111,13 @@ void car_simulatorImpl::run() {
 
             const auto finished = run_simulation_loop();
 
+            auto& modify_session_cmds = car_simulation->get_modify_charging_session_cmds();
+            if (modify_session_cmds.has_value()) {
+                auto cmds = modify_session_cmds.value();
+                handle_modify_charging_session(cmds);
+                modify_session_cmds.reset();
+            }
+
             if (finished) {
                 EVLOG_info << "Finished simulation.";
                 set_execution_active(false);
@@ -292,6 +299,7 @@ void car_simulatorImpl::subscribe_to_variables_on_init() {
         _ev->subscribe_AC_StopFromCharger([this]() { car_simulation->set_iso_stopped(true); });
         _ev->subscribe_V2G_Session_Finished([this]() { car_simulation->set_v2g_finished(true); });
         _ev->subscribe_DC_PowerOn([this]() { car_simulation->set_dc_power_on(true); });
+        _ev->subscribe_pause_from_charger([this]() { car_simulation->set_iso_d20_paused(true); });
     }
 }
 
@@ -320,13 +328,8 @@ void car_simulatorImpl::subscribe_to_external_mqtt() {
     const auto& mqtt = mod->mqtt;
     mqtt.subscribe("everest_external/nodered/" + std::to_string(mod->config.connector_id) + "/carsim/cmd/enable",
                    [this](const std::string& message) {
-                       if (message == "true") {
-                           auto enable = true;
-                           handle_enable(enable);
-                       } else {
-                           auto enable = false;
-                           handle_enable(enable);
-                       }
+                       auto enable = (message == "true") ? true : false;
+                       handle_enable(enable);
                    });
     mqtt.subscribe("everest_external/nodered/" + std::to_string(mod->config.connector_id) +
                        "/carsim/cmd/execute_charging_session",

--- a/modules/EvManager/main/simulation_data.hpp
+++ b/modules/EvManager/main/simulation_data.hpp
@@ -25,6 +25,11 @@ enum class SimState {
     UNDEFINED,
 };
 
+enum class EnergyMode {
+    AC,
+    DC,
+};
+
 struct SimulationData {
 
     SimulationData() = default;
@@ -36,9 +41,13 @@ struct SimulationData {
 
     bool v2g_finished{false};
     bool iso_stopped{false};
+    bool iso_d20_paused{false};
     size_t evse_maxcurrent{0};
     size_t max_current{0};
     std::string payment{"ExternalPayment"};
+
+    EnergyMode energy_mode{EnergyMode::AC};
+    std::optional<std::string> modify_charging_session_cmds{std::nullopt};
 
     bool iso_pwr_ready{false};
 

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -583,6 +583,13 @@ void ISO15118_chargerImpl::handle_stop_charging(bool& stop) {
     }
 }
 
+void ISO15118_chargerImpl::handle_pause_charging(bool& pause) {
+    std::scoped_lock lock(GEL);
+    if (controller) {
+        controller->send_control_event(iso15118::d20::PauseCharging{pause});
+    }
+}
+
 void ISO15118_chargerImpl::handle_update_ac_max_current(double& max_current) {
     // your code for cmd update_ac_max_current goes here
 }

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.hpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.hpp
@@ -53,6 +53,7 @@ protected:
     virtual void handle_cable_check_finished(bool& status) override;
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
+    virtual void handle_pause_charging(bool& pause) override;
     virtual void handle_update_ac_max_current(double& max_current) override;
     virtual void handle_update_dc_maximum_limits(types::iso15118::DcEvseMaximumLimits& maximum_limits) override;
     virtual void handle_update_dc_minimum_limits(types::iso15118::DcEvseMinimumLimits& minimum_limits) override;

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -728,13 +728,26 @@ void Charger::run_state_machine() {
             if (initialize_state) {
                 signal_simple_event(types::evse_manager::SessionEventEnum::ChargingPausedEVSE);
                 if (shared_context.hlc_charging_active) {
-                    // currentState = EvseState::StoppingCharging;
-                    shared_context.last_stop_transaction_reason = types::evse_manager::StopTransactionReason::Local;
-                    // tell HLC stack to stop the session
-                    signal_hlc_stop_charging();
-                    pwm_off();
+                    if (config_context.charge_mode == ChargeMode::DC) {
+                        signal_dc_supply_off();
+                    }
                 } else {
                     pwm_off();
+                }
+            }
+
+            if (shared_context.hlc_charging_active) {
+                if (shared_context.hlc_charging_terminate_pause == HlcTerminatePause::Terminate) {
+                    // EV wants to terminate session
+                    shared_context.current_state = EvseState::StoppingCharging;
+                    if (shared_context.pwm_running) {
+                        pwm_off();
+                    }
+                } else if (shared_context.hlc_charging_terminate_pause == HlcTerminatePause::Pause) {
+                    // EV wants an actual pause
+                    if (shared_context.pwm_running) {
+                        pwm_off();
+                    }
                 }
             }
             break;
@@ -1077,6 +1090,9 @@ bool Charger::set_max_current(float c, std::chrono::time_point<date::utc_clock> 
 bool Charger::pause_charging() {
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_pause_charging);
     if (shared_context.current_state == EvseState::Charging) {
+        if (shared_context.hlc_charging_active and shared_context.transaction_active) {
+            signal_hlc_pause_charging();
+        }
         shared_context.legacy_wakeup_done = false;
         shared_context.current_state = EvseState::ChargingPausedEVSE;
         return true;
@@ -1090,8 +1106,9 @@ bool Charger::resume_charging() {
     if (shared_context.hlc_charging_active and shared_context.transaction_active and
         shared_context.current_state == EvseState::ChargingPausedEVSE) {
         shared_context.current_state = EvseState::PrepareCharging;
-        // wake up SLAC as well
-        signal_slac_start();
+        if (shared_context.hlc_charging_terminate_pause == HlcTerminatePause::Terminate) {
+            signal_slac_start(); // wake up SLAC as well
+        }
         return true;
     } else if (shared_context.transaction_active and shared_context.current_state == EvseState::ChargingPausedEVSE) {
         shared_context.current_state = EvseState::WaitingForEnergy;

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -168,6 +168,7 @@ public:
     sigslot::signal<> signal_slac_start;
 
     sigslot::signal<> signal_hlc_stop_charging;
+    sigslot::signal<> signal_hlc_pause_charging;
     sigslot::signal<types::iso15118::EvseError> signal_hlc_error;
 
     void process_event(CPEvent event);

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -250,6 +250,7 @@ void EvseManager::ready() {
 
         // Ask HLC to stop charging session
         charger->signal_hlc_stop_charging.connect([this] { r_hlc[0]->call_stop_charging(true); });
+        charger->signal_hlc_pause_charging.connect([this] { r_hlc[0]->call_pause_charging(true); });
 
         // Charger needs to inform ISO stack about emergency stop
         charger->signal_hlc_error.connect(

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -289,6 +289,10 @@ void ISO15118_chargerImpl::handle_stop_charging(bool& stop) {
     }
 }
 
+void ISO15118_chargerImpl::handle_pause_charging(bool& pause) {
+    EVLOG_warning << "Pause initialized by the charger is not supported in DIN70121 and ISO15118-2";
+}
+
 void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) {
 
     if (physical_values.ac_nominal_voltage.has_value()) {

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
@@ -48,6 +48,7 @@ protected:
     virtual void handle_cable_check_finished(bool& status) override;
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
+    virtual void handle_pause_charging(bool& pause) override;
     virtual void handle_update_ac_max_current(double& max_current) override;
     virtual void handle_update_dc_maximum_limits(types::iso15118::DcEvseMaximumLimits& maximum_limits) override;
     virtual void handle_update_dc_minimum_limits(types::iso15118::DcEvseMinimumLimits& minimum_limits) override;

--- a/modules/EvseV2G/tests/ISO15118_chargerImplStub.hpp
+++ b/modules/EvseV2G/tests/ISO15118_chargerImplStub.hpp
@@ -54,6 +54,9 @@ struct ISO15118_chargerImplStub : public ISO15118_chargerImplBase {
     virtual void handle_stop_charging(bool& stop) {
         std::cout << "ISO15118_chargerImplBase::handle_stop_charging called" << std::endl;
     }
+    virtual void handle_pause_charging(bool& pause) {
+        std::cout << "ISO15118_chargerImplBase::handle_pause_charging called" << std::endl;
+    }
     virtual void handle_update_ac_max_current(double& max_current) {
         std::cout << "ISO15118_chargerImplBase::handle_update_ac_max_current called" << std::endl;
     }

--- a/modules/IsoMux/charger/ISO15118_chargerImpl.cpp
+++ b/modules/IsoMux/charger/ISO15118_chargerImpl.cpp
@@ -539,6 +539,14 @@ void ISO15118_chargerImpl::handle_stop_charging(bool& stop) {
     }
 }
 
+void ISO15118_chargerImpl::handle_pause_charging(bool& pause) {
+    if (mod->selected_iso20()) {
+        mod->r_iso20->call_pause_charging(pause);
+    } else {
+        mod->r_iso2->call_pause_charging(pause);
+    }
+}
+
 void ISO15118_chargerImpl::handle_update_ac_max_current(double& max_current) {
     mod->r_iso20->call_update_ac_max_current(max_current);
     mod->r_iso2->call_update_ac_max_current(max_current);

--- a/modules/IsoMux/charger/ISO15118_chargerImpl.hpp
+++ b/modules/IsoMux/charger/ISO15118_chargerImpl.hpp
@@ -48,6 +48,7 @@ protected:
     virtual void handle_cable_check_finished(bool& status) override;
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
+    virtual void handle_pause_charging(bool& pause) override;
     virtual void handle_update_ac_max_current(double& max_current) override;
     virtual void handle_update_dc_maximum_limits(types::iso15118::DcEvseMaximumLimits& maximum_limits) override;
     virtual void handle_update_dc_minimum_limits(types::iso15118::DcEvseMinimumLimits& minimum_limits) override;


### PR DESCRIPTION
## Describe your changes
Adding pause/resume feature for ISO15118-20. Right now the charger can pause and resume the session in dynamic mode. Pause/Resume in scheduled mode is partially supported.

To test pause/resume please update your node-red flows if you dont use the nodered scripts. To pause the d20 session click on the `PAUSE` button, not the `EV Pause` button.

## Issue ticket number and link
Missing pause/resume feature from ISO15118-20

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

