### PR TITLE
Fix(EvseManager): Removing inform_max_hlc_limits() when the power supply updates its capabilities

### DIFF
--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -260,15 +260,6 @@ public:
         // energy, so it is enough to set the powersupply_capabilities here.
         // FIXME: this is not implemented yet: enforce_limits uses the enforced limits to tell HLC, but capabilities
         // limits are not yet included in request.
-
-        // Inform charger about new max limits
-        types::iso15118::DcEvseMaximumLimits evse_max_limits;
-        evse_max_limits.evse_maximum_current_limit = powersupply_capabilities.max_export_current_A;
-        evse_max_limits.evse_maximum_power_limit = powersupply_capabilities.max_export_power_W;
-        evse_max_limits.evse_maximum_voltage_limit = powersupply_capabilities.max_export_voltage_V;
-        if (charger) {
-            charger->inform_new_evse_max_hlc_limits(evse_max_limits);
-        }
     }
     std::atomic_int ac_nr_phases_active{0};
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1


### PR DESCRIPTION
## Describe your changes
See title

## Issue ticket number and link
In some cases hlc max limits was overwritten when the power supply updates its capabilities. If the previous max hlc limits are smaller than the capabilities, then the EvseManager was falsely overriding the new capabilities max limits to the powersupply. In this case the output of the powersupply was bigger than actually set by the EnergyManager.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

