### PR TITLE
EnergyManager: Initialize node_type to "Undefined" in ctor

### DIFF
--- a/modules/EnergyManager/EnergyManagerImpl.cpp
+++ b/modules/EnergyManager/EnergyManagerImpl.cpp
@@ -68,6 +68,7 @@ EnergyManagerImpl::EnergyManagerImpl(
     const EnergyManagerConfig& config,
     const std::function<void(const std::vector<types::energy::EnforcedLimits>& limits)>& enforced_limits_callback) :
     config(config), enforced_limits_callback(enforced_limits_callback) {
+    this->energy_flow_request.node_type = types::energy::NodeType::Undefined;
 }
 
 void EnergyManagerImpl::start() {


### PR DESCRIPTION
Otherwise this is left undefined until the first energy flow request is received, which can lead to this non-initialized value being used in the run_optimizer() run

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

