### PR TITLE
Adding a tls server state check before announcing security in the sdp response message

### DIFF
--- a/modules/IsoMux/sdp.cpp
+++ b/modules/IsoMux/sdp.cpp
@@ -149,9 +149,15 @@ int sdp_send_response(int sdp_socket, struct sdp_query* sdp_query) {
         return 1;
     }
 
+    using state_t = tls::Server::state_t;
+    const auto tls_server_state = sdp_query->v2g_ctx->tls_server->state();
+
+    const auto tls_server_available =
+        (tls_server_state == state_t::init_complete or tls_server_state == state_t::running);
+
     switch (sdp_query->security_requested) {
     case SDP_SECURITY_TLS:
-        if (sdp_query->v2g_ctx->local_tls_addr) {
+        if (sdp_query->v2g_ctx->local_tls_addr and tls_server_available) {
             dlog(DLOG_LEVEL_INFO, "SDP requested TLS, announcing TLS");
             sdp_create_response(buffer, sdp_query->v2g_ctx->local_tls_addr, SDP_SECURITY_TLS,
                                 SDP_TRANSPORT_PROTOCOL_TCP);
@@ -173,7 +179,7 @@ int sdp_send_response(int sdp_socket, struct sdp_query* sdp_query) {
                                 SDP_TRANSPORT_PROTOCOL_TCP);
             break;
         }
-        if (sdp_query->v2g_ctx->local_tls_addr) {
+        if (sdp_query->v2g_ctx->local_tls_addr and tls_server_available) {
             dlog(DLOG_LEVEL_INFO, "SDP requested NO-TLS, announcing TLS");
             sdp_create_response(buffer, sdp_query->v2g_ctx->local_tls_addr, SDP_SECURITY_TLS,
                                 SDP_TRANSPORT_PROTOCOL_TCP);


### PR DESCRIPTION
## Describe your changes
See title

## Issue ticket number and link
We found out that EvseV2G falsely tells the car TLS is supported in the SDP message even if no V2G Leaf Certificate is available. With this PR a check is added to check if the tls server is available.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

