### PR TITLE
feat(simulation): Make it possible to keep EV plug in state cross boot

### DIFF
--- a/config/config-sil-ocpp201.yaml
+++ b/config/config-sil-ocpp201.yaml
@@ -29,6 +29,7 @@ active_modules:
       ac_hlc_use_5percent: false
       ac_enforce_hlc: false
       request_zero_power_in_idle: true
+      external_ready_to_start_charging: true
     connections:
       bsp:
         - module_id: yeti_driver_1
@@ -58,6 +59,7 @@ active_modules:
       ac_hlc_use_5percent: false
       ac_enforce_hlc: false
       request_zero_power_in_idle: true
+      external_ready_to_start_charging: true
     connections:
       bsp:
         - module_id: yeti_driver_2

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,7 +68,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: fb391b4ff16a0a07150e5a8eebf0856fb6623cbe
+  git_tag: ec4949cc8d2887c9d19d97b44b9236b8b88a8a7b
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/EvManager/EvManager.hpp
+++ b/modules/EvManager/EvManager.hpp
@@ -14,6 +14,7 @@
 #include <generated/interfaces/car_simulator/Implementation.hpp>
 
 // headers for required interface implementations
+#include "generated/interfaces/kvs/Interface.hpp"
 #include <generated/interfaces/ISO15118_ev/Interface.hpp>
 #include <generated/interfaces/ev_board_support/Interface.hpp>
 #include <generated/interfaces/ev_slac/Interface.hpp>
@@ -26,24 +27,25 @@
 namespace module {
 
 struct Conf {
-    int connector_id;
-    bool auto_enable;
-    bool auto_exec;
-    bool auto_exec_infinite;
     std::string auto_exec_commands;
+    double max_current;
+    int dc_discharge_max_current_limit;
+    int dc_discharge_max_power_limit;
+    int dc_discharge_target_current;
+    int dc_discharge_v2g_minimal_soc;
+    int connector_id;
     int dc_max_current_limit;
     int dc_max_power_limit;
     int dc_max_voltage_limit;
     int dc_energy_capacity;
     int dc_target_current;
     int dc_target_voltage;
+    bool auto_enable;
+    bool auto_exec;
+    bool auto_exec_infinite;
     bool support_sae_j2847;
-    int dc_discharge_max_current_limit;
-    int dc_discharge_max_power_limit;
-    int dc_discharge_target_current;
-    int dc_discharge_v2g_minimal_soc;
-    double max_current;
     bool three_phases;
+    bool keep_cross_boot_plugin_state;
 };
 
 class EvManager : public Everest::ModuleBase {
@@ -52,7 +54,8 @@ public:
     EvManager(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider,
               std::unique_ptr<car_simulatorImplBase> p_main, std::unique_ptr<ev_board_supportIntf> r_ev_board_support,
               std::vector<std::unique_ptr<ISO15118_evIntf>> r_ev, std::vector<std::unique_ptr<ev_slacIntf>> r_slac,
-              std::vector<std::unique_ptr<powermeterIntf>> r_powermeter, Conf& config) :
+              std::vector<std::unique_ptr<powermeterIntf>> r_powermeter, std::vector<std::unique_ptr<kvsIntf>> r_kvs,
+              Conf& config) :
         ModuleBase(info),
         mqtt(mqtt_provider),
         p_main(std::move(p_main)),
@@ -60,6 +63,7 @@ public:
         r_ev(std::move(r_ev)),
         r_slac(std::move(r_slac)),
         r_powermeter(std::move(r_powermeter)),
+        r_kvs(std::move(r_kvs)),
         config(config){};
 
     Everest::MqttProvider& mqtt;
@@ -68,6 +72,7 @@ public:
     const std::vector<std::unique_ptr<ISO15118_evIntf>> r_ev;
     const std::vector<std::unique_ptr<ev_slacIntf>> r_slac;
     const std::vector<std::unique_ptr<powermeterIntf>> r_powermeter;
+    const std::vector<std::unique_ptr<kvsIntf>> r_kvs;
     const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1

--- a/modules/EvManager/main/car_simulatorImpl.hpp
+++ b/modules/EvManager/main/car_simulatorImpl.hpp
@@ -71,9 +71,14 @@ private:
 
     bool enabled{false};
     std::atomic<bool> execution_active{false};
+    std::atomic<bool> plugged_in{false};
     size_t loop_interval_ms{};
 
     std::queue<SimulationCommand> command_queue;
+
+    std::string simulated_already_plugged_in_key;
+    std::string simulated_plugged_in_command_key;
+    std::string last_commands;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };

--- a/modules/EvManager/manifest.yaml
+++ b/modules/EvManager/manifest.yaml
@@ -76,6 +76,10 @@ config:
     description: Support three phase
     type: boolean
     default: true
