### PR TITLE
OCPP1.6: Report a powermeter/CommunicationFault as a PowerMeterFailure

### DIFF
--- a/config/nodered/config-sil-flow.json
+++ b/config/nodered/config-sil-flow.json
@@ -373,6 +373,17 @@
         "className": ""
     },
     {
+        "id": "c61999446e2e0400",
+        "type": "ui_group",
+        "name": "Powermeter errors",
+        "tab": "d3ada9fa4cf6ac53",
+        "order": 3,
+        "disp": true,
+        "width": "6",
+        "collapse": false,
+        "className": ""
+    },
+    {
         "id": "c8955752ad17f297",
         "type": "mqtt in",
         "z": "9aafbf849d4d6e12",
@@ -3325,6 +3336,87 @@
         "wires": [
             [
                 "36bc757cecd5777c"
+            ]
+        ]
+    },
+    {
+        "id": "e17f0c84ed298eab",
+        "type": "change",
+        "z": "cb7609df6138407d",
+        "name": "Insert Connector number",
+        "rules": [
+            {
+                "t": "change",
+                "p": "topic",
+                "pt": "msg",
+                "from": "#",
+                "fromt": "str",
+                "to": "connector_number",
+                "tot": "flow"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 690,
+        "y": 1300,
+        "wires": [
+            [
+                "8ff9765278a8f1a2"
+            ]
+        ]
+    },
+    {
+        "id": "8ff9765278a8f1a2",
+        "type": "mqtt out",
+        "z": "cb7609df6138407d",
+        "name": "",
+        "topic": "",
+        "qos": "1",
+        "retain": "false",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "fc8686af.48d178",
+        "x": 890,
+        "y": 1300,
+        "wires": []
+    },
+    {
+        "id": "d478d2aec1bfc809",
+        "type": "ui_switch",
+        "z": "cb7609df6138407d",
+        "name": "",
+        "label": "CommunicationFault",
+        "tooltip": "",
+        "group": "c61999446e2e0400",
+        "order": 1,
+        "width": 0,
+        "height": 0,
+        "passthru": true,
+        "decouple": "false",
+        "topic": "everest_external/nodered/#/carsim/error",
+        "topicType": "str",
+        "style": "",
+        "onvalue": "{\"error_type\":\"powermeter/CommunicationFault\",\"raise\":\"true\"}",
+        "onvalueType": "json",
+        "onicon": "",
+        "oncolor": "",
+        "offvalue": "{\"error_type\":\"powermeter/CommunicationFault\",\"raise\":\"false\"}",
+        "offvalueType": "json",
+        "officon": "",
+        "offcolor": "",
+        "animate": false,
+        "className": "",
+        "x": 200,
+        "y": 1300,
+        "wires": [
+            [
+                "e17f0c84ed298eab"
             ]
         ]
     }

--- a/modules/OCPP/error_mapping.hpp
+++ b/modules/OCPP/error_mapping.hpp
@@ -35,6 +35,11 @@ const std::unordered_map<std::string, std::pair<ocpp::v16::ChargePointErrorCode,
     {"ac_rcd/MREC2GroundFailure", {ocpp::v16::ChargePointErrorCode::GroundFailure, "CX002"}},
 };
 
+// TODO: add other ChargePointErrorCode mappings
+const std::unordered_map<std::string, ocpp::v16::ChargePointErrorCode> OCPP_ERROR_MAP = {
+    {"powermeter/CommunicationFault", ocpp::v16::ChargePointErrorCode::PowerMeterFailure},
+};
+
 } // namespace module
 
 #endif

