### PR TITLE
Auth module: Unlock before token validation callbacks

### DIFF
--- a/modules/Auth/lib/AuthHandler.cpp
+++ b/modules/Auth/lib/AuthHandler.cpp
@@ -198,7 +198,11 @@ TokenHandlingResult AuthHandler::handle_token(const ProvidedIdToken& provided_to
         validation_result.parent_id_token = provided_token.parent_id_token;
         validation_results.push_back(validation_result);
     } else {
+        // release event_mutex before potentially blocking callback(s) via MQTT
+        // validate_token_callback does not touch any shared state
+        lk.unlock();
         validation_results = this->validate_token_callback(provided_token);
+        lk.lock();
     }
 
     bool attempt_stop_with_parent_id_token = false;

--- a/modules/Auth/tests/auth_tests.cpp
+++ b/modules/Auth/tests/auth_tests.cpp
@@ -1872,7 +1872,7 @@ TEST_F(AuthTest, test_token_swipe_race_with_timeout) {
                 Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Processing));
 
     EXPECT_CALL(mock_publish_token_validation_status_callback,
-                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Accepted));
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Rejected));
 
     TokenHandlingResult result;
 
@@ -1892,8 +1892,8 @@ TEST_F(AuthTest, test_token_swipe_race_with_timeout) {
     timeout_simulation_thread.join();
 
     ASSERT_TRUE(timeout_triggered);
-    ASSERT_EQ(result, TokenHandlingResult::ACCEPTED);
-    ASSERT_TRUE(this->auth_receiver->get_authorization(0));
+    ASSERT_EQ(result, TokenHandlingResult::NO_CONNECTOR_AVAILABLE);
+    ASSERT_FALSE(this->auth_receiver->get_authorization(0));
 }
 
 } // namespace module


### PR DESCRIPTION
## Describe your changes
https://github.com/EVerest/everest-core/actions/runs/14448151700/job/40515405321?pr=1128 revealed that in very rare cases an inter module deadlock could occur when:

* Thread1 calls handleChangeConfigurationRequest(ConnectionTimeout) in OCPP. A callback in the OCPP module will call `r_auth->set_connection_timeout(...)` as an effect. This requires the `event_mutex` in the Auth module
* RFID token is published so Thread2 calls `on_token` in the Auth module, acquiring the `event_mutex` so that `set_connection_timeout` needs to wait. `on_token` calls `validate_token_callback` initiating an `Authorize.req` in OCPP. Since the `AuthorizeResponse` from the CSMS can only be processed once `handleChangeConfigurationRequest` has returned this results in both modules waiting for each other.

OCPP waits for `set_connection_timeout` to return
Auth waits for `validate_token_callback` to return

This change unlocks the `event_mutex` when a potential blocking `validate_token_callback` in the Auth module is executing. Since the `validate_token_callback` does not change any shared state protected by the `event_mutex`, this can be done safely.

NOTE: This changes to the test case apply because a token timeout can now actually occur during the validation of tokens since the token timeout handle is able to acquire the mutex during the validaiton.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

