### PR TITLE
Update libcurl to 8.13.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -50,11 +50,12 @@ libiso15118:
   git_tag: v0.5.1
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBISO15118"
 
-# LEM DCBM 400/600 module
+# LEM DCBM 400/600, IsabellenhuetteIemDcr modules
 libcurl:
   git: https://github.com/curl/curl.git
-  git_tag: curl-8_4_0
+  git_tag: curl-8_13_0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBCURL"
+  options: ["CURL_USE_LIBPSL OFF"]
 
 # EvseSecurity
 # This has to appear before libocpp in this file since it is also a direct dependency

--- a/module-dependencies.cmake
+++ b/module-dependencies.cmake
@@ -24,7 +24,7 @@ ev_define_dependency(
 
 ev_define_dependency(
     DEPENDENCY_NAME libcurl
-    DEPENDENT_MODULES_LIST LemDCBM400600)
+    DEPENDENT_MODULES_LIST LemDCBM400600 IsabellenhuetteIemDcr)
 
 ev_define_dependency(
     DEPENDENCY_NAME libocpp


### PR DESCRIPTION
Mention that libcurl is also a dependency of IsabellenhuetteIemDcr module

Disable libpsl dependency for libcurl since it is not used in these modules (this list can certainly be extended in the future)

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

