### PR TITLE
Add get_uuid() to staging helpers as a common implementation

### DIFF
--- a/lib/staging/helpers/BUILD.bazel
+++ b/lib/staging/helpers/BUILD.bazel
@@ -6,6 +6,7 @@ cc_library(
     visibility = ["//visibility:public"],
     includes = ["include"],
     deps = [
+        "@//third-party/bazel:boost_uuid",
         "@com_github_fmtlib_fmt//:fmt",
         "@com_github_nlohmann_json//:json",
         "//types:types_lib",

--- a/lib/staging/helpers/CMakeLists.txt
+++ b/lib/staging/helpers/CMakeLists.txt
@@ -27,6 +27,7 @@ target_include_directories(everest_staging_helpers
 
 target_link_libraries(everest_staging_helpers
     PRIVATE
+        Boost::headers
         fmt::fmt
         nlohmann_json::nlohmann_json
 )

--- a/lib/staging/helpers/include/everest/staging/helpers/helpers.hpp
+++ b/lib/staging/helpers/include/everest/staging/helpers/helpers.hpp
@@ -18,6 +18,10 @@ std::string redact(const std::string& token);
 
 types::authorization::ProvidedIdToken redact(const types::authorization::ProvidedIdToken& token);
 
+/// \brief Provide a UUID
+/// \returns a UUID string
+std::string get_uuid();
+
 } // namespace everest::staging::helpers
 
 #endif

--- a/lib/staging/helpers/lib/helpers.cpp
+++ b/lib/staging/helpers/lib/helpers.cpp
@@ -5,6 +5,9 @@
 
 #include <unordered_map>
 
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <fmt/format.h>
 
 #include <generated/types/authorization.hpp>
@@ -23,5 +26,9 @@ types::authorization::ProvidedIdToken redact(const types::authorization::Provide
         parent_id_token.value = redact(parent_id_token.value);
     }
     return redacted_token;
+}
+
+std::string get_uuid() {
+    return boost::uuids::to_string(boost::uuids::random_generator()());
 }
 } // namespace everest::staging::helpers

--- a/lib/staging/helpers/tests/helpers_test.cpp
+++ b/lib/staging/helpers/tests/helpers_test.cpp
@@ -17,3 +17,13 @@ TEST(HelpersTest, redact_token) {
 
     EXPECT_THAT(redacted, StartsWith("[redacted] hash: "));
 }
+
+TEST(HelpersTest, get_uuid) {
+    auto uuid1 = get_uuid();
+    auto uuid2 = get_uuid();
+
+    EXPECT_GT(uuid1.length(), 0);
+    EXPECT_GT(uuid2.length(), 0);
+    EXPECT_EQ(uuid1.length(), uuid2.length());
+    EXPECT_NE(uuid1, uuid2);
+}

--- a/modules/DummyBankSessionTokenProvider/CMakeLists.txt
+++ b/modules/DummyBankSessionTokenProvider/CMakeLists.txt
@@ -9,6 +9,10 @@ ev_setup_cpp_module()
 
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 # insert your custom targets and additional config variables here
+target_link_libraries(${MODULE_NAME}
+    PRIVATE
+        everest::staging::helpers
+)
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 
 target_sources(${MODULE_NAME}

--- a/modules/DummyBankSessionTokenProvider/main/bank_session_token_providerImpl.cpp
+++ b/modules/DummyBankSessionTokenProvider/main/bank_session_token_providerImpl.cpp
@@ -3,10 +3,7 @@
 
 #include "bank_session_token_providerImpl.hpp"
 
-#include <boost/uuid/random_generator.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <string>
+#include <everest/staging/helpers/helpers.hpp>
 
 namespace module {
 namespace main {
@@ -22,7 +19,7 @@ types::payment_terminal::BankSessionToken bank_session_token_providerImpl::handl
     bank_session_token.token = config.token;
 
     if (config.randomize) {
-        bank_session_token.token = boost::uuids::to_string(boost::uuids::random_generator()());
+        bank_session_token.token = everest::staging::helpers::get_uuid();
     }
     return bank_session_token;
 }

--- a/modules/EvseManager/BUILD.bazel
+++ b/modules/EvseManager/BUILD.bazel
@@ -12,6 +12,7 @@ cc_everest_module(
     deps = [
         "@pugixml//:libpugixml",
         "@sigslot//:sigslot",
+        "//lib/staging/helpers",
     ],
     impls = IMPLS,
     srcs = glob(

--- a/modules/EvseManager/CMakeLists.txt
+++ b/modules/EvseManager/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(${MODULE_NAME}
 
 target_link_libraries(${MODULE_NAME}
     PRIVATE
+        everest::staging::helpers
         Pal::Sigslot
         pugixml::pugixml
 )

--- a/modules/EvseManager/tests/CMakeLists.txt
+++ b/modules/EvseManager/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(${TEST_TARGET_NAME} PRIVATE
     GTest::gtest_main
     everest::log
     everest::framework
+    everest::staging::helpers
     sigslot
 )
 
@@ -59,6 +60,7 @@ target_link_libraries(${CHARGER_TEST_TARGET_NAME} PRIVATE
     GTest::gmock
     GTest::gtest_main
     everest::framework
+    everest::staging::helpers
     sigslot
 )
 

--- a/modules/EvseManager/utils.hpp
+++ b/modules/EvseManager/utils.hpp
@@ -4,16 +4,14 @@
 #ifndef _EVSEMANAGER_UTILS_H_
 #define _EVSEMANAGER_UTILS_H_
 
-#include <boost/uuid/random_generator.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_io.hpp>
+#include <everest/staging/helpers/helpers.hpp>
 #include <generated/types/powermeter.hpp>
 
 namespace module {
 namespace utils {
 
 inline std::string generate_session_uuid() {
-    return boost::uuids::to_string(boost::uuids::random_generator()());
+    return everest::staging::helpers::get_uuid();
 }
 
 inline types::powermeter::OCMFIdentificationType


### PR DESCRIPTION
Use it in EvseManager and DummyBankSessionTokenProvider instead of directly using boosts uuid

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