+  keep_cross_boot_plugin_state:
+    description: Keep plugin state across boot (use for simulation only).
+    type: boolean
+    default: false
 provides:
   main:
     interface: car_simulator
@@ -93,6 +97,10 @@ requires:
     max_connections: 1
   powermeter:
     interface: powermeter
+    min_connections: 0
+    max_connections: 1
+  kvs:
+    interface: kvs
     min_connections: 0
     max_connections: 1
 enable_external_mqtt: true

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -578,25 +578,22 @@ void OCPP::ready() {
     this->charge_point->register_pause_charging_callback([this](int32_t connector) {
         if (this->connector_evse_index_map.count(connector)) {
             return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))->call_pause_charging();
-        } else {
-            return false;
         }
+        return false;
     });
     this->charge_point->register_resume_charging_callback([this](int32_t connector) {
         if (this->connector_evse_index_map.count(connector)) {
             return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))->call_resume_charging();
-        } else {
-            return false;
         }
+        return false;
     });
     this->charge_point->register_stop_transaction_callback([this](int32_t connector, ocpp::v16::Reason reason) {
         if (this->connector_evse_index_map.count(connector)) {
             types::evse_manager::StopTransactionRequest req;
             req.reason = conversions::to_everest_stop_transaction_reason(reason);
             return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))->call_stop_transaction(req);
-        } else {
-            return false;
         }
+        return false;
     });
 
     this->charge_point->register_unlock_connector_callback([this](int32_t connector) {
@@ -606,9 +603,8 @@ void OCPP::ready() {
             return this->r_evse_manager.at(this->connector_evse_index_map.at(connector))->call_force_unlock(1)
                        ? ocpp::v16::UnlockStatus::Unlocked
                        : ocpp::v16::UnlockStatus::NotSupported;
-        } else {
-            return ocpp::v16::UnlockStatus::NotSupported;
         }
+        return ocpp::v16::UnlockStatus::NotSupported;
     });
 
     // int32_t reservation_id, CiString<20> auth_token, DateTime expiry_time,
@@ -968,6 +964,8 @@ void OCPP::ready() {
         });
     }
 
