### PR TITLE
feat(OCPP2.x): Dynamic device model initialization

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -79,7 +79,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 663f59772c37ac7e83a051b3042504f4d013fe85
+  git_tag: 7b4ba2c8a106b2eefad4009b515148888ba1133a
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/OCPP201/CMakeLists.txt
+++ b/modules/OCPP201/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(${MODULE_NAME}
         "session_cost/session_costImpl.cpp"
         "device_model/everest_device_model_storage.cpp"
         "device_model/composed_device_model_storage.cpp"
+        "device_model/definitions.cpp"
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -32,6 +32,7 @@
 // insert your custom include headers here
 #include <tuple>
 
+#include <generated/types/evse_board_support.hpp>
 #include <ocpp/v2/charge_point.hpp>
 #include <transaction_handler.hpp>
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
@@ -129,6 +130,7 @@ private:
     // key represents evse_id, value indicates if ready
     std::map<int32_t, bool> evse_ready_map;
     std::map<int32_t, std::optional<float>> evse_soc_map;
+    std::map<int32_t, types::evse_board_support::HardwareCapabilities> evse_hardware_capabilities_map;
     int32_t event_id_counter{0};
     std::mutex evse_ready_mutex;
     std::mutex session_event_mutex;

--- a/modules/OCPP201/device_model/composed_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.cpp
@@ -19,6 +19,14 @@ bool ComposedDeviceModelStorage::register_device_model_storage(
     // store the sources of each variable to be able to lookup requests to the device model storage
     for (const auto& [component, variable_map] : device_model_map) {
         for (const auto& [variable, variable_meta] : variable_map) {
+            // check if component variable source is already exist in the map
+            if (this->component_variable_source_map.find(component) != this->component_variable_source_map.end() &&
+                this->component_variable_source_map.at(component).find(variable) !=
+                    this->component_variable_source_map.at(component).end()) {
+                EVLOG_warning << "Component variable source already exists for component: " << component.name
+                              << ", variable: " << variable.name << ". Fix your device model configuration.";
+            }
+
             // Note: Source should not be optional, should be changed in libocpp
             this->component_variable_source_map[component][variable] =
                 variable_meta.source.value_or(VARIABLE_SOURCE_OCPP);

--- a/modules/OCPP201/device_model/composed_device_model_storage.hpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.hpp
@@ -11,7 +11,7 @@ namespace module::device_model {
 
 using ComponentVariableSourceMap = std::map<ocpp::v2::Component, std::map<ocpp::v2::Variable, std::string>>;
 class ComposedDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
-private: // Members
+private:
     std::map<std::string, std::unique_ptr<ocpp::v2::DeviceModelStorageInterface>>
         device_model_storages; // key is identifier for the device model storage
     ComponentVariableSourceMap component_variable_source_map;
@@ -49,14 +49,13 @@ public:
     virtual int32_t clear_custom_variable_monitors() override;
     virtual void check_integrity() override;
 
-private: // Functions
-         ///
-         /// \brief Get variable source of given variable.
-         /// \param component    Component the variable belongs to.
-         /// \param variable     The variable to get the source from.
-         /// \return The variable source. Defaults to 'OCPP'.
-         /// \throws DeviceModelError    When source is something else than 'OCPP' (not implemented yet)
-         ///
+private:
+    ///
+    /// \brief Get variable source of given variable.
+    /// \param component    Component the variable belongs to.
+    /// \param variable     The variable to get the source from.
+    /// \return The variable source. Defaults to 'OCPP'.
+    ///
     std::string get_variable_source(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable);
 };
 } // namespace module::device_model

--- a/modules/OCPP201/device_model/definitions.cpp
+++ b/modules/OCPP201/device_model/definitions.cpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <device_model/definitions.hpp>
+#include <optional>
+
+#include <ocpp/v2/ocpp_types.hpp>
+
+using ocpp::CiString;
+using ocpp::v2::DataEnum;
+
+namespace EvseDefinitions {
+
+EVSE get_evse(const int32_t evse_id, const std::optional<int32_t>& connector_id) {
+    EVSE evse;
+    evse.id = evse_id;
+    evse.connectorId = connector_id;
+    return evse;
+}
+
+namespace Characteristics {
+
+const VariableCharacteristics AllowReset = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::boolean;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
+const VariableCharacteristics AvailabilityState = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::OptionList;
+    var.supportsMonitoring = false;
+    var.valuesList = CiString<1000>("Available,Occupied,Reserved,Unavailable,Faulted");
+    return var;
+}();
+
+const VariableCharacteristics Available = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::boolean;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
+const VariableCharacteristics EvseId = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::string;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
+VariableCharacteristics EVSEPower = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::decimal;
+    var.supportsMonitoring = false;
+    var.unit = CiString<16>("W");
+    var.maxLimit = 0.0f; // will be updated at runtime
+    return var;
+}();
+
+const VariableCharacteristics SupplyPhases = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::integer;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
+const VariableCharacteristics ISO15118EvseId = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::string;
+    var.supportsMonitoring = false;
+    var.minLimit = 7.0f;
+    var.maxLimit = 37.0f;
+    return var;
+}();
+} // namespace Characteristics
+} // namespace EvseDefinitions
+
+namespace ConnectorDefinitions {
+namespace Characteristics {
+
+const VariableCharacteristics AvailabilityState = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::OptionList;
+    var.supportsMonitoring = false;
+    var.valuesList = CiString<1000>("Available,Occupied,Reserved,Unavailable,Faulted");
+    return var;
+}();
+
+const VariableCharacteristics Available = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::boolean;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
+const VariableCharacteristics ConnectorType = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::string;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
+const VariableCharacteristics SupplyPhases = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::integer;
+    var.supportsMonitoring = false;
+    return var;
+}();
+} // namespace Characteristics
+} // namespace ConnectorDefinitions

