### PR TITLE
Connection timeout, TZ and DST in NTP, cache OCMF

### DIFF
--- a/modules/LemDCBM400600/LemDCBM400600.hpp
+++ b/modules/LemDCBM400600/LemDCBM400600.hpp
@@ -38,6 +38,7 @@ struct Conf {
     int SC;
     std::string UV;
     std::string UD;
+    int command_timeout_ms;
 };
 
 class LemDCBM400600 : public Everest::ModuleBase {

--- a/modules/LemDCBM400600/main/http_client.cpp
+++ b/modules/LemDCBM400600/main/http_client.cpp
@@ -40,7 +40,7 @@ static HttpClientError client_error(const std::string& host, unsigned int port, 
 }
 
 static void setup_connection(CURL* connection, struct payloadInTransit& request_payload, std::string& response_body,
-                             curl_slist*& headers) {
+                             curl_slist*& headers, const int command_timeout_ms) {
     // Override the Content-Type header
     headers = curl_slist_append(nullptr, CONTENT_TYPE_HEADER);
     if (curl_easy_setopt(connection, CURLOPT_HTTPHEADER, headers) != CURLE_OK) {
@@ -53,6 +53,7 @@ static void setup_connection(CURL* connection, struct payloadInTransit& request_
     curl_easy_setopt(connection, CURLOPT_WRITEDATA, &response_body);
     curl_easy_setopt(connection, CURLOPT_READFUNCTION, send_data);
     curl_easy_setopt(connection, CURLOPT_READDATA, &request_payload);
+    curl_easy_setopt(connection, CURLOPT_TIMEOUT_MS, command_timeout_ms);
 
     // Misc. settings come here
     curl_easy_setopt(connection, CURLOPT_FORBID_REUSE, 1);
@@ -89,6 +90,10 @@ static void setup_libcurl_tls_options_for_connection(CURL* connection, struct cu
     }
 }
 
+void HttpClient::set_command_timeout(const int command_timeout_ms) {
+    this->command_timeout_ms = command_timeout_ms;
+}
+
 // Note: method_name and path are only there for the error message
 HttpResponse HttpClient::perform_request(CURL* connection, const std::string& request_body, const char* method_name,
                                          const std::string& path) const {
@@ -102,7 +107,7 @@ HttpResponse HttpClient::perform_request(CURL* connection, const std::string& re
         request_body, 0
     };
     struct curl_slist* headers;
-    setup_connection(connection, request_payload, response_body, headers);
+    setup_connection(connection, request_payload, response_body, headers, command_timeout_ms);
 
     // Set up TLS options if TLS is enabled
     // we define dcbm_cert outside the "if" statement to ensure it outlives curl_easy_perform().

--- a/modules/LemDCBM400600/main/http_client.hpp
+++ b/modules/LemDCBM400600/main/http_client.hpp
@@ -46,6 +46,7 @@ public:
         curl_global_cleanup();
     }
 
+    virtual void set_command_timeout(const int command_timeout_ms);
     [[nodiscard]] HttpResponse get(const std::string& path) const override;
     [[nodiscard]] HttpResponse put(const std::string& path, const std::string& body) const override;
     [[nodiscard]] HttpResponse post(const std::string& path, const std::string& body) const override;
@@ -55,6 +56,7 @@ private:
     int port;
     bool tls_enabled;
     std::string dcbm_tls_certificate;
+    int command_timeout_ms = 5000; // default timeout in milliseconds
 
     [[nodiscard]] CURL* create_curl_handle_and_setup_url(const std::string& path) const;
     HttpResponse perform_request(CURL* connection, const std::string& request_body, const char* method_name,

--- a/modules/LemDCBM400600/main/http_client_interface.hpp
+++ b/modules/LemDCBM400600/main/http_client_interface.hpp
@@ -33,6 +33,7 @@ struct HttpClientInterface {
 
     virtual ~HttpClientInterface() = default;
 
+    virtual void set_command_timeout(const int command_timeout_ms) = 0;
     [[nodiscard]] virtual HttpResponse get(const std::string& path) const = 0;
     [[nodiscard]] virtual HttpResponse put(const std::string& path, const std::string& body) const = 0;
     [[nodiscard]] virtual HttpResponse post(const std::string& path, const std::string& body) const = 0;

--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.cpp
@@ -11,6 +11,7 @@ void LemDCBM400600Controller::init() {
     call_with_retry([this]() { this->fetch_meter_id_from_device(); }, this->config.init_number_of_http_retries,
                     this->config.init_retry_wait_in_milliseconds);
     this->time_sync_helper->restart_unsafe_period();
+    this->http_client->set_command_timeout(this->config.command_timeout_ms);
 }
 
 std::vector<std::string> split(const std::string& str, char delimiter) {
@@ -208,6 +209,14 @@ LemDCBM400600Controller::stop_transaction(const std::string& transaction_id) {
         std::string error_message =
             fmt::format("Failed to stop transaction {} - connection to device failed: {}", tid, error.what());
         EVLOG_error << error_message;
+        // if we have the last known OCMF value, we can return it
+        if (current_signed_meter_value.public_key.has_value()) {
+            EVLOG_warning << "LEM DCBM 400/600: Returning the last known OCMF value for transaction " << tid
+                          << " with value: " << current_signed_meter_value;
+            return types::powermeter::TransactionStopResponse{
+                types::powermeter::TransactionRequestStatus::OK, {}, current_signed_meter_value};
+        }
+        current_signed_meter_value = types::units_signed::SignedMeterValue{};
         return types::powermeter::TransactionStopResponse{
             types::powermeter::TransactionRequestStatus::UNEXPECTED_ERROR, {}, {}, error_message};
     }
@@ -257,14 +266,33 @@ types::powermeter::Powermeter LemDCBM400600Controller::get_powermeter() {
 
     const std::string endpoint = v2_capable ? "/v2/livemeasure" : "/v1/livemeasure";
     auto response = this->http_client->get(endpoint);
+    types::powermeter::Powermeter powermeter_result;
     if (response.status_code != 200) {
         throw UnexpectedDCBMResponseCode(endpoint, 200, response);
     }
     try {
-        return this->convert_livemeasure_to_powermeter(response.body);
+        powermeter_result = this->convert_livemeasure_to_powermeter(response.body);
     } catch (json::exception& json_error) {
         throw UnexpectedDCBMResponseBody(endpoint, fmt::format("Json error '{}'", json_error.what()));
     }
+    if (this->need_to_stop_transaction) {
+        // if there is no ongoing transaction, we do need to fetch the signed meter value to have it available
+        // for the upper layers, otherwise we will not have the OCMF value if we lose connection to the device
+        try {
+            current_signed_meter_value = types::units_signed::SignedMeterValue{fetch_ocmf_result(current_transaction_id), "", "OCMF"};
+            current_signed_meter_value.public_key.emplace(public_key_ocmf);
+            current_signed_meter_value.timestamp.emplace(powermeter_result.timestamp);
+        } catch (UnexpectedDCBMResponseCode& error) {
+            EVLOG_error << "LEM DCBM 400/600: Could not get the OCMF value: " << error.what();
+        } catch (UnexpectedDCBMResponseBody& error) {
+            EVLOG_error << "LEM DCBM 400/600: Invalid OCMF value: " << error.what();
+        } catch (HttpClientError& error) {
+            std::string error_message =
+                fmt::format("Failed get the OCMF field {} - connection to device failed: {}", current_transaction_id, error.what());
+            EVLOG_error << error_message;
+        }
+    }
+    return powermeter_result;
 }
 
 types::powermeter::Powermeter

--- a/modules/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_400600_controller.hpp
@@ -41,6 +41,8 @@ public:
         const std::string UV;
         // UD
         const std::string UD;
+        // command timeout in milliseconds
+        const int command_timeout_ms;
     };
 
     class DCBMUnexpectedResponseException : public std::exception {
@@ -97,6 +99,7 @@ private:
     bool v2_capable = false;
     bool need_to_stop_transaction = false;
     std::string current_transaction_id;
+    types::units_signed::SignedMeterValue current_signed_meter_value;
     std::unique_ptr<LemDCBMTimeSyncHelper> time_sync_helper;
     Conf config;
 

--- a/modules/LemDCBM400600/main/lem_dcbm_time_sync_helper.cpp
+++ b/modules/LemDCBM400600/main/lem_dcbm_time_sync_helper.cpp
@@ -57,6 +57,8 @@ void LemDCBMTimeSyncHelper::sync(const HttpClientInterface& httpClient) {
 
     if (this->ntp_spec.ntp_enabled) {
         this->set_ntp_settings_on_device(httpClient);
+        this->sync_timezone(httpClient);
+        this->sync_dst(httpClient);
     } else {
         this->sync_system_time(httpClient);
         this->sync_timezone(httpClient);

--- a/modules/LemDCBM400600/main/powermeterImpl.cpp
+++ b/modules/LemDCBM400600/main/powermeterImpl.cpp
@@ -26,7 +26,7 @@ void powermeterImpl::init() {
             mod->config.resilience_initial_connection_retries, mod->config.resilience_initial_connection_retry_delay,
             mod->config.resilience_transaction_request_retries, mod->config.resilience_transaction_request_retry_delay,
             mod->config.cable_id, mod->config.tariff_id, mod->config.meter_timezone, mod->config.meter_dst,
-            mod->config.SC, mod->config.UV, mod->config.UD});
+            mod->config.SC, mod->config.UV, mod->config.UD, mod->config.command_timeout_ms});
 }
 
 void powermeterImpl::ready() {

--- a/modules/LemDCBM400600/manifest.yaml
+++ b/modules/LemDCBM400600/manifest.yaml
@@ -28,7 +28,7 @@ config:
     type: integer
     default: 123
   meter_timezone:
-    description: The timezone offset (ignored if NTP servers are set) - it can go from -11 to +14 for hours and 00, 15, 30, 45 for minutes 
+    description: The timezone offset (ignored if NTP servers are set) - it can go from -11 to +14 for hours and 00, 15, 30, 45 for minutes
     type: string
     default: "+00:00"
   meter_dst:
@@ -71,6 +71,12 @@ config:
     description: UD (OCMF/transaction fields)
     type: string
     default: ""
+  command_timeout_ms:
+    description: The timeout in milliseconds for a command to the power meter.
+    type: integer
+    default: 5000
+    max: 20000
+    min: 1000
 
 provides:
   main:


### PR DESCRIPTION
Fix: (a)Add param for connection timeout, (b)Allow TZ and DST in NTP case, (c)Cache the OCMF field and provide it in stop transaction response

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