+    // We must wait for EVSEs to be marked as ready before initializing ocpp since we will potentially update the
+    // operative status of the connectors
     std::unique_lock lk(this->evse_ready_mutex);
     while (!this->all_evse_ready()) {
         this->evse_ready_cv.wait(lk);
@@ -978,12 +976,27 @@ void OCPP::ready() {
 
     this->init_module_configuration();
 
-    const auto boot_reason = conversions::to_ocpp_boot_reason_enum(this->r_system->call_get_boot_reason());
-    if (this->charge_point->start({}, boot_reason, this->resuming_session_ids)) {
+    // we can now call init(), which initializes the charge points state machine. It reads the connector availability
+    // from the internal database and potentially triggers enable/disable callbacks at the evse.
+    if (this->charge_point->init({}, this->resuming_session_ids)) {
         // signal that we're started
         this->started = true;
         EVLOG_info << "OCPP initialized";
+    }
 
+    // this signals to the evses they can now start their internal state machines
+    // signal to the EVSEs that OCPP is initialized
+    for (const auto& evse : this->r_evse_manager) {
+        evse->call_external_ready_to_start_charging();
+    }
+
+    // wait for potential events from the evses in order to start OCPP with the correct initial state (e.g. EV might be
+    // plugged in at startup)
+    std::this_thread::sleep_for(std::chrono::milliseconds(this->config.DelayOcppStart));
+    const auto boot_reason = conversions::to_ocpp_boot_reason_enum(this->r_system->call_get_boot_reason());
+    // we can now start the OCPP connection
+    if (this->charge_point->start({}, boot_reason, this->resuming_session_ids)) {
+        EVLOG_info << "OCPP started";
         // process session event queue
         std::scoped_lock lock(this->session_event_mutex);
         for (auto& [evse_id, evse_event_queue] : this->event_queue) {
@@ -1009,11 +1022,6 @@ void OCPP::ready() {
                 evse_event_queue.pop();
             }
         }
-    }
-
-    // signal to the EVSEs that OCPP is initialized
-    for (const auto& evse : this->r_evse_manager) {
-        evse->call_external_ready_to_start_charging();
     }
 }
 

--- a/modules/OCPP/OCPP.hpp
+++ b/modules/OCPP/OCPP.hpp
@@ -65,6 +65,7 @@ struct Conf {
     std::string MessageLogPath;
     int MessageQueueResumeDelay;
     std::string RequestCompositeScheduleUnit;
+    int DelayOcppStart;
 };
 
 class OCPP : public Everest::ModuleBase {

--- a/modules/OCPP/manifest.yaml
+++ b/modules/OCPP/manifest.yaml
@@ -1,15 +1,15 @@
 description: A OCPP charge point / charging station module, currently targeting OCPP-J 1.6
 config:
   ChargePointConfigPath:
-    description: >- 
+    description: >-
       Path to the ocpp configuration file. Libocpp defines a JSON schema for this file. Please refer to the documentation
-      of libocpp for more information about the configuration options.  
+      of libocpp for more information about the configuration options.
     type: string
     default: ocpp-config.json
   UserConfigPath:
     description: >-
       Path to the file of the OCPP user config. The user config is used as an overlay for the original config defined
-      by the ChargePointConfigPath. Any changes to configuration keys turned out internally or by the CSMS will be 
+      by the ChargePointConfigPath. Any changes to configuration keys turned out internally or by the CSMS will be
       written to the user config file.
     type: string
     default: user_config.json
@@ -50,9 +50,15 @@ config:
       Amps for AC and Watts for DC charging stations.
       Allowed values:
         - 'A' for Amps
-        - 'W' for Watts 
+        - 'W' for Watts
     type: string
     default: 'A'
+  DelayOcppStart:
+    description: >-
+      Small delay in time (milliseconds) to start the ocpp chargepoint to allow time for the rest of everest to update the connector status.
+      This is only used to prevent issues from passing by availlable before preparing on a restart.
+    type: integer
+    default: 0
 provides:
   main:
     description: This is a OCPP 1.6 charge point

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -49,6 +49,7 @@ struct Conf {
     int CompositeScheduleIntervalS;
     int RequestCompositeScheduleDurationS;
     std::string RequestCompositeScheduleUnit;
+    int DelayOcppStart;
 };
 
 class OCPP201 : public Everest::ModuleBase {

--- a/modules/OCPP201/manifest.yaml
+++ b/modules/OCPP201/manifest.yaml
@@ -39,8 +39,8 @@ config:
     type: integer
     default: 30
   RequestCompositeScheduleDurationS:
-    description: >- 
-      Time (seconds) for which composite schedules are requested. 
+    description: >-
+      Time (seconds) for which composite schedules are requested.
       Schedules are requested from now until now + RequestCompositeScheduleDurationS
     type: integer
     default: 600
@@ -50,9 +50,15 @@ config:
       Amps for AC and Watts for DC charging stations.
       Allowed values:
         - 'A' for Amps
-        . 'W' for Watts 
+        . 'W' for Watts
     type: string
     default: 'A'
+  DelayOcppStart:
+    description: >-
+      Small delay in time (milliseconds) to start the ocpp chargepoint to allow time for the rest of everest to update the connector status.
+      This is only used to prevent issues from passing by availlable before preparing on a restart.
+    type: integer
+    default: 0
 provides:
   auth_validator:
     description: Validates the provided token using CSMS, AuthorizationList or AuthorizationCache

--- a/modules/simulation/YetiSimulator/YetiSimulator.cpp
+++ b/modules/simulation/YetiSimulator/YetiSimulator.cpp
@@ -392,9 +392,9 @@ void YetiSimulator::read_from_car() {
 }
 
 void YetiSimulator::simulation_statemachine() {
-
-    if (module_state->last_state not_eq module_state->current_state) {
+    if (module_state->republish_state or module_state->last_state not_eq module_state->current_state) {
         publish_event(module_state->current_state);
+        module_state->republish_state = false;
     }
 
     switch (module_state->current_state) {

--- a/modules/simulation/YetiSimulator/board_support/evse_board_supportImpl.cpp
+++ b/modules/simulation/YetiSimulator/board_support/evse_board_supportImpl.cpp
@@ -35,6 +35,8 @@ void evse_board_supportImpl::handle_enable(bool& value) {
     if (value) {
         if (current_state == state::State::STATE_DISABLED) {
             current_state = state::State::STATE_A;
+        } else {
+            mod->module_state->republish_state = true;
         }
     } else {
         current_state = state::State::STATE_DISABLED;

--- a/modules/simulation/YetiSimulator/util/state.hpp
+++ b/modules/simulation/YetiSimulator/util/state.hpp
@@ -230,6 +230,8 @@ struct ModuleState {
 
     double ev_max_current = 0.0;
     int ev_three_phases = 3;
+
+    bool republish_state = false;
 };
 
 std::string state_to_string(const state::ModuleState& module_state);


### PR DESCRIPTION
## Describe your changes

Update allowing to keep whether a simulated EV is still plugged in or not across reboots of the software. This is mainly used for testing / simulating the scenario with a hard reset or power loss during a transaction.

Requires changes from https://github.com/EVerest/libocpp/pull/1053

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

