### PR TITLE
feat(EvseSecurity): Extended evse_security interface by CertificateStoreUpdate var

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -73,13 +73,13 @@ libcurl:
 # of libocpp and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: v0.9.6
+  git_tag: 3b1231392c9f93e1a1375e4691cb20b83cc63a9b
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: v0.27.1
+  git_tag: 663f59772c37ac7e83a051b3042504f4d013fe85
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/interfaces/evse_security.yaml
+++ b/interfaces/evse_security.yaml
@@ -226,5 +226,13 @@ cmds:
     result:
       description: True if verification succeeded, false if not
       type: boolean
+vars:
+  certificate_store_update:
+    description: >-
+      Variable that indicates that the certificate store has been updated, i.e. either a certificate has been installed or deleted. 
+      This is used to notify other modules that the certificate store has changed.
+    type: object
+    $ref: /evse_security#/CertificateStoreUpdate
+
 
 

--- a/modules/EvseSecurity/main/evse_securityImpl.cpp
+++ b/modules/EvseSecurity/main/evse_securityImpl.cpp
@@ -57,6 +57,7 @@ evse_securityImpl::handle_delete_certificate(types::evse_security::CertificateHa
 
         if (result == types::evse_security::DeleteCertificateResult::Accepted) {
             types::evse_security::CertificateStoreUpdate update;
+
             update.operation = types::evse_security::CertificateStoreUpdateOperation::Deleted;
 
             if (response.ca_certificate_type.has_value()) {

--- a/modules/EvseSecurity/main/evse_securityImpl.cpp
+++ b/modules/EvseSecurity/main/evse_securityImpl.cpp
@@ -34,8 +34,15 @@ types::evse_security::InstallCertificateResult
 evse_securityImpl::handle_install_ca_certificate(std::string& certificate,
                                                  types::evse_security::CaCertificateType& certificate_type) {
     try {
-        return conversions::to_everest(
+        const auto response = conversions::to_everest(
             this->evse_security->install_ca_certificate(certificate, conversions::from_everest(certificate_type)));
+        if (response == types::evse_security::InstallCertificateResult::Accepted) {
+            types::evse_security::CertificateStoreUpdate update;
+            update.operation = types::evse_security::CertificateStoreUpdateOperation::Installed;
+            update.ca_certificate_type = certificate_type;
+            this->publish_certificate_store_update(update);
+        }
+        return response;
     } catch (const std::out_of_range& e) {
         EVLOG_warning << e.what();
         return types::evse_security::InstallCertificateResult::WriteError;
@@ -45,8 +52,15 @@ evse_securityImpl::handle_install_ca_certificate(std::string& certificate,
 types::evse_security::DeleteCertificateResult
 evse_securityImpl::handle_delete_certificate(types::evse_security::CertificateHashData& certificate_hash_data) {
     try {
-        return conversions::to_everest(
+        const auto response = conversions::to_everest(
             this->evse_security->delete_certificate(conversions::from_everest(certificate_hash_data)));
+        if (response == types::evse_security::DeleteCertificateResult::Accepted) {
+            types::evse_security::CertificateStoreUpdate update;
+            update.operation = types::evse_security::CertificateStoreUpdateOperation::Deleted;
+            update.deleted_certificate_hash_data = certificate_hash_data;
+            this->publish_certificate_store_update(update);
+        }
+        return response;
     } catch (const std::out_of_range& e) {
         EVLOG_warning << e.what();
         return types::evse_security::DeleteCertificateResult::Failed;
@@ -57,8 +71,15 @@ types::evse_security::InstallCertificateResult
 evse_securityImpl::handle_update_leaf_certificate(std::string& certificate_chain,
                                                   types::evse_security::LeafCertificateType& certificate_type) {
     try {
-        return conversions::to_everest(this->evse_security->update_leaf_certificate(
+        const auto response = conversions::to_everest(this->evse_security->update_leaf_certificate(
             certificate_chain, conversions::from_everest(certificate_type)));
+        if (response == types::evse_security::InstallCertificateResult::Accepted) {
+            types::evse_security::CertificateStoreUpdate update;
+            update.operation = types::evse_security::CertificateStoreUpdateOperation::Installed;
+            update.leaf_certificate_type = certificate_type;
+            this->publish_certificate_store_update(update);
+        }
+        return response;
     } catch (const std::out_of_range& e) {
         EVLOG_warning << e.what();
         return types::evse_security::InstallCertificateResult::WriteError;

--- a/types/evse_security.yaml
+++ b/types/evse_security.yaml
@@ -289,7 +289,7 @@ types:
       - Deleted
   CertificateStoreUpdate:
     description: >-
-      Type that specifies the update of the certificate store. If operation is Installed, one of leaf_certificate_type 
+      Type that specifies the update of the certificate store. One of leaf_certificate_type 
       or ca_certificate_type must be present.
     type: object
     required:
@@ -298,11 +298,7 @@ types:
       operation:
         description: The operation perfomred on the certificate store
         type: string
-        $ref: /evse_security#/CertificateStoreUpdateOperation
-      deleted_certificate_hash_data:
-        description: The hash data of the certificate that was deleted. Only present if the operation is "Deleted"
-        type: object
-        $ref: /evse_security#/CertificateHashData
+        $ref: /evse_security#/CertificateStoreUpdateOperation      
       leaf_certificate_type:
         description: The type of the leaf certificate that was installed or deleted. Only present if type of updated certificate is a leaf certificate
         type: string

--- a/types/evse_security.yaml
+++ b/types/evse_security.yaml
@@ -281,4 +281,33 @@ types:
           minimum: 0
           type: object
           $ref: /evse_security#/CertificateInfo
-
+  CertificateStoreUpdateOperation:
+    description: Type that specifies the operation performed on the certificate store
+    type: string
+    enum:
+      - Installed
+      - Deleted
+  CertificateStoreUpdate:
+    description: >-
+      Type that specifies the update of the certificate store. If operation is Installed, one of leaf_certificate_type 
+      or ca_certificate_type must be present.
+    type: object
+    required:
+      - operation
+    properties:
+      operation:
+        description: The operation perfomred on the certificate store
+        type: string
+        $ref: /evse_security#/CertificateStoreUpdateOperation
+      deleted_certificate_hash_data:
+        description: The hash data of the certificate that was deleted. Only present if the operation is "Deleted"
+        type: object
+        $ref: /evse_security#/CertificateHashData
+      leaf_certificate_type:
+        description: The type of the leaf certificate that was installed or deleted. Only present if type of updated certificate is a leaf certificate
+        type: string
+        $ref: /evse_security#/LeafCertificateType
+      ca_certificate_type:
+        description: The type of the CA certificate that was installed or deleted. Only present if type of updated certificate is a CA certificate
+        type: string
+        $ref: /evse_security#/CaCertificateType


### PR DESCRIPTION
## Describe your changes
Extended evse_security interface by a new var of type CertificateStoreUpdate . This var is published when the certificate store has been updated, either be installing or deleting a leaf or root certificate. The CertificateStoreUpdate type indicates which kind of update was performed.

This allows modules requiring the evse_security interface to react to certificate updates.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

