### PR TITLE
GenericPowermeter: improve error handling

### DIFF
--- a/modules/GenericPowermeter/CMakeLists.txt
+++ b/modules/GenericPowermeter/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(${MODULE_NAME}
         "main/powermeterImpl.cpp"
 )
 
+target_compile_features(${MODULE_NAME} PRIVATE cxx_std_17)
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 # insert other things like install cmds etc here
 target_link_libraries(${MODULE_NAME} PRIVATE everest::framework)

--- a/modules/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.cpp
@@ -3,6 +3,8 @@
 
 #include "powermeterImpl.hpp"
 #include <fmt/core.h>
+#include <functional>
+#include <optional>
 #include <thread>
 #include <utils/date.hpp>
 #include <utils/yaml_loader.hpp>
@@ -16,35 +18,34 @@ namespace main {
 
 void powermeterImpl::init() {
 
-    std::size_t found = config.model.find(".."); // check for invalid path
+    const std::size_t found = this->config.model.find(".."); // check for invalid path
     if (found != std::string::npos) {
-        EVLOG_error << "Error! Substring \"..\" not allowed in model name!\n";
-    } else {
-        // FIXME (aw): path validation?
-        auto model = this->mod->info.paths.share / MODELS_SUB_DIR / fmt::format("{}.yaml", config.model);
+        EVLOG_error << fmt::format("Error! Substring \"..\" not allowed in given model name '{}'!", this->config.model);
+        throw std::runtime_error("Incorrect model name in GenericPowermeter config");
+    }
 
-        try {
-            json powermeter_registers = Everest::load_yaml(model);
-            this->init_register_assignments(std::move(powermeter_registers));
-            this->init_default_values();
-        } catch (const std::exception& e) {
-            EVLOG_error << "opening file \"" << config.model << ".yaml\" from path " << model
-                        << "\" failed: " << e.what();
-            throw std::runtime_error("Module \"GenericPowermeter\" could not be initialized!");
-        }
+    const auto model = this->mod->info.paths.share / MODELS_SUB_DIR / fmt::format("{}.yaml", this->config.model);
+
+    try {
+        const json powermeter_registers = Everest::load_yaml(model);
+        this->init_register_assignments(std::move(powermeter_registers));
+        this->init_default_values();
+    } catch (const std::exception& e) {
+        EVLOG_error << "opening file \"" << this->config.model << ".yaml\" from path " << model
+                    << " failed: " << e.what();
+        throw std::runtime_error(fmt::format("Module \"GenericPowermeter\" could not be initialized: {}", e.what()));
     }
 }
 
 void powermeterImpl::ready() {
-    if (this->config_loaded_successfully) {
-        std::thread t([this] {
-            while (true) {
-                read_powermeter_values();
-                sleep(1);
-            }
-        });
-        t.detach();
-    }
+    std::thread([this] {
+        while (true) {
+            this->read_powermeter_values();
+            // Note: reading the power meter values may take several seconds already, so the complete loop
+            // time of this function will be well beyond the sleep time given below.
+            sleep(1);
+        }
+    }).detach();
 }
 
 types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
@@ -64,7 +65,7 @@ void powermeterImpl::init_default_values() {
     this->pm_last_values.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     this->pm_last_values.meter_id = std::string(this->mod->info.id);
 
-    for (auto& register_data : this->pm_configuration) {
+    for (const auto& register_data : this->pm_configuration) {
         if (register_data.type == ENERGY_WH_IMPORT_TOTAL) {
             this->pm_last_values.energy_Wh_import.total = 0.0f;
         } else if (register_data.type == ENERGY_WH_IMPORT_L1) {
@@ -239,39 +240,37 @@ void powermeterImpl::init_default_values() {
 }
 
 void powermeterImpl::init_register_assignments(const json& loaded_registers) {
-    uint8_t failed = 0;
-    failed += assign_register_data(loaded_registers, ENERGY_WH_IMPORT_TOTAL, "energy_Wh_import");
-    failed += assign_register_data(loaded_registers, ENERGY_WH_EXPORT_TOTAL, "energy_Wh_export");
-    failed += assign_register_data(loaded_registers, POWER_W_TOTAL, "power_W");
-    failed += assign_register_data(loaded_registers, VOLTAGE_V_DC, "voltage_V");
-    failed += assign_register_data(loaded_registers, REACTIVE_POWER_VAR_TOTAL, "reactive_power_VAR");
-    failed += assign_register_data(loaded_registers, CURRENT_A_DC, "current_A");
-    failed += assign_register_data(loaded_registers, FREQUENCY_HZ_L1, "frequency_Hz");
+    bool failed{false};
+    failed |= not this->assign_register_data(loaded_registers, ENERGY_WH_IMPORT_TOTAL, "energy_Wh_import");
+    failed |= not this->assign_register_data(loaded_registers, ENERGY_WH_EXPORT_TOTAL, "energy_Wh_export");
+    failed |= not this->assign_register_data(loaded_registers, POWER_W_TOTAL, "power_W");
+    failed |= not this->assign_register_data(loaded_registers, VOLTAGE_V_DC, "voltage_V");
+    failed |= not this->assign_register_data(loaded_registers, REACTIVE_POWER_VAR_TOTAL, "reactive_power_VAR");
+    failed |= not this->assign_register_data(loaded_registers, CURRENT_A_DC, "current_A");
+    failed |= not this->assign_register_data(loaded_registers, FREQUENCY_HZ_L1, "frequency_Hz");
 
     if (failed) {
-        EVLOG_error << "Could not load powermeter configuration!\n";
-        this->config_loaded_successfully = false;
-    } else {
-        this->config_loaded_successfully = true;
+        EVLOG_error << "Could not load powermeter model configuration!";
+        throw std::runtime_error("Could not load GenericPowermeter model configuration");
     }
 }
 
-int powermeterImpl::assign_register_data(const json& registers, const PowermeterRegisters register_type,
-                                         const std::string& register_selector) {
+bool powermeterImpl::assign_register_data(const json& registers, const PowermeterRegisters register_type,
+                                          const std::string& register_selector) {
     try {
         if (registers.contains(register_selector)) {
             if (registers.at(register_selector).at("num_registers") > 0) {
                 RegisterData data = {};
                 data.type = register_type;
                 data.start_register = registers.at(register_selector).at("start_register");
-                data.start_register_function = select_modbus_function(
+                data.start_register_function = this->select_modbus_function(
                     (const uint8_t)registers.at(register_selector).at("function_code_start_reg"));
                 data.num_registers = registers.at(register_selector).at("num_registers");
                 data.exponent_register = registers.at(register_selector).at("exponent_register");
-                data.exponent_register_function =
-                    select_modbus_function((const uint8_t)registers.at(register_selector).at("function_code_exp_reg"));
+                data.exponent_register_function = this->select_modbus_function(
+                    (const uint8_t)registers.at(register_selector).at("function_code_exp_reg"));
                 data.multiplier = registers.at(register_selector).at("multiplier");
-                pm_configuration.push_back(data);
+                this->pm_configuration.push_back(data);
             }
             if (registers.at(register_selector).contains("L1")) {
                 if (registers.at(register_selector).at("L1").at("num_registers") > 0) {
@@ -290,11 +289,11 @@ int powermeterImpl::assign_register_data(const json& registers, const Powermeter
             }
         }
     } catch (const std::exception& e) {
-        EVLOG_error << "assigning configuration data for register \"" << register_selector << "\" failed: " << e.what();
-        return -1;
+        EVLOG_error << "Assigning configuration data for register \"" << register_selector << "\" failed: " << e.what();
+        return false;
     }
 
-    return 0;
+    return true;
 }
 
 void powermeterImpl::assign_register_sublevel_data(const json& registers, const PowermeterRegisters& register_type,
@@ -304,14 +303,14 @@ void powermeterImpl::assign_register_sublevel_data(const json& registers, const 
     RegisterData sublevel_data = {};
     sublevel_data.type = static_cast<PowermeterRegisters>((register_type + offset) % NUM_PM_REGISTERS);
     sublevel_data.start_register = registers.at(register_selector).at(sublevel_selector).at("start_register");
-    sublevel_data.start_register_function = select_modbus_function(
+    sublevel_data.start_register_function = this->select_modbus_function(
         (const uint8_t)registers.at(register_selector).at(sublevel_selector).at("function_code_start_reg"));
     sublevel_data.num_registers = registers.at(register_selector).at(sublevel_selector).at("num_registers");
     sublevel_data.exponent_register = registers.at(register_selector).at(sublevel_selector).at("exponent_register");
-    sublevel_data.exponent_register_function = select_modbus_function(
+    sublevel_data.exponent_register_function = this->select_modbus_function(
         (const uint8_t)registers.at(register_selector).at(sublevel_selector).at("function_code_exp_reg"));
     sublevel_data.multiplier = registers.at(register_selector).at(sublevel_selector).at("multiplier");
-    pm_configuration.push_back(sublevel_data);
+    this->pm_configuration.push_back(sublevel_data);
 }
 
 powermeterImpl::ModbusFunctionType powermeterImpl::select_modbus_function(const uint8_t function_code) {
@@ -325,184 +324,73 @@ powermeterImpl::ModbusFunctionType powermeterImpl::select_modbus_function(const 
         break;
 
     default:
-        throw std::runtime_error("Incorrect Modbus RTU function code!\n");
+        throw std::runtime_error(fmt::format("Incorrect Modbus RTU function code {}!", function_code));
         break;
     }
     return REGISTER_TYPE_UNDEFINED;
 }
 
 void powermeterImpl::read_powermeter_values() {
-    for (auto& register_data : this->pm_configuration) {
-        readRegister(register_data);
+    static bool pm_values_are_complete{false};
+    bool all_pm_registers_success{true};
+    for (const auto& register_data : this->pm_configuration) {
+        all_pm_registers_success &= this->read_register(register_data);
     }
+    if (all_pm_registers_success) {
+        pm_values_are_complete = true;
+    }
+
+    if (not pm_values_are_complete) {
+        EVLOG_warning << "No complete set of power meter values has been acquired yet. Not publishing.";
+        return;
+    }
+
     this->pm_last_values.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
     this->publish_powermeter(this->pm_last_values);
 }
 
-void powermeterImpl::readRegister(const RegisterData& register_config) {
+bool powermeterImpl::read_register(const RegisterData& register_config) {
 
     types::serial_comm_hub_requests::Result register_response{};
-    types::serial_comm_hub_requests::Result exponent_response{};
+    std::optional<types::serial_comm_hub_requests::Result> exponent_response;
 
     if (register_config.start_register_function == READ_HOLDING_REGISTER) {
         register_response = mod->r_serial_comm_hub->call_modbus_read_holding_registers(
-            config.powermeter_device_id, register_config.start_register, register_config.num_registers);
-    }
-
-    if (register_config.start_register_function == READ_INPUT_REGISTER) {
+            this->config.powermeter_device_id, register_config.start_register, register_config.num_registers);
+    } else if (register_config.start_register_function == READ_INPUT_REGISTER) {
         register_response = mod->r_serial_comm_hub->call_modbus_read_input_registers(
-            config.powermeter_device_id, register_config.start_register - config.modbus_base_address,
+            this->config.powermeter_device_id, register_config.start_register - this->config.modbus_base_address,
             register_config.num_registers);
     }
 
     if (register_config.exponent_register != 0) {
         if (register_config.exponent_register_function == READ_HOLDING_REGISTER) {
             exponent_response = mod->r_serial_comm_hub->call_modbus_read_holding_registers(
-                config.powermeter_device_id, register_config.exponent_register, register_config.num_registers);
-        }
-
-        if (register_config.exponent_register_function == READ_INPUT_REGISTER) {
+                this->config.powermeter_device_id, register_config.exponent_register, register_config.num_registers);
+        } else if (register_config.exponent_register_function == READ_INPUT_REGISTER) {
             exponent_response = mod->r_serial_comm_hub->call_modbus_read_input_registers(
-                config.powermeter_device_id, register_config.exponent_register - config.modbus_base_address,
+                this->config.powermeter_device_id, register_config.exponent_register - this->config.modbus_base_address,
                 register_config.num_registers);
         }
+        return this->process_response(register_config, std::move(register_response), std::move(exponent_response));
+    } else {
+        // no exponent
+        return this->process_response(register_config, std::move(register_response), std::nullopt);
     }
-
-    process_response(register_config, std::move(register_response), std::move(exponent_response));
 }
 
-void powermeterImpl::process_response(const RegisterData& register_data,
-                                      const types::serial_comm_hub_requests::Result register_message,
-                                      const types::serial_comm_hub_requests::Result exponent_message) {
+bool powermeterImpl::process_response(
+    const RegisterData& register_data, const types::serial_comm_hub_requests::Result& register_message,
+    std::optional<std::reference_wrapper<const types::serial_comm_hub_requests::Result>> exponent_message) {
 
-    if (register_message.status_code == types::serial_comm_hub_requests::StatusCodeEnum::Success) {
-        // in case the meter was unavailable before and now the query succeeded,
-        // we can tell the user about this good news and reset our flag
-        if (meter_is_unavailable) {
-            EVLOG_info << "Communication with power meter restored.";
-            meter_is_unavailable = false;
-        }
-
-        int16_t exponent{0};
-        if (exponent_message.value.has_value()) {
-            exponent = exponent_message.value.value()[0];
-        } else {
-            exponent = 0.0;
-        }
-
-        if (register_data.type == ENERGY_WH_IMPORT_TOTAL) {
-            types::units::Energy energy_in = this->pm_last_values.energy_Wh_import;
-            energy_in.total = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.energy_Wh_import = energy_in;
-        } else if (register_data.type == ENERGY_WH_IMPORT_L1) {
-            types::units::Energy energy_in = this->pm_last_values.energy_Wh_import;
-            energy_in.L1 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.energy_Wh_import = energy_in;
-        } else if (register_data.type == ENERGY_WH_IMPORT_L2) {
-            types::units::Energy energy_in = this->pm_last_values.energy_Wh_import;
-            energy_in.L2 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.energy_Wh_import = energy_in;
-        } else if (register_data.type == ENERGY_WH_IMPORT_L3) {
-            types::units::Energy energy_in = this->pm_last_values.energy_Wh_import;
-            energy_in.L3 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.energy_Wh_import = energy_in;
-        } else if (register_data.type == ENERGY_WH_EXPORT_TOTAL) {
-            types::units::Energy energy_out = this->pm_last_values.energy_Wh_export.value();
-            energy_out.total = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.energy_Wh_export = energy_out;
-        } else if (register_data.type == ENERGY_WH_EXPORT_L1) {
-            types::units::Energy energy_out = this->pm_last_values.energy_Wh_export.value();
-            energy_out.L1 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.energy_Wh_export = energy_out;
-        } else if (register_data.type == ENERGY_WH_EXPORT_L2) {
-            types::units::Energy energy_out = this->pm_last_values.energy_Wh_export.value();
-            energy_out.L2 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.energy_Wh_export = energy_out;
-        } else if (register_data.type == ENERGY_WH_EXPORT_L3) {
-            types::units::Energy energy_out = this->pm_last_values.energy_Wh_export.value();
-            energy_out.L3 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.energy_Wh_export = energy_out;
-        } else if (register_data.type == POWER_W_TOTAL) {
-            types::units::Power power = this->pm_last_values.power_W.value();
-            power.total = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.power_W = power;
-        } else if (register_data.type == POWER_W_L1) {
-            types::units::Power power = this->pm_last_values.power_W.value();
-            power.L1 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.power_W = power;
-        } else if (register_data.type == POWER_W_L2) {
-            types::units::Power power = this->pm_last_values.power_W.value();
-            power.L2 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.power_W = power;
-        } else if (register_data.type == POWER_W_L3) {
-            types::units::Power power = this->pm_last_values.power_W.value();
-            power.L3 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.power_W = power;
-        } else if (register_data.type == VOLTAGE_V_DC) {
-            types::units::Voltage volt = this->pm_last_values.voltage_V.value();
-            volt.DC = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.voltage_V = volt;
-        } else if (register_data.type == VOLTAGE_V_L1) {
-            types::units::Voltage volt = this->pm_last_values.voltage_V.value();
-            volt.L1 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.voltage_V = volt;
-        } else if (register_data.type == VOLTAGE_V_L2) {
-            types::units::Voltage volt = this->pm_last_values.voltage_V.value();
-            volt.L2 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.voltage_V = volt;
-        } else if (register_data.type == VOLTAGE_V_L3) {
-            types::units::Voltage volt = this->pm_last_values.voltage_V.value();
-            volt.L3 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.voltage_V = volt;
-        } else if (register_data.type == REACTIVE_POWER_VAR_TOTAL) {
-            types::units::ReactivePower var = this->pm_last_values.VAR.value();
-            var.total = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.VAR = var;
-        } else if (register_data.type == REACTIVE_POWER_VAR_L1) {
-            types::units::ReactivePower var = this->pm_last_values.VAR.value();
-            var.L1 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.VAR = var;
-        } else if (register_data.type == REACTIVE_POWER_VAR_L2) {
-            types::units::ReactivePower var = this->pm_last_values.VAR.value();
-            var.L2 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.VAR = var;
-        } else if (register_data.type == REACTIVE_POWER_VAR_L3) {
-            types::units::ReactivePower var = this->pm_last_values.VAR.value();
-            var.L3 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.VAR = var;
-        } else if (register_data.type == CURRENT_A_DC) {
-            types::units::Current amp = this->pm_last_values.current_A.value();
-            amp.DC = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.current_A = amp;
-        } else if (register_data.type == CURRENT_A_L1) {
-            types::units::Current amp = this->pm_last_values.current_A.value();
-            amp.L1 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.current_A = amp;
-        } else if (register_data.type == CURRENT_A_L2) {
-            types::units::Current amp = this->pm_last_values.current_A.value();
-            amp.L2 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.current_A = amp;
-        } else if (register_data.type == CURRENT_A_L3) {
-            types::units::Current amp = this->pm_last_values.current_A.value();
-            amp.L3 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.current_A = amp;
-        } else if (register_data.type == FREQUENCY_HZ_L1) {
-            types::units::Frequency freq = this->pm_last_values.frequency_Hz.value();
-            freq.L1 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.frequency_Hz = freq;
-        } else if (register_data.type == FREQUENCY_HZ_L2) {
-            types::units::Frequency freq = this->pm_last_values.frequency_Hz.value();
-            freq.L2 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.frequency_Hz = freq;
-        } else if (register_data.type == FREQUENCY_HZ_L3) {
-            types::units::Frequency freq = this->pm_last_values.frequency_Hz.value();
-            freq.L3 = merge_register_values_into_element(register_data, exponent, register_message);
-            this->pm_last_values.frequency_Hz = freq;
-        } else {
-        }
-    } else {
+    if ((register_message.status_code != types::serial_comm_hub_requests::StatusCodeEnum::Success) ||
+        (exponent_message &&
+         exponent_message->get().status_code != types::serial_comm_hub_requests::StatusCodeEnum::Success)) {
         // error: message sending failed
         output_error_with_content(register_message);
+        if (exponent_message) {
+            output_error_with_content(exponent_message.value());
+        }
 
         // let's warn the user about the meter's unavailability once only
         // (since we keep trying communicating an 'error' is not justified)
@@ -510,31 +398,171 @@ void powermeterImpl::process_response(const RegisterData& register_data,
             EVLOG_warning << "Lost communication with power meter.";
             meter_is_unavailable = true;
         }
+
+        return false;
     }
+
+    // SerialCommHub implementation should be preventing this in case of StatusCodeEnum::Success
+    if (not register_message.value.has_value()) {
+        EVLOG_warning << "Power meter reading returned without a value, skipping";
+        return false;
+    }
+    if (exponent_message and not exponent_message->get().value.has_value()) {
+        EVLOG_warning << "Power meter reading returned without an exponent value, skipping";
+        return false;
+    }
+    if (register_message.value.value().size() == 0) {
+        EVLOG_warning << "Power meter reading returned an empty value, skipping";
+        return false;
+    }
+    if (exponent_message and exponent_message->get().value.value().size() == 0) {
+        EVLOG_warning << "Power meter reading returned an empty exponent value, skipping";
+        return false;
+    }
+
+    // in case the meter was unavailable before and now the query succeeded,
+    // we can tell the user about this good news and reset our flag
+    if (meter_is_unavailable) {
+        EVLOG_info << "Communication with power meter restored.";
+        meter_is_unavailable = false;
+    }
+
+    int16_t exponent = 0;
+    if (exponent_message) {
+        exponent_message->get().value.value()[0];
+    }
+
+    if (register_data.type == ENERGY_WH_IMPORT_TOTAL) {
+        types::units::Energy energy_in = this->pm_last_values.energy_Wh_import;
+        energy_in.total = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.energy_Wh_import = energy_in;
+    } else if (register_data.type == ENERGY_WH_IMPORT_L1) {
+        types::units::Energy energy_in = this->pm_last_values.energy_Wh_import;
+        energy_in.L1 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.energy_Wh_import = energy_in;
+    } else if (register_data.type == ENERGY_WH_IMPORT_L2) {
+        types::units::Energy energy_in = this->pm_last_values.energy_Wh_import;
+        energy_in.L2 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.energy_Wh_import = energy_in;
+    } else if (register_data.type == ENERGY_WH_IMPORT_L3) {
+        types::units::Energy energy_in = this->pm_last_values.energy_Wh_import;
+        energy_in.L3 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.energy_Wh_import = energy_in;
+    } else if (register_data.type == ENERGY_WH_EXPORT_TOTAL) {
+        types::units::Energy energy_out = this->pm_last_values.energy_Wh_export.value();
+        energy_out.total = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.energy_Wh_export = energy_out;
+    } else if (register_data.type == ENERGY_WH_EXPORT_L1) {
+        types::units::Energy energy_out = this->pm_last_values.energy_Wh_export.value();
+        energy_out.L1 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.energy_Wh_export = energy_out;
+    } else if (register_data.type == ENERGY_WH_EXPORT_L2) {
+        types::units::Energy energy_out = this->pm_last_values.energy_Wh_export.value();
+        energy_out.L2 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.energy_Wh_export = energy_out;
+    } else if (register_data.type == ENERGY_WH_EXPORT_L3) {
+        types::units::Energy energy_out = this->pm_last_values.energy_Wh_export.value();
+        energy_out.L3 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.energy_Wh_export = energy_out;
+    } else if (register_data.type == POWER_W_TOTAL) {
+        types::units::Power power = this->pm_last_values.power_W.value();
+        power.total = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.power_W = power;
+    } else if (register_data.type == POWER_W_L1) {
+        types::units::Power power = this->pm_last_values.power_W.value();
+        power.L1 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.power_W = power;
+    } else if (register_data.type == POWER_W_L2) {
+        types::units::Power power = this->pm_last_values.power_W.value();
+        power.L2 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.power_W = power;
+    } else if (register_data.type == POWER_W_L3) {
+        types::units::Power power = this->pm_last_values.power_W.value();
+        power.L3 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.power_W = power;
+    } else if (register_data.type == VOLTAGE_V_DC) {
+        types::units::Voltage volt = this->pm_last_values.voltage_V.value();
+        volt.DC = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.voltage_V = volt;
+    } else if (register_data.type == VOLTAGE_V_L1) {
+        types::units::Voltage volt = this->pm_last_values.voltage_V.value();
+        volt.L1 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.voltage_V = volt;
+    } else if (register_data.type == VOLTAGE_V_L2) {
+        types::units::Voltage volt = this->pm_last_values.voltage_V.value();
+        volt.L2 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.voltage_V = volt;
+    } else if (register_data.type == VOLTAGE_V_L3) {
+        types::units::Voltage volt = this->pm_last_values.voltage_V.value();
+        volt.L3 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.voltage_V = volt;
+    } else if (register_data.type == REACTIVE_POWER_VAR_TOTAL) {
+        types::units::ReactivePower var = this->pm_last_values.VAR.value();
+        var.total = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.VAR = var;
+    } else if (register_data.type == REACTIVE_POWER_VAR_L1) {
+        types::units::ReactivePower var = this->pm_last_values.VAR.value();
+        var.L1 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.VAR = var;
+    } else if (register_data.type == REACTIVE_POWER_VAR_L2) {
+        types::units::ReactivePower var = this->pm_last_values.VAR.value();
+        var.L2 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.VAR = var;
+    } else if (register_data.type == REACTIVE_POWER_VAR_L3) {
+        types::units::ReactivePower var = this->pm_last_values.VAR.value();
+        var.L3 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.VAR = var;
+    } else if (register_data.type == CURRENT_A_DC) {
+        types::units::Current amp = this->pm_last_values.current_A.value();
+        amp.DC = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.current_A = amp;
+    } else if (register_data.type == CURRENT_A_L1) {
+        types::units::Current amp = this->pm_last_values.current_A.value();
+        amp.L1 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.current_A = amp;
+    } else if (register_data.type == CURRENT_A_L2) {
+        types::units::Current amp = this->pm_last_values.current_A.value();
+        amp.L2 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.current_A = amp;
+    } else if (register_data.type == CURRENT_A_L3) {
+        types::units::Current amp = this->pm_last_values.current_A.value();
+        amp.L3 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.current_A = amp;
+    } else if (register_data.type == FREQUENCY_HZ_L1) {
+        types::units::Frequency freq = this->pm_last_values.frequency_Hz.value();
+        freq.L1 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.frequency_Hz = freq;
+    } else if (register_data.type == FREQUENCY_HZ_L2) {
+        types::units::Frequency freq = this->pm_last_values.frequency_Hz.value();
+        freq.L2 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.frequency_Hz = freq;
+    } else if (register_data.type == FREQUENCY_HZ_L3) {
+        types::units::Frequency freq = this->pm_last_values.frequency_Hz.value();
+        freq.L3 = this->merge_register_values_into_element(register_data, exponent, register_message);
+        this->pm_last_values.frequency_Hz = freq;
+    } else {
+    }
+
+    return true;
 }
 
 float powermeterImpl::merge_register_values_into_element(const RegisterData& reg_data, const int16_t exponent,
                                                          const types::serial_comm_hub_requests::Result& reg_message) {
-    if (reg_message.value.has_value()) {
-        uint32_t value{0};
-        auto& reg_value = reg_message.value.value();
-        if (reg_data.num_registers == 1 && reg_value.size() == 1) {
-            value = reg_value.at(0);
-        } else if (reg_data.num_registers == 2 && reg_value.size() == 2) {
-            value += reg_value.at(0) << 16;
-            value += reg_value.at(1);
-        } else {
-            throw std::runtime_error("Values of more than 2 registers in size are currently not supported!");
-        }
-
-        auto val = *reinterpret_cast<float*>(&value);
-        auto val_scaled = float(val * reg_data.multiplier * pow(10.0, exponent));
-
-        return val_scaled;
+    uint32_t value{0};
+    const auto& reg_value = reg_message.value.value();
+    if (reg_data.num_registers == 1 && reg_value.size() == 1) {
+        value = reg_value.at(0);
+    } else if (reg_data.num_registers == 2 && reg_value.size() == 2) {
+        value += reg_value.at(0) << 16;
+        value += reg_value.at(1);
     } else {
-        EVLOG_error << "Error! Received message is empty!\n";
+        throw std::runtime_error("Values of more than 2 registers in size are currently not supported!");
     }
-    return 0.0;
+
+    const auto val = *reinterpret_cast<float*>(&value);
+    const auto val_scaled = float(val * reg_data.multiplier * pow(10.0, exponent));
+
+    return val_scaled;
 }
 
 void powermeterImpl::output_error_with_content(const types::serial_comm_hub_requests::Result& response) {
@@ -549,7 +577,7 @@ void powermeterImpl::output_error_with_content(const types::serial_comm_hub_requ
     }
 
     EVLOG_debug << "received error response: " << status_code_enum_to_string(response.status_code) << " (" << ss.str()
-                << ")\n";
+                << ")";
 }
 
 } // namespace main

--- a/modules/GenericPowermeter/main/powermeterImpl.hpp
+++ b/modules/GenericPowermeter/main/powermeterImpl.hpp
@@ -14,6 +14,8 @@
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
+#include <optional>
+#include <string>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {
@@ -102,7 +104,6 @@ private:
     };
 
     std::vector<RegisterData> pm_configuration;
-    bool config_loaded_successfully = {false};
 
     types::powermeter::Powermeter pm_last_values;
 
@@ -113,17 +114,17 @@ private:
 
     void init_default_values();
     void init_register_assignments(const json& loaded_registers);
-    int assign_register_data(const json& registers, const PowermeterRegisters register_type,
-                             const std::string& register_selector);
+    bool assign_register_data(const json& registers, const PowermeterRegisters register_type,
+                              const std::string& register_selector);
     void assign_register_sublevel_data(const json& registers, const PowermeterRegisters& register_type,
                                        const std::string& register_selector, const std::string& sublevel_selector,
                                        const uint8_t offset);
     powermeterImpl::ModbusFunctionType select_modbus_function(const uint8_t function_code);
     void read_powermeter_values();
-    void readRegister(const RegisterData& register_config);
-    void process_response(const RegisterData& message_type,
-                          const types::serial_comm_hub_requests::Result register_message,
-                          const types::serial_comm_hub_requests::Result exponent_message);
+    bool read_register(const RegisterData& register_config);
+    bool process_response(
+        const RegisterData& register_data, const types::serial_comm_hub_requests::Result& register_message,
+        std::optional<std::reference_wrapper<const types::serial_comm_hub_requests::Result>> exponent_message);
     float merge_register_values_into_element(const RegisterData& reg_data, const int16_t exponent,
                                              const types::serial_comm_hub_requests::Result& reg_message);
     void process_current_rate_message(const types::serial_comm_hub_requests::Result message);


### PR DESCRIPTION
## Describe your changes
This PR addresses a few error handling issues:
- If the power meter failed to deliver values initially, GenericPowerMeter would report incorrect values (`0`) instead of not reporting at all. Expected: Wait with reporting values until a complete value set has been successfully acquired.
- Reading of exponent values (which are optional) was not properly checked for errors from `serial_communication_hub`, silently falling back to the possibly incorrect value `0`. Expected: Ignore readings which return an error.
- Failure to read or parse the configuration would print an error, but the module would silently continue running without ever reporting any meter values. Expected: The module terminates if it is mis-configured.

The read failures are not hypothetical, as customers have observed power meters which occasionally fail to answer correctly.

All these issues are fixed in this PR. Furthermore, quite a bit of refactoring was done, to drop unneeded code and use structures which easier to understand and modify. Reading the PR commit by commit makes more sense, if the complete diff seems to large.

The delay of initial values was tested with a mockup of an Eastron meter (in place of SerialCommHub), returning errors:
https://github.com/chargebyte/everest-core/tree/feature/serialcomm_powermetersim

The handling of configuration parsing was tested with modified model configs.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

