### PR TITLE
module-dependencies, tests: drop PyJosev

### DIFF
--- a/module-dependencies.cmake
+++ b/module-dependencies.cmake
@@ -32,7 +32,7 @@ ev_define_dependency(
 
 ev_define_dependency(
     DEPENDENCY_NAME Josev
-    DEPENDENT_MODULES_LIST PyJosev PyEvJosev)
+    DEPENDENT_MODULES_LIST PyEvJosev)
 
 ev_define_dependency(
     DEPENDENCY_NAME libcbv2g

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-two-evse-dc.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-two-evse-dc.yaml
@@ -1,9 +1,9 @@
 active_modules:
   iso15118_charger_1:
-    module: PyJosev
+    module: EvseV2G
     config_module:
       device: auto
-      supported_DIN70121: true
+      tls_security: allow
   iso15118_car:
     module: PyEvJosev
     config_module:


### PR DESCRIPTION
The PyJosev module was removed over a year ago.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

