### PR TITLE
Introduce charger information interface and example implementation

### DIFF
--- a/interfaces/charger_information.yaml
+++ b/interfaces/charger_information.yaml
@@ -1,0 +1,8 @@
+description: This interface is the internal charger information inteface between nodes.
+cmds:
+  get_charger_information:
+    description: Queries the current charger information
+    result:
+      description: Returns an object with the current charger meta information
+      type: object
+      $ref: /charger_information#/ChargerInformation

--- a/modules/API/API.cpp
+++ b/modules/API/API.cpp
@@ -736,6 +736,10 @@ void API::init() {
 void API::ready() {
     invoke_ready(*p_main);
 
+    if (not r_charger_information.empty()) {
+        this->charger_information = r_charger_information.at(0)->call_get_charger_information();
+    }
+
     std::string var_active_errors = this->api_base + "errors/var/active_errors";
     this->api_threads.push_back(std::thread([this, var_active_errors]() {
         auto next_tick = std::chrono::steady_clock::now();

--- a/modules/API/API.hpp
+++ b/modules/API/API.hpp
@@ -14,6 +14,7 @@
 #include <generated/interfaces/empty/Implementation.hpp>
 
 // headers for required interface implementations
+#include <generated/interfaces/charger_information/Interface.hpp>
 #include <generated/interfaces/error_history/Interface.hpp>
 #include <generated/interfaces/evse_manager/Interface.hpp>
 #include <generated/interfaces/external_energy_limits/Interface.hpp>
@@ -159,6 +160,7 @@ class API : public Everest::ModuleBase {
 public:
     API() = delete;
     API(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider, std::unique_ptr<emptyImplBase> p_main,
+        std::vector<std::unique_ptr<charger_informationIntf>> r_charger_information,
         std::vector<std::unique_ptr<evse_managerIntf>> r_evse_manager, std::vector<std::unique_ptr<ocppIntf>> r_ocpp,
         std::vector<std::unique_ptr<uk_random_delayIntf>> r_random_delay,
         std::vector<std::unique_ptr<error_historyIntf>> r_error_history,
@@ -166,6 +168,7 @@ public:
         ModuleBase(info),
         mqtt(mqtt_provider),
         p_main(std::move(p_main)),
+        r_charger_information(std::move(r_charger_information)),
         r_evse_manager(std::move(r_evse_manager)),
         r_ocpp(std::move(r_ocpp)),
         r_random_delay(std::move(r_random_delay)),
@@ -175,6 +178,7 @@ public:
 
     Everest::MqttProvider& mqtt;
     const std::unique_ptr<emptyImplBase> p_main;
+    const std::vector<std::unique_ptr<charger_informationIntf>> r_charger_information;
     const std::vector<std::unique_ptr<evse_managerIntf>> r_evse_manager;
     const std::vector<std::unique_ptr<ocppIntf>> r_ocpp;
     const std::vector<std::unique_ptr<uk_random_delayIntf>> r_random_delay;

--- a/modules/API/manifest.yaml
+++ b/modules/API/manifest.yaml
@@ -173,6 +173,10 @@ provides:
     description: EVerest API
     interface: empty
 requires:
+  charger_information:
+    interface: charger_information
+    min_connections: 0
+    max_connections: 1
   evse_manager:
     interface: evse_manager
     min_connections: 1

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,5 +1,6 @@
 ev_add_module(API)
 ev_add_module(Auth)
+ev_add_module(ChargerInfo)
 ev_add_module(EnergyManager)
 ev_add_module(EnergyNode)
 ev_add_module(EvManager)

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -36,6 +36,7 @@ ev_add_module(DummyTokenValidator)
 ev_add_module(DummyTokenProvider)
 ev_add_module(DummyTokenProviderManual)
 ev_add_module(PhyVersoBSP)
+ev_add_module(YamlStore)
 
 add_subdirectory(examples)
 add_subdirectory(simulation)

--- a/modules/ChargerInfo/CMakeLists.txt
+++ b/modules/ChargerInfo/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+# template version 3
+#
+
+# module setup:
+#   - ${MODULE_NAME}: module name
+ev_setup_cpp_module()
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+# insert your custom targets and additional config variables here
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+
+target_sources(${MODULE_NAME}
+    PRIVATE
+        "main/charger_informationImpl.cpp"
+)
+
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/ChargerInfo/ChargerInfo.cpp
+++ b/modules/ChargerInfo/ChargerInfo.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "ChargerInfo.hpp"
+
+namespace module {
+
+void ChargerInfo::init() {
+    invoke_init(*p_main);
+}
+
+void ChargerInfo::ready() {
+    invoke_ready(*p_main);
+}
+
+} // namespace module

--- a/modules/ChargerInfo/ChargerInfo.hpp
+++ b/modules/ChargerInfo/ChargerInfo.hpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef CHARGER_INFO_HPP
+#define CHARGER_INFO_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 2
+//
+
+#include "ld-ev.hpp"
+
+// headers for provided interface implementations
+#include <generated/interfaces/charger_information/Implementation.hpp>
+
+// headers for required interface implementations
+#include <generated/interfaces/kvs/Interface.hpp>
+
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+// insert your custom include headers here
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
+
+struct Conf {
+    std::string firmware_version_file;
+};
+
+class ChargerInfo : public Everest::ModuleBase {
+public:
+    ChargerInfo() = delete;
+    ChargerInfo(const ModuleInfo& info, std::unique_ptr<charger_informationImplBase> p_main,
+                std::vector<std::unique_ptr<kvsIntf>> r_kvs, Conf& config) :
+        ModuleBase(info), p_main(std::move(p_main)), r_kvs(std::move(r_kvs)), config(config){};
+
+    const std::unique_ptr<charger_informationImplBase> p_main;
+    const std::vector<std::unique_ptr<kvsIntf>> r_kvs;
+    const Conf& config;
+
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+    // insert your public definitions here
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+
+protected:
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+    // insert your protected definitions here
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+
+private:
+    friend class LdEverest;
+    void init();
+    void ready();
+
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+    // insert your private definitions here
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+};
+
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+// insert other definitions here
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+
+} // namespace module
+
+#endif // CHARGER_INFO_HPP

--- a/modules/ChargerInfo/charger_info.yaml
+++ b/modules/ChargerInfo/charger_info.yaml
@@ -1,0 +1,6 @@
+manufacturer: "Pionix GmbH"
+manufacturer_url: "https://www.pionix.com/"
+vendor: "Pionix"
+model: "BelayBox"
+serial: "0123"
+firmware_version: "0.1.2"

--- a/modules/ChargerInfo/main/charger_informationImpl.cpp
+++ b/modules/ChargerInfo/main/charger_informationImpl.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "charger_informationImpl.hpp"
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace module {
+namespace main {
+
+void charger_informationImpl::init() {
+}
+
+void charger_informationImpl::ready() {
+    json info(handle_get_charger_information());
+
+    EVLOG_debug << "ChargerInformation: " << info.dump();
+}
+
+std::string charger_informationImpl::load_fw_version_from_file(const std::string& fn) {
+    std::ifstream fw_version_file(fn);
+    std::string first_line;
+
+    if (!fw_version_file)
+        return "";
+
+    if (!std::getline(fw_version_file, first_line))
+        return "";
+
+    return first_line;
+}
+
+types::charger_information::ChargerInformation charger_informationImpl::handle_get_charger_information() {
+    std::vector<std::string> keys = {"vendor",           "model",     "serial",   "friendly_name", "manufacturer",
+                                     "manufacturer_url", "model_url", "model_no", "revision",      "board_revision",
+                                     "firmware_version"};
+    json info = {};
+
+    // iterate over all linked key-value stores and merge all items,
+    // when a key exists in more than one kvs then the last one wins
+    for (const auto& kvs : mod->r_kvs) {
+        for (const auto k : keys)
+            if (kvs->call_exists(k)) {
+                const auto v = kvs->call_load(k);
+                info[k] = std::get<std::string>(v);
+            }
+    }
+
+    // finally check whether we should load the firmware version from a simple plain text file
+    if (!mod->config.firmware_version_file.empty()) {
+        info["firmware_version"] = load_fw_version_from_file(mod->config.firmware_version_file);
+    }
+
+    // generate fallback friendly_name
+    if (info.contains("vendor") and info.contains("model") and info.contains("serial") and
+        not info.contains("friendly_name")) {
+        info["friendly_name"] = info["vendor"].get<std::string>() + " " + info["model"].get<std::string>() + " [" +
+                                info["serial"].get<std::string>() + "]";
+    }
+
+    EVLOG_debug << "ChargerInformation: " << info.dump();
+
+    return info;
+}
+
+} // namespace main
+} // namespace module

--- a/modules/ChargerInfo/main/charger_informationImpl.hpp
+++ b/modules/ChargerInfo/main/charger_informationImpl.hpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef MAIN_CHARGER_INFORMATION_IMPL_HPP
+#define MAIN_CHARGER_INFORMATION_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/charger_information/Implementation.hpp>
+
+#include "../ChargerInfo.hpp"
+
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+// insert your custom include headers here
+#include <string>
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+
+namespace module {
+namespace main {
+
+struct Conf {};
+
+class charger_informationImpl : public charger_informationImplBase {
+public:
+    charger_informationImpl() = delete;
+    charger_informationImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<ChargerInfo>& mod, Conf& config) :
+        charger_informationImplBase(ev, "main"), mod(mod), config(config){};
+
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+    // insert your public definitions here
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+
+protected:
+    // command handler functions (virtual)
+    virtual types::charger_information::ChargerInformation handle_get_charger_information() override;
+
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+    // insert your protected definitions here
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+
+private:
+    const Everest::PtrContainer<ChargerInfo>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+    // insert your private definitions here
+    std::string load_fw_version_from_file(const std::string& fn);
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+};
+
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+// insert other definitions here
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+
+} // namespace main
+} // namespace module
+
+#endif // MAIN_CHARGER_INFORMATION_IMPL_HPP

--- a/modules/ChargerInfo/manifest.yaml
+++ b/modules/ChargerInfo/manifest.yaml
@@ -1,0 +1,23 @@
+description: Provides a charger information interface, backed by simple KVS interface.
+config:
+  firmware_version_file:
+    description: >-
+      Sometimes the firmware version cannot be retrieved from the key-value interface.
+      Then it is possible to provide the firmware version string from a simple text file
+      in the filesystem. The first line of this file is used as-is, the remaining file content
+      is ignored.
+      Give the full path to the file which contains the firmware version string.
+    type: string
+provides:
+  main:
+    interface: charger_information
+    description: Provides the charger information interface
+requires:
+  kvs:
+    interface: kvs
+    min_connections: 1
+    max_connections: 3
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Michael Heimpold

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -901,6 +901,13 @@ void OCPP::ready() {
         this->evse_ready_cv.wait(lk);
     }
 
+    // if charger information interface is connected, override only these specific properties
+    // which were loaded from configuration file(s)
+    if (!this->r_charger_information.empty()) {
+        auto ci = this->r_charger_information.at(0)->call_get_charger_information();
+        this->charge_point->update_chargepoint_information(ci.vendor, ci.model, ci.serial, ci.firmware_version);
+    }
+
     const auto boot_reason = conversions::to_ocpp_boot_reason_enum(this->r_system->call_get_boot_reason());
     if (this->charge_point->start({}, boot_reason, this->resuming_session_ids)) {
         // signal that we're started

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -20,6 +20,7 @@
 
 // headers for required interface implementations
 #include <generated/interfaces/auth/Interface.hpp>
+#include <generated/interfaces/charger_information/Interface.hpp>
 #include <generated/interfaces/display_message/Interface.hpp>
 #include <generated/interfaces/evse_manager/Interface.hpp>
 #include <generated/interfaces/evse_security/Interface.hpp>
@@ -76,6 +77,7 @@ public:
          std::unique_ptr<auth_token_providerImplBase> p_auth_provider,
          std::unique_ptr<ocpp_data_transferImplBase> p_data_transfer, std::unique_ptr<ocppImplBase> p_ocpp_generic,
          std::unique_ptr<session_costImplBase> p_session_cost,
+         std::vector<std::unique_ptr<charger_informationIntf>> r_charger_information,
          std::vector<std::unique_ptr<evse_managerIntf>> r_evse_manager,
          std::vector<std::unique_ptr<external_energy_limitsIntf>> r_evse_energy_sink,
          std::unique_ptr<reservationIntf> r_reservation, std::unique_ptr<authIntf> r_auth,
@@ -91,6 +93,7 @@ public:
         p_data_transfer(std::move(p_data_transfer)),
         p_ocpp_generic(std::move(p_ocpp_generic)),
         p_session_cost(std::move(p_session_cost)),
+        r_charger_information(std::move(r_charger_information)),
         r_evse_manager(std::move(r_evse_manager)),
         r_evse_energy_sink(std::move(r_evse_energy_sink)),
         r_reservation(std::move(r_reservation)),
@@ -109,6 +112,7 @@ public:
     const std::unique_ptr<ocpp_data_transferImplBase> p_data_transfer;
     const std::unique_ptr<ocppImplBase> p_ocpp_generic;
     const std::unique_ptr<session_costImplBase> p_session_cost;
+    const std::vector<std::unique_ptr<charger_informationIntf>> r_charger_information;
     const std::vector<std::unique_ptr<evse_managerIntf>> r_evse_manager;
     const std::vector<std::unique_ptr<external_energy_limitsIntf>> r_evse_energy_sink;
     const std::unique_ptr<reservationIntf> r_reservation;

--- a/modules/OCPP/manifest.yaml
+++ b/modules/OCPP/manifest.yaml
@@ -73,6 +73,10 @@ provides:
     description: Send session cost
     interface: session_cost
 requires:
+  charger_information:
+    interface: charger_information
+    min_connections: 0
+    max_connections: 1
   evse_manager:
     interface: evse_manager
     min_connections: 1

--- a/modules/YamlStore/CMakeLists.txt
+++ b/modules/YamlStore/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+# template version 3
+#
+
+# module setup:
+#   - ${MODULE_NAME}: module name
+ev_setup_cpp_module()
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+# insert your custom targets and additional config variables here
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+
+target_sources(${MODULE_NAME}
+    PRIVATE
+        "main/kvsImpl.cpp"
+)
+
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/YamlStore/YamlStore.cpp
+++ b/modules/YamlStore/YamlStore.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "YamlStore.hpp"
+
+namespace module {
+
+void YamlStore::init() {
+    invoke_init(*p_main);
+}
+
+void YamlStore::ready() {
+    invoke_ready(*p_main);
+}
+
+} // namespace module

--- a/modules/YamlStore/YamlStore.hpp
+++ b/modules/YamlStore/YamlStore.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef YAML_STORE_HPP
+#define YAML_STORE_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 2
+//
+
+#include "ld-ev.hpp"
+
+// headers for provided interface implementations
+#include <generated/interfaces/kvs/Implementation.hpp>
+
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+// insert your custom include headers here
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
+
+struct Conf {
+    std::string file;
+};
+
+class YamlStore : public Everest::ModuleBase {
+public:
+    YamlStore() = delete;
+    YamlStore(const ModuleInfo& info, std::unique_ptr<kvsImplBase> p_main, Conf& config) :
+        ModuleBase(info), p_main(std::move(p_main)), config(config){};
+
+    const std::unique_ptr<kvsImplBase> p_main;
+    const Conf& config;
+
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+    // insert your public definitions here
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+
+protected:
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+    // insert your protected definitions here
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+
+private:
+    friend class LdEverest;
+    void init();
+    void ready();
+
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+    // insert your private definitions here
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+};
+
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+// insert other definitions here
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+
+} // namespace module
+
+#endif // YAML_STORE_HPP

--- a/modules/YamlStore/main/kvsImpl.cpp
+++ b/modules/YamlStore/main/kvsImpl.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "kvsImpl.hpp"
+#include <filesystem>
+#include <string>
+#include <utils/yaml_loader.hpp>
+#include <variant>
+
+namespace module {
+namespace main {
+
+void kvsImpl::init() {
+    auto kv_file_path = std::filesystem::path(mod->config.file);
+
+    try {
+        data = Everest::load_yaml(kv_file_path);
+    } catch (const std::exception& err) {
+        EVLOG_error << "Error parsing YAML file at " << mod->config.file << ": " << err.what();
+    }
+}
+
+void kvsImpl::ready() {
+}
+
+void kvsImpl::handle_store(std::string& key,
+                           std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string>& value) {
+    // this is a read-only kvs - do nothing but prevent compiler warnings about unused parameters
+    (void)key;
+    (void)value;
+}
+
+std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string> kvsImpl::handle_load(std::string& key) {
+    if (data.contains(key)) {
+        std::string value{data[key]};
+        return value;
+    }
+    return nullptr;
+}
+
+void kvsImpl::handle_delete(std::string& key) {
+    // this is a read-only kvs - do nothing but prevent compiler warnings about unused parameters
+    (void)key;
+}
+
+bool kvsImpl::handle_exists(std::string& key) {
+    return data.contains(key);
+}
+
+} // namespace main
+} // namespace module

--- a/modules/YamlStore/main/kvsImpl.hpp
+++ b/modules/YamlStore/main/kvsImpl.hpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef MAIN_KVS_IMPL_HPP
+#define MAIN_KVS_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/kvs/Implementation.hpp>
+
+#include "../YamlStore.hpp"
+
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+// insert your custom include headers here
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+
+namespace module {
+namespace main {
+
+struct Conf {};
+
+class kvsImpl : public kvsImplBase {
+public:
+    kvsImpl() = delete;
+    kvsImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<YamlStore>& mod, Conf& config) :
+        kvsImplBase(ev, "main"), mod(mod), config(config){};
+
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+    // insert your public definitions here
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+
+protected:
+    // command handler functions (virtual)
+    virtual void
+    handle_store(std::string& key,
+                 std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string>& value) override;
+    virtual std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string>
+    handle_load(std::string& key) override;
+    virtual void handle_delete(std::string& key) override;
+    virtual bool handle_exists(std::string& key) override;
+
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+    // insert your protected definitions here
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+
+private:
+    const Everest::PtrContainer<YamlStore>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+    // cached data
+    json data;
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+};
+
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+// insert other definitions here
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+
+} // namespace main
+} // namespace module
+
+#endif // MAIN_KVS_IMPL_HPP

--- a/modules/YamlStore/manifest.yaml
+++ b/modules/YamlStore/manifest.yaml
@@ -1,0 +1,13 @@
+description: Provides a (read-only) key-value store interface, backed by a simple YAML file.
+config:
+  file:
+    description: Path to the YAML file used as persistent key-value store.
+    type: string
+provides:
+  main:
+    interface: kvs
+    description: Provides the key-value interface
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Michael Heimpold

--- a/types/charger_information.yaml
+++ b/types/charger_information.yaml
@@ -1,0 +1,82 @@
+description: EVerest charger information type
+types:
+  ChargerInformation:
+    description: >-
+      Type holding meta information about the whole charger.
+      Note: Vendor and manufacturer refer here to the very same company - it is the brand
+      which appears physically on the device label and/or which is shown on device's web
+      frontend, in UPnP etc.
+    type: object
+    additionalProperties: false
+    required:
+      - vendor
+      - model
+      - serial
+    properties:
+      vendor:
+        description: >-
+          Name of vendor, not including any legal form. Is typically used with `model` to
+          form a unique product name aka `vendor` + `single whitespace` + `model`.
+          Example: Pionix
+        type: string
+      model:
+        description: >-
+          A human-friedly name of the model, aka the product name; without vendor name,
+          without any device specific data/numbers (serial numbers/MAC addresses).
+          Example: BelayBox
+        type: string
+      serial:
+        description: >-
+          The traditional serial number as string. It does not necessarily consist of digits only.
+          Usually, this serial appears also on a label on the device.
+          Example: SH4CAWN00123
+        type: string
+      friendly_name:
+        description: >-
+          A string with can be used to display the device eg. in network listings/enumerations.
+          As mentioned above, this could typically consist of eg.:
+          `vendor` + `single whitespace` + `model` + ` [` + `serial` + `]`
+          Printers or wifi access points for example often use the last digits of their
+          MAC address instead of the serial number to allow users to differentiate multiple
+          instances in the network.
+        type: string
+      manufacturer:
+        description: >-
+          The name of the vendor, but this may include the legal form.
+          Typically used in product property lists or as text for the following URL.
+        type: string
+      manufacturer_url:
+        description: >-
+          An URL to the vendor website, ideally not a deep link so that it is available for
+          the whole product lifetime.
+        type: string
+      model_url:
+        description: >-
+          An URL to the model website (if any); as above, ideally not a deep link.
+        type: string
+      model_no:
+        description: >-
+          A model number as string (if any).
+        type: string
+      revision:
+        description: >-
+          A product revision string. Very often this is not defined for the first product
+          revision so that users of this variable should consider reasonable fallback/default
+          values. For later product revisions, this is typically printed also on a device label
+          so that customers can refer to it when e.g requesting product support.
+        type: string
+      board_revision:
+        description: >-
+          The revision (aka version) of the internal (main) PCB, ie. that one with
+          the CPU running the EVerest system.
+        type: string
+      firmware_version:
+        description: >-
+          A string containing the current running firmware version of the complete system.
+          This is typically not the EVerest version itself, but a firmware version which appears
+          e.g. on the web frontend and as part of the filenames the customer can download from
+          the manufacturer website.
+          This is the only property which is typically not static for the product lifetime,
+          but determined at runtime.
+        type: string
+      


### PR DESCRIPTION
## Describe your changes

This PR introduces a new 'charger information' interface and corresponding types. The idea is that this interface is a common base to bundle some meta/high-level information about the charger itself.
To illustrate the usage, the existing API and OCPP 1.6 modules are extended while keeping existing functionality and thus backwards compatibility if this new approach is not needed in existing installations.

## Issue ticket number and link

Note: this PR depends on https://github.com/EVerest/libocpp/pull/1026

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

