### PR TITLE
Fix(ISO15118): Move Plug&Charge contract request into Authorize handler 

### DIFF
--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -995,7 +995,7 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
         ProvidedIdToken.authorization_type = types::authorization::AuthorizationType::PlugAndCharge;
         ProvidedIdToken.iso15118CertificateHashData = iso15118_certificate_hash_data;
         ProvidedIdToken.certificate = contract_cert_chain_pem;
-        conn->ctx->session.provided_id_token = ProvidedIdToken;
+        conn->ctx->session.provided_id_token.emplace(ProvidedIdToken);
 
     } else {
         res->ResponseCode = iso2_responseCodeType_FAILED;
@@ -1064,7 +1064,16 @@ static enum v2g_event handle_iso_authorization(struct v2g_connection* conn) {
             res->ResponseCode = iso2_responseCodeType_FAILED_SignatureError;
             goto error_out;
         }
-        conn->ctx->p_charger->publish_require_auth_pnc(conn->ctx->session.provided_id_token);
+        if (conn->ctx->session.provided_id_token.has_value()) {
+            conn->ctx->p_charger->publish_require_auth_pnc(conn->ctx->session.provided_id_token.value());
+            conn->ctx->session.provided_id_token.reset();
+        } else {
+            // this should never happen, since the contract certificate is set in handle_iso_payment_details in case
+            // contract is selected
+            dlog(DLOG_LEVEL_ERROR, "No contract certificate could be retrieved!");
+            res->ResponseCode = iso2_responseCodeType_FAILED;
+            goto error_out;
+        }
     }
     res->EVSEProcessing = (iso2_EVSEProcessingType)conn->ctx->evse_v2g_data.evse_processing[PHASE_AUTH];
 

--- a/modules/EvseV2G/v2g.hpp
+++ b/modules/EvseV2G/v2g.hpp
@@ -302,12 +302,12 @@ struct v2g_context {
         iso2_paymentOptionType iso_selected_payment_option;
         long long int auth_start_timeout;
         int auth_timeout_eim;
-        int auth_timeout_pnc;                                       // for PnC
-        uint8_t gen_challenge[16];                                  // for PnC
-        bool verify_contract_cert_chain;                            // for PnC
-        types::authorization::CertificateStatus certificate_status; // for PnC
-        bool authorization_rejected;                                // for PnC
-        types::authorization::ProvidedIdToken provided_id_token;    // for PnC
+        int auth_timeout_pnc;                                                   // for PnC
+        uint8_t gen_challenge[16];                                              // for PnC
+        bool verify_contract_cert_chain;                                        // for PnC
+        types::authorization::CertificateStatus certificate_status;             // for PnC
+        bool authorization_rejected;                                            // for PnC
+        std::optional<types::authorization::ProvidedIdToken> provided_id_token; // for PnC
 
         bool renegotiation_required;  /* Is set to true if renegotiation is required. Only relevant for ISO */
         bool is_charging;             /* set to true if ChargeProgress is set to Start */


### PR DESCRIPTION

## Describe your changes
Moved publish_require_auth_pnc into ISO15118 Authorization handler. This allows us to error out in case of a signature error or invalid gen challenge. Before this, a (OCPP) transaction may have been started already

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

