### PR TITLE
feat(simulation): Add powermeter reset config option

### DIFF
--- a/modules/simulation/YetiSimulator/YetiSimulator.cpp
+++ b/modules/simulation/YetiSimulator/YetiSimulator.cpp
@@ -683,9 +683,11 @@ void YetiSimulator::pwm_f() {
 }
 
 void YetiSimulator::reset_powermeter() const {
-    module_state->watt_hr.L1 = 0;
-    module_state->watt_hr.L2 = 0;
-    module_state->watt_hr.L3 = 0;
+    if (config.reset_powermeter_on_session_start) {
+        module_state->watt_hr.L1 = 0;
+        module_state->watt_hr.L2 = 0;
+        module_state->watt_hr.L3 = 0;
+    }
     module_state->powermeter_sim_last_time_stamp = 0;
 }
 

--- a/modules/simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/simulation/YetiSimulator/YetiSimulator.hpp
@@ -25,6 +25,7 @@ namespace module {
 
 struct Conf {
     int connector_id;
+    bool reset_powermeter_on_session_start;
 };
 
 class YetiSimulator : public Everest::ModuleBase {

--- a/modules/simulation/YetiSimulator/manifest.yaml
+++ b/modules/simulation/YetiSimulator/manifest.yaml
@@ -3,6 +3,10 @@ config:
   connector_id:
     description: Connector id of the evse manager to which this simulator is connected to
     type: integer
+  reset_powermeter_on_session_start:
+    description: Reset absolute powermeter readings to zero when CP changes from state A to B
+    type: boolean
+    default: true
 provides:
   powermeter:
     interface: powermeter


### PR DESCRIPTION
## Describe your changes

Resetting the simulated Yeti's powermeter readings on session start (CP state A->B transition) can be disabled via a new config option.

## Issue ticket number and link

-

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

