### PR TITLE
Addressed added argument to libevse-security for verify_certificate

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -61,13 +61,13 @@ libcurl:
 # of libocpp and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: v0.9.4
+  git_tag: v0.9.5
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 3b1edda8c4e721a5bde3ce16fd9190263358a063
+  git_tag: a43df192cd0712cf71e921058021f9a78ccdabcd
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/interfaces/evse_security.yaml
+++ b/interfaces/evse_security.yaml
@@ -49,10 +49,13 @@ cmds:
       certificate_chain:
         description: Leaf certificate or certificate chain that is to be verified
         type: string
-      certificate_type:
+      certificate_types:
         description: Indicates the type of the certificate
-        type: string
-        $ref: /evse_security#/LeafCertificateType
+        type: array
+        items:
+          minimum: 1
+          type: string
+          $ref: /evse_security#/LeafCertificateType
     result:
       description: Result of the verification
       type: string

--- a/lib/staging/ocpp/evse_security_ocpp.hpp
+++ b/lib/staging/ocpp/evse_security_ocpp.hpp
@@ -22,6 +22,9 @@ public:
     delete_certificate(const ocpp::CertificateHashDataType& certificate_hash_data) override;
     ocpp::CertificateValidationResult verify_certificate(const std::string& certificate_chain,
                                                          const ocpp::LeafCertificateType& certificate_type) override;
+    ocpp::CertificateValidationResult
+    verify_certificate(const std::string& certificate_chain,
+                       const std::vector<ocpp::LeafCertificateType>& certificate_types) override;
     ocpp::InstallCertificateResult
     update_leaf_certificate(const std::string& certificate_chain,
                             const ocpp::CertificateSigningUseEnum& certificate_type) override;

--- a/modules/EvseSecurity/main/evse_securityImpl.cpp
+++ b/modules/EvseSecurity/main/evse_securityImpl.cpp
@@ -65,12 +65,21 @@ evse_securityImpl::handle_update_leaf_certificate(std::string& certificate_chain
     }
 }
 
-types::evse_security::CertificateValidationResult
-evse_securityImpl::handle_verify_certificate(std::string& certificate_chain,
-                                             types::evse_security::LeafCertificateType& certificate_type) {
+types::evse_security::CertificateValidationResult evse_securityImpl::handle_verify_certificate(
+    std::string& certificate_chain, std::vector<types::evse_security::LeafCertificateType>& certificate_types) {
+
+    std::vector<evse_security::LeafCertificateType> _certificate_types;
+
+    for (const auto& certificate_type : certificate_types) {
+        try {
+            _certificate_types.push_back(conversions::from_everest(certificate_type));
+        } catch (const std::out_of_range& e) {
+            EVLOG_warning << e.what();
+        }
+    }
+
     try {
-        return conversions::to_everest(
-            this->evse_security->verify_certificate(certificate_chain, conversions::from_everest(certificate_type)));
+        return conversions::to_everest(this->evse_security->verify_certificate(certificate_chain, _certificate_types));
     } catch (const std::out_of_range& e) {
         EVLOG_warning << e.what();
         return types::evse_security::CertificateValidationResult::Unknown;

--- a/modules/EvseSecurity/main/evse_securityImpl.hpp
+++ b/modules/EvseSecurity/main/evse_securityImpl.hpp
@@ -44,7 +44,7 @@ protected:
                                    types::evse_security::LeafCertificateType& certificate_type) override;
     virtual types::evse_security::CertificateValidationResult
     handle_verify_certificate(std::string& certificate_chain,
-                              types::evse_security::LeafCertificateType& certificate_type) override;
+                              std::vector<types::evse_security::LeafCertificateType>& certificate_types) override;
     virtual types::evse_security::GetInstalledCertificatesResult
     handle_get_installed_certificates(std::vector<types::evse_security::CertificateType>& certificate_types) override;
     virtual types::evse_security::OCSPRequestDataList handle_get_v2g_ocsp_request_data() override;


### PR DESCRIPTION
## Describe your changes
Addressed changed API in libevse-security, which added a new function.

```cpp
CertificateValidationResult verify_certificate(const std::string& certificate_chain,
    const std::vector<LeafCertificateType>& certificate_types);
```

The EVerest `evse_security` interface has been changed from using a single certificate type / trust anchor to using a vector. The usage of this function has been adapted in the `EvseSecurity` module.

## Issue ticket number and link
PR in libevse-security: https://github.com/EVerest/libevse-security/pull/105

[ ] Update libocpp dependency once merged: https://github.com/EVerest/libocpp/pull/1033

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

