### PR TITLE
Updated OCPP module documentation for California Pricing

### DIFF
--- a/modules/OCPP/doc.rst
+++ b/modules/OCPP/doc.rst
@@ -253,13 +253,11 @@ Requires: display_message
 **Interface**: `display_message <../../interfaces/display_message.yaml>`_
 
 This module optionally requires a connection to a module implementing the **display_message** interface. This connection is used to allow  
-the CSMS to display pricing or other information on the display of a charging station. In order to fulfill the requirements of the  
-California Pricing whitepaper, it is required to connect a module implementing this interface.
+the CSMS to display pricing or other information on the display of a charging station.
 
 This module makes use of the following commands of this interface:
 
 * **set_display_message** to set a message on the charging station's display. This is executed when the CSMS sends a  
-  **DataTransfer.req(SetUserPrice)** message to the charging station.
 
 Requires: extensions_15118
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/modules/OCPP201/doc.rst
+++ b/modules/OCPP201/doc.rst
@@ -252,8 +252,7 @@ module implementing this interface.
 
 This module makes use of the following commands of this interface:
 
-* **set_display_message** to set a message on the charging station's display. This is executed when the CSMS sends a **SetDisplayMessage.req** or **TransactionEvent.conf**
-  (including cost and tariff data) message to the charging station.
+* **set_display_message** to set a message on the charging station's display. This is executed when the CSMS sends a **SetDisplayMessage.req** message to the charging station.
 * **get_display_messages** to forward a **GetDisplayMessage.req** from the CSMS
 * **clear_display_message** to forward a **ClearDisplayMessage.req** from the CSMS
 


### PR DESCRIPTION

## Describe your changes
Fixed outdated documentation about display_message callbacks being used wrt California Pricing. The california pricing integration only uses the session_cost interface, not display_message anymore

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

