### PR TITLE
[OCPP 1.6] Update EvseManager Inoperative error to include details of the original cause

### DIFF
--- a/modules/EvseManager/ErrorHandling.hpp
+++ b/modules/EvseManager/ErrorHandling.hpp
@@ -39,6 +39,8 @@
 
 namespace module {
 
+class EvseManager;
+
 class ErrorHandling {
 
 public:
@@ -51,7 +53,8 @@ public:
                            const std::vector<std::unique_ptr<isolation_monitorIntf>>& _r_imd,
                            const std::vector<std::unique_ptr<power_supply_DCIntf>>& _r_powersupply,
                            const std::vector<std::unique_ptr<powermeterIntf>>& _r_powermeter,
-                           const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& _r_over_voltage_monitor);
+                           const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& _r_over_voltage_monitor,
+                           bool _inoperative_error_use_vendor_id);
 
     // Signal that error set has changed. Bool argument is true if it is preventing charging at the moment and false if
     // charging can continue.
@@ -71,11 +74,13 @@ public:
     void raise_powermeter_transaction_start_failed_error(const std::string& description);
     void clear_powermeter_transaction_start_failed_error();
 
+protected:
+    void raise_inoperative_error(const Everest::error::Error& caused_by);
+
 private:
     void process_error();
-    void raise_inoperative_error(const std::string& caused_by);
     void clear_inoperative_error();
-    std::optional<std::string> errors_prevent_charging();
+    std::optional<Everest::error::Error> errors_prevent_charging();
 
     const std::unique_ptr<evse_board_supportIntf>& r_bsp;
     const std::vector<std::unique_ptr<ISO15118_chargerIntf>>& r_hlc;
@@ -86,6 +91,7 @@ private:
     const std::vector<std::unique_ptr<power_supply_DCIntf>>& r_powersupply;
     const std::vector<std::unique_ptr<powermeterIntf>>& r_powermeter;
     const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& r_over_voltage_monitor;
+    const bool inoperative_error_use_vendor_id;
 };
 
 } // namespace module

