### PR TITLE
fix(OCPP201): Typo in PnCEnabled name

### DIFF
--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -19,6 +19,15 @@ namespace module {
 const std::string SQL_CORE_MIGRATIONS = "core_migrations";
 const std::string CERTS_DIR = "certs";
 
+// OCPP 2.0.1 specific configuration variable names
+const std::string PNC_ENABLED_VAR_NAME = "PnCEnabled";
+const std::string MASTER_PASS_GROUP_ID_VAR_NAME = "MasterPassGroupId";
+const std::string EV_CONNECTION_TIMEOUT_VAR_NAME = "EVConnectionTimeOut";
+const std::string CENTRAL_CONTRACT_VALIDATION_ALLOWED_VAR_NAME = "CentralContractValidationAllowed";
+const std::string CONTRACT_CERTIFICATE_INSTALLATION_ENABLED_VAR_NAME = "ContractCertificateInstallationEnabled";
+const std::string TX_START_POINT_VAR_NAME = "TxStartPoint";
+const std::string TX_STOP_POINT_VAR_NAME = "TxStopPoint";
+
 namespace fs = std::filesystem;
 
 TxEvent get_tx_event(const ocpp::v2::ReasonEnum reason) {
@@ -146,7 +155,7 @@ void OCPP201::init_evse_maps() {
 
 void OCPP201::init_module_configuration() {
     const auto ev_connection_timeout_request_value_response = this->charge_point->request_value<int32_t>(
-        ocpp::v2::ControllerComponents::TxCtrlr, ocpp::v2::Variable{"EVConnectionTimeOut"},
+        ocpp::v2::ControllerComponents::TxCtrlr, ocpp::v2::Variable{EV_CONNECTION_TIMEOUT_VAR_NAME},
         ocpp::v2::AttributeEnum::Actual);
     if (ev_connection_timeout_request_value_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         ev_connection_timeout_request_value_response.value.has_value()) {
@@ -154,7 +163,7 @@ void OCPP201::init_module_configuration() {
     }
 
     const auto master_pass_group_id_response = this->charge_point->request_value<std::string>(
-        ocpp::v2::ControllerComponents::AuthCtrlr, ocpp::v2::Variable{"MasterPassGroupId"},
+        ocpp::v2::ControllerComponents::AuthCtrlr, ocpp::v2::Variable{MASTER_PASS_GROUP_ID_VAR_NAME},
         ocpp::v2::AttributeEnum::Actual);
     if (master_pass_group_id_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         master_pass_group_id_response.value.has_value()) {
@@ -162,16 +171,16 @@ void OCPP201::init_module_configuration() {
     }
 
     types::evse_manager::PlugAndChargeConfiguration pnc_config;
-    const auto iso15118_pnc_enabled_response =
-        this->charge_point->request_value<bool>(ocpp::v2::ControllerComponents::ISO15118Ctrlr,
-                                                ocpp::v2::Variable{"PncEnabled"}, ocpp::v2::AttributeEnum::Actual);
+    const auto iso15118_pnc_enabled_response = this->charge_point->request_value<bool>(
+        ocpp::v2::ControllerComponents::ISO15118Ctrlr, ocpp::v2::Variable{PNC_ENABLED_VAR_NAME},
+        ocpp::v2::AttributeEnum::Actual);
     if (iso15118_pnc_enabled_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         iso15118_pnc_enabled_response.value.has_value()) {
         pnc_config.pnc_enabled = iso15118_pnc_enabled_response.value.value();
     }
 
     const auto central_contract_validation_allowed_response = this->charge_point->request_value<bool>(
-        ocpp::v2::ControllerComponents::ISO15118Ctrlr, ocpp::v2::Variable{"CentralContractValidationAllowed"},
+        ocpp::v2::ControllerComponents::ISO15118Ctrlr, ocpp::v2::Variable{CENTRAL_CONTRACT_VALIDATION_ALLOWED_VAR_NAME},
         ocpp::v2::AttributeEnum::Actual);
     if (central_contract_validation_allowed_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         central_contract_validation_allowed_response.value.has_value()) {
@@ -179,8 +188,8 @@ void OCPP201::init_module_configuration() {
     }
 
     const auto contract_certificate_installation_enabled_response = this->charge_point->request_value<bool>(
-        ocpp::v2::ControllerComponents::ISO15118Ctrlr, ocpp::v2::Variable{"ContractCertificateInstallationEnabled"},
-        ocpp::v2::AttributeEnum::Actual);
+        ocpp::v2::ControllerComponents::ISO15118Ctrlr,
+        ocpp::v2::Variable{CONTRACT_CERTIFICATE_INSTALLATION_ENABLED_VAR_NAME}, ocpp::v2::AttributeEnum::Actual);
     if (contract_certificate_installation_enabled_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         contract_certificate_installation_enabled_response.value.has_value()) {
         pnc_config.contract_certificate_installation_enabled =
@@ -543,7 +552,7 @@ void OCPP201::ready() {
 
     callbacks.variable_changed_callback = [this](const ocpp::v2::SetVariableData& set_variable_data) {
         if (set_variable_data.component == ocpp::v2::ControllerComponents::TxCtrlr and
-            set_variable_data.variable.name == "EVConnectionTimeOut") {
+            set_variable_data.variable.name.get() == EV_CONNECTION_TIMEOUT_VAR_NAME) {
             try {
                 auto ev_connection_timeout = std::stoi(set_variable_data.attributeValue.get());
                 this->r_auth->call_set_connection_timeout(ev_connection_timeout);
@@ -553,10 +562,10 @@ void OCPP201::ready() {
                 return;
             }
         } else if (set_variable_data.component == ocpp::v2::ControllerComponents::AuthCtrlr and
-                   set_variable_data.variable.name == "MasterPassGroupId") {
+                   set_variable_data.variable.name.get() == MASTER_PASS_GROUP_ID_VAR_NAME) {
             this->r_auth->call_set_master_pass_group_id(set_variable_data.attributeValue.get());
         } else if (set_variable_data.component == ocpp::v2::ControllerComponents::TxCtrlr and
-                   set_variable_data.variable.name == "TxStartPoint") {
+                   set_variable_data.variable.name.get() == TX_START_POINT_VAR_NAME) {
             const auto tx_start_points = get_tx_start_stop_points(set_variable_data.attributeValue.get());
             if (tx_start_points.empty()) {
                 EVLOG_warning << "Could not set TxStartPoints";
@@ -564,7 +573,7 @@ void OCPP201::ready() {
             }
             this->transaction_handler->set_tx_start_points(tx_start_points);
         } else if (set_variable_data.component == ocpp::v2::ControllerComponents::TxCtrlr and
-                   set_variable_data.variable.name == "TxStopPoint") {
+                   set_variable_data.variable.name.get() == TX_STOP_POINT_VAR_NAME) {
             const auto tx_stop_points = get_tx_start_stop_points(set_variable_data.attributeValue.get());
             if (tx_stop_points.empty()) {
                 EVLOG_warning << "Could not set TxStartPoints";
@@ -572,14 +581,14 @@ void OCPP201::ready() {
             }
             this->transaction_handler->set_tx_stop_points(tx_stop_points);
         } else if (set_variable_data.component == ocpp::v2::ControllerComponents::ISO15118Ctrlr and
-                   set_variable_data.variable.name == "PncEnabled") {
+                   set_variable_data.variable.name.get() == PNC_ENABLED_VAR_NAME) {
             types::evse_manager::PlugAndChargeConfiguration pnc_config;
             pnc_config.pnc_enabled = ocpp::conversions::string_to_bool(set_variable_data.attributeValue.get());
             for (const auto& evse_manager : this->r_evse_manager) {
                 evse_manager->call_set_plug_and_charge_configuration(pnc_config);
             }
         } else if (set_variable_data.component == ocpp::v2::ControllerComponents::ISO15118Ctrlr and
-                   set_variable_data.variable.name == "CentralContractValidationAllowed") {
+                   set_variable_data.variable.name.get() == CENTRAL_CONTRACT_VALIDATION_ALLOWED_VAR_NAME) {
             types::evse_manager::PlugAndChargeConfiguration pnc_config;
             pnc_config.central_contract_validation_allowed =
                 ocpp::conversions::string_to_bool(set_variable_data.attributeValue.get());
@@ -587,7 +596,7 @@ void OCPP201::ready() {
                 evse_manager->call_set_plug_and_charge_configuration(pnc_config);
             }
         } else if (set_variable_data.component == ocpp::v2::ControllerComponents::ISO15118Ctrlr and
-                   set_variable_data.variable.name == "ContractCertificateInstallationEnabled") {
+                   set_variable_data.variable.name.get() == CONTRACT_CERTIFICATE_INSTALLATION_ENABLED_VAR_NAME) {
             types::evse_manager::PlugAndChargeConfiguration pnc_config;
             pnc_config.contract_certificate_installation_enabled =
                 ocpp::conversions::string_to_bool(set_variable_data.attributeValue.get());
@@ -876,7 +885,7 @@ void OCPP201::ready() {
     std::set<TxStartStopPoint> tx_stop_points;
 
     const auto tx_start_point_request_value_response = this->charge_point->request_value<std::string>(
-        ocpp::v2::Component{"TxCtrlr"}, ocpp::v2::Variable{"TxStartPoint"}, ocpp::v2::AttributeEnum::Actual);
+        ocpp::v2::Component{"TxCtrlr"}, ocpp::v2::Variable{TX_START_POINT_VAR_NAME}, ocpp::v2::AttributeEnum::Actual);
     if (tx_start_point_request_value_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         tx_start_point_request_value_response.value.has_value()) {
         auto tx_start_point_csl =
@@ -890,7 +899,7 @@ void OCPP201::ready() {
     }
 
     const auto tx_stop_point_request_value_response = this->charge_point->request_value<std::string>(
-        ocpp::v2::Component{"TxCtrlr"}, ocpp::v2::Variable{"TxStopPoint"}, ocpp::v2::AttributeEnum::Actual);
+        ocpp::v2::Component{"TxCtrlr"}, ocpp::v2::Variable{TX_STOP_POINT_VAR_NAME}, ocpp::v2::AttributeEnum::Actual);
     if (tx_stop_point_request_value_response.status == ocpp::v2::GetVariableStatusEnum::Accepted and
         tx_stop_point_request_value_response.value.has_value()) {
         auto tx_stop_point_csl =


### PR DESCRIPTION
Fixed typo in PnCEnabled variable. Defined other variable names as well instead of using the same string multiple times

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

