### PR TITLE
feat(OCPP2.1): Add AllowedEnergyTransferModes to auth validator

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -47,7 +47,7 @@ libcbv2g:
 # libiso15118
 libiso15118:
   git: https://github.com/EVerest/libiso15118.git
-  git_tag: v0.6.0
+  git_tag: efb46a2b38ba01be792e5d18d98b00d881b512b0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBISO15118"
 
 # LEM DCBM 400/600, IsabellenhuetteIemDcr modules

--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -7,18 +7,9 @@ cmds:
       evse_id:
         description: >-
           Set an ID that uniquely identifies the EVSE and the power outlet the
-          vehicle is connected to 
+          vehicle is connected to
         type: object
         $ref: /iso15118#/EVSEID
-      supported_energy_transfer_modes:
-        description: Available energy transfer modes supported by the EVSE
-        type: array
-        items:
-          description: The different energy modes supported by the SECC 
-          type: object
-          $ref: /iso15118#/SupportedEnergyMode
-        minItems: 1
-        maxItems: 6
       sae_j2847_mode:
         description: Charger is supporting SAE J2847 V2G/V2H version
         type: string
@@ -54,7 +45,7 @@ cmds:
         type: boolean
       central_contract_validation_allowed:
         description: >-
-          Indicates if the vehicle contract may be forwarded to and validated by a CSMS in case 
+          Indicates if the vehicle contract may be forwarded to and validated by a CSMS in case
           local validation was not successful
         type: boolean
 # Response messages to vars:
@@ -80,7 +71,7 @@ cmds:
       status:
         description: Set to true when contactor is closed, false when contactor is open
         type: boolean
-# Events 
+# Events
   dlink_ready:
     description: >-
       Signals dlink_ready from SLAC layer according to ISO15118-3
@@ -120,6 +111,22 @@ cmds:
         description: Set to true when to pause, set to false when to continue
         type: boolean
 # Update physical values
+  update_energy_transfer_modes:
+    description: >-
+      Update the supported energy transfer modes. Call at least once during start up.
+      Typically for ISO15118-2 and basic charging we expect unidirectional charging modes.
+      For ISO15118-20 the user can set what type of modes the hardware supports, may that be
+      bidirectional, unidirectional, wireless, etc charging.
+    arguments:
+      supported_energy_transfer_modes:
+        description: Available energy transfer modes supported by the EVSE
+        type: array
+        items:
+          description: The different energy modes supported by the SECC
+          type: object
+          $ref: /iso15118#/EnergyTransferMode
+        minItems: 1
+        maxItems: 6
   update_ac_max_current:
     description: Update the maximum allowed line current restriction per phase. Call at least once during start up.
     arguments:
@@ -143,7 +150,7 @@ cmds:
         type: object
         $ref: /iso15118#/DcEvseMinimumLimits
   update_isolation_status:
-    description: Update the isolation condition 
+    description: Update the isolation condition
     arguments:
       isolation_status:
         description: Result of the isolation monitoring
@@ -180,7 +187,7 @@ vars:
     description: An EIM authorization is requiered
     type: "null"
   require_auth_pnc:
-    description: >- 
+    description: >-
       The EVCC provides the payment details for a PnC authorization by sending
       the signature certificate chain and eMAID.
     type: object

--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -120,6 +120,26 @@ cmds:
         description: The plug and charge configuration object
         type: object
         $ref: /evse_manager#/PlugAndChargeConfiguration
