### PR TITLE
Updating fedora version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ zypper install -y git rsync wget cmake doxygen graphviz clang-tools cppcheck \
   libcap-devel
 ```
 
-### Fedora 38, 39 & 40
+### Fedora 40, 41 & 42
 
 ```bash
 sudo dnf update
 sudo dnf install make automake gcc gcc-c++ kernel-devel python3-pip \
   python3-devel git rsync wget cmake doxygen graphviz clang-tools-extra \
-  cppcheck java-17-openjdk java-17-openjdk-devel boost-devel nodejs \
+  cppcheck java-21-openjdk java-21-openjdk-devel boost-devel nodejs \
   nodejs-devel npm openssl openssl-devel libsqlite3x-devel curl rfkill \
   libpcap-devel libevent-devel libcap-devel
 ```


### PR DESCRIPTION
## Describe your changes
Fedora 41 and 42 is supported.
Also openjdk version 17 is deprecated from Fedora version 42. Added `java-21-openjdk`.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

