### PR TITLE
tls/tests: Use 127.0.0.1 instead of localhost as host

### DIFF
--- a/lib/staging/tls/tests/tls_connection_test.cpp
+++ b/lib/staging/tls/tests/tls_connection_test.cpp
@@ -40,7 +40,7 @@ tls::Server::OptionalConfig ssl_init() {
     ref.private_key_file = "server_priv.pem";
     ref.trust_anchor_file = "server_root_cert.pem";
     ref.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
-    server_config->host = "localhost";
+    server_config->host = "127.0.0.1";
     server_config->service = "8444";
     server_config->ipv6_only = false;
     server_config->verify_client = false;
@@ -857,7 +857,7 @@ TEST_F(TlsTest, TCKeysInvalid) {
     client.reset();
     // localhost works in some cases but not in the CI pipeline for IPv6
     // use ip6-localhost
-    auto connection = client.connect("localhost", "8444", false, 1000);
+    auto connection = client.connect("127.0.0.1", "8444", false, 1000);
     if (connection) {
         if (connection->connect() == result_t::success) {
             set(ClientTest::flags_t::connected);

--- a/lib/staging/tls/tests/tls_connection_test.hpp
+++ b/lib/staging/tls/tests/tls_connection_test.hpp
@@ -182,7 +182,7 @@ protected:
         ref1.trust_anchor_file = "alt_server_root_cert.pem";
         ref1.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
         // server_config.verify_locations_file = "client_root_cert.pem";
-        server_config.host = "localhost";
+        server_config.host = "127.0.0.1";
         server_config.service = "8444";
         server_config.ipv6_only = false;
         server_config.verify_client = false;
@@ -231,7 +231,7 @@ protected:
         client.reset();
         // localhost works in some cases but not in the CI pipeline for IPv6
         // use ip6-localhost
-        auto connection = client.connect("localhost", "8444", false, 1000);
+        auto connection = client.connect("127.0.0.1", "8444", false, 1000);
         if (handler == nullptr) {
             if (connection) {
                 if (connection->connect() == tls::Connection::result_t::success) {
@@ -301,7 +301,7 @@ protected:
         // ref1.private_key_file = "alt_server_priv.pem";
         // ref1.trust_anchor_file = "alt_server_root_cert.pem";
         // ref1.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
-        server_config.host = "localhost";
+        server_config.host = "127.0.0.1";
         server_config.service = "8444";
         server_config.ipv6_only = false;
         server_config.verify_client = false;


### PR DESCRIPTION
The use of localhost leads to issues in some cases for example in CI

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