+  update_allowed_energy_transfer_modes:
+    description: >-
+      Sets the supported energy transfer mode for ISO15118. It is expected that this command will update the ISO15118
+      software stack to only propose the list of allowed_energy_transfer_modes presented in this message.
+      If a transaction is already in progress, it is expected that this triggers a service renegotiation.
+      If no HLC is present, this will be accepted, but do nothing.
+    arguments:
+      allowed_energy_transfer_modes:
+        description: >-
+          The list of supported energy transfer modes. It cannot be empty as we need to propose something
+          to the EV.
+        type: array
+        items:
+          type: string
+          $ref: /iso15118#/EnergyTransferMode
+        minItems: 1
+    result:
+      description: Returns an enum indicating whether the update was successful or not.
+      type: string
+      $ref: /evse_manager#/UpdateAllowedEnergyTransferModesResult
 vars:
   session_event:
     description: Emits all events related to sessions

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
@@ -12,11 +12,14 @@ void ISO15118_chargerImpl::init() {
 void ISO15118_chargerImpl::ready() {
 }
 
-void ISO15118_chargerImpl::handle_setup(
-    types::iso15118::EVSEID& evse_id,
-    std::vector<types::iso15118::SupportedEnergyMode>& supported_energy_transfer_modes,
-    types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) {
+void ISO15118_chargerImpl::handle_setup(types::iso15118::EVSEID& evse_id,
+                                        types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) {
     // your code for cmd setup goes here
+}
+
+void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
+    std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
+    // your code for cmd update_energy_transfer_modes goes here
 }
 
 void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) {

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
@@ -33,9 +33,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual void handle_setup(types::iso15118::EVSEID& evse_id,
-                              std::vector<types::iso15118::SupportedEnergyMode>& supported_energy_transfer_modes,
-                              types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) override;
+    virtual void handle_setup(types::iso15118::EVSEID& evse_id, types::iso15118::SaeJ2847BidiMode& sae_j2847_mode,
+                              bool& debug_mode) override;
     virtual void handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) override;
     virtual void handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
                                       bool& supported_certificate_service,
@@ -48,6 +47,8 @@ protected:
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
     virtual void handle_pause_charging(bool& pause) override;
+    virtual void handle_update_energy_transfer_modes(
+        std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) override;
     virtual void handle_update_ac_max_current(double& max_current) override;
     virtual void handle_update_dc_maximum_limits(types::iso15118::DcEvseMaximumLimits& maximum_limits) override;
     virtual void handle_update_dc_minimum_limits(types::iso15118::DcEvseMinimumLimits& minimum_limits) override;

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -477,37 +477,63 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
     return callbacks;
 }
 
