### PR TITLE
feat(EvseV2G, IsoMux): TLS config based on CertificateStoreUpdates

### DIFF
--- a/modules/EvseV2G/EvseV2G.cpp
+++ b/modules/EvseV2G/EvseV2G.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2022-2023 Contributors to EVerest
 #include "EvseV2G.hpp"
 #include "connection/connection.hpp"
+#include "connection/tls_connection.hpp"
 #include "log.hpp"
 #include "sdp.hpp"
 #include <everest/logging.hpp>
@@ -43,6 +44,27 @@ void EvseV2G::init() {
     (void)openssl::set_log_handler(log_handler);
     tls::Server::configure_signal_handler(SIGUSR1);
     v2g_ctx->tls_server = &tls_server;
+
+    this->r_security->subscribe_certificate_store_update(
+        [this](const types::evse_security::CertificateStoreUpdate& update) {
+            if (!update.leaf_certificate_type.has_value()) {
+                return;
+            }
+
+            if (update.leaf_certificate_type.value() != types::evse_security::LeafCertificateType::V2G) {
+                return;
+            }
+
+            dlog(DLOG_LEVEL_INFO, "Certificate store update received, reconfiguring TLS server");
+            auto config = std::make_unique<tls::Server::config_t>();
+            if (build_config(*config, v2g_ctx)) {
+                dlog(DLOG_LEVEL_INFO, "Configuration of TLS server successful, updating it");
+                v2g_ctx->tls_server->update(*config);
+            } else {
+                dlog(DLOG_LEVEL_INFO, "Configuration of TLS server failed, suspending it");
+                v2g_ctx->tls_server->suspend();
+            }
+        });
 
     invoke_init(*p_charger);
     invoke_init(*p_extensions);

--- a/modules/EvseV2G/connection/tls_connection.cpp
+++ b/modules/EvseV2G/connection/tls_connection.cpp
@@ -91,79 +91,6 @@ void server_loop_thread(struct v2g_context* ctx) {
     }
 }
 
