### PR TITLE
refactor(OCPP201): Simplified ComposedDeviceModel initialization and extensibility 

### DIFF
--- a/modules/OCPP201/device_model/composed_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.cpp
@@ -6,92 +6,99 @@
 static constexpr auto VARIABLE_SOURCE_OCPP = "OCPP";
 
 namespace module::device_model {
-ComposedDeviceModelStorage::ComposedDeviceModelStorage(const std::string& libocpp_device_model_storage_address,
-                                                       const bool libocpp_initialize_device_model,
-                                                       const std::string& device_model_migration_path,
-                                                       const std::string& device_model_config_path) :
-    everest_device_model_storage(std::make_unique<EverestDeviceModelStorage>()),
-    libocpp_device_model_storage(std::make_unique<ocpp::v2::DeviceModelStorageSqlite>(
-        libocpp_device_model_storage_address, device_model_migration_path, device_model_config_path,
-        libocpp_initialize_device_model)),
-    device_model_map(get_device_model()) {
+ComposedDeviceModelStorage::ComposedDeviceModelStorage() {
+}
+
+bool ComposedDeviceModelStorage::register_device_model_storage(
+    std::string device_model_storage_id, std::unique_ptr<ocpp::v2::DeviceModelStorageInterface> device_model_storage) {
+    if (this->device_model_storages.find(device_model_storage_id) != this->device_model_storages.end()) {
+        return false;
+    }
+    this->device_model_storages[device_model_storage_id] = std::move(device_model_storage);
+    return true;
 }
 
 ocpp::v2::DeviceModelMap ComposedDeviceModelStorage::get_device_model() {
-    ocpp::v2::DeviceModelMap everest_dm = everest_device_model_storage->get_device_model();
-    ocpp::v2::DeviceModelMap libocpp_dm = libocpp_device_model_storage->get_device_model();
-    everest_dm.merge(libocpp_dm);
-    return everest_dm;
+    ocpp::v2::DeviceModelMap device_model_map;
+    for (const auto& [name, device_model_storage] : this->device_model_storages) {
+        device_model_map.merge(device_model_storage->get_device_model());
+    }
+    return device_model_map;
 }
 
 std::optional<ocpp::v2::VariableAttribute>
 ComposedDeviceModelStorage::get_variable_attribute(const ocpp::v2::Component& component_id,
                                                    const ocpp::v2::Variable& variable_id,
                                                    const ocpp::v2::AttributeEnum& attribute_enum) {
-    if (get_variable_source(component_id, variable_id) == VARIABLE_SOURCE_OCPP) {
-        return libocpp_device_model_storage->get_variable_attribute(component_id, variable_id, attribute_enum);
+    const auto variable_source = get_variable_source(component_id, variable_id);
+    if (this->device_model_storages.find(variable_source) == this->device_model_storages.end()) {
+        return std::nullopt;
     }
-
-    return everest_device_model_storage->get_variable_attribute(component_id, variable_id, attribute_enum);
+    return this->device_model_storages.at(variable_source)
+        ->get_variable_attribute(component_id, variable_id, attribute_enum);
 }
 
 std::vector<ocpp::v2::VariableAttribute>
 ComposedDeviceModelStorage::get_variable_attributes(const ocpp::v2::Component& component_id,
                                                     const ocpp::v2::Variable& variable_id,
                                                     const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) {
-    if (get_variable_source(component_id, variable_id) == VARIABLE_SOURCE_OCPP) {
-        return libocpp_device_model_storage->get_variable_attributes(component_id, variable_id, attribute_enum);
+    const auto variable_source = get_variable_source(component_id, variable_id);
+    if (this->device_model_storages.find(variable_source) == this->device_model_storages.end()) {
+        return {};
     }
-
-    return everest_device_model_storage->get_variable_attributes(component_id, variable_id, attribute_enum);
+    return this->device_model_storages.at(variable_source)
+        ->get_variable_attributes(component_id, variable_id, attribute_enum);
 }
 
 bool ComposedDeviceModelStorage::set_variable_attribute_value(const ocpp::v2::Component& component_id,
                                                               const ocpp::v2::Variable& variable_id,
                                                               const ocpp::v2::AttributeEnum& attribute_enum,
                                                               const std::string& value, const std::string& source) {
-    if (get_variable_source(component_id, variable_id) == VARIABLE_SOURCE_OCPP) {
-        return libocpp_device_model_storage->set_variable_attribute_value(component_id, variable_id, attribute_enum,
-                                                                          value, source);
+    // the "source" parameter is the VALUE_SOURCE
+    const auto variable_source = get_variable_source(component_id, variable_id);
+    if (this->device_model_storages.find(variable_source) == this->device_model_storages.end()) {
+        return false;
     }
-    return everest_device_model_storage->set_variable_attribute_value(component_id, variable_id, attribute_enum, value,
-                                                                      source);
+    return this->device_model_storages.at(variable_source)
+        ->set_variable_attribute_value(component_id, variable_id, attribute_enum, value, source);
 }
 
 std::optional<ocpp::v2::VariableMonitoringMeta>
 ComposedDeviceModelStorage::set_monitoring_data(const ocpp::v2::SetMonitoringData& data,
                                                 const ocpp::v2::VariableMonitorType type) {
-    return libocpp_device_model_storage->set_monitoring_data(data, type);
+    return this->device_model_storages.at(VARIABLE_SOURCE_OCPP)->set_monitoring_data(data, type);
 }
 
 bool ComposedDeviceModelStorage::update_monitoring_reference(const int32_t monitor_id,
                                                              const std::string& reference_value) {
-    return libocpp_device_model_storage->update_monitoring_reference(monitor_id, reference_value);
+    return this->device_model_storages.at(VARIABLE_SOURCE_OCPP)
+        ->update_monitoring_reference(monitor_id, reference_value);
 }
 
 std::vector<ocpp::v2::VariableMonitoringMeta>
 ComposedDeviceModelStorage::get_monitoring_data(const std::vector<ocpp::v2::MonitoringCriterionEnum>& criteria,
                                                 const ocpp::v2::Component& component_id,
                                                 const ocpp::v2::Variable& variable_id) {
-    if (get_variable_source(component_id, variable_id) == VARIABLE_SOURCE_OCPP) {
-        return libocpp_device_model_storage->get_monitoring_data(criteria, component_id, variable_id);
+    const auto variable_source = get_variable_source(component_id, variable_id);
+    if (this->device_model_storages.find(variable_source) == this->device_model_storages.end()) {
+        return {};
     }
-
-    return everest_device_model_storage->get_monitoring_data(criteria, component_id, variable_id);
+    return this->device_model_storages.at(variable_source)->get_monitoring_data(criteria, component_id, variable_id);
 }
 
 ocpp::v2::ClearMonitoringStatusEnum ComposedDeviceModelStorage::clear_variable_monitor(int monitor_id,
                                                                                        bool allow_protected) {
-    return libocpp_device_model_storage->clear_variable_monitor(monitor_id, allow_protected);
+    return this->device_model_storages.at(VARIABLE_SOURCE_OCPP)->clear_variable_monitor(monitor_id, allow_protected);
 }
 
 int32_t ComposedDeviceModelStorage::clear_custom_variable_monitors() {
-    return libocpp_device_model_storage->clear_custom_variable_monitors();
+    return this->device_model_storages.at(VARIABLE_SOURCE_OCPP)->clear_custom_variable_monitors();
 }
 
 void ComposedDeviceModelStorage::check_integrity() {
-    everest_device_model_storage->check_integrity();
-    libocpp_device_model_storage->check_integrity();
+    for (const auto& [name, device_model_storage] : this->device_model_storages) {
+        device_model_storage->check_integrity();
+    }
 }
 
 std::string module::device_model::ComposedDeviceModelStorage::get_variable_source(const ocpp::v2::Component& component,

--- a/modules/OCPP201/device_model/composed_device_model_storage.hpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.hpp
@@ -10,15 +10,20 @@
 namespace module::device_model {
 class ComposedDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
 private: // Members
-    std::unique_ptr<EverestDeviceModelStorage> everest_device_model_storage;
-    std::unique_ptr<ocpp::v2::DeviceModelStorageSqlite> libocpp_device_model_storage;
+    std::map<std::string, std::unique_ptr<ocpp::v2::DeviceModelStorageInterface>>
+        device_model_storages; // key is identifier for the device model storage
     ocpp::v2::DeviceModelMap device_model_map;
 
 public:
-    ComposedDeviceModelStorage(const std::string& libocpp_device_model_storage_address,
-                               const bool libocpp_initialize_device_model,
-                               const std::string& device_model_migration_path,
-                               const std::string& device_model_config_path);
+    ComposedDeviceModelStorage();
+
+    /// \brief Register a device model storage.
+    /// \param device_model_storage_id   The id of the device model storage. Component variable combinations can be
+    /// used to map to this id to identify which device model is adressed for certain requests.
+    /// \param  device_model_storage The device model storage to register.
+    /// \return True if the device model storage name is not yet registered, false otherwise.
+    bool register_device_model_storage(std::string device_model_storage_id,
+                                       std::unique_ptr<ocpp::v2::DeviceModelStorageInterface> device_model_storage);
     virtual ~ComposedDeviceModelStorage() override = default;
     virtual ocpp::v2::DeviceModelMap get_device_model() override;
     virtual std::optional<ocpp::v2::VariableAttribute>


### PR DESCRIPTION
Refactored composed device model to allow for a more simple and structured initialization of the individual device models (OCPP, EVerest, ...). The individual device models can now be registered at the ComposedDeviceModel and are identified by their device_model_storage_id

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