-void ISO15118_chargerImpl::handle_setup(
-    types::iso15118::EVSEID& evse_id,
-    std::vector<types::iso15118::SupportedEnergyMode>& supported_energy_transfer_modes,
-    types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) {
+void ISO15118_chargerImpl::handle_setup(types::iso15118::EVSEID& evse_id,
+                                        types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) {
 
     std::scoped_lock lock(GEL);
     setup_config.evse_id = evse_id.evse_id; // TODO(SL): Check format for d20
 
+    setup_steps_done.set(to_underlying_value(SetupStep::SETUP));
+}
+
+void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
+    std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
+
+    std::scoped_lock lock(GEL);
+
     std::vector<dt::ServiceCategory> services;
 
     for (const auto& mode : supported_energy_transfer_modes) {
-        if (mode.energy_transfer_mode == types::iso15118::EnergyTransferMode::AC_single_phase_core ||
-            mode.energy_transfer_mode == types::iso15118::EnergyTransferMode::AC_three_phase_core) {
-            if (mode.bidirectional) {
-                services.push_back(dt::ServiceCategory::AC_BPT);
-            } else {
-                services.push_back(dt::ServiceCategory::AC);
-            }
-        } else if (mode.energy_transfer_mode == types::iso15118::EnergyTransferMode::DC_core ||
-                   mode.energy_transfer_mode == types::iso15118::EnergyTransferMode::DC_extended ||
-                   mode.energy_transfer_mode == types::iso15118::EnergyTransferMode::DC_combo_core ||
-                   mode.energy_transfer_mode == types::iso15118::EnergyTransferMode::DC_unique) {
-            if (mode.bidirectional) {
-                services.push_back(dt::ServiceCategory::DC_BPT);
-            } else {
-                services.push_back(dt::ServiceCategory::DC);
-            }
+        switch (mode) {
+        case types::iso15118::EnergyTransferMode::AC_single_phase_core:
+        case types::iso15118::EnergyTransferMode::AC_two_phase:
+        case types::iso15118::EnergyTransferMode::AC_three_phase_core:
+            services.push_back(dt::ServiceCategory::AC);
+            break;
+        case types::iso15118::EnergyTransferMode::AC_BPT:
+        case types::iso15118::EnergyTransferMode::AC_BPT_DER:
+            services.push_back(dt::ServiceCategory::AC_BPT);
+            break;
+        case types::iso15118::EnergyTransferMode::AC_DER:
+            services.push_back(dt::ServiceCategory::AC_DER);
+            break;
+        case types::iso15118::EnergyTransferMode::DC:
+        case types::iso15118::EnergyTransferMode::DC_core:
+        case types::iso15118::EnergyTransferMode::DC_extended:
+        case types::iso15118::EnergyTransferMode::DC_combo_core:
+        case types::iso15118::EnergyTransferMode::DC_unique:
+            services.push_back(dt::ServiceCategory::DC);
+            break;
+        case types::iso15118::EnergyTransferMode::DC_BPT:
+            services.push_back(dt::ServiceCategory::DC_BPT);
+            break;
+        case types::iso15118::EnergyTransferMode::DC_ACDP:
+            services.push_back(dt::ServiceCategory::DC_ACDP);
+            break;
+        case types::iso15118::EnergyTransferMode::DC_ACDP_BPT:
+            services.push_back(dt::ServiceCategory::DC_ACDP_BPT);
+            break;
+        case types::iso15118::EnergyTransferMode::WPT:
+            services.push_back(dt::ServiceCategory::WPT);
+            break;
         }
     }
 
     setup_config.supported_energy_services = services;
+
+    if (controller) {
+        controller->update_energy_modes(services);
+    }
 
     setup_steps_done.set(to_underlying_value(SetupStep::ENERGY_SERVICE));
 }

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.hpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.hpp
@@ -39,9 +39,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual void handle_setup(types::iso15118::EVSEID& evse_id,
-                              std::vector<types::iso15118::SupportedEnergyMode>& supported_energy_transfer_modes,
-                              types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) override;
+    virtual void handle_setup(types::iso15118::EVSEID& evse_id, types::iso15118::SaeJ2847BidiMode& sae_j2847_mode,
+                              bool& debug_mode) override;
     virtual void handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) override;
     virtual void handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
                                       bool& supported_certificate_service,
@@ -54,6 +53,8 @@ protected:
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
     virtual void handle_pause_charging(bool& pause) override;
+    virtual void handle_update_energy_transfer_modes(
+        std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) override;
     virtual void handle_update_ac_max_current(double& max_current) override;
     virtual void handle_update_dc_maximum_limits(types::iso15118::DcEvseMaximumLimits& maximum_limits) override;
     virtual void handle_update_dc_minimum_limits(types::iso15118::DcEvseMinimumLimits& minimum_limits) override;

--- a/modules/Evse15118D20/charger/utils.hpp
+++ b/modules/Evse15118D20/charger/utils.hpp
@@ -5,9 +5,10 @@
 #include <generated/types/iso15118.hpp>
 #include <iso15118/message/type.hpp>
 
-static constexpr auto NUMBER_OF_SETUP_STEPS = 4;
+static constexpr auto NUMBER_OF_SETUP_STEPS = 5;
 
 enum class SetupStep {
+    SETUP,
     ENERGY_SERVICE,
     AUTH_SETUP,
     MAX_LIMITS,

--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -455,5 +455,18 @@ void evse_managerImpl::handle_set_plug_and_charge_configuration(
     }
 }
 
+types::evse_manager::UpdateAllowedEnergyTransferModesResult
+evse_managerImpl::handle_update_allowed_energy_transfer_modes(
+    std::vector<types::iso15118::EnergyTransferMode>& allowed_energy_transfer_modes) {
+    // if (incompatible) {
+    //   return "IncompatibleType";
+    // }
+    if (!mod->r_hlc.empty() && mod->r_hlc[0]) {
+        mod->r_hlc[0]->call_update_energy_transfer_modes(allowed_energy_transfer_modes);
+        return types::evse_manager::UpdateAllowedEnergyTransferModesResult::Accepted;
+    }
+    return types::evse_manager::UpdateAllowedEnergyTransferModesResult::NoHlc;
+}
+
 } // namespace evse
 } // namespace module

