### PR TITLE
Refactoring vars from iso15118_ev interface.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -84,7 +84,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: 2025.5.0
+  git_tag: 2025.7.0
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT AND EVEREST_DEPENDENCY_ENABLED_JOSEV"
 # everest-testing and ev-dev-tools
 everest-utils:

--- a/interfaces/ISO15118_ev.yaml
+++ b/interfaces/ISO15118_ev.yaml
@@ -37,22 +37,22 @@ cmds:
   enable_sae_j2847_v2g_v2h:
     description: Enable the SAE J2847 2 V2H V2G
 vars:
-  V2G_Session_Finished:
+  v2g_session_finished:
     description: The v2g session between the charger and the car is finished
     type: 'null'
-  AC_EVPowerReady:
+  ev_power_ready:
     description: The car is ready for power (HLC)
     type: boolean
-  AC_EVSEMaxCurrent:
+  ac_evse_max_current:
     description: EVSE max current per phase
     type: number
     minimum: 0
     maximum: 400
-  AC_StopFromCharger:
-    description: The charger wants to stop the charging process
-    type: 'null'
-  DC_PowerOn:
+  dc_power_on:
     description: The ev wants to close the dc contactors
+    type: 'null'
+  stop_from_charger:
+    description: The charger wants to stop the charging process
     type: 'null'
   pause_from_charger:
     description: The charger wants to pause the session (only d20)

--- a/modules/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EvManager/main/car_simulatorImpl.cpp
@@ -301,11 +301,11 @@ void car_simulatorImpl::subscribe_to_variables_on_init() {
     // subscribe ev events
     if (!mod->r_ev.empty()) {
         const auto& _ev = mod->r_ev.at(0);
-        _ev->subscribe_AC_EVPowerReady([this](auto value) { car_simulation->set_iso_pwr_ready(value); });
-        _ev->subscribe_AC_EVSEMaxCurrent([this](auto value) { car_simulation->set_evse_max_current(value); });
-        _ev->subscribe_AC_StopFromCharger([this]() { car_simulation->set_iso_stopped(true); });
-        _ev->subscribe_V2G_Session_Finished([this]() { car_simulation->set_v2g_finished(true); });
-        _ev->subscribe_DC_PowerOn([this]() { car_simulation->set_dc_power_on(true); });
+        _ev->subscribe_ev_power_ready([this](auto value) { car_simulation->set_iso_pwr_ready(value); });
+        _ev->subscribe_ac_evse_max_current([this](auto value) { car_simulation->set_evse_max_current(value); });
+        _ev->subscribe_stop_from_charger([this]() { car_simulation->set_iso_stopped(true); });
+        _ev->subscribe_v2g_session_finished([this]() { car_simulation->set_v2g_finished(true); });
+        _ev->subscribe_dc_power_on([this]() { car_simulation->set_dc_power_on(true); });
         _ev->subscribe_pause_from_charger([this]() { car_simulation->set_iso_d20_paused(true); });
     }
 }

--- a/modules/PyEvJosev/module.py
+++ b/modules/PyEvJosev/module.py
@@ -85,7 +85,7 @@ class PyEVJosevModule():
             self._ready_event.wait()
             try:
                 asyncio.run(evcc_handler_main_loop(self._setup.configs.module))
-                self._mod.publish_variable('ev', 'V2G_Session_Finished', None)
+                self._mod.publish_variable('ev', 'v2g_session_finished', None)
             except KeyboardInterrupt:
                 log.debug("SECC program terminated manually")
                 break


### PR DESCRIPTION
## Describe your changes
See title: Changing to snake_case and removing ac for some vars

The Josev PR should be merged before merging this one: https://github.com/EVerest/ext-switchev-iso15118/pull/42

## Issue ticket number and link
The iso15118_ev interface vars were defined in PascalCase.
For some vars an `AC` was added but were used for DC and AC.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

