### PR TITLE
Cancel Reservation signaling

### DIFF
--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -137,7 +137,7 @@ void evse_managerImpl::ready() {
             if (mod->is_reserved()) {
                 session_started.reservation_id = mod->get_reservation_id();
                 if (start_reason == types::evse_manager::StartSessionReason::Authorized) {
-                    this->mod->cancel_reservation(true);
+                    this->mod->cancel_reservation(false);
                 }
             }
 
@@ -170,7 +170,7 @@ void evse_managerImpl::ready() {
         transaction_started.meter_value = mod->get_latest_powermeter_data_billing();
         if (mod->is_reserved()) {
             transaction_started.reservation_id.emplace(mod->get_reservation_id());
-            mod->cancel_reservation(true);
+            mod->cancel_reservation(false); // this allows OCPP1.6 to not move back to available.
         }
 
         transaction_started.id_tag = id_token;


### PR DESCRIPTION
## Describe your changes
Not singaling cancel reservation in case the reservation is consumed in EvseManager. This fixes some state transition issues in OCPP1.6.

The ReservationCanceled event caused state transition in OCPP1.6 from Reserved->Available->Preparing or Reserved->Available->Charging when transactions started. This change allows for clean transitions Reserved->Preparing in case a transaction starts for both: Authorization First, then plug in and Plug in, then authorization.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

