### PR TITLE
Fixing bad_optional access in EvseManager

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -1175,7 +1175,7 @@ void EvseManager::setup_v2h_mode() {
     types::energy::ExternalLimits external_limits;
     types::energy::ScheduleReqEntry target_entry;
     target_entry.timestamp = timestamp;
-    target_entry.limits_to_leaves.total_power_W = {powersupply_capabilities.max_import_power_W.value(),
+    target_entry.limits_to_leaves.total_power_W = {powersupply_capabilities.max_import_power_W.value_or(0.),
                                                    info.id + "/setup_v2h_mode"};
 
     types::energy::ScheduleReqEntry zero_entry;

--- a/modules/EvseManager/energy_grid/energyImpl.hpp
+++ b/modules/EvseManager/energy_grid/energyImpl.hpp
@@ -52,7 +52,8 @@ private:
     // types::energy_price_information::PricePerkWh price_limit;
     // types::energy::OptimizerTarget optimizer_target;
     types::energy::EnergyFlowRequest energy_flow_request;
-    types::energy::LimitsRes last_enforced_limits;
+    float last_enforced_limits_ampere{-9999};
+    float last_enforced_limits_watt{-9999};
     float last_target_voltage{-9999};
     float last_actual_voltage{-9999};
     void clear_import_request_schedule();


### PR DESCRIPTION
EvseManger crashed with bad_optional access, if the optional values in the capabilities of a power supply DC are not set.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

