### PR TITLE
Adapt to generated (in)equality operators for types in ev-cli v0.5.2

### DIFF
--- a/cmake/ev-project-bootstrap.cmake
+++ b/cmake/ev-project-bootstrap.cmake
@@ -1,6 +1,6 @@
 set_property(
     GLOBAL
-    PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION "0.5.0"
+    PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION "0.5.2"
 )
 
 # FIXME (aw): clean up this inclusion chain

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -78,7 +78,7 @@ Josev:
 # everest-testing and ev-dev-tools
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
-  git_tag: v0.5.1
+  git_tag: v0.5.2
 # linux_libnfc-nci for RFID
 libnfc-nci:
   git: https://github.com/EVerest/linux_libnfc-nci.git

--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -27,14 +27,6 @@ using namespace types::reservation;
 namespace types {
 namespace authorization {
 
-inline bool operator==(const IdToken& lhs, const IdToken& rhs) {
-    return lhs.value == rhs.value and lhs.type == rhs.type;
-}
-
-inline bool operator==(const ProvidedIdToken& lhs, const ProvidedIdToken& rhs) {
-    return lhs.id_token == rhs.id_token;
-}
-
 inline bool operator<(const IdToken& lhs, const IdToken& rhs) {
     return lhs.value < rhs.value;
 }

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -447,14 +447,4 @@ protected:
 
 } // namespace module
 
-namespace types::evse_manager {
-constexpr bool operator==(const EnableDisableSource& lhs, const EnableDisableSource& rhs) {
-    return lhs.enable_source == rhs.enable_source && lhs.enable_state == rhs.enable_state &&
-           lhs.enable_priority == rhs.enable_priority;
-}
-constexpr bool operator!=(const EnableDisableSource& lhs, const EnableDisableSource& rhs) {
-    return !operator==(lhs, rhs);
-}
-} // namespace types::evse_manager
-
 #endif // SRC_EVDRIVERS_CHARGER_H_


### PR DESCRIPTION
## Describe your changes
https://github.com/EVerest/everest-utils/pull/184 introduces autogenerated (in)equality comparison operators for types, so the manually defined ones have to be removed to prevent ambiguous overloads

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

