### PR TITLE
Feat/slac reset instead of failed

### DIFF
--- a/lib/staging/slac/fsm/evse/include/slac/fsm/evse/context.hpp
+++ b/lib/staging/slac/fsm/evse/include/slac/fsm/evse/context.hpp
@@ -182,6 +182,8 @@ struct EvseSlacConfig {
 
     // offset for adjusting the calculated sounding attenuation
     int sounding_atten_adjustment = 0;
+
+    bool reset_instead_of_fail{false};
 };
 
 struct Context {

--- a/lib/staging/slac/fsm/evse/src/states/matching.cpp
+++ b/lib/staging/slac/fsm/evse/src/states/matching.cpp
@@ -175,8 +175,6 @@ FSMSimpleState::HandleEventReturnType MatchingState::handle_event(AllocatorType&
             num_retries = 0;
 
             return sa.HANDLED_INTERNALLY;
-
-            // Or return sa.create_simple<MatchingState>(ctx); // Todo(sl): Test
         }
         return sa.create_simple<FailedState>(ctx);
     }

--- a/lib/staging/slac/fsm/evse/src/states/matching.cpp
+++ b/lib/staging/slac/fsm/evse/src/states/matching.cpp
@@ -163,6 +163,21 @@ FSMSimpleState::HandleEventReturnType MatchingState::handle_event(AllocatorType&
             std::chrono::steady_clock::now() + std::chrono::milliseconds(slac::defs::TT_EVSE_SLAC_INIT_MS);
         return sa.HANDLED_INTERNALLY;
     } else if (ev == Event::FAILED) {
+        if (ctx.slac_config.reset_instead_of_fail) {
+            ctx.log_info("Resetting MatchingState. Waiting for the next CM_SLAC_PARAM.REQ message.");
+
+            // Resetting all relevant MatchingState members
+            sessions.clear();
+            // timeout for getting CM_SLAC_PARM_REQ
+            timeout_slac_parm_req =
+                std::chrono::steady_clock::now() + std::chrono::milliseconds(slac::defs::TT_EVSE_SLAC_INIT_MS);
+            seen_slac_parm_req = false;
+            num_retries = 0;
+
+            return sa.HANDLED_INTERNALLY;
+
+            // Or return sa.create_simple<MatchingState>(ctx); // Todo(sl): Test
+        }
         return sa.create_simple<FailedState>(ctx);
     }
 

--- a/modules/EvseSlac/main/slacImpl.cpp
+++ b/modules/EvseSlac/main/slacImpl.cpp
@@ -85,6 +85,8 @@ void slacImpl::run() {
     fsm_ctx.slac_config.link_status.timeout_ms = config.link_status_timeout_ms;
     fsm_ctx.slac_config.link_status.debug_simulate_failed_matching = config.debug_simulate_failed_matching;
 
+    fsm_ctx.slac_config.reset_instead_of_fail = config.reset_instead_of_fail;
+
     fsm_ctx.slac_config.generate_nmk();
 
     fsm_ctrl = std::make_unique<FSMController>(fsm_ctx);

--- a/modules/EvseSlac/main/slacImpl.hpp
+++ b/modules/EvseSlac/main/slacImpl.hpp
@@ -34,6 +34,7 @@ struct Conf {
     int link_status_retry_ms;
     int link_status_timeout_ms;
     bool debug_simulate_failed_matching;
+    bool reset_instead_of_fail;
 };
 
 class slacImpl : public slacImplBase {

--- a/modules/EvseSlac/manifest.yaml
+++ b/modules/EvseSlac/manifest.yaml
@@ -66,6 +66,13 @@ provides:
         description: Only for debugging. Simulate failed matching by sending a wrong NMK to the EV.
         type: boolean
         default: false
+      reset_instead_of_fail:
+        description: >-
+          Go to reset state instead of failed state. This is against the ISO15118-3.
+          But some cars directly send a CM_SLAC_PARAM.req message when the SLAC process aborts.
+          To react to this message and restart the SLAC process, the EVSE go to the reset state here.
+        type: boolean
+        default: true
 metadata:
   base_license: https://directory.fsf.org/wiki/License:BSD-3-Clause-Clear
   license: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
## Describe your changes

Some cars (especially stellantis) reset while doing SLAC and start again. According to ISO15118-3 the EVSE should enter failed state and a replug is neccessary, however, it is nicer for real world compliance to just allow the slac session to restart.
Disable this option for conformance testing.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