--- a/modules/OCPP201/device_model/definitions.hpp
+++ b/modules/OCPP201/device_model/definitions.hpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+
+using ocpp::v2::EVSE;
+using ocpp::v2::VariableCharacteristics;
+
+namespace EvseDefinitions {
+
+EVSE get_evse(const int32_t evse_id, const std::optional<int32_t>& connector_id = std::nullopt);
+
+namespace Characteristics {
+extern const VariableCharacteristics AllowReset;
+extern const VariableCharacteristics AvailabilityState;
+extern const VariableCharacteristics Available;
+extern const VariableCharacteristics EvseId;
+extern VariableCharacteristics EVSEPower;
+extern const VariableCharacteristics SupplyPhases;
+extern const VariableCharacteristics ISO15118EvseId;
+} // namespace Characteristics
+} // namespace EvseDefinitions
+
+namespace ConnectorDefinitions {
+namespace Characteristics {
+extern const VariableCharacteristics AvailabilityState;
+extern const VariableCharacteristics Available;
+extern const VariableCharacteristics ConnectorType;
+extern const VariableCharacteristics SupplyPhases;
+} // namespace Characteristics
+} // namespace ConnectorDefinitions

--- a/modules/OCPP201/device_model/everest_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/everest_device_model_storage.cpp
@@ -1,31 +1,216 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
+#include <device_model/definitions.hpp>
 #include <device_model/everest_device_model_storage.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+using ocpp::v2::Component;
