### PR TITLE
Allow power on in ISO_POWER_READY state

### DIFF
--- a/modules/EvManager/main/car_simulation.cpp
+++ b/modules/EvManager/main/car_simulation.cpp
@@ -70,6 +70,7 @@ void CarSimulation::state_machine() {
     case SimState::ISO_POWER_READY:
         if (state_has_changed) {
             r_ev_board_support->call_set_cp_state(EvCpState::C);
+            r_ev_board_support->call_allow_power_on(true);
         }
         break;
     case SimState::ISO_CHARGING_REGULATED:


### PR DESCRIPTION
We are switching into CP state C here, but do not call `allow_power_on` which leads to the contactors remaining open.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