-bool build_config(tls::Server::config_t& config, struct v2g_context* ctx) {
-    assert(ctx != nullptr);
-    assert(ctx->r_security != nullptr);
-
-    using types::evse_security::CaCertificateType;
-    using types::evse_security::EncodingFormat;
-    using types::evse_security::GetCertificateInfoStatus;
-    using types::evse_security::LeafCertificateType;
-
-    /*
-     * libevse-security checks for an optional password and when one
-     * isn't set is uses an empty string as the password rather than nullptr.
-     * hence private keys are always encrypted.
-     */
-
-    bool bResult{false};
-
-    config.cipher_list = "ECDHE-ECDSA-AES128-SHA256:ECDH-ECDSA-AES128-SHA256";
-    config.ciphersuites = "";     // disable TLS 1.3
-    config.verify_client = false; // contract certificate managed in-band in 15118-2
-
-    // use the existing configured socket
-    // TODO(james-ctc): switch to server socket init code otherwise there
-    //                  may be issues with reinitialisation
-    config.socket = ctx->tls_socket.fd;
-    config.io_timeout_ms = static_cast<std::int32_t>(ctx->network_read_timeout_tls);
-
-    config.tls_key_logging = ctx->tls_key_logging;
-    config.tls_key_logging_path = ctx->tls_key_logging_path;
-    config.host = ctx->if_name;
-
-    // information from libevse-security
-    const auto cert_info =
-        ctx->r_security->call_get_all_valid_certificates_info(LeafCertificateType::V2G, EncodingFormat::PEM, true);
-    if (cert_info.status != GetCertificateInfoStatus::Accepted) {
-        dlog(DLOG_LEVEL_ERROR, "Failed to read cert_info! Not Accepted");
-    } else {
-        if (!cert_info.info.empty()) {
-            // process all known certificate chains
-            for (const auto& chain : cert_info.info) {
-                const auto cert_path = chain.certificate.value_or("");
-                const auto key_path = chain.key;
-                const auto root_pem = chain.certificate_root.value_or("");
-
-                // workaround (see above libevse-security comment)
-                const auto key_password = chain.password.value_or("");
-
-                auto& ref = config.chains.emplace_back();
-                ref.certificate_chain_file = cert_path.c_str();
-                ref.private_key_file = key_path.c_str();
-                ref.private_key_password = key_password.c_str();
-                ref.trust_anchor_pem = root_pem.c_str();
-
-                if (chain.ocsp) {
-                    for (const auto& ocsp : chain.ocsp.value()) {
-                        const char* file{nullptr};
-                        if (ocsp.ocsp_path) {
-                            file = ocsp.ocsp_path.value().c_str();
-                        }
-                        ref.ocsp_response_files.push_back(file);
-                    }
-                }
-            }
-
-            bResult = true;
-        } else {
-            dlog(DLOG_LEVEL_ERROR, "Failed to read cert_info! Empty response");
-        }
-    }
-
-    return bResult;
-}
-
 tls::Server::OptionalConfig configure_ssl(struct v2g_context* ctx) {
     try {
         dlog(DLOG_LEVEL_WARNING, "configure_ssl");
@@ -321,6 +248,79 @@ ssize_t connection_write(struct v2g_connection* conn, unsigned char* buf, std::s
     }
 
     return (result < 0) ? result : static_cast<ssize_t>(bytes_written);
+}
+
+bool build_config(tls::Server::config_t& config, struct v2g_context* ctx) {
+    assert(ctx != nullptr);
+    assert(ctx->r_security != nullptr);
+
+    using types::evse_security::CaCertificateType;
+    using types::evse_security::EncodingFormat;
+    using types::evse_security::GetCertificateInfoStatus;
+    using types::evse_security::LeafCertificateType;
+
+    /*
+     * libevse-security checks for an optional password and when one
+     * isn't set is uses an empty string as the password rather than nullptr.
+     * hence private keys are always encrypted.
+     */
+
+    bool bResult{false};
+
+    config.cipher_list = "ECDHE-ECDSA-AES128-SHA256:ECDH-ECDSA-AES128-SHA256";
+    config.ciphersuites = "";     // disable TLS 1.3
+    config.verify_client = false; // contract certificate managed in-band in 15118-2
+
+    // use the existing configured socket
+    // TODO(james-ctc): switch to server socket init code otherwise there
+    //                  may be issues with reinitialisation
+    config.socket = ctx->tls_socket.fd;
+    config.io_timeout_ms = static_cast<std::int32_t>(ctx->network_read_timeout_tls);
+
+    config.tls_key_logging = ctx->tls_key_logging;
+    config.tls_key_logging_path = ctx->tls_key_logging_path;
+    config.host = ctx->if_name;
+
+    // information from libevse-security
+    const auto cert_info =
+        ctx->r_security->call_get_all_valid_certificates_info(LeafCertificateType::V2G, EncodingFormat::PEM, true);
+    if (cert_info.status != GetCertificateInfoStatus::Accepted) {
+        dlog(DLOG_LEVEL_ERROR, "Failed to read cert_info! Not Accepted");
+    } else {
+        if (!cert_info.info.empty()) {
+            // process all known certificate chains
+            for (const auto& chain : cert_info.info) {
+                const auto cert_path = chain.certificate.value_or("");
+                const auto key_path = chain.key;
+                const auto root_pem = chain.certificate_root.value_or("");
+
+                // workaround (see above libevse-security comment)
+                const auto key_password = chain.password.value_or("");
+
+                auto& ref = config.chains.emplace_back();
+                ref.certificate_chain_file = cert_path.c_str();
+                ref.private_key_file = key_path.c_str();
+                ref.private_key_password = key_password.c_str();
+                ref.trust_anchor_pem = root_pem.c_str();
+
+                if (chain.ocsp) {
+                    for (const auto& ocsp : chain.ocsp.value()) {
+                        const char* file{nullptr};
+                        if (ocsp.ocsp_path) {
+                            file = ocsp.ocsp_path.value().c_str();
+                        }
+                        ref.ocsp_response_files.push_back(file);
+                    }
+                }
+            }
+
+            bResult = true;
+        } else {
+            dlog(DLOG_LEVEL_ERROR, "Failed to read cert_info! Empty response");
+        }
+    }
+
+    return bResult;
 }
 
 } // namespace tls

