### PR TITLE
Configurable Plug&Charge options in EvseManager

### DIFF
--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -112,6 +112,14 @@ cmds:
     result:
       description: Returns true if the signal was used by the evse manager implementation
       type: boolean
+  set_plug_and_charge_configuration:
+    description: >-
+      Sets the configuration required for an ISO15118 to handle contract authorization.
+    arguments:
+      plug_and_charge_configuration:
+        description: The configuration object
+        type: object
+        $ref: /evse_manager#/PlugAndChargeConfiguration
 vars:
   session_event:
     description: Emits all events related to sessions

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -105,6 +105,12 @@ struct Conf {
     int state_F_after_fault_ms;
     bool fail_on_powermeter_errors;
     bool raise_mrec9;
+<<<<<<< Updated upstream
+=======
+    int sleep_before_enabling_pwm_hlc_mode_ms;
+    bool central_contract_validation_allowed;
+    bool contract_certificate_installation_enabled;
+>>>>>>> Stashed changes
 };
 
 class EvseManager : public Everest::ModuleBase {
@@ -193,6 +199,10 @@ public:
 
     bool get_hlc_enabled();
     bool get_hlc_waiting_for_auth_pnc();
+    void set_pnc_enabled(const bool pnc_enabled);
+    void set_central_contract_validation_allowed(const bool central_contract_validation_allowed);
+    void set_contract_certificate_installation_enabled(const bool contract_certificate_installation_enabled);
+
     sigslot::signal<types::evse_manager::SessionEvent> signalReservationEvent;
 
     void charger_was_authorized();
@@ -298,6 +308,10 @@ private:
 
     bool hlc_waiting_for_auth_eim;
     bool hlc_waiting_for_auth_pnc;
+
+    bool pnc_enabled{false};
+    bool central_contract_validation_allowed{false};
+    bool contract_certificate_installation_enabled{false};
 
     VarContainer<types::isolation_monitor::IsolationMeasurement> isolation_measurement;
     VarContainer<types::power_supply_DC::VoltageCurrent> powersupply_measurement;

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -439,5 +439,20 @@ bool evse_managerImpl::handle_force_unlock(int& connector_id) {
     return false;
 };
 
+void evse_managerImpl::handle_set_plug_and_charge_configuration(
+    types::evse_manager::PlugAndChargeConfiguration& plug_and_charge_configuration) {
+    if (plug_and_charge_configuration.pnc_enabled.has_value()) {
+        mod->set_pnc_enabled(plug_and_charge_configuration.pnc_enabled.value());
+    }
+    if (plug_and_charge_configuration.central_contract_validation_allowed.has_value()) {
+        mod->set_central_contract_validation_allowed(
+            plug_and_charge_configuration.central_contract_validation_allowed.value());
+    }
+    if (plug_and_charge_configuration.contract_certificate_installation_enabled.has_value()) {
+        mod->set_contract_certificate_installation_enabled(
+            plug_and_charge_configuration.contract_certificate_installation_enabled.value());
+    }
+}
+
 } // namespace evse
 } // namespace module

--- a/modules/EvseManager/evse/evse_managerImpl.hpp
+++ b/modules/EvseManager/evse/evse_managerImpl.hpp
@@ -48,6 +48,8 @@ protected:
     virtual bool handle_stop_transaction(types::evse_manager::StopTransactionRequest& request) override;
     virtual bool handle_force_unlock(int& connector_id) override;
     virtual bool handle_external_ready_to_start_charging() override;
+    virtual void handle_set_plug_and_charge_configuration(
+        types::evse_manager::PlugAndChargeConfiguration& plug_and_charge_configuration) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -302,6 +302,26 @@ config:
       timeout occurs. It is recommended to disable it if OCPP1.6 is used.
     type: boolean
     default: false
+<<<<<<< Updated upstream
+=======
+  sleep_before_enabling_pwm_hlc_mode_ms:
+    description: >- 
+      Sleep before the PWM signal is updated in HLC mode. Teslas are really fast with sending the first slac packet after
+      enabling PWM, so the sleep allows SLAC to be ready for it. Some EV testers have issues with a value >= 1000ms,
+      although ISO15118 or IEC61851 does not specify a timeout.
+    type: integer
+    default: 1000
+  central_contract_validation_allowed:
+    description: >-
+      Used for ISO15118 plug and charge: If false, Contract shall not be present in PaymentOptionList. If true, Contract may be present in PaymentOptionList if TLS is used. 
+    type: boolean
+    default: false
+  contract_certificate_installation_enabled:
+    description: >-
+      Used for ISO15118 plug and charge: Indicates if the charger support contract CertificateInstall and CertificateUpdate
+    type: boolean
+    default: true
+>>>>>>> Stashed changes
 provides:
   evse:
     interface: evse_manager