--- a/modules/EvseManager/evse/evse_managerImpl.hpp
+++ b/modules/EvseManager/evse/evse_managerImpl.hpp
@@ -50,6 +50,8 @@ protected:
     virtual bool handle_external_ready_to_start_charging() override;
     virtual void handle_set_plug_and_charge_configuration(
         types::evse_manager::PlugAndChargeConfiguration& plug_and_charge_configuration) override;
+    virtual types::evse_manager::UpdateAllowedEnergyTransferModesResult handle_update_allowed_energy_transfer_modes(
+        std::vector<types::iso15118::EnergyTransferMode>& allowed_energy_transfer_modes) override;
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here

--- a/modules/EvseManager/tests/EvseManagerStub.hpp
+++ b/modules/EvseManager/tests/EvseManagerStub.hpp
@@ -67,6 +67,10 @@ struct evse_managerImplStub : public evse_managerImplBase {
     virtual void handle_set_plug_and_charge_configuration(
         types::evse_manager::PlugAndChargeConfiguration& plug_and_charge_configuration) {
     }
+    virtual types::evse_manager::UpdateAllowedEnergyTransferModesResult handle_update_allowed_energy_transfer_modes(
+        std::vector<types::iso15118::EnergyTransferMode>& allowed_energy_transfer_modes) {
+        return types::evse_manager::UpdateAllowedEnergyTransferModesResult::Accepted;
+    }
 };
 
 struct EvseManagerModuleAdapter : public ModuleAdapterStub {

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
@@ -34,9 +34,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual void handle_setup(types::iso15118::EVSEID& evse_id,
-                              std::vector<types::iso15118::SupportedEnergyMode>& supported_energy_transfer_modes,
-                              types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) override;
+    virtual void handle_setup(types::iso15118::EVSEID& evse_id, types::iso15118::SaeJ2847BidiMode& sae_j2847_mode,
+                              bool& debug_mode) override;
     virtual void handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) override;
     virtual void handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
                                       bool& supported_certificate_service,
@@ -49,6 +48,8 @@ protected:
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
     virtual void handle_pause_charging(bool& pause) override;
+    virtual void handle_update_energy_transfer_modes(
+        std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) override;
     virtual void handle_update_ac_max_current(double& max_current) override;
     virtual void handle_update_dc_maximum_limits(types::iso15118::DcEvseMaximumLimits& maximum_limits) override;
     virtual void handle_update_dc_minimum_limits(types::iso15118::DcEvseMinimumLimits& minimum_limits) override;

