### PR TITLE
module-dependencies: fix sqlite_cpp leftover

### DIFF
--- a/module-dependencies.cmake
+++ b/module-dependencies.cmake
@@ -45,7 +45,7 @@ ev_define_dependency(
     DEPENDENT_MODULES_LIST OCPP OCPP201 EvseSecurity EvseV2G)
 
 ev_define_dependency(
-    DEPENDENCY_NAME sqlite_cpp
+    DEPENDENCY_NAME everest-sqlite
     DEPENDENT_MODULES_LIST ErrorHistory)
 
 ev_define_dependency(


### PR DESCRIPTION
The dependency was migrated to everest-sqlite.

## Describe your changes

Update the module dependency of the ErrorHistory module from sqlite_cpp to everest-sqlite.

This is a change by review, as-of-yet untested by myself.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

