### PR TITLE
feat(OcppAuth): Updates to id_token_info for token in use on connector

### DIFF
--- a/interfaces/auth_token_validator.yaml
+++ b/interfaces/auth_token_validator.yaml
@@ -13,5 +13,12 @@ cmds:
         Result object containing validation result
       type: object
       $ref: /authorization#/ValidationResult
+vars:
+  validate_result_update:
+    description: >-
+      Updated validation result for a given token due to some changes. These
+      can be triggered by TransactionEvent messages or StartTransaction.
+    type: object
+    $ref: /authorization#/ValidationResultUpdate
 errors:
   - reference: /errors/generic

--- a/modules/Auth/Auth.cpp
+++ b/modules/Auth/Auth.cpp
@@ -24,6 +24,11 @@ void Auth::init() {
             t.detach();
         });
     }
+    for (const auto& token_validator : this->r_token_validator) {
+        token_validator->subscribe_validate_result_update([this](ValidationResultUpdate validation_result_update) {
+            this->auth_handler->handle_token_validation_result_update(validation_result_update);
+        });
+    }
 }
 
 void Auth::ready() {

--- a/modules/Auth/include/AuthHandler.hpp
+++ b/modules/Auth/include/AuthHandler.hpp
@@ -90,6 +90,13 @@ public:
     TokenHandlingResult on_token(const ProvidedIdToken& provided_token);
 
     /**
+     * @brief Handler for an update to a token validation result. This is mainly used to update if we have a parent id.
+     *
+     * @param validation_result_update
+     */
+    void handle_token_validation_result_update(const ValidationResultUpdate& validation_result_update);
+
+    /**
      * @brief Handler for new incoming \p reservation for the given \p connector . Places the reservation if possible.
      *
      * @param reservation

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -890,6 +890,18 @@ void OCPP::ready() {
             tevent.session_id = session_id;
             tevent.transaction_id = std::to_string(transaction_id);
             p_ocpp_generic->publish_ocpp_transaction_event(tevent);
+            if (id_tag_info.parentIdTag.has_value()) {
+                types::authorization::ValidationResultUpdate result_update;
+                types::authorization::IdToken id_token;
+                id_token.value = id_tag_info.parentIdTag.value();
+                // Default to RFID auth type for parentIdTag since we have no information about it in ocpp1.6
+                id_token.type = types::authorization::IdTokenType::ISO14443;
+                result_update.validation_result.parent_id_token = id_token;
+                result_update.validation_result.authorization_status =
+                    conversions::to_everest_authorization_status(id_tag_info.status);
+                result_update.connector_id = connector;
+                p_auth_validator->publish_validate_result_update(result_update);
+            }
         });
 
     this->charge_point->register_transaction_stopped_callback(

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -623,6 +623,13 @@ void OCPP201::ready() {
                 conversions::to_everest_transaction_event_response(transaction_event_response);
             ocpp_transaction_event_response.original_transaction_event = ocpp_transaction_event;
             this->p_ocpp_generic->publish_ocpp_transaction_event_response(ocpp_transaction_event_response);
+            if (transaction_event_response.idTokenInfo.has_value() and transaction_event.evse.has_value()) {
+                types::authorization::ValidationResultUpdate result_update;
+                result_update.validation_result =
+                    conversions::to_everest_validation_result(transaction_event_response.idTokenInfo.value());
+                result_update.connector_id = transaction_event.evse->id;
+                p_auth_validator->publish_validate_result_update(result_update);
+            }
         };
 
     callbacks.boot_notification_callback =

--- a/modules/OCPP201/conversions.hpp
+++ b/modules/OCPP201/conversions.hpp
@@ -154,6 +154,9 @@ types::ocpp::DataTransferRequest to_everest_data_transfer_request(ocpp::v2::Data
 /// \brief Converts a given ocpp::v2::DataTransferResponse \p status to a types::ocpp::DataTransferResponse.
 types::ocpp::DataTransferResponse to_everest_data_transfer_response(ocpp::v2::DataTransferResponse response);
 
+/// \brief Converts a given ocpp::v2::IdTokenInfo \p idTokenInfo to a types::authorization::ValidationResult.
+types::authorization::ValidationResult to_everest_validation_result(const ocpp::v2::IdTokenInfo& idTokenInfo);
+
 /// \brief Converts a given ocpp::v2::AuthorizeResponse \p response to a types::authorization::ValidationResult.
 types::authorization::ValidationResult to_everest_validation_result(const ocpp::v2::AuthorizeResponse& response);
 

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -635,6 +635,118 @@ async def test_stop_transaction_parent_id_tag(
 
 
 @pytest.mark.asyncio
+async def test_stop_transaction_parent_id_tag_in_start_transaction(
+    test_config: OcppTestConfiguration,
+    charge_point_v16: ChargePoint16,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+
+    logging.info(
+        "######### test_stop_transaction_parent_id_tag_in_start_transaction #########")
+
+    # StartTransaction.conf with parent id
+    @on(Action.StartTransaction)
+    def on_start_transaction(**kwargs):
+        id_tag_info = IdTagInfo(
+            status=AuthorizationStatus.accepted,
+            parent_id_tag=test_config.authorization_info.parent_id_tag,
+        )
+        return call_result.StartTransactionPayload(
+            transaction_id=1, id_tag_info=id_tag_info
+        )
+
+    setattr(charge_point_v16, "on_start_transaction", on_start_transaction)
+    charge_point_v16.route_map = create_route_map(charge_point_v16)
+
+    # start charging session
+    test_controller.plug_in()
+
+    # expect StatusNotification with status preparing
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        call.StatusNotificationPayload(
+            1, ChargePointErrorCode.no_error, ChargePointStatus.preparing
+        ),
+    )
+
+    # swipe id tag to authorize
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
+
+    # expect authorize.req
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "Authorize",
+        call.AuthorizePayload(test_config.authorization_info.valid_id_tag_1),
+    )
+
+    # expect StartTransaction.req
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StartTransaction",
+        call.StartTransactionPayload(
+            1, test_config.authorization_info.valid_id_tag_1, 0, ""
+        ),
+        validate_standard_start_transaction,
+    )
+
+    # expect StatusNotification with status charging
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        call.StatusNotificationPayload(
+            1, ChargePointErrorCode.no_error, ChargePointStatus.charging
+        ),
+    )
+    # authorize.conf with parent id tag
+
+    @on(Action.Authorize)
+    def on_authorize(**kwargs):
+        id_tag_info = IdTagInfo(
+            status=AuthorizationStatus.accepted,
+            parent_id_tag=test_config.authorization_info.parent_id_tag,
+        )
+        return call_result.AuthorizePayload(id_tag_info=id_tag_info)
+    setattr(charge_point_v16, "on_authorize", on_authorize)
+    charge_point_v16.route_map = create_route_map(charge_point_v16)
+
+    # swipe other id tag to authorize (same parent id)
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_2)
+
+    # expect authorize.req
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "Authorize",
+        call.AuthorizePayload(test_config.authorization_info.valid_id_tag_2),
+    )
+
+    # expect StatusNotification with status finishing
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        call.StatusNotificationPayload(
+            1, ChargePointErrorCode.no_error, ChargePointStatus.finishing
+        ),
+    )
+
+    # expect StopTransaction.req
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StopTransaction",
+        call.StopTransactionPayload(0, "", 1, Reason.local),
+        validate_standard_stop_transaction,
+    )
+
+
+@pytest.mark.asyncio
 async def test_005_1_ev_side_disconnect(
     test_config: OcppTestConfiguration,
     charge_point_v16: ChargePoint16,

--- a/tests/ocpp_tests/test_sets/ocpp201/transactions.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/transactions.py
@@ -10,13 +10,14 @@ import logging
 
 from everest.testing.core_utils.controller.test_controller_interface import TestController
 
+from ocpp.routing import on, create_route_map
 from ocpp.v201 import call as call201
 from ocpp.v201 import call_result as call_result201
 from ocpp.v201.enums import *
 from ocpp.v201.datatypes import *
 from everest.testing.ocpp_utils.fixtures import *
 from everest_test_utils import * # Needs to be before the datatypes below since it overrides the v201 Action enum with the v16 one
-from ocpp.v201.enums import (IdTokenType as IdTokenTypeEnum, SetVariableStatusType, ClearCacheStatusType, ConnectorStatusType)
+from ocpp.v201.enums import (Action, IdTokenType as IdTokenTypeEnum, SetVariableStatusType, ClearCacheStatusType, ConnectorStatusType)
 from validations import validate_status_notification_201
 from everest.testing.core_utils._configuration.libocpp_configuration_helper import GenericOCPP201ConfigAdjustment, OCPP201ConfigVariableIdentifier
 from everest.testing.ocpp_utils.charge_point_utils import wait_for_and_validate, TestUtility
@@ -453,3 +454,138 @@ async def test_two_parallel_transactions(
         "TransactionEvent",
         {"eventType": "Ended", "offline": False},
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+async def test_id_token_info_updated_in_tx_event(
+    central_system_v201: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    # prepare data for the test
+    evse_id1 = 1
+    connector_id = 1
+
+    evse_id2 = 2
+
+    # make an unknown IdToken
+    id_token = IdTokenType(id_token="8BADF00D", type=IdTokenTypeEnum.iso14443)
+
+    log.info(
+        "##################### Transaction with token info updated in transaction event #################"
+    )
+
+    test_controller.start()
+    charge_point_v201 = await central_system_v201.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    # expect StatusNotification with status available
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call201.StatusNotificationPayload(
+            datetime.now().isoformat(),
+            ConnectorStatusType.available,
+            evse_id=evse_id1,
+            connector_id=connector_id,
+        ),
+        validate_status_notification_201,
+    )
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "StatusNotification",
+        call201.StatusNotificationPayload(
+            datetime.now().isoformat(),
+            ConnectorStatusType.available,
+            evse_id=evse_id2,
+            connector_id=connector_id,
+        ),
+        validate_status_notification_201,
+    )
+
+    @on(Action.TransactionEvent)
+    def on_transaction_event(**kwargs):
+        msg = call201.TransactionEventPayload(**kwargs)
+        if msg.id_token != None:
+            msg_token = IdTokenType(**msg.id_token)
+            return call_result201.TransactionEventPayload(
+                id_token_info=IdTokenInfoType(
+                    status=AuthorizationStatusType.accepted,
+                    group_id_token=IdTokenType(
+                        id_token="123", type=IdTokenTypeEnum.central
+                    ),
+                )
+            )
+        else:
+            return call_result201.TransactionEventPayload()
+
+    setattr(charge_point_v201, "on_transaction_event", on_transaction_event)
+    central_system_v201.chargepoint.route_map = create_route_map(
+        central_system_v201.chargepoint
+    )
+    # swipe id tag to authorize
+    test_controller.swipe(id_token.id_token)
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "Authorize",
+        {},
+    )
+    # start charging session
+    test_controller.plug_in()
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Started"},
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Updated"},
+    )
+
+    # charge for 10 seconds
+    await asyncio.sleep(10)
+
+    @on(Action.Authorize)
+    def on_authorize(**kwargs):
+        msg = call201.AuthorizePayload(**kwargs)
+        msg_token = IdTokenType(**msg.id_token)
+        return call_result201.AuthorizePayload(
+            id_token_info=IdTokenInfoType(
+                status=AuthorizationStatusType.accepted,
+                group_id_token=IdTokenType(
+                    id_token="123", type=IdTokenTypeEnum.central
+                ),
+            )
+        )
+    setattr(charge_point_v201, "on_authorize", on_authorize)
+    central_system_v201.chargepoint.route_map = create_route_map(
+        central_system_v201.chargepoint
+    )
+    # swipe id tag to de-authorize
+    id_token = IdTokenType(id_token="8BADF00A", type=IdTokenTypeEnum.iso14443)
+    test_controller.swipe(id_token.id_token)
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "Authorize",
+        {},
+    )
+    # should send a  Transaction event C15.FR.02
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "TransactionEvent",
+        {"eventType": "Ended"},
+    )
+
+    # stop charging session
+    test_controller.plug_out()

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -175,7 +175,7 @@ types:
         $ref: /authorization#/IdToken
       evse_ids:
         description: >-
-          Only used when the id token is valid for one or more specific evses, 
+          Only used when the id token is valid for one or more specific evses,
           not for the whole charging station. Indicates for which evse ids the
           provided token is valid
         type: array
@@ -201,7 +201,7 @@ types:
       - FindFirst
   AuthorizationType:
     description: >-
-      Type of authorization of the provided token. The value 
+      Type of authorization of the provided token. The value
       of AuthorizationType can influence the authorization process
     type: string
     enum:
@@ -254,3 +254,23 @@ types:
       - AuthorizationNotFound
       - EvseNotFound
       - Rejected
+  ValidationResultUpdate:
+    description: >-
+      Result object containing an updated validation result for a given token.
+      This is needed since certain information can be updated at a later time.
+    type: object
+    additionalProperties: false
+    required:
+      - validation_result
+      - connector_id
+    properties:
+      validation_result:
+        description: >-
+          Result object containing authorization status enum value and an optional
+          parentIdTag
+        type: object
+        $ref: /authorization#/ValidationResult
+      connector_id:
+        description: >-
+          Id of the connector on which the id token information has been updated.
+        type: integer


### PR DESCRIPTION
We can now update id token info for a specific connector in case we receive updated info in a transaction event or start transaction message from OCPP. This allows to properly support new edges cases for the parent id tag. This is required for OCPP certification.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