--- a/modules/EvseV2G/tests/ISO15118_chargerImplStub.hpp
+++ b/modules/EvseV2G/tests/ISO15118_chargerImplStub.hpp
@@ -23,10 +23,13 @@ struct ISO15118_chargerImplStub : public ISO15118_chargerImplBase {
     virtual void ready() {
     }
 
-    virtual void handle_setup(types::iso15118::EVSEID& evse_id,
-                              std::vector<types::iso15118::SupportedEnergyMode>& supported_energy_transfer_modes,
-                              types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) {
+    virtual void handle_setup(types::iso15118::EVSEID& evse_id, types::iso15118::SaeJ2847BidiMode& sae_j2847_mode,
+                              bool& debug_mode) {
         std::cout << "ISO15118_chargerImplBase::handle_setup called" << std::endl;
+    }
+    virtual void handle_update_energy_transfer_modes(
+        std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
+        std::cout << "ISO15118_chargerImplBase::handle_update_energy_transfer_modes called" << std::endl;
     }
     virtual void handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) {
         std::cout << "ISO15118_chargerImplBase::handle_set_charging_parameters called" << std::endl;

--- a/modules/IsoMux/charger/ISO15118_chargerImpl.cpp
+++ b/modules/IsoMux/charger/ISO15118_chargerImpl.cpp
@@ -470,12 +470,16 @@ void ISO15118_chargerImpl::init() {
 void ISO15118_chargerImpl::ready() {
 }
 
-void ISO15118_chargerImpl::handle_setup(
-    types::iso15118::EVSEID& evse_id,
-    std::vector<types::iso15118::SupportedEnergyMode>& supported_energy_transfer_modes,
-    types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) {
-    mod->r_iso20->call_setup(evse_id, supported_energy_transfer_modes, sae_j2847_mode, debug_mode);
-    mod->r_iso2->call_setup(evse_id, supported_energy_transfer_modes, sae_j2847_mode, debug_mode);
+void ISO15118_chargerImpl::handle_setup(types::iso15118::EVSEID& evse_id,
+                                        types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) {
+    mod->r_iso20->call_setup(evse_id, sae_j2847_mode, debug_mode);
+    mod->r_iso2->call_setup(evse_id, sae_j2847_mode, debug_mode);
+}
+
+void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
+    std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
+    mod->r_iso20->call_update_energy_transfer_modes(supported_energy_transfer_modes);
+    mod->r_iso2->call_update_energy_transfer_modes(supported_energy_transfer_modes);
 }
 
 void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) {

--- a/modules/IsoMux/charger/ISO15118_chargerImpl.hpp
+++ b/modules/IsoMux/charger/ISO15118_chargerImpl.hpp
@@ -34,9 +34,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual void handle_setup(types::iso15118::EVSEID& evse_id,
-                              std::vector<types::iso15118::SupportedEnergyMode>& supported_energy_transfer_modes,
-                              types::iso15118::SaeJ2847BidiMode& sae_j2847_mode, bool& debug_mode) override;
+    virtual void handle_setup(types::iso15118::EVSEID& evse_id, types::iso15118::SaeJ2847BidiMode& sae_j2847_mode,
+                              bool& debug_mode) override;
     virtual void handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) override;
     virtual void handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
                                       bool& supported_certificate_service,
@@ -49,6 +48,8 @@ protected:
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
     virtual void handle_pause_charging(bool& pause) override;
+    virtual void handle_update_energy_transfer_modes(
+        std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) override;
     virtual void handle_update_ac_max_current(double& max_current) override;
     virtual void handle_update_dc_maximum_limits(types::iso15118::DcEvseMaximumLimits& maximum_limits) override;
     virtual void handle_update_dc_minimum_limits(types::iso15118::DcEvseMinimumLimits& minimum_limits) override;

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -177,6 +177,9 @@ private:
 
     /// \brief This function applies given \p composite_schedules for each connected evse_energy_sink
     void set_external_limits(const std::vector<ocpp::v2::CompositeSchedule>& composite_schedules);
+
+    /// \brief This function updates the additionalIdToken of the additionalTokenInfo field with the evcc_id.
+    void update_evcc_id_token(const int& evse_id, const std::string& evcc_id);
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/OCPP201/conversions.cpp
+++ b/modules/OCPP201/conversions.cpp
@@ -1035,6 +1035,9 @@ types::authorization::ValidationResult to_everest_validation_result(const ocpp::
     if (response.certificateStatus.has_value()) {
         validation_result.certificate_status.emplace(to_everest_certificate_status(response.certificateStatus.value()));
     }
+
+    validation_result.allowed_energy_transfer_modes =
+        to_everest_allowed_energy_transfer_modes(response.allowedEnergyTransfer);
     return validation_result;
 }
 
@@ -1511,6 +1514,49 @@ to_ocpp_clear_display_message_response(const types::display_message::ClearDispla
     }
 
     return result_response;
+}
+
+types::iso15118::EnergyTransferMode
+to_everest_allowed_energy_transfer_mode(const ocpp::v2::EnergyTransferModeEnum& allowed_energy_transfer_mode) {
+    switch (allowed_energy_transfer_mode) {
+    case ocpp::v2::EnergyTransferModeEnum::AC_BPT:
+        return types::iso15118::EnergyTransferMode::AC_BPT;
+    case ocpp::v2::EnergyTransferModeEnum::AC_BPT_DER:
+        return types::iso15118::EnergyTransferMode::AC_BPT_DER;
+    case ocpp::v2::EnergyTransferModeEnum::AC_DER:
+        return types::iso15118::EnergyTransferMode::AC_DER;
+    case ocpp::v2::EnergyTransferModeEnum::AC_single_phase:
+        return types::iso15118::EnergyTransferMode::AC_single_phase_core;
+    case ocpp::v2::EnergyTransferModeEnum::AC_three_phase:
+        return types::iso15118::EnergyTransferMode::AC_three_phase_core;
+    case ocpp::v2::EnergyTransferModeEnum::AC_two_phase:
+        return types::iso15118::EnergyTransferMode::AC_two_phase;
+    case ocpp::v2::EnergyTransferModeEnum::DC:
+        return types::iso15118::EnergyTransferMode::DC;
+    case ocpp::v2::EnergyTransferModeEnum::DC_BPT:
+        return types::iso15118::EnergyTransferMode::DC_BPT;
+    case ocpp::v2::EnergyTransferModeEnum::DC_ACDP:
+        return types::iso15118::EnergyTransferMode::DC_ACDP;
+    case ocpp::v2::EnergyTransferModeEnum::DC_ACDP_BPT:
+        return types::iso15118::EnergyTransferMode::DC_ACDP_BPT;
+    case ocpp::v2::EnergyTransferModeEnum::WPT:
+        return types::iso15118::EnergyTransferMode::WPT;
+    }
+    throw std::out_of_range("Could not convert EnergyTransferModeEnum");
+}
+
+std::optional<std::vector<types::iso15118::EnergyTransferMode>> to_everest_allowed_energy_transfer_modes(
+    const std::optional<std::vector<ocpp::v2::EnergyTransferModeEnum>>& allowed_energy_transfer_modes) {
+    std::optional<std::vector<types::iso15118::EnergyTransferMode>> ret = std::nullopt;
+
+    if (allowed_energy_transfer_modes.has_value()) {
+        std::vector<types::iso15118::EnergyTransferMode> value{};
+        for (const auto& mode : allowed_energy_transfer_modes.value()) {
+            value.push_back(to_everest_allowed_energy_transfer_mode(mode));
+        }
+        ret = value;
+    }
+    return ret;
 }
 
 } // namespace conversions

