### PR TITLE
Adjust OCPP1.6 E2E Composite Schedule test cases because of change in libocpp

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -68,7 +68,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.26.3
+  git_tag: 8df1ee20f87d2be353cc80ee7825e35114361baf
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
@@ -556,8 +556,7 @@ class TestOCPP16GenericInterfaceIntegration:
                             "charging_rate_unit": "A",
                             "charging_schedule_period": [
                                 {
-                                    "limit": 48,
-                                    "number_phases": 3,
+                                    "limit": 64,
                                     "stack_level": 0,
                                     "start_period": 0,
                                 }
@@ -571,7 +570,6 @@ class TestOCPP16GenericInterfaceIntegration:
                             "charging_schedule_period": [
                                 {
                                     "limit": 32,
-                                    "number_phases": 3,
                                     "stack_level": 1,
                                     "start_period": 0,
                                 }
@@ -585,7 +583,6 @@ class TestOCPP16GenericInterfaceIntegration:
                             "charging_schedule_period": [
                                 {
                                     "limit": 32,
-                                    "number_phases": 3,
                                     "stack_level": 1,
                                     "start_period": 0,
                                 }

--- a/tests/ocpp_tests/test_sets/ocpp16/smart_charging_profiles/absolute_profiles.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/smart_charging_profiles/absolute_profiles.py
@@ -23,7 +23,7 @@ def abs_req1_test1():
                 start_schedule=datetime.now(timezone.utc).isoformat(),
                 charging_rate_unit=ChargingRateUnitType.amps,
                 charging_schedule_period=[
-                    ChargingSchedulePeriod(start_period=0, limit=10)
+                    ChargingSchedulePeriod(start_period=0, limit=10, number_phases=3)
                 ],
             ),
         ),
@@ -45,11 +45,11 @@ def abs_req2_test1():
                 start_schedule=datetime.now(timezone.utc).isoformat(),
                 charging_rate_unit=ChargingRateUnitType.amps,
                 charging_schedule_period=[
-                    ChargingSchedulePeriod(start_period=0, limit=6),
-                    ChargingSchedulePeriod(start_period=60, limit=10),
-                    ChargingSchedulePeriod(start_period=120, limit=8),
-                    ChargingSchedulePeriod(start_period=180, limit=25),
-                    ChargingSchedulePeriod(start_period=260, limit=8),
+                    ChargingSchedulePeriod(start_period=0, limit=6, number_phases=3),
+                    ChargingSchedulePeriod(start_period=60, limit=10, number_phases=3),
+                    ChargingSchedulePeriod(start_period=120, limit=8, number_phases=3),
+                    ChargingSchedulePeriod(start_period=180, limit=25, number_phases=3),
+                    ChargingSchedulePeriod(start_period=260, limit=8, number_phases=3),
                 ],
             ),
         ),
@@ -223,15 +223,15 @@ def abs_exp_test3(passed_seconds):
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
                 ChargingSchedulePeriod(
-                    start_period=0, limit=6, number_phases=3),
+                    start_period=0, limit=6),
                 ChargingSchedulePeriod(
-                    start_period=60 - passed_seconds, limit=10, number_phases=3
+                    start_period=60 - passed_seconds, limit=10
                 ),
                 ChargingSchedulePeriod(
-                    start_period=120 - passed_seconds, limit=8, number_phases=3
+                    start_period=120 - passed_seconds, limit=8
                 ),
                 ChargingSchedulePeriod(
-                    start_period=260 - passed_seconds, limit=48, number_phases=3
+                    start_period=260 - passed_seconds, limit=48
                 ),
             ],
         ),
@@ -297,15 +297,15 @@ def abs_exp_test5_1(passed_seconds):
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
                 ChargingSchedulePeriod(
-                    start_period=0, limit=7, number_phases=3),
+                    start_period=0, limit=7),
                 ChargingSchedulePeriod(
-                    start_period=100 - passed_seconds, limit=9, number_phases=3
+                    start_period=100 - passed_seconds, limit=9
                 ),
                 ChargingSchedulePeriod(
-                    start_period=150 - passed_seconds, limit=8, number_phases=3
+                    start_period=150 - passed_seconds, limit=8
                 ),
                 ChargingSchedulePeriod(
-                    start_period=200 - passed_seconds, limit=10, number_phases=3
+                    start_period=200 - passed_seconds, limit=10
                 ),
             ],
         ),