--- a/modules/simulation/YetiSimulator/YetiSimulator.cpp
+++ b/modules/simulation/YetiSimulator/YetiSimulator.cpp
@@ -134,30 +134,36 @@ void YetiSimulator::init() {
 
     reset_module_state();
 
-    mqtt.subscribe("everest_external/nodered/" + std::to_string(config.connector_id) + "/carsim/error",
-                   [this](const std::string& payload) {
-                       const auto [raise, error_definition] = parse_error_type(payload);
+    mqtt.subscribe(
+        "everest_external/nodered/" + std::to_string(config.connector_id) + "/carsim/error",
+        [this](const std::string& payload) {
+            const auto [raise, error_definition] = parse_error_type(payload);
 
-                       if (not error_definition.has_value()) {
-                           return;
-                       }
-                       if (error_definition->error_target == ErrorTarget::BoardSupport) {
-                           const auto error = p_board_support->error_factory->create_error(
-                               error_definition->type, error_definition->sub_type, error_definition->message,
-                               error_definition->severity);
-                           forward_error(p_board_support, error, raise);
-                       } else if (error_definition->error_target == ErrorTarget::ConnectorLock) {
-                           const auto error = p_connector_lock->error_factory->create_error(
-                               error_definition->type, error_definition->sub_type, error_definition->message,
-                               error_definition->severity);
-                       } else if (error_definition->error_target == ErrorTarget::Rcd) {
-                           const auto error = p_rcd->error_factory->create_error(
-                               error_definition->type, error_definition->sub_type, error_definition->message,
-                               error_definition->severity);
-                       } else {
-                           EVLOG_error << "No known ErrorTarget";
-                       }
-                   });
+            if (not error_definition.has_value()) {
+                return;
+            }
+            if (error_definition->error_target == ErrorTarget::BoardSupport) {
+                const auto error =
+                    p_board_support->error_factory->create_error(error_definition->type, error_definition->sub_type,
+                                                                 error_definition->message, error_definition->severity);
+                forward_error(p_board_support, error, raise);
+            } else if (error_definition->error_target == ErrorTarget::ConnectorLock) {
+                const auto error = p_connector_lock->error_factory->create_error(
+                    error_definition->type, error_definition->sub_type, error_definition->message,
+                    error_definition->severity);
+            } else if (error_definition->error_target == ErrorTarget::Rcd) {
+                const auto error =
+                    p_rcd->error_factory->create_error(error_definition->type, error_definition->sub_type,
+                                                       error_definition->message, error_definition->severity);
+            } else if (error_definition->error_target == ErrorTarget::Powermeter) {
+                const auto error =
+                    p_powermeter->error_factory->create_error(error_definition->type, error_definition->sub_type,
+                                                              error_definition->message, error_definition->severity);
+                forward_error(p_powermeter, error, raise);
+            } else {
+                EVLOG_error << "No known ErrorTarget";
+            }
+        });
 }
 
 void YetiSimulator::ready() {

--- a/modules/simulation/YetiSimulator/util/errors.cpp
+++ b/modules/simulation/YetiSimulator/util/errors.cpp
@@ -14,6 +14,9 @@ std::tuple<bool, std::optional<ErrorDefinition>> parse_error_type(const std::str
 
     const auto error_type = static_cast<std::string>(e.at("error_type"));
 
+    if (error_type == "powermeter/CommunicationFault") {
+        return {raise, error_definitions::powermeter_CommunicationFault};
+    }
     if (error_type == "DiodeFault") {
         return {raise, error_definitions::evse_board_support_DiodeFault};
     }

--- a/modules/simulation/YetiSimulator/util/errors.hpp
+++ b/modules/simulation/YetiSimulator/util/errors.hpp
@@ -13,6 +13,7 @@ enum class ErrorTarget {
     BoardSupport,
     ConnectorLock,
     Rcd,
+    Powermeter
 };
 
 struct ErrorDefinition {
@@ -129,5 +130,9 @@ inline const auto connector_lock_MREC1ConnectorLockFailure =
 
 inline const auto connector_lock_VendorError =
     ErrorDefinition{"connector_lock/VendorError", "", "Simulated fault event"};
+
+inline const auto powermeter_CommunicationFault =
+    ErrorDefinition{"powermeter/CommunicationFault", "", "Simulated fault event", Everest::error::Severity::High,
+                    ErrorTarget::Powermeter};
 
 } // namespace error_definitions


### PR DESCRIPTION
## Describe your changes
Instead of just reporting a generic OtherError with an error message showing that it was a communication fault

Allow a powermeter/CommunicationFault to be triggered by the YetiSimulator

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