--- a/modules/OCPP201/conversions.cpp
+++ b/modules/OCPP201/conversions.cpp
@@ -1036,8 +1036,10 @@ types::authorization::ValidationResult to_everest_validation_result(const ocpp::
         validation_result.certificate_status.emplace(to_everest_certificate_status(response.certificateStatus.value()));
     }
 
-    validation_result.allowed_energy_transfer_modes =
-        to_everest_allowed_energy_transfer_modes(response.allowedEnergyTransfer);
+    if (validation_result.allowed_energy_transfer_modes.has_value()) {
+        validation_result.allowed_energy_transfer_modes =
+            to_everest_allowed_energy_transfer_modes(response.allowedEnergyTransfer.value());
+    }
     return validation_result;
 }
 
@@ -1545,18 +1547,15 @@ to_everest_allowed_energy_transfer_mode(const ocpp::v2::EnergyTransferModeEnum& 
     throw std::out_of_range("Could not convert EnergyTransferModeEnum");
 }
 
-std::optional<std::vector<types::iso15118::EnergyTransferMode>> to_everest_allowed_energy_transfer_modes(
-    const std::optional<std::vector<ocpp::v2::EnergyTransferModeEnum>>& allowed_energy_transfer_modes) {
-    std::optional<std::vector<types::iso15118::EnergyTransferMode>> ret = std::nullopt;
+std::vector<types::iso15118::EnergyTransferMode> to_everest_allowed_energy_transfer_modes(
+    const std::vector<ocpp::v2::EnergyTransferModeEnum>& allowed_energy_transfer_modes) {
 
-    if (allowed_energy_transfer_modes.has_value()) {
-        std::vector<types::iso15118::EnergyTransferMode> value{};
-        for (const auto& mode : allowed_energy_transfer_modes.value()) {
-            value.push_back(to_everest_allowed_energy_transfer_mode(mode));
-        }
-        ret = value;
+    std::vector<types::iso15118::EnergyTransferMode> value{};
+    value.reserve(allowed_energy_transfer_modes.size());
+    for (const auto& mode : allowed_energy_transfer_modes) {
+        value.push_back(to_everest_allowed_energy_transfer_mode(mode));
     }
-    return ret;
+    return value;
 }
 
 } // namespace conversions

--- a/modules/OCPP201/conversions.hpp
+++ b/modules/OCPP201/conversions.hpp
@@ -274,6 +274,14 @@ to_ocpp_clear_message_response_enum(const types::display_message::ClearMessageRe
 ocpp::v2::ClearDisplayMessageResponse
 to_ocpp_clear_display_message_response(const types::display_message::ClearDisplayMessageResponse& response);
 
+/// \brief Converst a given ocpp::v2::EnergyTransferModeEnum \p to a types::iso15118::EnergyTransferMode
+types::iso15118::EnergyTransferMode
+to_everest_allowed_energy_transfer_mode(const ocpp::v2::EnergyTransferModeEnum& allowed_energy_transfer_mode);
+
+/// \brief Converst a given std::optional<std::vector<ocpp::v2::EnergyTransferModeEnum>> \p to a
+/// std::optional<std::vector<types::iso15118::EnergyTransferMode>>
+std::optional<std::vector<types::iso15118::EnergyTransferMode>> to_everest_allowed_energy_transfer_modes(
+    const std::optional<std::vector<ocpp::v2::EnergyTransferModeEnum>>& allowed_energy_transfer_modes);
 } // namespace conversions
 } // namespace module
 

