### PR TITLE
feature(OCPP): Added support for OCMF TT (tariff text) information for powermeter start transaction

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -79,7 +79,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 70556eb98661ccd3df8b5caab551ed9f2281e7d4
+  git_tag: c76f5ef1928f8bd4f22d1d5c3fbca0f3ce5eabdc
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/DummyTokenValidator/main/auth_token_validatorImpl.cpp
+++ b/modules/DummyTokenValidator/main/auth_token_validatorImpl.cpp
@@ -20,11 +20,6 @@ auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedId
                << everest::staging::helpers::redact(provided_token.id_token.value);
     types::authorization::ValidationResult ret;
     ret.authorization_status = types::authorization::string_to_authorization_status(config.validation_result);
-    ret.reason = types::authorization::TokenValidationStatusMessage();
-    ret.reason->messages = std::vector<types::text_message::MessageContent>();
-    types::text_message::MessageContent content;
-    content.content = config.validation_reason;
-    ret.reason->messages->push_back(content);
     std::this_thread::sleep_for(std::chrono::milliseconds(static_cast<int>(config.sleep * 1000)));
     EVLOG_info << "Returning validation status: " << config.validation_result;
     return ret;

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -124,7 +124,8 @@ public:
     std::string get_session_id() const;
 
     // call when in state WaitingForAuthentication
-    void authorize(bool a, const types::authorization::ProvidedIdToken& token);
+    void authorize(bool a, const types::authorization::ProvidedIdToken& token,
+                   const types::authorization::ValidationResult& result);
     bool deauthorize();
 
     bool get_authorized_pnc();
@@ -287,6 +288,7 @@ private:
         std::optional<types::authorization::ProvidedIdToken>
             stop_transaction_id_token; // only set in case transaction was stopped locally
         types::authorization::ProvidedIdToken id_token;
+        types::authorization::ValidationResult validation_result;
         bool authorized;
         // set to true if auth is from PnC, otherwise to false (EIM)
         bool authorized_pnc;

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -124,7 +124,8 @@ void evse_managerImpl::ready() {
                     provided_token.authorization_type = types::authorization::AuthorizationType::RFID;
                     provided_token.id_token = {"FREESERVICE", types::authorization::IdTokenType::Local};
                     provided_token.prevalidated = true;
-                    mod->charger->authorize(true, provided_token);
+                    mod->charger->authorize(true, provided_token,
+                                            {types::authorization::AuthorizationStatus::Accepted});
                     mod->charger_was_authorized();
                 });
                 authorize_thread.detach();
@@ -360,7 +361,7 @@ void evse_managerImpl::handle_authorize_response(types::authorization::ProvidedI
             return;
         }
 