--- a/modules/EvseManager/scoped_lock_timeout.hpp
+++ b/modules/EvseManager/scoped_lock_timeout.hpp
@@ -88,6 +88,9 @@ enum class MutexDescription {
     EVSE_is_reserved,
     EVSE_get_hlc_enabled,
     EVSE_get_hlc_waiting_for_auth_pnc,
+    EVSE_set_pnc_enabled,
+    EVSE_set_central_contract_validation_allowed,
+    EVSE_set_contract_certificate_installation_enabled,
     EVSE_charger_was_authorized,
     EVSE_get_ev_info
 };
@@ -238,6 +241,12 @@ static std::string to_string(MutexDescription d) {
         return "EvseManager.cpp: get_hlc_enabled";
     case MutexDescription::EVSE_get_hlc_waiting_for_auth_pnc:
         return "EvseManager.cpp: get_hlc_waiting_for_auth_pnc";
+    case MutexDescription::EVSE_set_pnc_enabled:
+        return "EvseManager.cpp: EVSE_set_pnc_enabled";
+    case MutexDescription::EVSE_set_central_contract_validation_allowed:
+        return "EvseManager.cpp: EVSE_set_central_contract_validation_allowed";
+    case MutexDescription::EVSE_set_contract_certificate_installation_enabled:
+        return "EvseManager.cpp: EVSE_set_contract_certificate_installation_enabled";
     case MutexDescription::EVSE_charger_was_authorized:
         return "EvseManager.cpp: charger_was_authorized";
     case MutexDescription::EVSE_get_ev_info:

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -150,6 +150,8 @@ private:
     void init_evse_subscriptions(); // initialize subscriptions to all EVSEs provided by r_evse_manager
     void init_evse_connector_map();
     void init_evse_maps();
+    void init_module_configuration();
+    void handle_config_key(const ocpp::v16::KeyValue& kv);
     EvseConnectorMap evse_connector_map; // provides access to OCPP connector id by using EVerests evse and connector id
     std::map<int32_t, int32_t>
         connector_evse_index_map; // provides access to r_evse_manager index by using OCPP connector id

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -144,6 +144,49 @@ void OCPP201::init_evse_maps() {
     }
 }
 
+void OCPP201::init_module_configuration() {
+    const auto ev_connection_timeout_request_value_response = this->charge_point->request_value<int32_t>(
+        ocpp::v2::Component{"TxCtrlr"}, ocpp::v2::Variable{"EVConnectionTimeOut"});
+    if (ev_connection_timeout_request_value_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
+        ev_connection_timeout_request_value_response.value.has_value()) {
+        this->r_auth->call_set_connection_timeout(ev_connection_timeout_request_value_response.value.value());
+    }
+
+    const auto master_pass_group_id_response = this->charge_point->request_value<std::string>(
+        ocpp::v2::Component{"AuthCtrlr"}, ocpp::v2::Variable{"MasterPassGroupId"});
+    if (master_pass_group_id_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
+        master_pass_group_id_response.value.has_value()) {
+        this->r_auth->call_set_master_pass_group_id(master_pass_group_id_response.value.value());
+    }
+
+    types::evse_manager::PlugAndChargeConfiguration pnc_config;
+    const auto iso15118_pnc_enabled_response =
+        this->charge_point->request_value<bool>(ocpp::v2::Component{"ISO15118Ctrlr"}, ocpp::v2::Variable{"PncEnabled"});
+    if (iso15118_pnc_enabled_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
+        iso15118_pnc_enabled_response.value.has_value()) {
+        pnc_config.pnc_enabled = iso15118_pnc_enabled_response.value.value();
+    }
+
+    const auto central_contract_validation_allowed_response = this->charge_point->request_value<bool>(
+        ocpp::v2::Component{"ISO15118Ctrlr"}, ocpp::v2::Variable{"CentralContractValidationAllowed"});
+    if (central_contract_validation_allowed_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
+        central_contract_validation_allowed_response.value.has_value()) {
+        pnc_config.central_contract_validation_allowed = central_contract_validation_allowed_response.value.value();
+    }
+
+    const auto contract_certificate_installation_enabled_response = this->charge_point->request_value<bool>(
+        ocpp::v2::Component{"ISO15118Ctrlr"}, ocpp::v2::Variable{"ContractCertificateInstallationEnabled"});
+    if (contract_certificate_installation_enabled_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
+        contract_certificate_installation_enabled_response.value.has_value()) {
+        pnc_config.central_contract_validation_allowed =
+            contract_certificate_installation_enabled_response.value.value();
+    }
+
+    for (const auto& evse_manager : this->r_evse_manager) {
+        evse_manager->call_set_plug_and_charge_configuration(pnc_config);
+    }
+}
+
 std::map<int32_t, int32_t> OCPP201::get_connector_structure() {
     std::map<int32_t, int32_t> evse_connector_structure;
     int evse_id = 1;
@@ -508,6 +551,29 @@ void OCPP201::ready() {
                 return;
             }
             this->transaction_handler->set_tx_stop_points(tx_stop_points);
+        } else if (set_variable_data.component.name == "ISO15118Ctrlr" and
+                   set_variable_data.variable.name == "PncEnabled") {
+            types::evse_manager::PlugAndChargeConfiguration pnc_config;
+            pnc_config.pnc_enabled = ocpp::conversions::string_to_bool(set_variable_data.attributeValue.get());
+            for (const auto& evse_manager : this->r_evse_manager) {
+                evse_manager->call_set_plug_and_charge_configuration(pnc_config);
+            }
+        } else if (set_variable_data.component.name == "ISO15118Ctrlr" and
+                   set_variable_data.variable.name == "CentralContractValidationAllowed") {
+            types::evse_manager::PlugAndChargeConfiguration pnc_config;
+            pnc_config.central_contract_validation_allowed =
+                ocpp::conversions::string_to_bool(set_variable_data.attributeValue.get());
+            for (const auto& evse_manager : this->r_evse_manager) {
+                evse_manager->call_set_plug_and_charge_configuration(pnc_config);
+            }
+        } else if (set_variable_data.component.name == "ISO15118Ctrlr" and
+                   set_variable_data.variable.name == "ContractCertificateInstallationEnabled") {
+            types::evse_manager::PlugAndChargeConfiguration pnc_config;
+            pnc_config.contract_certificate_installation_enabled =
+                ocpp::conversions::string_to_bool(set_variable_data.attributeValue.get());
+            for (const auto& evse_manager : this->r_evse_manager) {
+                evse_manager->call_set_plug_and_charge_configuration(pnc_config);
+            }
         }
     };
 
