### PR TITLE
Fix(EvseManager): fail_on_powermeter_errors use after free

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -12,6 +12,10 @@
 
 using namespace std::literals::chrono_literals;
 
+namespace {
+static const std::vector<std::unique_ptr<powermeterIntf>> EMPTY_POWERMETER_VECTOR;
+}
+
 namespace module {
 
 static const types::power_supply_DC::Capabilities get_sane_default_power_supply_capabilities() {
@@ -167,11 +171,10 @@ void EvseManager::ready() {
 
     // we provide the powermeter interface to the ErrorHandling only if we need to react to powermeter errors
     // otherwise we provide an empty vector of pointers to the powermeter interface
-    const std::vector<std::unique_ptr<powermeterIntf>> empty;
     error_handling = std::unique_ptr<ErrorHandling>(
         new ErrorHandling(r_bsp, r_hlc, r_connector_lock, r_ac_rcd, p_evse, r_imd, r_powersupply_DC,
-                          config.fail_on_powermeter_errors ? r_powermeter_billing() : empty, r_over_voltage_monitor,
-                          config.inoperative_error_use_vendor_id));
+                          config.fail_on_powermeter_errors ? r_powermeter_billing() : EMPTY_POWERMETER_VECTOR,
+                          r_over_voltage_monitor, config.inoperative_error_use_vendor_id));
 
     if (not config.lock_connector_in_state_b) {
         EVLOG_warning << "Unlock connector in CP state B. This violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and "


### PR DESCRIPTION
Fix crash when fail_on_powermeter_errors is configured true. Using static empty vector

to avoid passing a local temporary vector of unique_ptrs to ErrorHandling, which led to use-after-free and segmentation faults.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

