### PR TITLE
Refactor behaviour of find_package(everest-cmake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ project(everest-core
 find_package(everest-cmake 0.5
     COMPONENTS bundling
     PATHS ../everest-cmake
+    NO_DEFAULT_PATH
+)
+find_package(everest-cmake 0.5
+    COMPONENTS bundling
 )
 
 if (NOT everest-cmake_FOUND)


### PR DESCRIPTION
Prefer everest-cmake repo located in workspace over system installation. This should improve the developer experience, since by checking out everest-cmake one would expect to force using this everes-cmake version.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

