### PR TITLE
Fix: Sending correct ResponseCode if the pnc contract certs are revoked

### DIFF
--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -1078,7 +1078,11 @@ static enum v2g_event handle_iso_authorization(struct v2g_connection* conn) {
             res->ResponseCode = iso2_responseCodeType_FAILED;
         }
     } else if (conn->ctx->session.authorization_rejected == true) {
-        res->ResponseCode = iso2_responseCodeType_FAILED;
+        if (conn->ctx->session.certificate_status == types::authorization::CertificateStatus::CertificateRevoked) {
+            res->ResponseCode = iso2_responseCodeType_FAILED_CertificateRevoked;
+        } else {
+            res->ResponseCode = iso2_responseCodeType_FAILED;
+        }
     }
 
 error_out:

--- a/tests/ocpp_tests/test_sets/ocpp201/plug_and_charge_tests201.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/plug_and_charge_tests201.py
@@ -10,7 +10,7 @@ from everest.testing.core_utils.controller.test_controller_interface import Test
 sys.path.append(os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../..")))
 from everest.testing.ocpp_utils.fixtures import *
-from ocpp.v201.enums import DeleteCertificateStatusType
+from ocpp.v201.enums import DeleteCertificateStatusType, AuthorizeCertificateStatusType
 from ocpp.v201 import call as call201
 from ocpp.routing import create_route_map
 import asyncio
@@ -31,7 +31,7 @@ def validate_authorize_req(
 
 
 @pytest.mark.skip(
-   "Plug and charge tests do currently interfere when they are run in parallel with other tests"
+    "Plug and charge tests do currently interfere when they are run in parallel with other tests"
 )
 @pytest.mark.ocpp_version("ocpp2.0.1")
 @pytest.mark.everest_core_config(
@@ -275,7 +275,6 @@ class TestPlugAndCharge:
             {"connectorStatus": "Available"},
         )
 
-
     @pytest.mark.asyncio
     @pytest.mark.source_certs_dir(Path(__file__).parent.parent / "everest-aux/certs")
     @pytest.mark.ocpp_config_adaptions(
@@ -354,9 +353,115 @@ class TestPlugAndCharge:
             test_utility, charge_point, "Get15118EVCertificate", {"action": "Install"}
         )
 
-
         test_utility.messages.clear()
         test_utility.forbidden_actions.append("Authorize")
+        test_utility.forbidden_actions.append("TransactionEvent")
+
+        test_utility.messages.clear()
+        test_controller.plug_out_iso()
+
+        # expect StatusNotification with status available
+        assert await wait_for_and_validate(
+            test_utility,
+            charge_point,
+            "StatusNotification",
+            {"connectorStatus": "Available"},
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.source_certs_dir(Path(__file__).parent.parent / "everest-aux/certs")
+    @pytest.mark.ocpp_config_adaptions(
+        GenericOCPP201ConfigAdjustment(
+            [
+                (
+                    OCPP201ConfigVariableIdentifier(
+                        "ISO15118Ctrlr",
+                        "CentralContractValidationAllowed",
+                        "Actual",
+                    ),
+                    True,
+                ),
+                (
+                    OCPP201ConfigVariableIdentifier(
+                        "ISO15118Ctrlr",
+                        "ContractCertificateInstallationEnabled",
+                        "Actual",
+                    ),
+                    True,
+                ),
+            ]
+        )
+    )
+    @pytest.mark.asyncio
+    async def test_contract_revoked(
+        self,
+        request,
+        central_system: CentralSystem,
+        charge_point: ChargePoint201,
+        test_controller: TestController,
+        test_utility: TestUtility,
+    ):
+        """
+        Test for contract installation on the vehicle and succeeding authorization request that is rejected by CSMS
+        """
+
+        @on(Action.Authorize)
+        def on_authorize(**kwargs):
+            return call_result201.AuthorizePayload(
+                id_token_info=IdTokenInfoType(status=AuthorizationStatusType.blocked),
+                certificate_status=AuthorizeCertificateStatusType.certificate_revoked,
+            )
+
+        setattr(
+            charge_point, "on_get_15118_ev_certificate", on_get_15118_ev_certificate
+        )
+        setattr(charge_point, "on_authorize", on_authorize)
+
+        central_system.chargepoint.route_map = create_route_map(
+            central_system.chargepoint
+        )
+
+        certificate_hash_data = {
+            "hashAlgorithm": "SHA256",
+            "issuerKeyHash": "66fce9295edc049f4a183458948ecaa8e3558e4aa3041f13a2363d1d953d33e5",
+            "issuerNameHash": "3a1ad85a129bd5db30c2f099a541f76e562b8a30e9f49f3f47077eeae3750a2a",
+            "serialNumber": "3041",
+        }
+
+        delete_certificate_req = {"certificate_hash_data": certificate_hash_data}
+
+        # delete MO root
+        delete_certificate_response: call_result201.DeleteCertificatePayload = (
+            await charge_point.delete_certificate_req(
+                **delete_certificate_req,
+            )
+        )
+
+        assert (
+            delete_certificate_response.status == DeleteCertificateStatusType.accepted
+        )
+
+        await asyncio.sleep(3)
+        test_controller.plug_in_dc_iso()
+
+        assert await wait_for_and_validate(
+            test_utility, charge_point, "Get15118EVCertificate", {"action": "Install"}
+        )
+
+        # expect authorize.req
+        authorize_req: call201.AuthorizePayload = call201.AuthorizePayload(
+            **await wait_for_and_validate(
+                test_utility,
+                charge_point,
+                "Authorize",
+                {"idToken": {"idToken": "UKSWI123456789A", "type": "eMAID"}},
+            )
+        )
+
+        assert validate_authorize_req(authorize_req, True, False)
+
+        test_utility.messages.clear()
+        # verify that transaction does not start
         test_utility.forbidden_actions.append("TransactionEvent")
 
         test_utility.messages.clear()


### PR DESCRIPTION
## Describe your changes
Sending correct iso-2 ResponseCode "FAILED_CertificateRevoked" in the AuthorizationRes if the contract certs are revoked

## Issue ticket number and link
Right now EvseV2G send a Failed ResponseCode if the contract certs are revoked. This is not correct. This should be FAILED_CertificateRevoked

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

