### PR TITLE
refactor: Changed certificate verification in openssl utils

### DIFF
--- a/lib/staging/tls/openssl_util.cpp
+++ b/lib/staging/tls/openssl_util.cpp
@@ -689,6 +689,10 @@ verify_result_t verify_certificate(const X509* cert, const certificate_list& tru
     auto* chain = sk_X509_new_null();
     X509* target{nullptr};
 
+    if (trust_anchors.empty()) {
+        log_error("No trust anchors provided");
+        return verify_result_t::NoCertificateAvailable;
+    }
     if (store_ctx == nullptr) {
         log_error("X509_STORE_CTX_new");
         result = verify_result_t::OtherError;
@@ -756,7 +760,7 @@ verify_result_t verify_certificate(const X509* cert, const certificate_list& tru
                     break;
                 case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
                 case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
-                    result = verify_result_t::NoCertificateAvailable;
+                    result = verify_result_t::CertificateNotAllowed;
                     break;
                 default:
                     break;

--- a/lib/staging/tls/openssl_util.hpp
+++ b/lib/staging/tls/openssl_util.hpp
@@ -27,7 +27,8 @@ enum class verify_result_t : std::uint8_t {
     CertChainError,
     CertificateExpired,
     CertificateRevoked,
-    NoCertificateAvailable,
+    NoCertificateAvailable, // no root certificate available at all
+    CertificateNotAllowed,  // correct root certificate not available
     OtherError,
 };
 

--- a/lib/staging/tls/tests/tls_test.cpp
+++ b/lib/staging/tls/tests/tls_test.cpp
@@ -289,9 +289,9 @@ TEST(TrustedCaKeys, CertChain) {
               openssl::verify_result_t::Verified);
 
     EXPECT_EQ(openssl::verify_certificate(server[0].get(), alt_server_root, chain),
-              openssl::verify_result_t::NoCertificateAvailable);
+              openssl::verify_result_t::CertificateNotAllowed);
     EXPECT_EQ(openssl::verify_certificate(alt_server[0].get(), server_root, chain),
-              openssl::verify_result_t::NoCertificateAvailable);
+              openssl::verify_result_t::CertificateNotAllowed);
 }
 
 TEST(TrustedCaKeys, matchNone) {

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -955,6 +955,14 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
                     res->ResponseCode = iso2_responseCodeType_FAILED_NoCertificateAvailable;
                 }
                 break;
+            case crypto::verify_result_t::CertificateNotAllowed:
+                // forward to csms if central_contract_validation_allowed is true
+                if (conn->ctx->evse_v2g_data.central_contract_validation_allowed) {
+                    forward_contract = true;
+                } else {
+                    res->ResponseCode = iso2_responseCodeType_FAILED_CertificateNotAllowedAtThisEVSE;
+                }
+                break;
             case crypto::verify_result_t::CertChainError:
             default:
                 res->ResponseCode = iso2_responseCodeType_FAILED_CertChainError;


### PR DESCRIPTION

## Describe your changes
* load_contract_root_cert always uses MO and V2G trust anchors instead of only using V2G trust anchors if MO trust anchors are empty
* introduced new response code CertificateNotAllowed that applies in case a contract trust anchor is installed but does not match. This will result in responding with iso2_responseCodeType_FAILED_CertificateNotAllowedAtThisEVSE as required for the Hubject Plug&Charge certification. NoCertificateAvailable is only used in case no contract trust anchor is installed at all

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

