### PR TITLE
Refactor: Add SQLite backend to EverestDeviceModelStorage in OCPP201

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -79,7 +79,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 7b4ba2c8a106b2eefad4009b515148888ba1133a
+  git_tag: refactor/sqlite-device-model # FIXME
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:

--- a/modules/OCPP201/CMakeLists.txt
+++ b/modules/OCPP201/CMakeLists.txt
@@ -35,9 +35,6 @@ target_sources(${MODULE_NAME}
         "data_transfer/ocpp_data_transferImpl.cpp"
         "ocpp_generic/ocppImpl.cpp"
         "session_cost/session_costImpl.cpp"
-        "device_model/everest_device_model_storage.cpp"
-        "device_model/composed_device_model_storage.cpp"
-        "device_model/definitions.cpp"
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
@@ -46,6 +43,9 @@ target_sources(${MODULE_NAME}
     PRIVATE
         "conversions.cpp"
         "transaction_handler.cpp"
+        "device_model/everest_device_model_storage.cpp"
+        "device_model/composed_device_model_storage.cpp"
+        "device_model/definitions.cpp"
 )
 
 if(EVEREST_CORE_BUILD_TESTING)

--- a/modules/OCPP201/OCPP201.hpp
+++ b/modules/OCPP201/OCPP201.hpp
@@ -32,6 +32,7 @@
 // insert your custom include headers here
 #include <tuple>
 
+#include <device_model/everest_device_model_storage.hpp>
 #include <generated/types/evse_board_support.hpp>
 #include <ocpp/v2/charge_point.hpp>
 #include <transaction_handler.hpp>
@@ -43,6 +44,7 @@ struct Conf {
     std::string MessageLogPath;
     std::string CoreDatabasePath;
     std::string DeviceModelDatabasePath;
+    std::string EverestDeviceModelDatabasePath;
     std::string DeviceModelDatabaseMigrationPath;
     std::string DeviceModelConfigPath;
     bool EnableExternalWebsocketControl;
@@ -120,6 +122,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+    std::shared_ptr<device_model::EverestDeviceModelStorage> everest_device_model_storage;
     std::unique_ptr<TransactionHandler> transaction_handler;
     Everest::SteadyTimer charging_schedules_timer;
 

--- a/modules/OCPP201/device_model/composed_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.cpp
@@ -10,7 +10,7 @@ ComposedDeviceModelStorage::ComposedDeviceModelStorage() {
 }
 
 bool ComposedDeviceModelStorage::register_device_model_storage(
-    std::string device_model_storage_id, std::unique_ptr<ocpp::v2::DeviceModelStorageInterface> device_model_storage) {
+    std::string device_model_storage_id, std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> device_model_storage) {
     if (this->device_model_storages.find(device_model_storage_id) != this->device_model_storages.end()) {
         return false;
     }
@@ -33,7 +33,7 @@ bool ComposedDeviceModelStorage::register_device_model_storage(
         }
     }
 
-    this->device_model_storages[device_model_storage_id] = std::move(device_model_storage);
+    this->device_model_storages[device_model_storage_id] = device_model_storage;
     return true;
 }
 

--- a/modules/OCPP201/device_model/composed_device_model_storage.hpp
+++ b/modules/OCPP201/device_model/composed_device_model_storage.hpp
@@ -12,7 +12,7 @@ namespace module::device_model {
 using ComponentVariableSourceMap = std::map<ocpp::v2::Component, std::map<ocpp::v2::Variable, std::string>>;
 class ComposedDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
 private:
-    std::map<std::string, std::unique_ptr<ocpp::v2::DeviceModelStorageInterface>>
+    std::map<std::string, std::shared_ptr<ocpp::v2::DeviceModelStorageInterface>>
         device_model_storages; // key is identifier for the device model storage
     ComponentVariableSourceMap component_variable_source_map;
 
@@ -25,7 +25,7 @@ public:
     /// \param  device_model_storage The device model storage to register.
     /// \return True if the device model storage name is not yet registered, false otherwise.
     bool register_device_model_storage(std::string device_model_storage_id,
-                                       std::unique_ptr<ocpp::v2::DeviceModelStorageInterface> device_model_storage);
+                                       std::shared_ptr<ocpp::v2::DeviceModelStorageInterface> device_model_storage);
     virtual ~ComposedDeviceModelStorage() override = default;
     virtual ocpp::v2::DeviceModelMap get_device_model() override;
     virtual std::optional<ocpp::v2::VariableAttribute>

--- a/modules/OCPP201/device_model/everest_device_model_storage.cpp
+++ b/modules/OCPP201/device_model/everest_device_model_storage.cpp
@@ -3,6 +3,7 @@
 
 #include <device_model/definitions.hpp>
 #include <device_model/everest_device_model_storage.hpp>
+#include <ocpp/v2/init_device_model_db.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 
 using ocpp::v2::Component;
@@ -15,6 +16,10 @@ using ocpp::v2::VariableMap;
 using ocpp::v2::VariableMetaData;
 
 static constexpr auto VARIABLE_SOURCE_EVEREST = "EVEREST";
+
+using ocpp::v2::ComponentKey;
+using ocpp::v2::DbVariableAttribute;
+using ocpp::v2::DeviceModelVariable;
 
 namespace module::device_model {
 
@@ -34,60 +39,109 @@ Component get_connector_component(const int32_t evse_id, const int32_t connector
     return component;
 }
 
-// Helper function to construct VariableData with common structure
-VariableData make_variable(const ocpp::v2::VariableCharacteristics& characteristics, const std::string& value = "") {
-    VariableData var_data;
+ComponentKey get_evse_component_key(const int32_t evse_id) {
+    ComponentKey component;
+    component.name = "EVSE";
+    component.evse_id = evse_id;
+    return component;
+}
+
+ComponentKey get_connector_component_key(const int32_t evse_id, const int32_t connector_id) {
+    ComponentKey component;
+    component.name = "Connector";
+    component.evse_id = evse_id;
+    component.connector_id = connector_id;
+    return component;
+}
+
+// Helper function to construct DeviceModelVariable with common structure
+DeviceModelVariable make_variable(const std::string& name, const ocpp::v2::VariableCharacteristics& characteristics,
+                                  const std::string& value = "") {
+    DeviceModelVariable var_data;
+    var_data.name = name;
     var_data.characteristics = characteristics;
     var_data.source = VARIABLE_SOURCE_EVEREST;
 
+    DbVariableAttribute db_attr;
     VariableAttribute attr;
     attr.type = ocpp::v2::AttributeEnum::Actual;
     attr.value = value;
     attr.mutability = ocpp::v2::MutabilityEnum::ReadOnly;
+    db_attr.variable_attribute = attr;
 
-    var_data.attributes[ocpp::v2::AttributeEnum::Actual] = attr;
+    var_data.attributes.push_back(db_attr);
     return var_data;
 }
 
 // Populates EVSE variables
-Variables build_evse_variables() {
-    return {
-        {ocpp::v2::EvseComponentVariables::Available,
-         make_variable(EvseDefinitions::Characteristics::Available, "true")},
-        {ocpp::v2::EvseComponentVariables::AvailabilityState,
-         make_variable(EvseDefinitions::Characteristics::AvailabilityState, "Available")},
-        {ocpp::v2::EvseComponentVariables::Power, make_variable(EvseDefinitions::Characteristics::EVSEPower)},
-        {ocpp::v2::EvseComponentVariables::SupplyPhases, make_variable(EvseDefinitions::Characteristics::SupplyPhases)},
-        {ocpp::v2::EvseComponentVariables::AllowReset,
-         make_variable(EvseDefinitions::Characteristics::AllowReset, "false")},
-        {ocpp::v2::EvseComponentVariables::ISO15118EvseId,
-         make_variable(EvseDefinitions::Characteristics::ISO15118EvseId, "DEFAULT_EVSE_ID")}};
+std::vector<DeviceModelVariable> build_evse_variables(const float max_power) {
+    std::vector<DeviceModelVariable> variables;
+
+    auto evse_power_characteristics = EvseDefinitions::Characteristics::EVSEPower;
+    evse_power_characteristics.maxLimit = max_power;
+
+    return {make_variable(ocpp::v2::EvseComponentVariables::Available.name, EvseDefinitions::Characteristics::Available,
+                          "true"),
+            make_variable(ocpp::v2::EvseComponentVariables::AvailabilityState.name,
+                          EvseDefinitions::Characteristics::AvailabilityState, "Available"),
+            make_variable(ocpp::v2::EvseComponentVariables::Power.name, evse_power_characteristics),
+            make_variable(ocpp::v2::EvseComponentVariables::SupplyPhases.name,
+                          EvseDefinitions::Characteristics::SupplyPhases),
+            make_variable(ocpp::v2::EvseComponentVariables::AllowReset.name,
+                          EvseDefinitions::Characteristics::AllowReset, "false"),
+            make_variable(ocpp::v2::EvseComponentVariables::ISO15118EvseId.name,
+                          EvseDefinitions::Characteristics::ISO15118EvseId, "DEFAULT_EVSE_ID")};
 }
 
 // Populates Connector variables
-Variables build_connector_variables() {
-    return {{ocpp::v2::ConnectorComponentVariables::Available,
-             make_variable(ConnectorDefinitions::Characteristics::Available, "true")},
-            {ocpp::v2::ConnectorComponentVariables::AvailabilityState,
-             make_variable(ConnectorDefinitions::Characteristics::AvailabilityState, "Available")},
-            {ocpp::v2::ConnectorComponentVariables::Type,
-             make_variable(ConnectorDefinitions::Characteristics::ConnectorType)},
-            {ocpp::v2::ConnectorComponentVariables::SupplyPhases,
-             make_variable(ConnectorDefinitions::Characteristics::SupplyPhases)}};
+std::vector<DeviceModelVariable> build_connector_variables() {
+
+    return {make_variable(ocpp::v2::ConnectorComponentVariables::Available.name,
+                          ConnectorDefinitions::Characteristics::Available, "true"),
+            make_variable(ocpp::v2::ConnectorComponentVariables::AvailabilityState.name,
+                          ConnectorDefinitions::Characteristics::AvailabilityState, "Available"),
+            make_variable(ocpp::v2::ConnectorComponentVariables::Type.name,
+                          ConnectorDefinitions::Characteristics::ConnectorType),
+            make_variable(ocpp::v2::ConnectorComponentVariables::SupplyPhases.name,
+                          ConnectorDefinitions::Characteristics::SupplyPhases)};
 }
 
 } // anonymous namespace
 
 EverestDeviceModelStorage::EverestDeviceModelStorage(
     const std::vector<std::unique_ptr<evse_managerIntf>>& r_evse_manager,
-    const std::map<int32_t, types::evse_board_support::HardwareCapabilities>& evse_hardware_capabilities_map) :
+    const std::map<int32_t, types::evse_board_support::HardwareCapabilities>& evse_hardware_capabilities_map,
+    const std::filesystem::path& db_path, const std::filesystem::path& migration_files_path) :
     r_evse_manager(r_evse_manager) {
+
+    std::map<ComponentKey, std::vector<DeviceModelVariable>> component_configs;
 
     for (const auto& evse_manager : r_evse_manager) {
         const auto evse_info = evse_manager->call_get_evse();
-        // Build EVSE Component
+        const auto& hw_capabilities = evse_hardware_capabilities_map.at(evse_info.id);
+
+        ComponentKey evse_component_key = get_evse_component_key(evse_info.id);
+        const auto max_power = hw_capabilities.max_current_A_import * 230.0f * hw_capabilities.max_phase_count_import;
+        component_configs[evse_component_key] = build_evse_variables(max_power);
+
+        for (const auto& connector : evse_info.connectors) {
+            ComponentKey connector_component_key = get_connector_component_key(evse_info.id, connector.id);
+            component_configs[connector_component_key] = build_connector_variables();
+        }
+    }
+
+    ocpp::v2::InitDeviceModelDb init_device_model_db(db_path, migration_files_path);
+    init_device_model_db.initialize_database(component_configs, false);
+    this->device_model_storage = std::make_unique<ocpp::v2::DeviceModelStorageSqlite>(db_path);
+
+    this->init_hw_capabilities(evse_hardware_capabilities_map);
+}
+
+void EverestDeviceModelStorage::init_hw_capabilities(
+    const std::map<int32_t, types::evse_board_support::HardwareCapabilities>& evse_hardware_capabilities_map) {
+    for (const auto& evse_manager : r_evse_manager) {
+        const auto evse_info = evse_manager->call_get_evse();
         Component evse_component = get_evse_component(evse_info.id);
-        this->device_model[evse_component] = build_evse_variables();
 
         if (evse_hardware_capabilities_map.find(evse_info.id) != evse_hardware_capabilities_map.end()) {
             this->update_hw_capabilities(evse_component, evse_hardware_capabilities_map.at(evse_info.id));
@@ -100,15 +154,13 @@ EverestDeviceModelStorage::EverestDeviceModelStorage(
                 this->update_hw_capabilities(evse_component, hw_capabilities);
             });
 
-        // Build Connector Components
         for (const auto& connector : evse_info.connectors) {
-            Component connector_component = get_connector_component(evse_info.id, connector.id);
-            this->device_model[connector_component] = build_connector_variables();
-
             if (connector.type.has_value()) {
-                this->device_model[connector_component][ocpp::v2::ConnectorComponentVariables::Type]
-                    .attributes[ocpp::v2::AttributeEnum::Actual]
-                    .value = types::evse_manager::connector_type_enum_to_string(connector.type.value());
+                const auto component = get_connector_component(evse_info.id, connector.id);
+                this->device_model_storage->set_variable_attribute_value(
+                    component, ocpp::v2::ConnectorComponentVariables::Type, ocpp::v2::AttributeEnum::Actual,
+                    types::evse_manager::connector_type_enum_to_string(connector.type.value()),
+                    VARIABLE_SOURCE_EVEREST);
             }
         }
     }
@@ -116,29 +168,23 @@ EverestDeviceModelStorage::EverestDeviceModelStorage(
 
 void EverestDeviceModelStorage::update_hw_capabilities(
     const Component& evse_component, const types::evse_board_support::HardwareCapabilities& hw_capabilities) {
-    this->device_model[evse_component][ocpp::v2::EvseComponentVariables::SupplyPhases]
-        .attributes[ocpp::v2::AttributeEnum::Actual]
-        .value = std::to_string(hw_capabilities.max_phase_count_import);
-    this->device_model[evse_component][ocpp::v2::EvseComponentVariables::Power].characteristics.maxLimit =
-        hw_capabilities.max_current_A_import * 230.0f *
-        hw_capabilities
-            .max_phase_count_import; // FIXME: this calculation is currently the best we can do with existing data
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    this->device_model_storage->set_variable_attribute_value(
+        evse_component, ocpp::v2::EvseComponentVariables::SupplyPhases, ocpp::v2::AttributeEnum::Actual,
+        std::to_string(hw_capabilities.max_phase_count_import), VARIABLE_SOURCE_EVEREST);
+}
+
+void EverestDeviceModelStorage::update_power(const int32_t evse_id, const float total_power_active_import) {
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    Component evse_component = get_evse_component(evse_id);
+    this->device_model_storage->set_variable_attribute_value(
+        evse_component, ocpp::v2::EvseComponentVariables::Power, ocpp::v2::AttributeEnum::Actual,
+        std::to_string(total_power_active_import), VARIABLE_SOURCE_EVEREST);
 }
 
 ocpp::v2::DeviceModelMap EverestDeviceModelStorage::get_device_model() {
     std::lock_guard<std::mutex> lock(device_model_mutex);
-    ocpp::v2::DeviceModelMap device_model;
-
-    for (const auto& [component, variables] : this->device_model) {
-        ocpp::v2::VariableMap variable_map;
-        for (const auto& [variable, variable_data] : variables) {
-            VariableMetaData meta_data = static_cast<VariableMetaData>(variable_data);
-            variable_map[variable] = meta_data;
-        }
-        device_model[component] = variable_map;
-    }
-
-    return device_model;
+    return this->device_model_storage->get_device_model();
 }
 
 std::optional<ocpp::v2::VariableAttribute>
@@ -146,20 +192,7 @@ EverestDeviceModelStorage::get_variable_attribute(const ocpp::v2::Component& com
                                                   const ocpp::v2::Variable& variable_id,
                                                   const ocpp::v2::AttributeEnum& attribute_enum) {
     std::lock_guard<std::mutex> lock(device_model_mutex);
-    auto component_it = device_model.find(component_id);
-    if (component_it == device_model.end()) {
-        return std::nullopt;
-    }
-    auto variable_it = component_it->second.find(variable_id);
-    if (variable_it == component_it->second.end()) {
-        return std::nullopt;
-    }
-    auto variable_data = variable_it->second;
-    auto attribute_it = variable_data.attributes.find(attribute_enum);
-    if (attribute_it == variable_data.attributes.end()) {
-        return std::nullopt;
-    }
-    return attribute_it->second;
+    return this->device_model_storage->get_variable_attribute(component_id, variable_id, attribute_enum);
 }
 
 std::vector<ocpp::v2::VariableAttribute>
@@ -167,77 +200,56 @@ EverestDeviceModelStorage::get_variable_attributes(const ocpp::v2::Component& co
                                                    const ocpp::v2::Variable& variable_id,
                                                    const std::optional<ocpp::v2::AttributeEnum>& attribute_enum) {
     std::lock_guard<std::mutex> lock(device_model_mutex);
-    std::vector<ocpp::v2::VariableAttribute> attributes;
-    auto component_it = device_model.find(component_id);
-    if (component_it == device_model.end()) {
-        return attributes;
-    }
-    auto variable_it = component_it->second.find(variable_id);
-    if (variable_it == component_it->second.end()) {
-        return attributes;
-    }
-    auto& variable_data = variable_it->second;
-    if (attribute_enum.has_value()) {
-        auto attribute_it = variable_data.attributes.find(attribute_enum.value());
-        if (attribute_it != variable_data.attributes.end()) {
-            attributes.push_back(attribute_it->second);
-        }
-    } else {
-        for (const auto& [type, attribute] : variable_data.attributes) {
-            attributes.push_back(attribute);
-        }
-    }
-    return attributes;
+    return this->device_model_storage->get_variable_attributes(component_id, variable_id, attribute_enum);
 }
 
 ocpp::v2::SetVariableStatusEnum EverestDeviceModelStorage::set_variable_attribute_value(
     const ocpp::v2::Component& component_id, const ocpp::v2::Variable& variable_id,
     const ocpp::v2::AttributeEnum& attribute_enum, const std::string& value, const std::string& source) {
     std::lock_guard<std::mutex> lock(device_model_mutex);
-    auto component_it = device_model.find(component_id);
-    if (component_it == device_model.end()) {
-        return ocpp::v2::SetVariableStatusEnum::UnknownComponent;
+
+    int evse_id = 0;
+    if (component_id.evse.has_value()) {
+        evse_id = component_id.evse.value().id;
     }
-    auto variable_it = component_it->second.find(variable_id);
-    if (variable_it == component_it->second.end()) {
-        return ocpp::v2::SetVariableStatusEnum::UnknownVariable;
-    }
-    auto& variable_data = variable_it->second;
-    auto attribute_it = variable_data.attributes.find(attribute_enum);
-    if (attribute_it == variable_data.attributes.end()) {
-        return ocpp::v2::SetVariableStatusEnum::NotSupportedAttributeType;
-    }
-    auto& attribute = attribute_it->second;
-    attribute.value = value;
-    variable_data.source = source;
-    return ocpp::v2::SetVariableStatusEnum::Accepted;
+
+    // FIXME: device_model_storage->set_variable_attribute_value does only return accepted or rejected, no other checks
+    // are performed. Since libocpp contains the full device model in memory and does these checks independently, it's
+    // currently only a minor issue.
+    return this->device_model_storage->set_variable_attribute_value(component_id, variable_id, attribute_enum, value,
+                                                                    source);
 }
 
 std::optional<ocpp::v2::VariableMonitoringMeta>
-EverestDeviceModelStorage::set_monitoring_data(const ocpp::v2::SetMonitoringData& /*data*/,
-                                               const ocpp::v2::VariableMonitorType /*type*/) {
-    return std::nullopt;
+EverestDeviceModelStorage::set_monitoring_data(const ocpp::v2::SetMonitoringData& data,
+                                               const ocpp::v2::VariableMonitorType type) {
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    return this->device_model_storage->set_monitoring_data(data, type);
 }
 
-bool EverestDeviceModelStorage::update_monitoring_reference(const int32_t /*monitor_id*/,
-                                                            const std::string& /*reference_value*/) {
-    return false;
+bool EverestDeviceModelStorage::update_monitoring_reference(const int32_t monitor_id,
+                                                            const std::string& reference_value) {
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    return this->device_model_storage->update_monitoring_reference(monitor_id, reference_value);
 }
 
 std::vector<ocpp::v2::VariableMonitoringMeta>
-EverestDeviceModelStorage::get_monitoring_data(const std::vector<ocpp::v2::MonitoringCriterionEnum>& /*criteria*/,
-                                               const ocpp::v2::Component& /*component_id*/,
-                                               const ocpp::v2::Variable& /*variable_id*/) {
-    return {};
+EverestDeviceModelStorage::get_monitoring_data(const std::vector<ocpp::v2::MonitoringCriterionEnum>& criteria,
+                                               const ocpp::v2::Component& component_id,
+                                               const ocpp::v2::Variable& variable_id) {
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    return this->device_model_storage->get_monitoring_data(criteria, component_id, variable_id);
 }
 
-ocpp::v2::ClearMonitoringStatusEnum EverestDeviceModelStorage::clear_variable_monitor(int /*monitor_id*/,
-                                                                                      bool /*allow_protected*/) {
-    return ocpp::v2::ClearMonitoringStatusEnum::NotFound;
+ocpp::v2::ClearMonitoringStatusEnum EverestDeviceModelStorage::clear_variable_monitor(int monitor_id,
+                                                                                      bool allow_protected) {
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    return this->device_model_storage->clear_variable_monitor(monitor_id, allow_protected);
 }
 
 int32_t EverestDeviceModelStorage::clear_custom_variable_monitors() {
-    return 0;
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    return this->device_model_storage->clear_custom_variable_monitors();
 }
 
 void EverestDeviceModelStorage::check_integrity() {

--- a/modules/OCPP201/manifest.yaml
+++ b/modules/OCPP201/manifest.yaml
@@ -13,8 +13,14 @@ config:
     description: Path to the SQLite database for the device model
     type: string
     default: device_model_storage.db
+  EverestDeviceModelDatabasePath:
+    description: >-
+      Path to the SQLite databse for the EVerest device model. This database stores components and variables
+      like EVSE and Connector that are closely related to everest-core and therefore not owned and managed by libocpp.
+    type: string
+    default: everest_device_model_storage.db
   DeviceModelDatabaseMigrationPath:
-    description: Path to the migration files for the device model
+    description: Path to the migration files for both device models
     type: string
     default: device_model_migrations
   DeviceModelConfigPath:

--- a/modules/OCPP201/session_cost/session_costImpl.hpp
+++ b/modules/OCPP201/session_cost/session_costImpl.hpp
@@ -25,8 +25,7 @@ class session_costImpl : public session_costImplBase {
 public:
     session_costImpl() = delete;
     session_costImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<OCPP201>& mod, Conf& config) :
-        session_costImplBase(ev, "session_cost"), mod(mod), config(config) {
-    }
+        session_costImplBase(ev, "session_cost"), mod(mod), config(config){};
 
     // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
     // insert your public definitions here


### PR DESCRIPTION

## Describe your changes
- Introduce EverestDeviceModelStorage with support for initialization and persistence using DeviceModelStorageSqlite
- Register both libocpp and Everest device models via shared_ptr in ComposedDeviceModelStorage
- Extend OCPP201 module configuration with EverestDeviceModelDatabasePath
- Move Everest device model variable storage and updates to SQLite-based structure
- Update EVSE power values in device model (removed that libocpp does that in companion PR)

## Issue ticket number and link
Companion PR lin libocpp: https://github.com/EVerest/libocpp/pull/1100

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

