### PR TITLE
Add tests for invalid OCPP 1.6 and 2.x message encoding

### DIFF
--- a/tests/ocpp_tests/test_sets/ocpp16/broken.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/broken.py
@@ -403,3 +403,25 @@ async def test_too_long_payload_field(
     assert await wait_for_callerror_and_validate(
         test_utility, charge_point_v16, "FormationViolation"
     )
+
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-sil-ocpp.yaml")
+)
+@pytest.mark.asyncio
+async def test_invalid_encoding_in_payload(
+    test_config,
+    charge_point_v16: ChargePoint16,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    logging.info("######### test_invalid_encoding_in_payload #########")
+
+    # a malformed CALL should trigger a RpcFrameworkError CALLERROR
+    call_msg = b"\xd8\x00\x00\x00"
+
+    async with charge_point_v16._call_lock:
+        await charge_point_v16._send(call_msg)
+
+    assert await wait_for_callerror_and_validate(
+        test_utility, charge_point_v16, "GenericError"
+    )

--- a/tests/ocpp_tests/test_sets/ocpp201/broken201.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/broken201.py
@@ -77,6 +77,16 @@ async def test_invalid_payloads(
         test_utility, charge_point_v201, "RpcFrameworkError"
     )
 
+    # a malformed CALL should trigger a RpcFrameworkError CALLERROR
+    call_msg = b"\xd8\x00\x00\x00"
+
+    async with charge_point_v201._call_lock:
+        await charge_point_v201._send(call_msg)
+
+    assert await wait_for_callerror_and_validate(
+        test_utility, charge_point_v201, "RpcFrameworkError"
+    )
+
     # a invalid payload should trigger a FormationViolation CALLERROR
     call_msg = Call(
         unique_id=str(charge_point_v201._unique_id_generator()),


### PR DESCRIPTION
Bump libocpp with a version that includes fixes for these problems

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

