### PR TITLE
EvseManager: Fix deadlock between hlc_mutex and state_machine_mutex

### DIFF
--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -194,7 +194,6 @@ public:
     bool reserve(int32_t id, const bool signal_reservation_event = true);
     int32_t get_reservation_id();
 
-    bool get_hlc_enabled();
     bool get_hlc_waiting_for_auth_pnc();
     void set_pnc_enabled(const bool pnc_enabled);
     void set_central_contract_validation_allowed(const bool central_contract_validation_allowed);
@@ -299,16 +298,14 @@ private:
 
     std::atomic_bool contactor_open{true};
 
-    Everest::timed_mutex_traceable hlc_mutex;
+    std::atomic_bool hlc_enabled;
 
-    bool hlc_enabled;
+    std::atomic_bool hlc_waiting_for_auth_eim;
+    std::atomic_bool hlc_waiting_for_auth_pnc;
 
-    bool hlc_waiting_for_auth_eim;
-    bool hlc_waiting_for_auth_pnc;
-
-    bool pnc_enabled{false};
-    bool central_contract_validation_allowed{false};
-    bool contract_certificate_installation_enabled{false};
+    std::atomic_bool pnc_enabled{false};
+    std::atomic_bool central_contract_validation_allowed{false};
+    std::atomic_bool contract_certificate_installation_enabled{false};
 
     VarContainer<types::isolation_monitor::IsolationMeasurement> isolation_measurement;
     VarContainer<types::power_supply_DC::VoltageCurrent> powersupply_measurement;

--- a/modules/EvseManager/scoped_lock_timeout.hpp
+++ b/modules/EvseManager/scoped_lock_timeout.hpp
@@ -74,24 +74,13 @@ enum class MutexDescription {
     EVSE_subscribe_dc_bulk_soc,
     EVSE_subscribe_dc_ev_remaining_time,
     EVSE_subscribe_dc_ev_status,
-    EVSE_subscribe_require_auth_eim,
-    EVSE_publish_provided_token,
     EVSE_subscribe_evcc_id,
-    EVSE_subscribe_require_auth_pnc,
-    EVSE_subscribe_require_auth_pnc2,
-    EVSE_signal_event,
     EVSE_subscribe_powermeter,
     EVSE_get_latest_powermeter_data_billing,
     EVSE_get_reservation_id,
     EVSE_reserve,
     EVSE_cancel_reservation,
     EVSE_is_reserved,
-    EVSE_get_hlc_enabled,
-    EVSE_get_hlc_waiting_for_auth_pnc,
-    EVSE_set_pnc_enabled,
-    EVSE_set_central_contract_validation_allowed,
-    EVSE_set_contract_certificate_installation_enabled,
-    EVSE_charger_was_authorized,
     EVSE_get_ev_info
 };
 
@@ -213,18 +202,8 @@ static std::string to_string(MutexDescription d) {
         return "EvseManager.cpp: subscribe_dc_ev_remaining_time";
     case MutexDescription::EVSE_subscribe_dc_ev_status:
         return "EvseManager.cpp subscribe_dc_ev_status";
-    case MutexDescription::EVSE_subscribe_require_auth_eim:
-        return "EvseManager.cpp: subscribe_require_auth_eim";
-    case MutexDescription::EVSE_publish_provided_token:
-        return "EvseManager.cpp: publish_provided_token";
     case MutexDescription::EVSE_subscribe_evcc_id:
         return "EvseManager.cpp: subscribe_evcc_id";
-    case MutexDescription::EVSE_subscribe_require_auth_pnc:
-        return "EvseManager.cpp: subscribe_require_auth_pnc 1";
-    case MutexDescription::EVSE_subscribe_require_auth_pnc2:
-        return "EvseManager.cpp: subscribe_require_auth_pnc 2";
-    case MutexDescription::EVSE_signal_event:
-        return "EvseManager.cpp: bsp->signal_event.connect";
     case MutexDescription::EVSE_subscribe_powermeter:
         return "EvseManager.cpp: subscribe_powermeter";
     case MutexDescription::EVSE_get_latest_powermeter_data_billing:
@@ -237,18 +216,6 @@ static std::string to_string(MutexDescription d) {
         return "EvseManager.cpp: cancel_reservation";
     case MutexDescription::EVSE_is_reserved:
         return "EvseManager.cpp: is_reserved";
-    case MutexDescription::EVSE_get_hlc_enabled:
-        return "EvseManager.cpp: get_hlc_enabled";
-    case MutexDescription::EVSE_get_hlc_waiting_for_auth_pnc:
-        return "EvseManager.cpp: get_hlc_waiting_for_auth_pnc";
-    case MutexDescription::EVSE_set_pnc_enabled:
-        return "EvseManager.cpp: EVSE_set_pnc_enabled";
-    case MutexDescription::EVSE_set_central_contract_validation_allowed:
-        return "EvseManager.cpp: EVSE_set_central_contract_validation_allowed";
-    case MutexDescription::EVSE_set_contract_certificate_installation_enabled:
-        return "EvseManager.cpp: EVSE_set_contract_certificate_installation_enabled";
-    case MutexDescription::EVSE_charger_was_authorized:
-        return "EvseManager.cpp: charger_was_authorized";
     case MutexDescription::EVSE_get_ev_info:
         return "EvseManager.cpp: get_ev_info";
     }


### PR DESCRIPTION
## Describe your changes

In rare occasions, a mutex deadlock could occur between hlc_mutex and state_machine_mutex. This PR removes hlc_mutex as it can be replaced by simple atomic_bools

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