--- a/modules/OCPP201/conversions.hpp
+++ b/modules/OCPP201/conversions.hpp
@@ -278,10 +278,10 @@ to_ocpp_clear_display_message_response(const types::display_message::ClearDispla
 types::iso15118::EnergyTransferMode
 to_everest_allowed_energy_transfer_mode(const ocpp::v2::EnergyTransferModeEnum& allowed_energy_transfer_mode);
 
-/// \brief Converst a given std::optional<std::vector<ocpp::v2::EnergyTransferModeEnum>> \p to a
-/// std::optional<std::vector<types::iso15118::EnergyTransferMode>>
-std::optional<std::vector<types::iso15118::EnergyTransferMode>> to_everest_allowed_energy_transfer_modes(
-    const std::optional<std::vector<ocpp::v2::EnergyTransferModeEnum>>& allowed_energy_transfer_modes);
+/// \brief Converst a given std::vector<ocpp::v2::EnergyTransferModeEnum> \p to a
+/// std::vector<types::iso15118::EnergyTransferMode>
+std::vector<types::iso15118::EnergyTransferMode> to_everest_allowed_energy_transfer_modes(
+    const std::vector<ocpp::v2::EnergyTransferModeEnum>& allowed_energy_transfer_modes);
 } // namespace conversions
 } // namespace module
 

