### PR TITLE
Slac: use AC style retries also for DC

### DIFF
--- a/lib/staging/slac/fsm/evse/include/slac/fsm/evse/states/matching.hpp
+++ b/lib/staging/slac/fsm/evse/include/slac/fsm/evse/states/matching.hpp
@@ -85,6 +85,7 @@ struct MatchingState : public FSMSimpleState {
     int num_retries{0};
 
     std::unique_ptr<slac::messages::cm_slac_match_cnf> match_cnf_message;
+    int failed_count{0};
 };
 
 } // namespace slac::fsm::evse

--- a/lib/staging/slac/fsm/evse/src/states/matching.cpp
+++ b/lib/staging/slac/fsm/evse/src/states/matching.cpp
@@ -163,7 +163,8 @@ FSMSimpleState::HandleEventReturnType MatchingState::handle_event(AllocatorType&
             std::chrono::steady_clock::now() + std::chrono::milliseconds(slac::defs::TT_EVSE_SLAC_INIT_MS);
         return sa.HANDLED_INTERNALLY;
     } else if (ev == Event::FAILED) {
-        if (ctx.slac_config.reset_instead_of_fail) {
+        failed_count++;
+        if (ctx.slac_config.reset_instead_of_fail and failed_count < 2) {
             ctx.log_info("Resetting MatchingState. Waiting for the next CM_SLAC_PARAM.REQ message.");
 
             // Resetting all relevant MatchingState members

--- a/modules/EvseSlac/manifest.yaml
+++ b/modules/EvseSlac/manifest.yaml
@@ -13,9 +13,12 @@ provides:
         type: integer
         default: 10
       ac_mode_five_percent:
-        description: Use 5% mode in AC (true). Set to false for DC. The only difference is the handling of retries.
+        description: >-
+          Use AC 5% mode according to ISO15118-3. This restarts SLAC sessions if they fail according to the standard.
+          The standard only allows the retries for AC, not for DC. However, it is strongly recommended to always
+          set this option to true, also for DC, otherwise some EVs in the field will fail to do SLAC frequently.
         type: boolean
-        default: false
+        default: true
       set_key_timeout_ms:
         description: Timeout for CM_SET_KEY.REQ. Default works for QCA7000/QCA7005/CG5317.
         type: integer


### PR DESCRIPTION
## Describe your changes

This enables SLAC retries by default. The standard uses them only on AC, but on DC they are also required especially in high noise environments.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