-        this->mod->charger->authorize(true, provided_token);
+        this->mod->charger->authorize(true, provided_token, validation_result);
         mod->charger_was_authorized();
         if (validation_result.reservation_id.has_value()) {
             EVLOG_debug << "Reserve evse manager reservation id for id " << validation_result.reservation_id.value();

--- a/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
@@ -99,9 +99,6 @@ auth_token_validatorImpl::validate_standard_request(const types::authorization::
         if (enhanced_id_tag_info.tariff_message.has_value()) {
             // this can be used as the TT field of the OCMF.
             const auto& tariff_message = enhanced_id_tag_info.tariff_message.value();
-            if (tariff_message.message.size() > 0) {
-                result.tariff_messages = std::vector<types::text_message::MessageContent>();
-            }
             for (const auto& message : tariff_message.message) {
                 result.tariff_messages.push_back(ocpp_conversions::to_everest_display_message_content(message));
             }

--- a/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/OCPP/auth_validator/auth_token_validatorImpl.cpp
@@ -5,6 +5,7 @@
 #include <ocpp/common/types.hpp>
 #include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
+#include <ocpp_conversions.hpp>
 
 namespace module {
 namespace auth_validator {
@@ -28,50 +29,52 @@ auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedId
 types::authorization::ValidationResult
 auth_token_validatorImpl::validate_pnc_request(const types::authorization::ProvidedIdToken& provided_token) {
 
-    // preparing payload for data_transfer_pnc_authorize
-    std::optional<std::vector<ocpp::v2::OCSPRequestData>> iso15118_certificate_hash_data_opt;
-    if (provided_token.iso15118CertificateHashData.has_value()) {
-        std::vector<ocpp::v2::OCSPRequestData> iso15118_certificate_hash_data;
-        for (const auto& certificate_hash_data : provided_token.iso15118CertificateHashData.value()) {
-            ocpp::v2::OCSPRequestData v2_certificate_hash_data;
-            v2_certificate_hash_data.hashAlgorithm =
-                conversions::to_ocpp_hash_algorithm_enum(certificate_hash_data.hashAlgorithm);
-            v2_certificate_hash_data.issuerKeyHash = certificate_hash_data.issuerKeyHash;
-            v2_certificate_hash_data.issuerNameHash = certificate_hash_data.issuerNameHash;
-            v2_certificate_hash_data.responderURL = certificate_hash_data.responderURL;
-            v2_certificate_hash_data.serialNumber = certificate_hash_data.serialNumber;
-            iso15118_certificate_hash_data.push_back(v2_certificate_hash_data);
-        }
-        iso15118_certificate_hash_data_opt.emplace(iso15118_certificate_hash_data);
-    }
-
-    // this is the actual OCPP request via DataTransfer.req to CSMS according to
-    // PnC1.6 whitepaper
-    const auto authorize_response = mod->charge_point->data_transfer_pnc_authorize(
-        provided_token.id_token.value, provided_token.certificate, iso15118_certificate_hash_data_opt);
-
-    // preparing the validation result
     types::authorization::ValidationResult validation_result;
-    validation_result.authorization_status =
-        conversions::to_everest_authorization_status(authorize_response.idTokenInfo.status);
-    validation_result.evse_ids = authorize_response.idTokenInfo.evseId;
-    if (authorize_response.certificateStatus.has_value()) {
-        validation_result.certificate_status.emplace(
-            conversions::to_everest_certificate_status(authorize_response.certificateStatus.value()));
-    }
-    if (authorize_response.idTokenInfo.cacheExpiryDateTime.has_value()) {
-        validation_result.expiry_time.emplace(authorize_response.idTokenInfo.cacheExpiryDateTime.value().to_rfc3339());
-    }
-    if (authorize_response.idTokenInfo.groupIdToken.has_value()) {
-        validation_result.parent_id_token = {authorize_response.idTokenInfo.groupIdToken.value().idToken.get(),
-                                             types::authorization::IdTokenType::Central};
-    }
+    try {
+        // preparing payload for data_transfer_pnc_authorize
+        std::optional<std::vector<ocpp::v2::OCSPRequestData>> iso15118_certificate_hash_data_opt;
+        if (provided_token.iso15118CertificateHashData.has_value()) {
+            std::vector<ocpp::v2::OCSPRequestData> iso15118_certificate_hash_data;
+            for (const auto& certificate_hash_data : provided_token.iso15118CertificateHashData.value()) {
+                ocpp::v2::OCSPRequestData v2_certificate_hash_data;
+                v2_certificate_hash_data.hashAlgorithm =
+                    conversions::to_ocpp_hash_algorithm_enum(certificate_hash_data.hashAlgorithm);
+                v2_certificate_hash_data.issuerKeyHash = certificate_hash_data.issuerKeyHash;
+                v2_certificate_hash_data.issuerNameHash = certificate_hash_data.issuerNameHash;
+                v2_certificate_hash_data.responderURL = certificate_hash_data.responderURL;
+                v2_certificate_hash_data.serialNumber = certificate_hash_data.serialNumber;
+                iso15118_certificate_hash_data.push_back(v2_certificate_hash_data);
+            }
+            iso15118_certificate_hash_data_opt.emplace(iso15118_certificate_hash_data);
+        }
 
-    validation_result.reason = types::authorization::TokenValidationStatusMessage();
-    validation_result.reason->messages = std::vector<types::text_message::MessageContent>();
-    types::text_message::MessageContent content;
-    content.content = "PnC OCPP1.6 Validiation result by CSMS";
-    validation_result.reason->messages->push_back(content);
+        // this is the actual OCPP request via DataTransfer.req to CSMS according to
+        // PnC1.6 whitepaper
+        const auto authorize_response = mod->charge_point->data_transfer_pnc_authorize(
+            provided_token.id_token.value, provided_token.certificate, iso15118_certificate_hash_data_opt);
+
+        validation_result.authorization_status =
+            conversions::to_everest_authorization_status(authorize_response.idTokenInfo.status);
+        validation_result.evse_ids = authorize_response.idTokenInfo.evseId;
+        if (authorize_response.certificateStatus.has_value()) {
+            validation_result.certificate_status.emplace(
+                conversions::to_everest_certificate_status(authorize_response.certificateStatus.value()));
+        }
+        if (authorize_response.idTokenInfo.cacheExpiryDateTime.has_value()) {
+            validation_result.expiry_time.emplace(
+                authorize_response.idTokenInfo.cacheExpiryDateTime.value().to_rfc3339());
+        }
+        if (authorize_response.idTokenInfo.groupIdToken.has_value()) {
+            validation_result.parent_id_token = {authorize_response.idTokenInfo.groupIdToken.value().idToken.get(),
+                                                 types::authorization::IdTokenType::Central};
+        }
+    } catch (const ocpp::StringConversionException& e) {
+        EVLOG_warning << "Error converting id token to validate: " << e.what();
+        validation_result.authorization_status = types::authorization::AuthorizationStatus::Unknown;
+    } catch (const std::exception& e) {
+        EVLOG_warning << "Unknown error during validation of id token: " << e.what();
+        validation_result.authorization_status = types::authorization::AuthorizationStatus::Unknown;
+    }
 
     return validation_result;
 }
@@ -80,8 +83,9 @@ types::authorization::ValidationResult
 auth_token_validatorImpl::validate_standard_request(const types::authorization::ProvidedIdToken& provided_token) {
     types::authorization::ValidationResult result;
     try {
-        const auto id_tag_info =
+        const auto enhanced_id_tag_info =
             mod->charge_point->authorize_id_token(ocpp::CiString<20>(provided_token.id_token.value));
+        const auto id_tag_info = enhanced_id_tag_info.id_tag_info;
         result.authorization_status = conversions::to_everest_authorization_status(id_tag_info.status);
         if (id_tag_info.expiryDate) {
             result.expiry_time = id_tag_info.expiryDate->to_rfc3339();
@@ -92,13 +96,16 @@ auth_token_validatorImpl::validate_standard_request(const types::authorization::
                 types::authorization::IdTokenType::Central}; // For OCPP1.6 no IdTokenType is given,
                                                              // so we assume it is a central token
         }
-
-        result.reason = types::authorization::TokenValidationStatusMessage();
-        result.reason->messages = std::vector<types::text_message::MessageContent>();
-        types::text_message::MessageContent content;
-        content.content = "Validation by OCPP 1.6 Central System";
-        result.reason->messages->push_back(content);
-
+        if (enhanced_id_tag_info.tariff_message.has_value()) {
+            // this can be used as the TT field of the OCMF.
+            const auto& tariff_message = enhanced_id_tag_info.tariff_message.value();
+            if (tariff_message.message.size() > 0) {
+                result.tariff_messages = std::vector<types::text_message::MessageContent>();
+            }
+            for (const auto& message : tariff_message.message) {
+                result.tariff_messages.push_back(ocpp_conversions::to_everest_display_message_content(message));
+            }
+        }
     } catch (const ocpp::StringConversionException& e) {
         EVLOG_warning << "Error converting id token to validate: " << e.what();
         result.authorization_status = types::authorization::AuthorizationStatus::Unknown;

--- a/modules/OCPP/conversions.hpp
+++ b/modules/OCPP/conversions.hpp
@@ -18,6 +18,7 @@
 #include <ocpp/v16/messages/LogStatusNotification.hpp>
 #include <ocpp/v16/messages/ReserveNow.hpp>
 #include <ocpp/v16/messages/StopTransaction.hpp>
+#include <ocpp/v16/types.hpp>
 #include <ocpp/v2/messages/DeleteCertificate.hpp>
 #include <ocpp/v2/messages/Get15118EVCertificate.hpp>
 

--- a/modules/OCPP201/conversions.cpp
+++ b/modules/OCPP201/conversions.cpp
@@ -1008,24 +1008,18 @@ types::authorization::ValidationResult to_everest_validation_result(const ocpp::
     }
 
     if (idTokenInfo.personalMessage.has_value()) {
-        validation_result.reason = types::authorization::TokenValidationStatusMessage();
-        validation_result.reason->messages = std::vector<types::text_message::MessageContent>();
         const types::text_message::MessageContent content =
             to_everest_message_content(idTokenInfo.personalMessage.value());
-        validation_result.reason->messages->push_back(content);
+        validation_result.tariff_messages.push_back(content);
     }
 
     if (idTokenInfo.customData.has_value() && idTokenInfo.customData.value().contains("vendorId") &&
         idTokenInfo.customData.value().at("vendorId").get<std::string>() == "org.openchargealliance.multilanguage" &&
         idTokenInfo.customData.value().contains("personalMessageExtra")) {
-        if (!validation_result.reason->messages.has_value()) {
-            validation_result.reason->messages = std::vector<types::text_message::MessageContent>();
-        }
-
         const json& multi_language_personal_messages = idTokenInfo.customData.value().at("personalMessageExtra");
         for (const auto& messages : multi_language_personal_messages.items()) {
             const types::text_message::MessageContent content = messages.value();
-            validation_result.reason->messages->push_back(content);
+            validation_result.tariff_messages.push_back(content);
         }
     }
 

--- a/tests/ocpp_tests/test_sets/everest-aux/config/libocpp-config-costandprice.json
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/libocpp-config-costandprice.json
@@ -85,7 +85,8 @@
         "CustomIdleFeeAfterStop": false,
         "SupportedLanguages": "en, nl, de, nb_NO",
         "CustomMultiLanguageMessages": true,
-        "Language": "en"
+        "Language": "en",
+        "WaitForSetUserPriceTimeout": 2000
     },
     "Reservation": {
         "ReserveConnectorZeroSupported": true

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -165,7 +165,7 @@ types:
         $ref: /authorization#/CertificateStatus
       tariff_messages:
         description: >-
-          Messages that can contain session price information to show the user. The array can contain multiple messages in different languages. Empty if no messages are available.
+          Messages that can contain session price information to show the user. The array can contain multiple messages in different languages. The first message in this array shall be used to start the transaction at the powermeter (for OCMF).  Empty if no messages are available.
         type: array
         items:
           description: Message with pricing information in a specific language

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -155,6 +155,7 @@ types:
     additionalProperties: false
     required:
       - authorization_status
+      - tariff_messages # defined as required to default initialize the vector, may be empty
     properties:
       authorization_status:
         type: string
@@ -162,9 +163,14 @@ types:
       certificate_status:
         type: string
         $ref: /authorization#/CertificateStatus
-      reason:
-        type: object
-        $ref: /authorization#/TokenValidationStatusMessage
+      tariff_messages:
+        description: >-
+          Messages that can contain session price information to show the user. The array can contain multiple messages in different languages. Empty if no messages are available.
+        type: array
+        items:
+          description: Message with pricing information in a specific language
+          type: object
+          $ref: /text_message#/MessageContent
       expiry_time:
         description: Absolute UTC time point when reservation expires in RFC3339 format
         type: string


### PR DESCRIPTION

## Describe your changes
Added support for OCMF TT (tariff text) information for powermeter start_transaction request to the powermeter. The TT information has been added as the personal_messages property to the EVerest ValidationResult type.

## Issue ticket number and link
Companion PR in libocpp: https://github.com/EVerest/libocpp/pull/1065

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

