### PR TITLE
Added TLS server suspend method to reject incoming connections

### DIFF
--- a/lib/staging/tls/tls.cpp
+++ b/lib/staging/tls/tls.cpp
@@ -1021,6 +1021,10 @@ bool Server::init_ssl(const config_t& cfg) {
     return ctx != nullptr;
 }
 
+void Server::deinit_ssl() {
+    m_context = std::make_unique<server_ctx>();
+}
+
 bool Server::init_certificates(const std::vector<certificate_config_t>& chain_files) {
     std::vector<OcspCache::ocsp_entry_t> entries;
     openssl::chain_list chains;
@@ -1091,18 +1095,25 @@ bool Server::init_certificates(const std::vector<certificate_config_t>& chain_fi
     if (chains.empty()) {
         // continue without trusted_ca_keys support
         log_warning("trusted_ca_keys support disabled");
-    } else {
-        m_server_trusted_ca_keys.update(std::move(chains));
     }
+    m_server_trusted_ca_keys.update(std::move(chains));
 
     // don't error when there are no OCSP cached responses
     if (!entries.empty()) {
         if (!m_cache.load(entries)) {
             result = false;
         }
+    } else {
+        // remove any existing entries
+        (void)m_cache.load(entries);
     }
 
     return result;
+}
+
+void Server::deinit_certificates() {
+    m_cache.load({});
+    m_server_trusted_ca_keys.update({});
 }
 
 void Server::wait_for_connection(const ConnectionHandler& handler) {
@@ -1114,6 +1125,9 @@ void Server::wait_for_connection(const ConnectionHandler& handler) {
         int soc{INVALID_SOCKET};
         while ((soc < 0) && !m_exit) {
             auto poll_res = wait_for(m_socket, false, c_serve_timeout_ms);
+            if (m_state == state_t::init_complete) {
+                m_state = state_t::running;
+            }
             if (poll_res == -1) {
                 // poll() has failed
                 m_exit = true;
@@ -1127,18 +1141,38 @@ void Server::wait_for_connection(const ConnectionHandler& handler) {
                     break;
                 }
             }
-        };
+        }
 
-        // attempt to get SSL configuration when not set yet
-        if ((soc >= 0) && (m_state == state_t::init_socket)) {
-            auto new_config = m_init_callback();
-            bool success{false};
-            if (new_config && new_config.value()) {
-                success = update(*new_config.value());
+        if (soc >= 0) {
+            bool reject{true};
+            state_t tmp = m_state;
+            switch (tmp) {
+            case state_t::init_socket: {
+                if (m_init_callback != nullptr) {
+                    // attempt to get SSL configuration when not set yet
+                    auto new_config = m_init_callback();
+                    bool success{false};
+                    if (new_config && new_config.value()) {
+                        success = update(*new_config.value());
+                    }
+                    if (success) {
+                        m_state = state_t::running;
+                        reject = false;
+                    }
+                }
+                break;
             }
-            if (success) {
-                m_state = state_t::running;
-            } else {
+            case state_t::init_complete:
+            case state_t::running:
+                reject = false;
+                break;
+            case state_t::init_needed:
+            case state_t::stopped:
+            default:
+                break;
+            }
+
+            if (reject) {
                 // updated configuration failed
                 BIO_closesocket(soc);
                 soc = INVALID_SOCKET;
@@ -1183,15 +1217,13 @@ Server::state_t Server::init(const config_t& cfg, const ConfigurationCallback& i
     m_init_callback = init_ssl_cb; // save handler for later
     m_state = state_t::init_needed;
     if (init_socket(cfg)) {
-        m_state = state_t::init_socket;
-        if (update(cfg)) {
-            m_state = state_t::init_complete;
-        }
+        (void)update(cfg);
     }
     return m_state;
 }
 
 bool Server::update(const config_t& cfg) {
+    std::lock_guard lock(m_update_mutex);
     // does not change server socket settings, use init() if needed
     std::vector<OcspCache::ocsp_entry_t> entries;
 
@@ -1201,6 +1233,7 @@ bool Server::update(const config_t& cfg) {
     if (!init_ssl(cfg)) {
         result = false;
     }
+    m_state = (result) ? state_t::init_complete : state_t::init_socket;
     return result;
 }
 
@@ -1246,6 +1279,9 @@ Server::state_t Server::serve(const ConnectionHandler& handler) {
         BIO_closesocket(m_socket);
         m_socket = INVALID_SOCKET;
         m_state = state_t::stopped;
+    } else {
+        // there wasn't a valid socket
+        m_state = state_t::init_needed;
     }
 
     // wakeup wait_stopped()
@@ -1255,6 +1291,27 @@ Server::state_t Server::serve(const ConnectionHandler& handler) {
     }
     m_cv.notify_all();
     return m_state;
+}
+
+bool Server::suspend() {
+    bool result{false};
+    std::lock_guard lock(m_update_mutex);
+    state_t tmp = m_state;
+    switch (tmp) {
+    case state_t::running:
+    case state_t::init_complete:
+        m_state = state_t::init_socket;
+        deinit_certificates();
+        deinit_ssl();
+        result = true;
+        break;
+    case state_t::init_socket:
+    case state_t::init_needed:
+    case state_t::stopped:
+    default:
+        break;
+    }
+    return result;
 }
 
 void Server::stop() {


### PR DESCRIPTION
## Describe your changes

feat: added TLS server suspend method
The TLS server can be suspended where it will reject all incoming connections until update() is called with new SSL configuration.

When suspended the state() is state_t::init_socket After update() the state() is state_t::init_complete and progresses to state_t::running following the next connection (or after a timeout)

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

