### PR TITLE
Fix: EVSE selection in Auth module

### DIFF
--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -257,6 +257,13 @@ TokenHandlingResult AuthHandler::handle_token(const ProvidedIdToken& provided_to
         return TokenHandlingResult::NO_CONNECTOR_AVAILABLE;
     }
 
+    // We can remove evse_ids from referenced_evses that already have an identifier assigend, since we don't want to
+    // consider those when selecting an evse
+    referenced_evses.erase(
+        std::remove_if(referenced_evses.begin(), referenced_evses.end(),
+                       [this](int32_t evse_id) { return this->evses.at(evse_id)->identifier != std::nullopt; }),
+        referenced_evses.end());
+
     types::authorization::ValidationResult validation_result = {types::authorization::AuthorizationStatus::Unknown};
     if (!validation_results.empty()) {
         bool authorized = false;
@@ -703,24 +710,27 @@ void AuthHandler::handle_session_event(const int evse_id, const SessionEvent& ev
 
     switch (event_type) {
     case SessionEventEnum::SessionStarted: {
-        this->plug_in_queue.push_back(evse_id);
-        this->cv.notify_all();
 
         // only set plug in timeout when SessionStart is caused by plug in
         if (event.session_started.value().reason == StartSessionReason::EVConnected) {
+            // Only add to plug_in_queue and set timer if the evse_id is not yet authorized
+            if (this->evses.at(evse_id)->identifier == std::nullopt) {
+                this->plug_in_queue.push_back(evse_id);
+                this->evses.at(evse_id)->timeout_timer.timeout(
+                    [this, evse_id]() {
+                        std::lock_guard<std::mutex> lk(this->event_mutex);
+
+                        EVLOG_info << "Plug In timeout for evse#" << evse_id << ". Replug required for this EVSE";
+                        this->withdraw_authorization_callback(this->evses.at(evse_id)->evse_index);
+
+                        this->plug_in_queue.remove_if([evse_id](int value) { return value == evse_id; });
+                        this->evses.at(evse_id)->plug_in_timeout = true;
+                    },
+                    std::chrono::seconds(this->connection_timeout));
+            }
+            this->cv.notify_all();
+
             this->evses.at(evse_id)->plugged_in = true;
-
-            this->evses.at(evse_id)->timeout_timer.timeout(
-                [this, evse_id]() {
-                    std::lock_guard<std::mutex> lk(this->event_mutex);
-
-                    EVLOG_info << "Plug In timeout for evse#" << evse_id << ". Replug required for this EVSE";
-                    this->withdraw_authorization_callback(this->evses.at(evse_id)->evse_index);
-
-                    this->plug_in_queue.remove_if([evse_id](int value) { return value == evse_id; });
-                    this->evses.at(evse_id)->plug_in_timeout = true;
-                },
-                std::chrono::seconds(this->connection_timeout));
         }
     } break;
     case SessionEventEnum::TransactionStarted: {

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -1793,7 +1793,7 @@ TEST_F(AuthTest, test_withdraw_authorization_during_transaction) {
 
 /// \brief Test two successive authorization requests and connector selection. The first authorization request targets
 /// only connector1, the second authorization request targets connector1 and connector2. Connector2 should be selected,
-/// since the transaction at connecto1 is already running.
+/// since the transaction at connector1 is already running.
 TEST_F(AuthTest, test_two_authorization_plug_events) {
 
     std::vector<int32_t> connector_1{1};

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -376,7 +376,7 @@ TEST_F(AuthTest, test_authorize_first) {
 
     std::thread t1([this, provided_token, &result]() { result = this->auth_handler->on_token(provided_token); });
 
-    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::Authorized);
+    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
 
     std::thread t2([this, session_event]() { this->auth_handler->handle_session_event(1, session_event); });
 
@@ -437,7 +437,7 @@ TEST_F(AuthTest, test_swipe_multiple_times_with_timeout) {
 
     std::thread t5([this, provided_token, &result5]() { result5 = this->auth_handler->on_token(provided_token); });
 
-    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::Authorized);
+    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
     std::thread t6([this, session_event]() { this->auth_handler->handle_session_event(2, session_event); });
 
     t5.join();
@@ -470,7 +470,7 @@ TEST_F(AuthTest, test_two_id_tokens) {
     std::thread t1([this, provided_token_1, &result1]() { result1 = this->auth_handler->on_token(provided_token_1); });
     std::thread t2([this, provided_token_2, &result2]() { result2 = this->auth_handler->on_token(provided_token_2); });
 
-    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::Authorized);
+    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
     std::thread t3([this, session_event]() { this->auth_handler->handle_session_event(1, session_event); });
     std::thread t4([this, session_event]() { this->auth_handler->handle_session_event(2, session_event); });
 
@@ -1032,7 +1032,7 @@ TEST_F(AuthTest, test_reservation_with_authorization_global_reservations) {
 
     // this token is not valid for the reservation
     std::thread t2([this, provided_token_1, &result]() { result = this->auth_handler->on_token(provided_token_1); });
-    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::Authorized);
+    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
     std::thread t3([this, session_event]() { this->auth_handler->handle_session_event(2, session_event); });
 
     t2.join();
@@ -1243,7 +1243,7 @@ TEST_F(AuthTest, test_authorization_timeout_and_reswipe) {
 
     std::thread t2([this, provided_token, &result]() { result = this->auth_handler->on_token(provided_token); });
 
-    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::Authorized);
+    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
 
     std::thread t3([this, session_event]() { this->auth_handler->handle_session_event(1, session_event); });
 
@@ -1789,6 +1789,54 @@ TEST_F(AuthTest, test_withdraw_authorization_during_transaction) {
     types::authorization::WithdrawAuthorizationRequest withdraw_request;
     withdraw_request.id_token = {VALID_TOKEN_1, types::authorization::IdTokenType::ISO14443};
     this->auth_handler->handle_withdraw_authorization(withdraw_request);
+}
+
+/// \brief Test two successive authorization requests and connector selection. The first authorization request targets
+/// only connector1, the second authorization request targets connector1 and connector2. Connector2 should be selected,
+/// since the transaction at connecto1 is already running.
+TEST_F(AuthTest, test_two_authorization_plug_events) {
+
+    std::vector<int32_t> connector_1{1};
+    std::vector<int32_t> all_connectors{1, 2};
+
+    ProvidedIdToken provided_token_1 = get_provided_token(VALID_TOKEN_1, connector_1);
+    ProvidedIdToken provided_token_2 = get_provided_token(VALID_TOKEN_2, all_connectors);
+
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::Accepted));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Accepted));
+
+    TokenHandlingResult result1;
+
+    std::thread t1([this, provided_token_1, &result1]() { result1 = this->auth_handler->on_token(provided_token_1); });
+
+    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
+
+    std::thread t2([this, session_event]() { this->auth_handler->handle_session_event(1, session_event); });
+
+    t1.join();
+    t2.join();
+
+    ASSERT_TRUE(result1 == TokenHandlingResult::ACCEPTED);
+    ASSERT_TRUE(this->auth_receiver->get_authorization(0));
+    ASSERT_FALSE(this->auth_receiver->get_authorization(1));
+
+    SessionEvent session_event2 = get_transaction_started_event(provided_token_1);
+    this->auth_handler->handle_session_event(1, session_event2);
+
+    TokenHandlingResult result2;
+    std::thread t3([this, provided_token_2, &result2]() { result2 = this->auth_handler->on_token(provided_token_2); });
+
+    t3.join();
+
+    ASSERT_TRUE(result2 == TokenHandlingResult::ACCEPTED);
+    ASSERT_TRUE(this->auth_receiver->get_authorization(0));
+    ASSERT_TRUE(this->auth_receiver->get_authorization(1));
 }
 
 } // namespace module


### PR DESCRIPTION
## Describe your changes
Before selecting an evse to authorize in the Auth module the change removes all evse ids from referenced_connectors if they already received authorization. Additionally, evse_ids are only added to the plug_in_queue in case they are not yet authorized.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