@@ -755,19 +821,7 @@ void OCPP201::ready() {
                                                 std::chrono::seconds(this->config.CompositeScheduleIntervalS));
     }
 
-    const auto ev_connection_timeout_request_value_response = this->charge_point->request_value<int32_t>(
-        ocpp::v2::Component{"TxCtrlr"}, ocpp::v2::Variable{"EVConnectionTimeOut"}, ocpp::v2::AttributeEnum::Actual);
-    if (ev_connection_timeout_request_value_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
-        ev_connection_timeout_request_value_response.value.has_value()) {
-        this->r_auth->call_set_connection_timeout(ev_connection_timeout_request_value_response.value.value());
-    }
-
-    const auto master_pass_group_id_response = this->charge_point->request_value<std::string>(
-        ocpp::v2::Component{"AuthCtrlr"}, ocpp::v2::Variable{"MasterPassGroupId"}, ocpp::v2::AttributeEnum::Actual);
-    if (master_pass_group_id_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
-        master_pass_group_id_response.value.has_value()) {
-        this->r_auth->call_set_master_pass_group_id(master_pass_group_id_response.value.value());
-    }
+    this->init_module_configuration();
 
     if (this->config.EnableExternalWebsocketControl) {
         const std::string connect_topic = "everest_api/ocpp/cmd/connect";

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -133,6 +133,7 @@ private:
     std::mutex session_event_mutex;
     std::condition_variable evse_ready_cv;
     void init_evse_maps();
+    void init_module_configuration();
     bool all_evse_ready();
     std::map<int32_t, int32_t> get_connector_structure();
     void process_session_event(const int32_t evse_id, const types::evse_manager::SessionEvent& session_event);

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -535,3 +535,17 @@ types:
           $ref: /evse_manager#/Connector
         minItems: 1
         maxItems: 128
+  PlugAndChargeConfiguration:
+    description: Configuration for contract authorization
+    type: object
+    properties:
+      pnc_enabled:
+        description: >-
+          If false, Contract shall not be present in PaymentOptionList. If true, Contract may be present in PaymentOptionList if TLS is used. 
+        type: boolean
+      central_contract_validation_allowed:
+        description: Indicates if the contract may be forwarded to and validated by a CSMS in case local validation was not successful
+        type: boolean
+      contract_certificate_installation_enabled:
+        description: Indicates if ISO 15118 contract certificate installation/update is enabled
+        type: boolean


### PR DESCRIPTION
Made plug and charge configuration in EvseManager configurable and controlable by OCPP:
* Added configuration parameters central_contract_validation_allowed and contract_certificate_installation_allowed to EvseManager
* Extended evse_manager interface by command to set plug and charge configuration
* Implemented usage of evse_manager command in OCPP modules so that plug and charge configuration can be controlled via ocpp at runtime

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

