### PR TITLE
Adapt to new set_variable_attribute_value return type

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -79,7 +79,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 8df1ee20f87d2be353cc80ee7825e35114361baf
+  git_tag: 70556eb98661ccd3df8b5caab551ed9f2281e7d4
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/OCPP201/device_model/composed_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.cpp
@@ -61,14 +61,13 @@ ComposedDeviceModelStorage::get_variable_attributes(const ocpp::v2::Component& c
         ->get_variable_attributes(component_id, variable_id, attribute_enum);
 }
 
-bool ComposedDeviceModelStorage::set_variable_attribute_value(const ocpp::v2::Component& component_id,
-                                                              const ocpp::v2::Variable& variable_id,
-                                                              const ocpp::v2::AttributeEnum& attribute_enum,
-                                                              const std::string& value, const std::string& source) {
+ocpp::v2::SetVariableStatusEnum ComposedDeviceModelStorage::set_variable_attribute_value(
+    const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
+    const ocpp::v2::AttributeEnum& attribute_enum, const std::string& value, const std::string& source) {
     // the "source" parameter is the VALUE_SOURCE
     const auto variable_source = get_variable_source(component_id, variable_id);
     if (this->device_model_storages.find(variable_source) == this->device_model_storages.end()) {
-        return false;
+        return ocpp::v2::SetVariableStatusEnum::Rejected;
     }
     return this->device_model_storages.at(variable_source)
         ->set_variable_attribute_value(component_id, variable_id, attribute_enum, value, source);

--- a/modules/OCPP201/device_model/composed_device_model_storage.hpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.hpp
@@ -34,10 +34,11 @@ public:
     virtual std::vector<ocpp::v2::VariableAttribute>
     get_variable_attributes(const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
                             const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) override;
-    virtual bool set_variable_attribute_value(const ocpp::v2::Component& component_id,
-                                              const ocpp::v2::Variable& variable_id,
-                                              const ocpp::v2::AttributeEnum& attribute_enum, const std::string& value,
-                                              const std::string& source) override;
+    virtual ocpp::v2::SetVariableStatusEnum set_variable_attribute_value(const ocpp::v2::Component& component_id,
+                                                                         const ocpp::v2::Variable& variable_id,
+                                                                         const ocpp::v2::AttributeEnum& attribute_enum,
+                                                                         const std::string& value,
+                                                                         const std::string& source) override;
     virtual std::optional<ocpp::v2::VariableMonitoringMeta>
     set_monitoring_data(const ocpp::v2::SetMonitoringData& data, const ocpp::v2::VariableMonitorType type) override;
     virtual bool update_monitoring_reference(const int32_t monitor_id, const std::string& reference_value) override;

--- a/modules/OCPP201/device_model/everest_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/everest_device_model_storage.cpp
@@ -22,12 +22,10 @@ EverestDeviceModelStorage::get_variable_attributes(const ocpp::v2::Component& /*
     return {};
 }
 
-bool EverestDeviceModelStorage::set_variable_attribute_value(const ocpp::v2::Component& /*component_id*/,
-                                                             const ocpp::v2::Variable& /*variable_id*/,
-                                                             const ocpp::v2::AttributeEnum& /*attribute_enum*/,
-                                                             const std::string& /*value*/,
-                                                             const std::string& /*source*/) {
-    return false;
+ocpp::v2::SetVariableStatusEnum EverestDeviceModelStorage::set_variable_attribute_value(
+    const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
+    const ocpp::v2::AttributeEnum& attribute_enum, const std::string& value, const std::string& source) {
+    return ocpp::v2::SetVariableStatusEnum::Rejected;
 }
 
 std::optional<ocpp::v2::VariableMonitoringMeta>

--- a/modules/OCPP201/device_model/everest_device_model_storage.hpp
+++ b/modules/OCPP201/device_model/everest_device_model_storage.hpp
@@ -16,10 +16,11 @@ public:
     virtual std::vector<ocpp::v2::VariableAttribute>
     get_variable_attributes(const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
                             const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) override;
-    virtual bool set_variable_attribute_value(const ocpp::v2::Component& component_id,
-                                              const ocpp::v2::Variable& variable_id,
-                                              const ocpp::v2::AttributeEnum& attribute_enum, const std::string& value,
-                                              const std::string& source) override;
+    virtual ocpp::v2::SetVariableStatusEnum set_variable_attribute_value(const ocpp::v2::Component& component_id,
+                                                                         const ocpp::v2::Variable& variable_id,
+                                                                         const ocpp::v2::AttributeEnum& attribute_enum,
+                                                                         const std::string& value,
+                                                                         const std::string& source) override;
     virtual std::optional<ocpp::v2::VariableMonitoringMeta>
     set_monitoring_data(const ocpp::v2::SetMonitoringData& data, const ocpp::v2::VariableMonitorType type) override;
     virtual bool update_monitoring_reference(const int32_t monitor_id, const std::string& reference_value) override;


### PR DESCRIPTION
## Describe your changes
This change in the OCPP201 module is necessitated by changes in the device model storage interface in libocpp

set_variable_attribute_value now returns a SetVariableStatusEnum instead of bool to eg. be able to report RebootRequired to the CSMS

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

