### PR TITLE
Fine-tune build options for libcurl

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -55,7 +55,18 @@ libcurl:
   git: https://github.com/curl/curl.git
   git_tag: curl-8_13_0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBCURL"
-  options: ["CURL_USE_LIBPSL OFF"]
+  options: [
+    "BUILD_EXAMPLES OFF",
+    "BUILD_LIBCURL_DOCS OFF",
+    "BUILD_MISC_DOCS OFF",
+    "BUILD_TESTING OFF",
+    "CURL_BROTLI OFF",
+    "CURL_DISABLE_LDAP ON",
+    "CURL_USE_LIBPSL OFF",
+    "CURL_USE_LIBSSH2 OFF",
+    "ENABLE_CURL_MANUAL OFF",
+    "USE_NGHTTP2 OFF",
+  ]
 
 # EvseSecurity
 # This has to appear before libocpp in this file since it is also a direct dependency


### PR DESCRIPTION
## Describe your changes

This disables some dependencies of libcurl which must be present otherwise because these are not pulled automatically.
This hurts eg. when cross-compiling directly, i.e. without a framework like Yocto or similar.

I disabled according to my understanding what is needed by the current modules, but a double-check would make sense.

I also disabled some build steps like building docs et al - saves some CPU cycles since not required here IMHO.

## Issue ticket number and link

none

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