+using ocpp::v2::DataEnum;
+using ocpp::v2::EVSE;
+using ocpp::v2::Variable;
+using ocpp::v2::VariableAttribute;
+using ocpp::v2::VariableCharacteristics;
+using ocpp::v2::VariableMap;
+using ocpp::v2::VariableMetaData;
+
+static constexpr auto VARIABLE_SOURCE_EVEREST = "EVEREST";
 
 namespace module::device_model {
+
+namespace {
+
+Component get_evse_component(const int32_t evse_id) {
+    Component component;
+    component.name = "EVSE";
+    component.evse = EvseDefinitions::get_evse(evse_id);
+    return component;
+}
+
+Component get_connector_component(const int32_t evse_id, const int32_t connector_id) {
+    Component component;
+    component.name = "Connector";
+    component.evse = EvseDefinitions::get_evse(evse_id, connector_id);
+    return component;
+}
+
+// Helper function to construct VariableData with common structure
+VariableData make_variable(const ocpp::v2::VariableCharacteristics& characteristics, const std::string& value = "") {
+    VariableData var_data;
+    var_data.characteristics = characteristics;
+    var_data.source = VARIABLE_SOURCE_EVEREST;
+
+    VariableAttribute attr;
+    attr.type = ocpp::v2::AttributeEnum::Actual;
+    attr.value = value;
+    attr.mutability = ocpp::v2::MutabilityEnum::ReadOnly;
+
+    var_data.attributes[ocpp::v2::AttributeEnum::Actual] = attr;
+    return var_data;
+}
+
+// Populates EVSE variables
+Variables build_evse_variables() {
+    return {
+        {ocpp::v2::EvseComponentVariables::Available,
+         make_variable(EvseDefinitions::Characteristics::Available, "true")},
+        {ocpp::v2::EvseComponentVariables::AvailabilityState,
+         make_variable(EvseDefinitions::Characteristics::AvailabilityState, "Available")},
+        {ocpp::v2::EvseComponentVariables::Power, make_variable(EvseDefinitions::Characteristics::EVSEPower)},
+        {ocpp::v2::EvseComponentVariables::SupplyPhases, make_variable(EvseDefinitions::Characteristics::SupplyPhases)},
+        {ocpp::v2::EvseComponentVariables::AllowReset,
+         make_variable(EvseDefinitions::Characteristics::AllowReset, "false")},
+        {ocpp::v2::EvseComponentVariables::ISO15118EvseId,
+         make_variable(EvseDefinitions::Characteristics::ISO15118EvseId, "DEFAULT_EVSE_ID")}};
+}
+
+// Populates Connector variables
+Variables build_connector_variables() {
+    return {{ocpp::v2::ConnectorComponentVariables::Available,
+             make_variable(ConnectorDefinitions::Characteristics::Available, "true")},
+            {ocpp::v2::ConnectorComponentVariables::AvailabilityState,
+             make_variable(ConnectorDefinitions::Characteristics::AvailabilityState, "Available")},
+            {ocpp::v2::ConnectorComponentVariables::Type,
+             make_variable(ConnectorDefinitions::Characteristics::ConnectorType)},
+            {ocpp::v2::ConnectorComponentVariables::SupplyPhases,
+             make_variable(ConnectorDefinitions::Characteristics::SupplyPhases)}};
+}
+
+} // anonymous namespace
+
+EverestDeviceModelStorage::EverestDeviceModelStorage(
+    const std::vector<std::unique_ptr<evse_managerIntf>>& r_evse_manager,
+    const std::map<int32_t, types::evse_board_support::HardwareCapabilities>& evse_hardware_capabilities_map) :
+    r_evse_manager(r_evse_manager) {
+
+    for (const auto& evse_manager : r_evse_manager) {
+        const auto evse_info = evse_manager->call_get_evse();
+        // Build EVSE Component
+        Component evse_component = get_evse_component(evse_info.id);
+        this->device_model[evse_component] = build_evse_variables();
+
+        if (evse_hardware_capabilities_map.find(evse_info.id) != evse_hardware_capabilities_map.end()) {
+            this->update_hw_capabilities(evse_component, evse_hardware_capabilities_map.at(evse_info.id));
+        } else {
+            EVLOG_error << "No hardware capabilities found for EVSE with ID " << evse_info.id;
+        }
+
+        evse_manager->subscribe_hw_capabilities(
+            [this, evse_component](const types::evse_board_support::HardwareCapabilities hw_capabilities) {
+                this->update_hw_capabilities(evse_component, hw_capabilities);
+            });
+
+        // Build Connector Components
+        for (const auto& connector : evse_info.connectors) {
+            Component connector_component = get_connector_component(evse_info.id, connector.id);
+            this->device_model[connector_component] = build_connector_variables();
+
+            if (connector.type.has_value()) {
+                this->device_model[connector_component][ocpp::v2::ConnectorComponentVariables::Type]
+                    .attributes[ocpp::v2::AttributeEnum::Actual]
+                    .value = types::evse_manager::connector_type_enum_to_string(connector.type.value());
+            }
+        }
+    }
+}
+
+void EverestDeviceModelStorage::update_hw_capabilities(
+    const Component& evse_component, const types::evse_board_support::HardwareCapabilities& hw_capabilities) {
+    this->device_model[evse_component][ocpp::v2::EvseComponentVariables::SupplyPhases]
+        .attributes[ocpp::v2::AttributeEnum::Actual]
+        .value = std::to_string(hw_capabilities.max_phase_count_import);
+    this->device_model[evse_component][ocpp::v2::EvseComponentVariables::Power].characteristics.maxLimit =
+        hw_capabilities.max_current_A_import * 230.0f *
+        hw_capabilities
+            .max_phase_count_import; // FIXME: this calculation is currently the best we can do with existing data
+}
+
 ocpp::v2::DeviceModelMap EverestDeviceModelStorage::get_device_model() {
-    return {};
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    ocpp::v2::DeviceModelMap device_model;
+
+    for (const auto& [component, variables] : this->device_model) {
+        ocpp::v2::VariableMap variable_map;
+        for (const auto& [variable, variable_data] : variables) {
+            VariableMetaData meta_data = static_cast<VariableMetaData>(variable_data);
+            variable_map[variable] = meta_data;
+        }
+        device_model[component] = variable_map;
+    }
+
+    return device_model;
 }
 
 std::optional<ocpp::v2::VariableAttribute>
-EverestDeviceModelStorage::get_variable_attribute(const ocpp::v2::Component& /*component_id*/,
-                                                  const ocpp::v2::Variable& /*variable_id*/,
-                                                  const ocpp::v2::AttributeEnum& /*attribute_enum*/) {
-    return std::nullopt;
+EverestDeviceModelStorage::get_variable_attribute(const ocpp::v2::Component& component_id,
+                                                  const ocpp::v2::Variable& variable_id,
+                                                  const ocpp::v2::AttributeEnum& attribute_enum) {
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    auto component_it = device_model.find(component_id);
+    if (component_it == device_model.end()) {
+        return std::nullopt;
+    }
+    auto variable_it = component_it->second.find(variable_id);
+    if (variable_it == component_it->second.end()) {
+        return std::nullopt;
+    }
+    auto variable_data = variable_it->second;
+    auto attribute_it = variable_data.attributes.find(attribute_enum);
+    if (attribute_it == variable_data.attributes.end()) {
+        return std::nullopt;
+    }
+    return attribute_it->second;
 }
 
 std::vector<ocpp::v2::VariableAttribute>
-EverestDeviceModelStorage::get_variable_attributes(const ocpp::v2::Component& /*component_id*/,
-                                                   const ocpp::v2::Variable& /*variable_id*/,
-                                                   const std::optional<ocpp::v2::AttributeEnum>& /*attribute_enum*/) {
-    return {};
+EverestDeviceModelStorage::get_variable_attributes(const ocpp::v2::Component& component_id,
+                                                   const ocpp::v2::Variable& variable_id,
+                                                   const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) {
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    std::vector<ocpp::v2::VariableAttribute> attributes;
+    auto component_it = device_model.find(component_id);
+    if (component_it == device_model.end()) {
+        return attributes;
+    }
+    auto variable_it = component_it->second.find(variable_id);
+    if (variable_it == component_it->second.end()) {
+        return attributes;
+    }
+    auto& variable_data = variable_it->second;
+    if (attribute_enum.has_value()) {
+        auto attribute_it = variable_data.attributes.find(attribute_enum.value());
+        if (attribute_it != variable_data.attributes.end()) {
+            attributes.push_back(attribute_it->second);
+        }
+    } else {
+        for (const auto& [type, attribute] : variable_data.attributes) {
+            attributes.push_back(attribute);
+        }
+    }
+    return attributes;
 }
 
 ocpp::v2::SetVariableStatusEnum EverestDeviceModelStorage::set_variable_attribute_value(
-    const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
+    const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
     const ocpp::v2::AttributeEnum& attribute_enum, const std::string& value, const std::string& source) {
-    return ocpp::v2::SetVariableStatusEnum::Rejected;
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    auto component_it = device_model.find(component_id);
+    if (component_it == device_model.end()) {
+        return ocpp::v2::SetVariableStatusEnum::UnknownComponent;
+    }
+    auto variable_it = component_it->second.find(variable_id);
+    if (variable_it == component_it->second.end()) {
+        return ocpp::v2::SetVariableStatusEnum::UnknownVariable;
+    }
+    auto& variable_data = variable_it->second;
+    auto attribute_it = variable_data.attributes.find(attribute_enum);
+    if (attribute_it == variable_data.attributes.end()) {
+        return ocpp::v2::SetVariableStatusEnum::NotSupportedAttributeType;
+    }
+    auto& attribute = attribute_it->second;
+    attribute.value = value;
+    variable_data.source = source;
+    return ocpp::v2::SetVariableStatusEnum::Accepted;
 }
 
 std::optional<ocpp::v2::VariableMonitoringMeta>

--- a/modules/OCPP201/device_model/everest_device_model_storage.hpp
+++ b/modules/OCPP201/device_model/everest_device_model_storage.hpp
@@ -3,11 +3,28 @@
 
 #pragma once
 
+#include <mutex>
+
+#include <generated/interfaces/evse_manager/Interface.hpp>
+#include <generated/types/evse_board_support.hpp>
+
 #include <ocpp/v2/device_model_storage_interface.hpp>
 
 namespace module::device_model {
+
+/// \brief Extends VariableMetaData to include a map of VariableAttributes that contain the actual values of a variable
+struct VariableData : ocpp::v2::VariableMetaData {
+    std::map<ocpp::v2::AttributeEnum, ocpp::v2::VariableAttribute> attributes;
+};
+
+using Variables = std::map<ocpp::v2::Variable, VariableData>;
+using ComponentsMap = std::map<ocpp::v2::Component, Variables>;
+
 class EverestDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
 public:
+    EverestDeviceModelStorage(
+        const std::vector<std::unique_ptr<evse_managerIntf>>& r_evse_manager,
+        const std::map<int32_t, types::evse_board_support::HardwareCapabilities>& evse_hardware_capabilities_map);
     virtual ~EverestDeviceModelStorage() override = default;
     virtual ocpp::v2::DeviceModelMap get_device_model() override;
     virtual std::optional<ocpp::v2::VariableAttribute>
@@ -30,5 +47,13 @@ public:
     virtual ocpp::v2::ClearMonitoringStatusEnum clear_variable_monitor(int monitor_id, bool allow_protected) override;
     virtual int32_t clear_custom_variable_monitors() override;
     virtual void check_integrity() override;
+
+private:
+    const std::vector<std::unique_ptr<evse_managerIntf>>& r_evse_manager;
+    ComponentsMap device_model;
+    std::mutex device_model_mutex;
+
+    void update_hw_capabilities(const ocpp::v2::Component& evse_component,
+                                const types::evse_board_support::HardwareCapabilities& hw_capabilities);
 };
 } // namespace module::device_model


### PR DESCRIPTION
## Describe your changes
This PR extends to OCPP201 module to dynamically initialize the EVSE and Connector device model components based on the EVerest configuration.

Before this change, the correct number of EVSE and Connector components had to be defined and installed manually. [This PR](https://github.com/EVerest/libocpp/pull/1093) in libocpp ensures that the custom EVSE and Connector components are not installed anymore by default. 

_____________

**Note**: To migrate using the EVSE and Connector components managed by OCPP201 module instead of the libocpp device model, the Connector and EVSE components should be removed from the installation directory. When EVerest starts up, it will then remove these components from libocpp's device model storage.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