--- a/modules/EvseV2G/connection/tls_connection.hpp
+++ b/modules/EvseV2G/connection/tls_connection.hpp
@@ -5,6 +5,7 @@
 #define TLS_CONNECTION_HPP_
 
 #include <cstddef>
+#include <tls.hpp>
 #include <unistd.h>
 
 struct v2g_context;
@@ -43,6 +44,14 @@ ssize_t connection_read(struct v2g_connection* conn, unsigned char* buf, std::si
  * \return Returns the number of read bytes if successful, otherwise returns -1 for reading errors and
  * -2 for closed connection */
 ssize_t connection_write(struct v2g_connection* conn, unsigned char* buf, std::size_t count);
+
+/*!
+ * \brief build_config This builds the TLS server configuration based on the v2g context.
+ * \param config TLS server configuration to be filled
+ * \param ctx v2g connection context
+ * \return Returns true if the configuration was built successfully, otherwise false.
+ */
+bool build_config(tls::Server::config_t& config, struct v2g_context* ctx);
 
 } // namespace tls
 

--- a/modules/IsoMux/IsoMux.cpp
+++ b/modules/IsoMux/IsoMux.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2022-2023 Contributors to EVerest
 #include "IsoMux.hpp"
 #include "connection.hpp"
+#include "connection/tls_connection.hpp"
 #include "log.hpp"
 #include "sdp.hpp"
 
@@ -46,6 +47,27 @@ void IsoMux::init() {
 
     (void)openssl::set_log_handler(log_handler);
     v2g_ctx->tls_server = &tls_server;
+
+    this->r_security->subscribe_certificate_store_update(
+        [this](const types::evse_security::CertificateStoreUpdate& update) {
+            if (!update.leaf_certificate_type.has_value()) {
+                return;
+            }
+
+            if (update.leaf_certificate_type.value() != types::evse_security::LeafCertificateType::V2G) {
+                return;
+            }
+
+            dlog(DLOG_LEVEL_INFO, "Certificate store update received, reconfiguring TLS server");
+            auto config = std::make_unique<tls::Server::config_t>();
+            if (build_config(*config, v2g_ctx)) {
+                dlog(DLOG_LEVEL_INFO, "Configuration of TLS server successful, updating it");
+                v2g_ctx->tls_server->update(*config);
+            } else {
+                dlog(DLOG_LEVEL_INFO, "Configuration of TLS server failed, suspending it");
+                v2g_ctx->tls_server->suspend();
+            }
+        });
 
     invoke_init(*p_charger);
     invoke_init(*p_extensions);

--- a/modules/IsoMux/connection/tls_connection.hpp
+++ b/modules/IsoMux/connection/tls_connection.hpp
@@ -5,6 +5,7 @@
 #define TLS_CONNECTION_HPP_
 
 #include <cstddef>
+#include <tls.hpp>
 #include <unistd.h>
 
 struct v2g_context;
@@ -43,6 +44,14 @@ ssize_t connection_read(struct v2g_connection* conn, unsigned char* buf, std::si
  * \return Returns the number of read bytes if successful, otherwise returns -1 for reading errors and
  * -2 for closed connection */
 ssize_t connection_write(struct v2g_connection* conn, unsigned char* buf, std::size_t count);
+
+/*!
+ * \brief build_config This builds the TLS server configuration based on the v2g context.
+ * \param config TLS server configuration to be filled
+ * \param ctx v2g connection context
+ * \return Returns true if the configuration was built successfully, otherwise false.
+ */
+bool build_config(tls::Server::config_t& config, struct v2g_context* ctx);
 
 int connection_proxy(struct v2g_connection* conn, int proxy_fd);
 


### PR DESCRIPTION

## Describe your changes
Subscribing to certificate updates in EvseV2G and IsoMux and adjusting tls server configuration when relevant certificate updates are tracked. Moved build_config into tls_connection header in order to use it in EvseV2G and IsoMux module

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

