### PR TITLE
IsoMux: fix memory leak

### DIFF
--- a/modules/IsoMux/v2g_server.cpp
+++ b/modules/IsoMux/v2g_server.cpp
@@ -134,6 +134,7 @@ static bool v2g_sniff_apphandshake(struct v2g_connection* conn, bool& iso20) {
         const char* iso20_urn = "urn:iso:std:iso:15118:-20";
         if (strncmp(iso20_urn, proto_ns, strlen(iso20_urn)) == 0) {
             iso20 = true;
+            free(proto_ns);
             return true;
         }
 


### PR DESCRIPTION
## Describe your changes
Fix a memory leak, where a result of `strndup()` wasn't being `free()`d in one code path.
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements