### PR TITLE
Auth: clarify hint about missing storage configuration

### DIFF
--- a/modules/Auth/lib/ReservationHandler.cpp
+++ b/modules/Auth/lib/ReservationHandler.cpp
@@ -32,7 +32,7 @@ ReservationHandler::~ReservationHandler() {
 void ReservationHandler::load_reservations() {
     std::lock_guard<std::recursive_mutex> lk(this->event_mutex);
     if (this->store == nullptr) {
-        EVLOG_info << "Can not load reservations because the store is a nullptr.";
+        EVLOG_warning << "Can not load reservations because no storage was configured.";
         return;
     }
 


### PR DESCRIPTION
## Describe your changes

The current message is kind of technical - re-word it to give a better hint that a configuration part is missing.

While at, upgrade the level to a warning since in most cases the reservations should be stored in a persistent manner over reboots.

## Issue ticket number and link

 -n/a-

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