--- a/modules/OCPP201/device_model/composed_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.cpp
@@ -6,8 +6,6 @@
 static constexpr auto VARIABLE_SOURCE_OCPP = "OCPP";
 
 namespace module::device_model {
-ComposedDeviceModelStorage::ComposedDeviceModelStorage() {
-}
 
 bool ComposedDeviceModelStorage::register_device_model_storage(
     std::string device_model_storage_id, std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> device_model_storage) {

--- a/modules/OCPP201/device_model/composed_device_model_storage.hpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.hpp
@@ -17,7 +17,7 @@ private:
     ComponentVariableSourceMap component_variable_source_map;
 
 public:
-    ComposedDeviceModelStorage();
+    ComposedDeviceModelStorage() = default;
 
     /// \brief Register a device model storage.
     /// \param device_model_storage_id   The id of the device model storage. Component variable combinations can be

--- a/tests/ocpp_tests/conftest.py
+++ b/tests/ocpp_tests/conftest.py
@@ -139,6 +139,13 @@ def probe_module(
         module,
         skip_implementation,
         "ProbeModuleConnectorA",
+        "update_allowed_energy_transfer_modes",
+        lambda arg: None,
+    )
+    implement_command(
+        module,
+        skip_implementation,
+        "ProbeModuleConnectorA",
         "withdraw_authorization",
         lambda arg: None,
     )
@@ -231,6 +238,13 @@ def probe_module(
         skip_implementation,
         "ProbeModuleConnectorB",
         "authorize_response",
+        lambda arg: None,
+    )
+    implement_command(
+        module,
+        skip_implementation,
+        "ProbeModuleConnectorB",
+        "update_allowed_energy_transfer_modes",
         lambda arg: None,
     )
     implement_command(

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
@@ -94,7 +94,10 @@ async def _env(
         _add_pm_command_mock(
             evse_manager, "stop_transaction", True, skip_implementation
         )
-        _add_pm_command_mock(evse_manager, "force_unlock", True, skip_implementation)
+        _add_pm_command_mock(evse_manager, "force_unlock",
+                             True, skip_implementation)
+        _add_pm_command_mock(
+            evse_manager, "update_allowed_energy_transfer_modes", None, skip_implementation)
         _add_pm_command_mock(
             evse_manager, "external_ready_to_start_charging", True, skip_implementation
         )

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -193,8 +193,8 @@ types:
         type: integer
       allowed_energy_transfer_modes:
         description: >-
-          Only used with OCPP 2.1, this allows the CSMS to transmit to the charging station
-          which energy transfer modes are allowed with the vehicle.
+          This is only used when we want to specify which energy transfer modes are allowed for
+          the respective authorization request.
         type: array
         items:
           type: string

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -191,6 +191,15 @@ types:
       reservation_id:
         description: The reservation id that is used with this validated token.
         type: integer
+      allowed_energy_transfer_modes:
+        description: >-
+          Only used with OCPP 2.1, this allows the CSMS to transmit to the charging station
+          which energy transfer modes are allowed with the vehicle.
+        type: array
+        items:
+          type: string
+          $ref: /iso15118#/EnergyTransferMode
+        minItems: 1
   SelectionAlgorithm:
     description: >-
       The selection algorithm defines the logic to select one connector

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -550,3 +550,11 @@ types:
       contract_certificate_installation_enabled:
         description: Indicates if ISO 15118 contract certificate installation/update is enabled
         type: boolean
+  UpdateAllowedEnergyTransferModesResult:
+    description: Enum used to indicate whether an UpdateAllowedEnergyTransferModes cmd was successful or not.
+    type: string
+    enum:
+      - Accepted
+      - IncompatibleEnergyTransfer
+      - ServiceRenegotiationFailed
+      - NoHlc

--- a/types/iso15118.yaml
+++ b/types/iso15118.yaml
@@ -133,7 +133,7 @@ types:
       - DcWeldingDetectionRes
       - UnknownMessage
   SaeJ2847BidiMode:
-    description: Bidi mode for sae j2847_2 
+    description: Bidi mode for sae j2847_2
     type: string
     enum:
       - None
@@ -499,7 +499,7 @@ types:
       iso15118_schema_version:
         description: Schema Version used for CertificateReq message between EV and Charger
         type: string
-        maxLength: 50 
+        maxLength: 50
       certificate_action:
         description: Type of the certificate request
         type: string
@@ -538,21 +538,6 @@ types:
         description: This contains the responder URL
         type: string
         maxLength: 512
-  SupportedEnergyMode:
-    description: Supported energy mode and if the mode supports bidirectional
-    type: object
-    additionalProperties: false
-    required:
-      - energy_transfer_mode
-      - bidirectional
-    properties:
-      energy_transfer_mode:
-        description: The energy mode supported by the SECC 
-        type: string
-        $ref: /iso15118#/EnergyTransferMode
-      bidirectional:
-        description: Set true if the powersupply (AC or DC) supports bidi mode
-        type: boolean
   DisplayParameters:
     description: Parameters that may be displayed on the EVSE
     type: object


### PR DESCRIPTION
This list of allowed energy transfer modes has been added to the auth validator interface so that the evse manager can be aware of what energy transfer modes are allowed so that it can properly update the ISO15118 stack.

## Describe your changes

Added allowed transfer modes to be added to the auth interface so that they can be passed to the evse manager. Now we just need this to be implemented evse manager side to tell the hlc which modes are allowed. This is not yet supported. 
The updates should be done in `EvseManager/evse/evse_managerImpl.cpp`.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