@@ -323,18 +323,18 @@ def abs_exp_test5_2(passed_seconds):
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
                 ChargingSchedulePeriod(
-                    start_period=0, limit=7, number_phases=3),
+                    start_period=0, limit=7),
                 ChargingSchedulePeriod(
-                    start_period=100 - passed_seconds, limit=9, number_phases=3
+                    start_period=100 - passed_seconds, limit=9
                 ),
                 ChargingSchedulePeriod(
-                    start_period=150 - passed_seconds, limit=8, number_phases=3
+                    start_period=150 - passed_seconds, limit=8
                 ),
                 ChargingSchedulePeriod(
-                    start_period=200 - passed_seconds, limit=10, number_phases=3
+                    start_period=200 - passed_seconds, limit=10
                 ),
                 ChargingSchedulePeriod(
-                    start_period=400 - passed_seconds, limit=48, number_phases=3
+                    start_period=400 - passed_seconds, limit=48
                 ),
             ],
         ),
@@ -423,13 +423,13 @@ def abs_exp_test6_con0():
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
                 ChargingSchedulePeriod(
-                    start_period=0, limit=18, number_phases=3),
+                    start_period=0, limit=18),
                 ChargingSchedulePeriod(
-                    start_period=50, limit=24, number_phases=3),
+                    start_period=50, limit=24),
                 ChargingSchedulePeriod(
-                    start_period=100, limit=14, number_phases=3),
+                    start_period=100, limit=14),
                 ChargingSchedulePeriod(
-                    start_period=200, limit=24, number_phases=3),
+                    start_period=200, limit=24),
             ],
         ),
     )
@@ -446,18 +446,18 @@ def abs_exp_test6_con1(passed_seconds):
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
                 ChargingSchedulePeriod(
-                    start_period=0, limit=16, number_phases=3),
+                    start_period=0, limit=16),
                 ChargingSchedulePeriod(
-                    start_period=100 - passed_seconds, limit=14, number_phases=3
+                    start_period=100 - passed_seconds, limit=14
                 ),
                 ChargingSchedulePeriod(
-                    start_period=200 - passed_seconds, limit=20, number_phases=3
+                    start_period=200 - passed_seconds, limit=20
                 ),
                 ChargingSchedulePeriod(
-                    start_period=400 - passed_seconds, limit=24, number_phases=3
+                    start_period=400 - passed_seconds, limit=24
                 ),
                 ChargingSchedulePeriod(
-                    start_period=800 - passed_seconds, limit=48, number_phases=3
+                    start_period=800 - passed_seconds, limit=48
                 ),
             ],
         ),
@@ -475,12 +475,12 @@ def abs_exp_test6_con2(passed_seconds):
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
                 ChargingSchedulePeriod(
-                    start_period=0, limit=10, number_phases=3),
+                    start_period=0, limit=10),
                 ChargingSchedulePeriod(
-                    start_period=100 - passed_seconds, limit=14, number_phases=3
+                    start_period=100 - passed_seconds, limit=14
                 ),
                 ChargingSchedulePeriod(
-                    start_period=200 - passed_seconds, limit=16, number_phases=3
+                    start_period=200 - passed_seconds, limit=16
                 ),
             ],
         ),
@@ -498,7 +498,7 @@ def abs_exp_test1_con0(passed_seconds):
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
                 ChargingSchedulePeriod(
-                    start_period=0, limit=10, number_phases=3)
+                    start_period=0, limit=10)
             ],
         ),
     )
@@ -515,7 +515,7 @@ def abs_exp_test2_con0(passed_seconds):
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
                 ChargingSchedulePeriod(
-                    start_period=0, limit=20, number_phases=3)
+                    start_period=0, limit=20)
             ],
         ),
     )
@@ -532,7 +532,7 @@ def abs_exp_test3_con0(passed_seconds):
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
                 ChargingSchedulePeriod(
-                    start_period=0, limit=48, number_phases=3)
+                    start_period=0, limit=48)
             ],
         ),
     )

--- a/tests/ocpp_tests/test_sets/ocpp16/smart_charging_profiles/combined_profiles.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/smart_charging_profiles/combined_profiles.py
@@ -143,7 +143,7 @@ def comb_exp_test2():
             start_schedule=datetime.now(timezone.utc).isoformat(),
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
-                ChargingSchedulePeriod(start_period=0, limit=10, number_phases=3),
+                ChargingSchedulePeriod(start_period=0, limit=10),
                 ChargingSchedulePeriod(start_period=80, limit=20, number_phases=2),
                 ChargingSchedulePeriod(start_period=160, limit=20, number_phases=3),
             ],

