### PR TITLE
Skip HLC startup tests in GitHub CI

### DIFF
--- a/tests/core_tests/startup_tests.py
+++ b/tests/core_tests/startup_tests.py
@@ -4,6 +4,7 @@
 # Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 
 import logging
+import os
 import pytest
 import time
 import threading
@@ -128,6 +129,10 @@ async def test_001_start_test_module(everest_core: EverestCore):
 
 @pytest.mark.everest_core_config('config-sil.yaml')
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.getenv("EXT_MOUNT") == "/ext",
+    reason="HLC tests do not work without a IPv6 link-local address, which currently seems to be the case in GitHub CI"
+)
 async def test_002_start_test_module_ac_hlc(everest_core: EverestCore):
     logging.info(">>>>>>>>> test_002_start_test_module_ac_hlc <<<<<<<<<")
 
@@ -151,6 +156,10 @@ async def test_002_start_test_module_ac_hlc(everest_core: EverestCore):
 
 @pytest.mark.everest_core_config('config-sil-dc.yaml')
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.getenv("EXT_MOUNT") == "/ext",
+    reason="HLC tests do not work without a IPv6 link-local address, which currently seems to be the case in GitHub CI"
+)
 async def test_003_start_test_module_dc(everest_core: EverestCore):
     logging.info(">>>>>>>>> test_003_start_test_module_dc <<<<<<<<<")
 


### PR DESCRIPTION
There seems to be an IPv6 issue with the current runner image: https://github.com/actions/runner-images/issues/12166
This skips the AC and DC HLC tests when the EXT_MOUNT environment variable is set to "/ext", which is the case for our CI.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

