### PR TITLE
fix(EvseV2G): Remove Certificate Install service from ServiceDiscoveryRes

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -184,7 +184,12 @@ void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::Pay
         }
     }
 
-    if (supported_certificate_service) {
+    const auto pnc_enabled = ((v2g_ctx->evse_v2g_data.payment_option_list[0] == iso2_paymentOptionType_Contract) or
+                              (v2g_ctx->evse_v2g_data.payment_option_list[1] == iso2_paymentOptionType_Contract))
+                                 ? true
+                                 : false;
+
+    if (pnc_enabled and supported_certificate_service) {
         // For setting "Certificate" in ServiceList in ServiceDiscoveryRes
         struct iso2_ServiceType cert_service;
 
@@ -205,6 +210,9 @@ void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::Pay
 
         add_service_to_service_list(v2g_ctx, cert_service, cert_parameter_set_id,
                                     sizeof(cert_parameter_set_id) / sizeof(cert_parameter_set_id[0]));
+    } else {
+        constexpr auto CERTIFICATE_INSTALL_ID = 2;
+        check_and_remove_service_in_list(v2g_ctx, CERTIFICATE_INSTALL_ID);
     }
 
     v2g_ctx->evse_v2g_data.central_contract_validation_allowed = central_contract_validation_allowed;

--- a/modules/EvseV2G/v2g.hpp
+++ b/modules/EvseV2G/v2g.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <netinet/in.h>
 #include <pthread.h>
+#include <vector>
 
 #include <openssl_util.hpp>
 #include <tls.hpp>
@@ -251,9 +252,8 @@ struct v2g_context {
         struct v2g_evse_id evse_id;
         unsigned int date_time_now_is_used;
         struct iso2_ChargeServiceType charge_service;
-        struct iso2_ServiceType evse_service_list[iso2_ServiceType_8_ARRAY_SIZE];
+        std::vector<iso2_ServiceType> evse_service_list{};
         struct iso2_ServiceParameterListType service_parameter_list[iso2_ServiceType_8_ARRAY_SIZE];
-        uint16_t evse_service_list_len;
 
         struct iso2_SAScheduleListType evse_sa_schedule_list;
         bool evse_sa_schedule_list_is_used;

--- a/modules/EvseV2G/v2g_ctx.hpp
+++ b/modules/EvseV2G/v2g_ctx.hpp
@@ -132,6 +132,13 @@ bool add_service_to_service_list(struct v2g_context* v2g_ctx, const struct iso2_
                                  const int16_t* parameter_set_id = NULL, uint8_t parameter_set_id_len = 0);
 
 /*!
+ * \brief check_and_remove_service_in_list This function removes a service list item from the service list.
+ * \param v2g_ctx is a pointer of type \c v2g_context
+ * \param service_id is the service which shall be provided by the EVSE in the service list.
+ */
+void check_and_remove_service_in_list(struct v2g_context* v2g_ctx, uint16_t service_id);
+
+/*!
  * \brief configure_parameter_set This function configures the parameter-set structure of a specific service ID.
  * \param v2g_ctx is a pointer of type \c v2g_context
  * \param parameterSetId is the parameter-set-ID which belongs to the service ID.


### PR DESCRIPTION
## Describe your changes
Remove Certificate Install service from ServiceDiscoveryRes if PnC or Cert Install service are disabled or the session is already authorized

## Issue ticket number and link
EvseV2G has offered the Certificate Install Service in the past, even when PnC or the service was not available. This PR fixes that.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