--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -170,7 +170,8 @@ void EvseManager::ready() {
     const std::vector<std::unique_ptr<powermeterIntf>> empty;
     error_handling = std::unique_ptr<ErrorHandling>(
         new ErrorHandling(r_bsp, r_hlc, r_connector_lock, r_ac_rcd, p_evse, r_imd, r_powersupply_DC,
-                          config.fail_on_powermeter_errors ? r_powermeter_billing() : empty, r_over_voltage_monitor));
+                          config.fail_on_powermeter_errors ? r_powermeter_billing() : empty, r_over_voltage_monitor,
+                          config.inoperative_error_use_vendor_id));
 
     if (not config.lock_connector_in_state_b) {
         EVLOG_warning << "Unlock connector in CP state B. This violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and "

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -108,6 +108,7 @@ struct Conf {
     int sleep_before_enabling_pwm_hlc_mode_ms;
     bool central_contract_validation_allowed;
     bool contract_certificate_installation_enabled;
+    bool inoperative_error_use_vendor_id;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -303,7 +303,7 @@ config:
     type: boolean
     default: false
   sleep_before_enabling_pwm_hlc_mode_ms:
-    description: >- 
+    description: >-
       Sleep before the PWM signal is updated in HLC mode. Teslas are really fast with sending the first slac packet after
       enabling PWM, so the sleep allows SLAC to be ready for it. Some EV testers have issues with a value >= 1000ms,
       although ISO15118 or IEC61851 does not specify a timeout.
@@ -311,9 +311,9 @@ config:
     default: 1000
   central_contract_validation_allowed:
     description: >-
-      Used for ISO15118 plug and charge: 
+      Used for ISO15118 plug and charge:
       If false, contract shall not be present in PaymentOptionList.
-      If true, contract may be present in PaymentOptionList if TLS is used. 
+      If true, contract may be present in PaymentOptionList if TLS is used.
     type: boolean
     default: false
   contract_certificate_installation_enabled:
@@ -321,6 +321,11 @@ config:
       Used for ISO15118 plug and charge: Indicates if the charger supports contract CertificateInstall and CertificateUpdate
     type: boolean
     default: true
+  inoperative_error_use_vendor_id:
+    description: >-
+      When raising evse_manager/Inoperative use the vendor ID from the original cause
+    type: boolean
+    default: false
 provides:
   evse:
     interface: evse_manager

--- a/modules/EvseManager/tests/CMakeLists.txt
+++ b/modules/EvseManager/tests/CMakeLists.txt
@@ -13,7 +13,9 @@ target_include_directories(${TEST_TARGET_NAME} PRIVATE
 
 target_sources(${TEST_TARGET_NAME} PRIVATE
     EventQueueTest.cpp
+    ErrorHandlingTest.cpp
     IECStateMachineTest.cpp
+    ../ErrorHandling.cpp
     ../IECStateMachine.cpp
     ../backtrace.cpp
 )

--- a/modules/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EvseManager/tests/ChargerTest.cpp
@@ -59,7 +59,7 @@ struct ChargerTest : public testing::Test {
         charger_error_handling(std::make_unique<ErrorHandling>(
             error_handler_bsp, error_handler_hlc, error_handler_connector_lock, error_handler_ac_rcd,
             error_handler_evse, error_handler_imd, error_handler_powersupply, error_handler_powermeter,
-            error_handler_over_voltage_monitor)) {
+            error_handler_over_voltage_monitor, false)) {
     }
 
     void SetUp() override {
@@ -736,7 +736,8 @@ ErrorHandling::ErrorHandling(const std::unique_ptr<evse_board_supportIntf>& r_bs
                              const std::vector<std::unique_ptr<isolation_monitorIntf>>& _r_imd,
                              const std::vector<std::unique_ptr<power_supply_DCIntf>>& _r_powersupply,
                              const std::vector<std::unique_ptr<powermeterIntf>>& _r_powermeter,
-                             const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& _r_over_voltage_monitor) :
+                             const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& _r_over_voltage_monitor,
+                             bool _inoperative_error_use_vendor_id) :
     r_bsp(r_bsp),
     r_hlc(r_hlc),
     r_connector_lock(r_connector_lock),
@@ -745,7 +746,8 @@ ErrorHandling::ErrorHandling(const std::unique_ptr<evse_board_supportIntf>& r_bs
     r_imd(_r_imd),
     r_powersupply(r_powersupply),
     r_powermeter(_r_powermeter),
-    r_over_voltage_monitor(_r_over_voltage_monitor) {
+    r_over_voltage_monitor(_r_over_voltage_monitor),
+    inoperative_error_use_vendor_id(_inoperative_error_use_vendor_id) {
 }
 
 void ErrorHandling::raise_overcurrent_error(const std::string& description) {

--- a/modules/EvseManager/tests/ErrorHandlingTest.cpp
+++ b/modules/EvseManager/tests/ErrorHandlingTest.cpp
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "ErrorHandling.hpp"
+#include "EvseManagerStub.hpp"
+#include "evse_board_supportIntfStub.hpp"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <set>
+
+namespace Everest::error {
+bool operator<(const Error& lhs, const Error& rhs) {
+    return lhs.type < rhs.type;
+}
+bool operator==(const Error& lhs, const Error& rhs) {
+    return (lhs.type == rhs.type) && (lhs.sub_type == rhs.sub_type);
+}
+} // namespace Everest::error
+
+namespace {
+
+struct ErrorHandlingTest : public module::ErrorHandling {
+    using module::ErrorHandling::ErrorHandling;
+    using module::ErrorHandling::raise_inoperative_error;
+};
+
+struct ErrorDatabaseStub : public Everest::error::ErrorDatabase {
+    using Error = Everest::error::Error;
+    using ErrorPtr = Everest::error::ErrorPtr;
+    using ErrorFilter = Everest::error::ErrorFilter;
+
+    std::list<Error>& active_errors;
+
+    ErrorDatabaseStub(std::list<Error>& active) : Everest::error::ErrorDatabase(), active_errors(active) {
+    }
+
+    virtual void add_error(ErrorPtr error) {
+    }
+    virtual std::list<ErrorPtr> get_errors(const std::list<ErrorFilter>& filters) const {
+        std::list<ErrorPtr> result;
+        for (const auto& error : active_errors) {
+            result.push_back(std::make_shared<Error>(error));
+        }
+        return result;
+    }
+    virtual std::list<ErrorPtr> edit_errors(const std::list<ErrorFilter>& filters, EditErrorFunc edit_func) {
+        return {};
+    }
+    virtual std::list<ErrorPtr> remove_errors(const std::list<ErrorFilter>& filters) {
+        return {};
+    }
+};
+
+struct EvseManagerModuleAdapterStub : public module::stub::EvseManagerModuleAdapter {
+    std::shared_ptr<Everest::error::ErrorTypeMap> error_type_map;
+    std::shared_ptr<ErrorDatabaseStub> error_database;
+    std::list<Everest::error::ErrorType> error_list;
+    std::list<Everest::error::Error> active_errors;
+
+    EvseManagerModuleAdapterStub() :
+        module::stub::EvseManagerModuleAdapter(),
+        error_type_map(std::make_shared<Everest::error::ErrorTypeMap>()),
+        error_database(std::make_shared<ErrorDatabaseStub>(active_errors)),
+        error_list{} {
+    }
+
+    virtual std::shared_ptr<Everest::error::ErrorManagerImpl> get_error_manager_impl_fn(const std::string& str) {
+        return std::make_shared<Everest::error::ErrorManagerImpl>(
+            error_type_map, std::make_shared<Everest::error::ErrorDatabaseMap>(), error_list,
+            [this](const Everest::error::Error& error) {
+                if (error_raise.find(error.type) == error_raise.end()) {
+                    throw std::runtime_error("Error type " + error.type + " not found");
+                }
+                error_raise[error.type](error);
+                active_errors.push_back(error);
+            },
+            [this](const Everest::error::Error& error) {
+                if (error_raise.find(error.type) == error_raise.end()) {
+                    throw std::runtime_error("Error type " + error.type + " not found");
+                }
+                error_clear[error.type](error);
+                active_errors.remove(error);
+            },
+            false);
+    }
+
+    virtual std::shared_ptr<Everest::error::ErrorManagerReq> get_error_manager_req_fn(const Requirement& req) {
+        return std::make_shared<Everest::error::ErrorManagerReq>(
+            error_type_map, std::make_shared<Everest::error::ErrorDatabaseMap>(), error_list,
+            [this](const Everest::error::ErrorType& error_type, const Everest::error::ErrorCallback& callback,
+                   const Everest::error::ErrorCallback& clear_callback) {
+                error_raise[error_type] = callback;
+                error_clear[error_type] = clear_callback;
+            });
+    }
+
+    virtual std::shared_ptr<Everest::error::ErrorFactory> get_error_factory_fn(const std::string&) {
+        return std::make_shared<Everest::error::ErrorFactory>(error_type_map);
+    }
+
+    virtual std::shared_ptr<Everest::error::ErrorStateMonitor> get_error_state_monitor_impl_fn(const std::string&) {
+        return std::make_shared<Everest::error::ErrorStateMonitor>(error_database);
+    }
+};
+
+struct ErrorHandlingTesting : public testing::Test {
+    EvseManagerModuleAdapterStub adapter;
+    std::map<Everest::error::ErrorType, std::string> error_types_map;
+
+    std::unique_ptr<evse_board_supportIntf> r_bsp{};
+    const std::vector<std::unique_ptr<ISO15118_chargerIntf>> r_hlc{};
+    const std::vector<std::unique_ptr<connector_lockIntf>> r_connector_lock{};
+    const std::vector<std::unique_ptr<ac_rcdIntf>> r_ac_rcd{};
+    std::unique_ptr<evse_managerImplBase> p_evse{};
+    const std::vector<std::unique_ptr<isolation_monitorIntf>> _r_imd{};
+    const std::vector<std::unique_ptr<power_supply_DCIntf>> _r_powersupply{};
+    const std::vector<std::unique_ptr<powermeterIntf>> _r_powermeter{};
+    const std::vector<std::unique_ptr<over_voltage_monitorIntf>> _r_over_voltage_monitor{};
+
+    std::unique_ptr<ErrorHandlingTest> error_handler;
+
+    void construct(bool _inoperative_error_use_vendor_id) {
+        error_types_map = {{"evse_board_support/VendorWarning", "warning"},
+                           {"evse_manager/Inoperative", "inoperative"}};
+        adapter.error_type_map->load_error_types_map(error_types_map);
+        adapter.active_errors.clear();
+        for (const auto& [error, description] : error_types_map) {
+            adapter.error_list.push_back(error);
+        }
+        r_bsp = std::make_unique<module::stub::evse_board_supportIntfStub>(adapter);
+        p_evse = std::make_unique<module::stub::evse_managerImplStub>(&adapter, "manager");
+        error_handler = std::make_unique<ErrorHandlingTest>(r_bsp, r_hlc, r_connector_lock, r_ac_rcd, p_evse, _r_imd,
+                                                            _r_powersupply, _r_powermeter, _r_over_voltage_monitor,
+                                                            _inoperative_error_use_vendor_id);
+    }
+
+    static constexpr std::string_view default_description{"description"};
+    static constexpr std::string_view default_no_vendor_id{"EVerest"};
+    static constexpr std::string_view default_vendor_id{"vendor_id"};
+
+    Everest::error::Error test_description(const std::string& type, const std::string& subtype) {
+        Everest::error::Error error{};
+        error.type = type;
+        error.sub_type = subtype;
+        error.message = "message";
+        error.description = default_description;
+        error.vendor_id = default_vendor_id;
+        error_handler->raise_inoperative_error(error);
+
+        EXPECT_EQ(adapter.active_errors.size(), 1);
+        auto& active = adapter.active_errors.front();
+        EXPECT_EQ(active.type, "evse_manager/Inoperative");
+        EXPECT_EQ(active.sub_type, "");
+        EXPECT_EQ(active.message, error.type);
+        return active;
+    }
+};
+
+TEST_F(ErrorHandlingTesting, NoType) {
+    construct(true);
+    auto error = test_description("", "sub-type");
+    EXPECT_EQ(error.description, default_description);
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("", "sub-type");
+    EXPECT_EQ(error.description, default_description);
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeNoSlashA) {
+    construct(true);
+    auto error = test_description("type", "sub-type");
+    EXPECT_EQ(error.description, default_description);
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("type", "sub-type");
+    EXPECT_EQ(error.description, default_description);
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeNoSlashB) {
+    construct(true);
+    auto error = test_description("type", "");
+    EXPECT_EQ(error.description, default_description);
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("type", "");
+    EXPECT_EQ(error.description, default_description);
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeSlashEndA) {
+    construct(true);
+    auto error = test_description("type/", "sub-type");
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("type/", "sub-type");
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeSlashEndB) {
+    construct(true);
+    auto error = test_description("type/", "");
+    EXPECT_EQ(error.description, "type");
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("type/", "");
+    EXPECT_EQ(error.description, "type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeSlashBeginA) {
+    construct(true);
+    auto error = test_description("/type", "sub-type");
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("/type", "sub-type");
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeSlashBeginB) {
+    construct(true);
+    auto error = test_description("/type", "");
+    EXPECT_EQ(error.description, "type");
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("/type", "");
+    EXPECT_EQ(error.description, "type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeFullA) {
+    construct(true);
+    auto error = test_description("module/type", "sub-type");
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("module/type", "sub-type");
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeFullB) {
+    construct(true);
+    auto error = test_description("module/type", "");
+    EXPECT_EQ(error.description, "type");
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("module/type", "");
+    EXPECT_EQ(error.description, "type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeFullC) {
+    construct(true);
+    auto error = test_description("module/type/", "sub-type");
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("module/type/", "sub-type");
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, TypeFullD) {
+    construct(true);
+    auto error = test_description("module/type/", "");
+    EXPECT_EQ(error.description, "type");
+    EXPECT_EQ(error.vendor_id, default_vendor_id);
+    construct(false);
+    error = test_description("module/type/", "");
+    EXPECT_EQ(error.description, "type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, NoVendorId) {
+    Everest::error::Error raised_error{};
+    raised_error.type = "module/type";
+    raised_error.sub_type = "sub-type";
+    raised_error.message = "message";
+    raised_error.description = default_description;
+    raised_error.vendor_id = "";
+
+    construct(true);
+    error_handler->raise_inoperative_error(raised_error);
+    EXPECT_EQ(adapter.active_errors.size(), 1);
+    auto& error = adapter.active_errors.front();
+    EXPECT_EQ(error.type, "evse_manager/Inoperative");
+    EXPECT_EQ(error.sub_type, "");
+    EXPECT_EQ(error.message, raised_error.type);
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+
+    construct(false);
+    error_handler->raise_inoperative_error(raised_error);
+    EXPECT_EQ(adapter.active_errors.size(), 1);
+    error = adapter.active_errors.front();
+    EXPECT_EQ(error.type, "evse_manager/Inoperative");
+    EXPECT_EQ(error.sub_type, "");
+    EXPECT_EQ(error.message, raised_error.type);
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, default_no_vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, IsActive) {
+    Everest::error::Error first_error{};
+    first_error.type = "module/type";
+    first_error.sub_type = "sub-type";
+    first_error.message = "message";
+    first_error.description = "description";
+    first_error.vendor_id = "vendor_id";
+
+    construct(true);
+    EXPECT_FALSE(p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", ""));
+
+    error_handler->raise_inoperative_error(first_error);
+    EXPECT_EQ(adapter.active_errors.size(), 1);
+    auto error = adapter.active_errors.front();
+    EXPECT_EQ(error.type, "evse_manager/Inoperative");
+    EXPECT_EQ(error.sub_type, "");
+    EXPECT_EQ(error.message, first_error.type);
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, first_error.vendor_id);
+
+    EXPECT_TRUE(p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", ""));
+
+    Everest::error::Error raised_error{};
+    raised_error.type = "module/new-type";
+    raised_error.sub_type = "new-sub-type";
+    raised_error.message = "new-message";
+    raised_error.description = "new-description";
+    raised_error.vendor_id = "new-vendor_id";
+
+    // should not be a new error
+    error_handler->raise_inoperative_error(raised_error);
+    EXPECT_EQ(adapter.active_errors.size(), 1);
+    error = adapter.active_errors.front();
+    // should be first error
+    EXPECT_EQ(error.type, "evse_manager/Inoperative");
+    EXPECT_EQ(error.sub_type, "");
+    EXPECT_EQ(error.message, first_error.type);
+    EXPECT_EQ(error.description, "type/sub-type");
+    EXPECT_EQ(error.vendor_id, first_error.vendor_id);
+}
+
+} // namespace

--- a/modules/EvseManager/tests/EvseManagerStub.hpp
+++ b/modules/EvseManager/tests/EvseManagerStub.hpp
@@ -11,6 +11,8 @@
 namespace module::stub {
 
 struct evse_managerImplStub : public evse_managerImplBase {
+    evse_managerImplStub(Everest::ModuleAdapter* ev, const std::string& name) : evse_managerImplBase(ev, name) {
+    }
     evse_managerImplStub() : evse_managerImplBase(nullptr, "manager") {
     }
     virtual void init() {
@@ -61,6 +63,9 @@ struct evse_managerImplStub : public evse_managerImplBase {
     }
     virtual bool handle_external_ready_to_start_charging() {
         return true;
+    }
+    virtual void handle_set_plug_and_charge_configuration(
+        types::evse_manager::PlugAndChargeConfiguration& plug_and_charge_configuration) {
     }
 };
 

--- a/modules/OCPP/OCPP.cpp
+++ b/modules/OCPP/OCPP.cpp
@@ -51,9 +51,12 @@ static ocpp::v16::ErrorInfo get_error_info(const Everest::error::Error& error) {
     }
 
     if (error_type == INOPERATIVE_ERROR_TYPE) {
-        return ocpp::v16::ErrorInfo{uuid,      ocpp::v16::ChargePointErrorCode::OtherError,
-                                    true,      "EVSE is inoperative",
-                                    "EVerest", "caused_by:" + error.message};
+        return ocpp::v16::ErrorInfo{uuid,
+                                    ocpp::v16::ChargePointErrorCode::OtherError,
+                                    true,
+                                    "caused_by:" + error.message,
+                                    error.vendor_id,
+                                    error.description};
     }
 
     const auto get_simplified_error_type = [](const std::string& error_type) {


### PR DESCRIPTION
## Describe your changes
Reformat EVSE Manager inopertative error to preserve original error

New configuration key added that optionally changes the vendor_id to be the ID from the original error rather than always being EVerest.

Added unit tests to check how different error types and sub-types will be presented.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