--- a/tests/ocpp_tests/test_sets/ocpp16/smart_charging_profiles/recurring_profiles.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/smart_charging_profiles/recurring_profiles.py
@@ -88,12 +88,12 @@ def rec_exp_test2():
             start_schedule=datetime.now(timezone.utc).isoformat(),
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
-                ChargingSchedulePeriod(start_period=0, limit=10, number_phases=3),
-                ChargingSchedulePeriod(start_period=10000, limit=22, number_phases=3),
-                ChargingSchedulePeriod(start_period=20000, limit=6, number_phases=3),
-                ChargingSchedulePeriod(start_period=86400, limit=10, number_phases=3),
-                ChargingSchedulePeriod(start_period=96400, limit=22, number_phases=3),
-                ChargingSchedulePeriod(start_period=106400, limit=6, number_phases=3),
+                ChargingSchedulePeriod(start_period=0, limit=10),
+                ChargingSchedulePeriod(start_period=10000, limit=22),
+                ChargingSchedulePeriod(start_period=20000, limit=6),
+                ChargingSchedulePeriod(start_period=86400, limit=10),
+                ChargingSchedulePeriod(start_period=96400, limit=22),
+                ChargingSchedulePeriod(start_period=106400, limit=6),
             ],
         ),
     )
@@ -158,10 +158,10 @@ def rec_exp_test3():
             start_schedule=datetime.now(timezone.utc).isoformat(),
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
-                ChargingSchedulePeriod(start_period=0, limit=10, number_phases=3),
-                ChargingSchedulePeriod(start_period=10000, limit=22, number_phases=3),
-                ChargingSchedulePeriod(start_period=20000, limit=6, number_phases=3),
-                ChargingSchedulePeriod(start_period=86400, limit=20, number_phases=3),
+                ChargingSchedulePeriod(start_period=0, limit=10),
+                ChargingSchedulePeriod(start_period=10000, limit=22),
+                ChargingSchedulePeriod(start_period=20000, limit=6),
+                ChargingSchedulePeriod(start_period=86400, limit=20),
             ],
         ),
     )

--- a/tests/ocpp_tests/test_sets/ocpp16/smart_charging_profiles/relative_profiles.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/smart_charging_profiles/relative_profiles.py
@@ -22,8 +22,8 @@ def rel_req1_test1():
             charging_schedule=ChargingSchedule(
                 charging_rate_unit=ChargingRateUnitType.amps,
                 charging_schedule_period=[
-                    ChargingSchedulePeriod(start_period=0, limit=16),
-                    ChargingSchedulePeriod(start_period=50, limit=20),
+                    ChargingSchedulePeriod(start_period=0, limit=16, number_phases=1),
+                    ChargingSchedulePeriod(start_period=50, limit=20, number_phases=3),
                 ],
             ),
         ),
@@ -40,7 +40,7 @@ def rel_exp_test1():
             start_schedule=datetime.now(timezone.utc).isoformat(),
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
-                ChargingSchedulePeriod(start_period=0, limit=16, number_phases=3),
+                ChargingSchedulePeriod(start_period=0, limit=16, number_phases=1),
                 ChargingSchedulePeriod(start_period=50, limit=20, number_phases=3),
             ],
         ),
@@ -60,8 +60,8 @@ def rel_req1_test2():
             charging_schedule=ChargingSchedule(
                 charging_rate_unit=ChargingRateUnitType.amps,
                 charging_schedule_period=[
-                    ChargingSchedulePeriod(start_period=0, limit=16),
-                    ChargingSchedulePeriod(start_period=100, limit=20),
+                    ChargingSchedulePeriod(start_period=0, limit=16, number_phases=3),
+                    ChargingSchedulePeriod(start_period=100, limit=20, number_phases=3),
                 ],
             ),
         ),
@@ -82,8 +82,8 @@ def rel_req2_test2():
                 duration=200,
                 charging_rate_unit=ChargingRateUnitType.amps,
                 charging_schedule_period=[
-                    ChargingSchedulePeriod(start_period=0, limit=10),
-                    ChargingSchedulePeriod(start_period=50, limit=6),
+                    ChargingSchedulePeriod(start_period=0, limit=10, number_phases=3),
+                    ChargingSchedulePeriod(start_period=50, limit=6, number_phases=3),
                 ],
             ),
         ),
@@ -160,9 +160,9 @@ def rel_exp_test3():
             start_schedule=datetime.now(timezone.utc).isoformat(),
             charging_rate_unit=ChargingRateUnitType.amps,
             charging_schedule_period=[
-                ChargingSchedulePeriod(start_period=0, limit=32, number_phases=3),
-                ChargingSchedulePeriod(start_period=6, limit=20, number_phases=3),
-                ChargingSchedulePeriod(start_period=12, limit=8, number_phases=3),
+                ChargingSchedulePeriod(start_period=0, limit=32),
+                ChargingSchedulePeriod(start_period=6, limit=20),
+                ChargingSchedulePeriod(start_period=12, limit=8),
             ],
         ),
     )


### PR DESCRIPTION
## Describe your changes
Adjusted OCPP1.6 E2E test cases to new composite schedule calculation. This omits the number_phases element if number_phases was not part of the profile sent in the SetChargingProfile.req

## Issue ticket number and link
PR in libocpp: https://github.com/EVerest/libocpp/pull/1062

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

