### PR TITLE
EvseV2G: Adding a check for out of bounds parameters in charge parameter discovery

### DIFF
--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -1324,8 +1324,9 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
         }
 
         constexpr auto physical_value_to_float = [](const iso2_PhysicalValueType& pv) {
-            return pv.Value * pow(10, pv.Multiplier);
+            return calc_physical_value(pv.Value, pv.Multiplier);
         };
+
         const auto ev_maximum_current_limit = physical_value_to_float(req->DC_EVChargeParameter.EVMaximumCurrentLimit);
         const auto ev_maximum_voltage_limit = physical_value_to_float(req->DC_EVChargeParameter.EVMaximumVoltageLimit);
         const auto evse_minimum_current_limit =


### PR DESCRIPTION
## Describe your changes

This pull request adds a check for a potential charge parameter mismatch between the ev max values and the evse min values.

## Issue ticket number and link

Closes #1160

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

