### PR TITLE
 feat(IsoExtension/EvseManager): Add vars to interfaces

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ bazel_dep(name = "everest-framework", version = "0.21.1")
 git_override(module_name="everest-framework", commit="8031136e5c31a345044e187a68de70b4dcae2912", remote="https://github.com/EVerest/everest-framework")
 
 bazel_dep(name = "everest-utils", version = "0.5.2")
-git_override(module_name="everest-utils", commit="a03ebb35c35f4b21f0b1604b9f46451feb187ec6", remote="https://github.com/EVerest/everest-utils")
+git_override(module_name="everest-utils", commit="824abc6293f1d130f6166a7765319102cd7d7d92", remote="https://github.com/EVerest/everest-utils")
 
 bazel_dep(name = "bazel_features", version = "1.21.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -47,7 +47,7 @@ libcbv2g:
 # libiso15118
 libiso15118:
   git: https://github.com/EVerest/libiso15118.git
-  git_tag: efb46a2b38ba01be792e5d18d98b00d881b512b0
+  git_tag: 9920f7449ab0eff62132c558975b0a3c5307eb99
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBISO15118"
 
 # LEM DCBM 400/600, IsabellenhuetteIemDcr modules
@@ -89,7 +89,7 @@ Josev:
 # everest-testing and ev-dev-tools
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
-  git_tag: c261e8a4be5367c5bc7e89106c5fb7a470de87bb
+  git_tag: 824abc6293f1d130f6166a7765319102cd7d7d92
 # linux_libnfc-nci for RFID
 libnfc-nci:
   git: https://github.com/EVerest/linux_libnfc-nci.git

--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -191,5 +191,13 @@ vars:
     description: >-
       Contains the selected protocol used for charging for informative purposes
     type: string
+  supported_energy_transfer_modes:
+    description: >-
+      Contains the list of supported energy transfers e.g. AC mono/tri, DC, DC_BPT, etc.
+    type: array
+    items:
+      type: object
+      $ref: /iso15118#/EnergyTransferMode
+    minItems: 1
 errors:
   - reference: /errors/evse_manager

--- a/interfaces/iso15118_extensions.yaml
+++ b/interfaces/iso15118_extensions.yaml
@@ -25,3 +25,12 @@ vars:
       has to be sent during the 'ChargeParameterDiscoveryReq' state machine
     type: object
     $ref: /iso15118#/ChargingNeeds
+  ev_info:
+    description: >-
+      The ISO15118 ev information concerning the certificates used for TLS, the supported protocols and evccId.
+    type: object
+    $ref: /iso15118#/EvInformation
+  service_renegotiation_supported:
+    description: >-
+      Indicates whether service renegotiation is supported or not.
+    type: boolean

--- a/modules/Evse15118D20/CMakeLists.txt
+++ b/modules/Evse15118D20/CMakeLists.txt
@@ -11,6 +11,7 @@ ev_setup_cpp_module()
 target_sources(${MODULE_NAME}
     PRIVATE
         charger/session_logger.cpp
+        charger/utils.cpp
 )
 
 target_link_libraries(${MODULE_NAME}

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -274,6 +274,9 @@ void ISO15118_chargerImpl::ready() {
     const auto v2g_root_cert_path = mod->r_security->call_get_verify_file(types::evse_security::CaCertificateType::V2G);
     const auto mo_root_cert_path = mod->r_security->call_get_verify_file(types::evse_security::CaCertificateType::MO);
 
+    // TODO(mlitre): Should be updated once libiso supports service renegotiation
+    this->mod->p_extensions->publish_service_renegotiation_supported(false);
+
     const iso15118::TbdConfig tbd_config = {
         {
             iso15118::config::CertificateBackend::EVEREST_LAYOUT,
@@ -473,6 +476,11 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
     callbacks.evccid = [this](const std::string& evccid) { publish_evcc_id(evccid); };
 
     callbacks.selected_protocol = [this](const std::string& protocol) { publish_selected_protocol(protocol); };
+
+    callbacks.ev_information = [this](const iso15118::d20::EVInformation& ev_info) {
+        types::iso15118::EvInformation info = convert_ev_info(ev_info);
+        this->mod->p_extensions->publish_ev_info(info);
+    };
 
     return callbacks;
 }

--- a/modules/Evse15118D20/charger/utils.cpp
+++ b/modules/Evse15118D20/charger/utils.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "utils.hpp"
+
+namespace module::charger {
+types::iso15118::AppProtocol convert_app_protocol(const iso15118::message_20::SupportedAppProtocol& app_protocol) {
+    types::iso15118::AppProtocol result;
+    result.protocol_namespace = app_protocol.protocol_namespace;
+    result.priority = app_protocol.priority;
+    result.schema_id = app_protocol.schema_id;
+    result.version_number_major = app_protocol.version_number_major;
+    result.version_number_minor = app_protocol.version_number_minor;
+    return result;
+}
+
+types::iso15118::EvInformation convert_ev_info(const iso15118::d20::EVInformation& ev_info) {
+    types::iso15118::EvInformation result;
+    result.evcc_id = ev_info.evcc_id;
+    result.selected_protocol = convert_app_protocol(ev_info.selected_app_protocol);
+    result.supported_protocols.Protocols.reserve(ev_info.ev_supported_app_protocols.size());
+    for (const auto& supported_app : ev_info.ev_supported_app_protocols) {
+        result.supported_protocols.Protocols.push_back(convert_app_protocol(supported_app));
+    }
+    result.tls_leaf_certificate = ev_info.ev_tls_leaf_cert;
+    result.tls_sub_ca_1_certificate = ev_info.ev_tls_sub_ca_1_cert;
+    result.tls_sub_ca_2_certificate = ev_info.ev_tls_sub_ca_2_cert;
+    result.tls_root_certificate = ev_info.ev_tls_root_cert;
+    return result;
+}
+} // namespace module::charger

--- a/modules/Evse15118D20/charger/utils.hpp
+++ b/modules/Evse15118D20/charger/utils.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <generated/types/iso15118.hpp>
+#include <iso15118/d20/ev_information.hpp>
 #include <iso15118/message/type.hpp>
 
 static constexpr auto NUMBER_OF_SETUP_STEPS = 5;
@@ -102,3 +103,8 @@ constexpr types::iso15118::V2gMessageId convert_v2g_message_type(iso15118::messa
 
     return Id::UnknownMessage;
 }
+
+namespace module::charger {
+types::iso15118::AppProtocol convert_app_protocol(const iso15118::message_20::SupportedAppProtocol& app_protocol);
+types::iso15118::EvInformation convert_ev_info(const iso15118::d20::EVInformation& ev_info);
+} // namespace module::charger

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -372,6 +372,9 @@ private:
 
     types::power_supply_DC::ChargingPhase last_power_supply_DC_charging_phase{
         types::power_supply_DC::ChargingPhase::Other};
+    std::mutex supported_energy_transfers_mutex;
+    std::vector<types::iso15118::EnergyTransferMode> supported_energy_transfers;
+    bool update_supported_energy_transfers(const types::iso15118::EnergyTransferMode& energy_transfer);
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/EvseManager/energy_grid/energyImpl.hpp
+++ b/modules/EvseManager/energy_grid/energyImpl.hpp
@@ -69,7 +69,6 @@ private:
     std::string source_base;
     std::string source_bsp_caps;
     std::string source_psu_caps;
-
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/EvseManager/token_provider/auth_token_providerImpl.hpp
+++ b/modules/EvseManager/token_provider/auth_token_providerImpl.hpp
@@ -25,8 +25,7 @@ class auth_token_providerImpl : public auth_token_providerImplBase {
 public:
     auth_token_providerImpl() = delete;
     auth_token_providerImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<EvseManager>& mod, Conf& config) :
-        auth_token_providerImplBase(ev, "token_provider"), mod(mod), config(config) {
-    }
+        auth_token_providerImplBase(ev, "token_provider"), mod(mod), config(config){};
 
     // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
     // insert your public definitions here

--- a/modules/EvseManager/utils.hpp
+++ b/modules/EvseManager/utils.hpp
@@ -5,7 +5,9 @@
 #define _EVSEMANAGER_UTILS_H_
 
 #include <everest/staging/helpers/helpers.hpp>
+#include <generated/types/evse_manager.hpp>
 #include <generated/types/powermeter.hpp>
+#include <vector>
 
 namespace module {
 namespace utils {

--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -370,6 +370,11 @@ void OCPP201::init() {
                 [this, evse_id](const types::evse_board_support::HardwareCapabilities& hw_capabilities) {
                     this->evse_hardware_capabilities_map[evse_id] = hw_capabilities;
                 });
+        this->r_evse_manager.at(evse_id - 1)
+            ->subscribe_supported_energy_transfer_modes(
+                [this](const std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
+                    // TODO(mlitre): Update device model
+                });
     }
 }
 
@@ -741,7 +746,8 @@ void OCPP201::ready() {
                 try {
                     currency = types::money::string_to_currency_code(currency_code.value());
                 } catch (const std::out_of_range& e) {
-                    // If conversion fails, we just don't add the currency code. But we want to see it in the logging.
+                    // If conversion fails, we just don't add the currency code. But we want to see it in the
+                    // logging.
                     EVLOG_error << e.what();
                 }
             }
@@ -956,7 +962,6 @@ void OCPP201::ready() {
             if (ev_info.soc.has_value()) {
                 this->evse_soc_map[evse_id] = ev_info.soc;
             }
-            // TODO(mlitre): Update ConnectedEVVehicleId DeviceModel
             if (ev_info.evcc_id.has_value()) {
                 update_evcc_id_token(evse_id, ev_info.evcc_id.value());
             }
@@ -977,7 +982,7 @@ void OCPP201::ready() {
     }
 
     int32_t extensions_id = 0;
-    for (auto& extension : this->r_extensions_15118) {
+    for (const auto& extension : this->r_extensions_15118) {
         extension->subscribe_iso15118_certificate_request(
             [this, extensions_id](const types::iso15118::RequestExiStreamSchema& certificate_request) {
                 auto ocpp_response = this->charge_point->on_get_15118_ev_certificate_request(
@@ -1011,6 +1016,16 @@ void OCPP201::ready() {
             } else {
                 EVLOG_warning << "ISO15118 Extension interface mapping not set! Not sending 'ChargingNeeds'!";
             }
+        });
+
+        extension->subscribe_service_renegotiation_supported(
+            [this, extensions_id](bool service_renegotiation_supported) {
+                // TODO(mlitre): Update device model
+            });
+
+        extension->subscribe_ev_info([this, extensions_id](const types::iso15118::EvInformation& ev_info) {
+            // TODO(mlitre): Update device model
+            update_evcc_id_token(extensions_id, ev_info.evcc_id);
         });
 
         extensions_id++;
@@ -1066,8 +1081,8 @@ void OCPP201::ready() {
         evse->call_external_ready_to_start_charging();
     }
 
-    // wait for potential events from the evses in order to start OCPP with the correct initial state (e.g. EV might be
-    // plugged in at startup)
+    // wait for potential events from the evses in order to start OCPP with the correct initial state (e.g. EV might
+    // be plugged in at startup)
     std::this_thread::sleep_for(std::chrono::milliseconds(this->config.DelayOcppStart));
     // start OCPP connection
     this->charge_point->connect_websocket();
@@ -1148,8 +1163,8 @@ void OCPP201::process_session_event(const int32_t evse_id, const types::evse_man
         break;
     }
 
-    // process authorized event which will inititate a TransactionEvent(Updated) message in case the token has not yet
-    // been authorized by the CSMS
+    // process authorized event which will inititate a TransactionEvent(Updated) message in case the token has not
+    // yet been authorized by the CSMS
     const auto authorized_id_token = get_authorized_id_token(session_event);
     if (authorized_id_token.has_value()) {
         this->charge_point->on_authorized(evse_id, connector_id, authorized_id_token.value());
@@ -1275,8 +1290,9 @@ void OCPP201::process_transaction_started(const int32_t evse_id, const int32_t c
         return;
     }
 
-    // at this point we dont know if the TransactionStarted event was triggered because of an Authorization or EV Plug
-    // in event. We assume cable has been plugged in first and then authorized and update if other order was applied
+    // at this point we dont know if the TransactionStarted event was triggered because of an Authorization or EV
+    // Plug in event. We assume cable has been plugged in first and then authorized and update if other order was
+    // applied
     auto tx_event = TxEvent::AUTHORIZED;
     auto trigger_reason = ocpp::v2::TriggerReasonEnum::Authorized;
     const auto transaction_started = session_event.transaction_started.value();
@@ -1359,8 +1375,8 @@ void OCPP201::process_transaction_finished(const int32_t evse_id, const int32_t 
                                                           ocpp::v2::TriggerReasonEnum::StopAuthorized);
         }
     } else {
-        // TODO(piet): If StopTxOnEVSideDisconnect is false, authorization shall still be present. This cannot only be
-        // handled within this module, but probably also within EvseManager and Auth
+        // TODO(piet): If StopTxOnEVSideDisconnect is false, authorization shall still be present. This cannot only
+        // be handled within this module, but probably also within EvseManager and Auth
 
         // authorization is always withdrawn in case of TransactionFinished, so in case we haven't updated the
         // transaction handler yet, we have to do it
@@ -1502,6 +1518,7 @@ void OCPP201::set_external_limits(const std::vector<ocpp::v2::CompositeSchedule>
 }
 
 void OCPP201::update_evcc_id_token(const int& evse_id, const std::string& evcc_id) {
+    // TODO(mlitre): Update ConnectedEVVehicleId DeviceModel
     auto tx_data = this->transaction_handler->get_transaction_data(evse_id);
     if (tx_data == nullptr) {
         return;

--- a/types/iso15118.yaml
+++ b/types/iso15118.yaml
@@ -1505,3 +1505,44 @@ types:
         type: number
         minimum: 0
         maximum: 99
+  EvInformation:
+    description: Information concerning TLS certificates used by EV, as well as supported protocols.
+    type: object
+    additionalProperties: false
+    required:
+      - supported_protocols
+      - selected_protocol
+      - evcc_id
+    properties:
+      supported_protocols:
+        type: object
+        description:
+          Ordered list of all of the supported protocols by the EV.
+        $ref: /iso15118#/AppProtocols
+      selected_protocol:
+        type: object
+        description:
+          The protocol chosen for the communication.
+        $ref: /iso15118#/AppProtocol
+      evcc_id:
+        description:
+          Specifies the EVs identification in a readable format. It contains
+          the MAC address of the EVCC in uppercase
+        type: string
+        pattern: ^[A-F0-9]{2}(:[A-F0-9]{2}){5}$
+      tls_leaf_certificate:
+        description:
+          Certificate used by the EV for the TLS1.3 communication.
+        type: string
+      tls_sub_ca_1_certificate:
+        description:
+          Certificate used by the EV for the TLS1.3 communication.
+        type: string
+      tls_sub_ca_2_certificate:
+        description:
+          Certificate used by the EV for the TLS1.3 communication.
+        type: string
+      tls_root_certificate:
+        description:
+          Certificate used by the EV for the TLS1.3 communication.
+        type: string


### PR DESCRIPTION
## Describe your changes

Added new vars to evse_manager interface so that we can broadcast the list of supported energy transfers as well as operation modes.

Added a new var to the iso15118_extensions interface to publish ev information. This is mainly used to update the device model for OCPP 2.1 requirements during V2X. 

## Issue ticket number and link

Related to https://github.com/EVerest/libocpp/issues/1068. 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

