### PR TITLE
Refactor OVM interface and include MCS limits

### DIFF
--- a/config/bringup/config-bringup-ovm-sil.yaml
+++ b/config/bringup/config-bringup-ovm-sil.yaml
@@ -1,0 +1,15 @@
+active_modules:
+  cli:
+    connections:
+      ovm:
+        - implementation_id: main
+          module_id: ovm
+    module: BUOverVoltageMonitor
+    standalone: true
+  ovm:
+    module: OVMSimulator
+    config_implementation:
+      main:
+        simulate_error_shutdown: true
+        simulate_emergency_shutdown: false
+        simulate_error_delay: 5

--- a/config/config-sil-dc.yaml
+++ b/config/config-sil-dc.yaml
@@ -65,7 +65,7 @@ active_modules:
     module: OVMSimulator
     config_implementation:
       main:
-        simulate_error: false
+        simulate_emergency_shutdown: false
         simulate_error_delay: 5
   ev_manager:
     module: EvManager

--- a/errors/over_voltage_monitor.yaml
+++ b/errors/over_voltage_monitor.yaml
@@ -6,7 +6,9 @@ description: >-
   to EVerest after the fact.
 errors:
   - name: MREC5OverVoltage
-    description: The output voltage was above IEC61851-23:2023 6.3.1.106.2 Table 103 limits for more than 9ms.
+    description: >-
+      The output voltage was above IEC61851-23:2023 6.3.1.106.2 Table 103 limits for more than 9ms. (severity high)
+      or above Table 104 (medium or low severity).
   - name: DeviceFault
     description: The over voltage monitoring device is no longer functional.
   - name: CommunicationFault

--- a/interfaces/over_voltage_monitor.yaml
+++ b/interfaces/over_voltage_monitor.yaml
@@ -1,36 +1,62 @@
 description: >-
   This interface defines a fast over voltage monitoring device according
-  to IEC61851-23:2023 6.3.1.106.2 for DC charging. An emergency shutdown needs to be triggered
-  if the DC output voltage is above the limit of Table 103 for 9ms. The actual shutdown needs
-  to be handled in a lower layer outside of EVerest, but this interface sets the 
-  correct voltage limit at the start of the session and stops monitoring at the 
-  end of the session. The over voltage error should be reported after the actual
-  shutdown was already performed.
-  Once an over voltage error was raised, it should only be cleared when the reset_over_voltage_error command is called.
-  All other errors should be raised/cleared when they occur/are no longer active immediately.
+  to IEC61851-23:2023 6.3.1.106.2 and 6.3.1.106.3 for DC charging. 
+  
+  6.3.1.106.2
+  An emergency shutdown needs to be triggered if the DC output voltage is above the limit of Table 103 for 9ms. 
+  The actual shutdown needs to be handled in a lower layer outside of EVerest, but this interface sets the 
+  correct voltage limit during the power transfer and stops monitoring at the end of the session. 
+  After the actual emergency shutdown was already performed, report an MREC5OverVoltage error with severity set to high. 
+
+  6.3.1.106.3
+  An error shutdown needs to be triggered if the DC output voltage is above the limits of Table 104:
+    - Present voltage > negotiated maximum for >400ms: Trigger error shutdown in <50ms.
+    - Present voltage > negotiated maximum for <400ms and >200ms: Allow energy transfer or error shutdown
+    - Present voltage > negotiated maximum for <200ms: Allow energy transfer
+  To trigger an error shutdown, raise the error MREC5OverVoltage with severity set to medium or low.
+
+  Once an MREC5OverVoltage error was raised, it shall only be cleared when the reset_over_voltage_error command is called.
+  All other errors shall be raised/cleared when they occur/are no longer active immediately.
+
   The var voltage_measurement_V should be published in regular intervals, e.g. 1 second. It is not
   used to compare it with the overvoltage threshold setting in EVerest, that has to be done in the OVM device itself.
   It will only be used to validate that the OVM and the IMD see the same voltage to ensure they are correctly wired to the same
   charging port. If it is not available in hardware, do not publish the voltage_measurement_V at all.
 cmds:
-  start:
+  set_limits:
     description: >-
-      Start over voltage monitoring
+      Set the overvoltage limits. It will be called any time the voltage limits change, independent of 
+      whether the monitoring is currently active or not.
+      The values shall be cached, and the last value received shall be used as threshold while monitoring is active.
     arguments:
-      over_voltage_limit_V:
+      emergency_over_voltage_limit_V:
         description: >-
-          Specifies the over voltage threshold [V] (based on IEC61851-23:2023 Table 103)
-          An emergency shutdown should be triggered if the DC output voltage is higher 
+          Specifies the over voltage threshold [V] for emergency shutdown
+          (based on IEC61851-23:2023 Table 103 and IEC61851-23-3:(DRAFT 2025) Table 202)
+          An emergency shutdown shall be triggered if the DC output voltage is higher 
           than this value.
         type: number
+      error_over_voltage_limit_V:
+        description: >-
+          Specifies the over voltage threshold [V] for error shutdown (for use with IEC61851-23:2023 Table 104).
+          An error shutdown shall be triggered if the DC output voltage is higher 
+          than this value. The OVM shall trigger an emergency shutdown if error shutdown does not work properly
+          (after 2.5s, see CC.3.4.2).
+        type: number
+  start:
+    description: >-
+      Start monitoring. Called once at the beginning of power transfer.
+      Use the last limits set by set_limits and make sure to update them when set_limits is called while monitoring is active.
+      Trigger shutdowns and raise errors as needed.
   stop:
     description: >-
-      Stop over voltage monitoring at the end of the power transfer.
+      Stop monitoring. Called once at the end of power transfer.
+      Do not raise any over voltage errors or trigger any shutdowns in this mode.
   reset_over_voltage_error:
     description: >-
       Resets the detection logic to allow for new charging session after an over voltage error occurred.
-      This should clear the over voltage error.
-      If monitoring is still active, it should be stopped.
+      This shall clear the over voltage error.
+      If monitoring is still active, it shall be stopped.
 vars:
   voltage_measurement_V:
     description: Measured voltage in V

--- a/modules/BringUp/BUOverVoltageMonitor/BUOverVoltageMonitor.cpp
+++ b/modules/BringUp/BUOverVoltageMonitor/BUOverVoltageMonitor.cpp
@@ -74,14 +74,21 @@ void BUOverVoltageMonitor::ready() {
     o.multiline = false;
     o.cursor_position = 0;
 
-    auto limit_input = Input(&limit, "800.0", o);
+    auto error_limit_input = Input(&error_limit, "800.0", o);
+    auto emergency_limit_input = Input(&emergency_limit, "1000.0", o);
+
+    Component ovm_set_limit = Button(
+                                  "Set Error/Emergency Limits",
+                                  [&] {
+                                      auto error_val = std::stof(error_limit);
+                                      auto emergency_val = std::stof(emergency_limit);
+                                      r_ovm->call_set_limits(error_val, emergency_val);
+                                  },
+                                  ButtonOption::Animated(Color::Blue, Color::White, Color::BlueLight, Color::White)) |
+                              flex_grow;
 
     Component ovm_start = Button(
-                              "Start",
-                              [&] {
-                                  auto val = std::stof(limit);
-                                  r_ovm->call_start(val);
-                              },
+                              "Start", [&] { r_ovm->call_start(); },
                               ButtonOption::Animated(Color::Blue, Color::White, Color::BlueLight, Color::White)) |
                           flex_grow;
 
@@ -97,7 +104,9 @@ void BUOverVoltageMonitor::ready() {
 
     auto action_component = Container::Horizontal({
         Container::Vertical({
-            limit_input,
+            ovm_set_limit,
+            error_limit_input,
+            emergency_limit_input,
             ovm_start,
             ovm_stop,
             ovm_reset,
@@ -105,8 +114,10 @@ void BUOverVoltageMonitor::ready() {
     });
 
     auto action_component_renderer = Renderer(action_component, [&] {
-        return vbox({hbox(ovm_start->Render()), hbox(text(" Over voltage limit (V): "), limit_input->Render()),
-                     hbox(ovm_stop->Render()), hbox(ovm_reset->Render())});
+        return vbox({hbox(text(" Over voltage error limit (V): "), error_limit_input->Render()),
+                     hbox(text(" Over voltage emergency limit (V): "), emergency_limit_input->Render()),
+                     hbox(ovm_set_limit->Render()), hbox(ovm_start->Render()), hbox(ovm_stop->Render()),
+                     hbox(ovm_reset->Render())});
     });
 
     auto action_renderer = Renderer(action_component, [&] {

--- a/modules/BringUp/BUOverVoltageMonitor/BUOverVoltageMonitor.hpp
+++ b/modules/BringUp/BUOverVoltageMonitor/BUOverVoltageMonitor.hpp
@@ -52,7 +52,8 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    std::string limit{"800.0"};
+    std::string error_limit{"800.0"};
+    std::string emergency_limit{"1000.0"};
     std::mutex data_mutex;
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -2034,7 +2034,6 @@ void Charger::error_shutdown() {
 
     // open contactors
     bsp->allow_power_on(false, types::evse_board_support::Reason::PowerOff);
-
     this->signal_hlc_error(types::iso15118::EvseError::Error_EmergencyShutdown);
 }
 

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -349,7 +349,8 @@ private:
 
     bool cable_check_should_exit();
 
-    double get_over_voltage_threshold();
+    double get_emergency_over_voltage_threshold();
+    double get_error_over_voltage_threshold();
 
     // EV information
     Everest::timed_mutex_traceable ev_info_mutex;

--- a/modules/Simulation/OVMSimulator/main/over_voltage_monitorImpl.cpp
+++ b/modules/Simulation/OVMSimulator/main/over_voltage_monitorImpl.cpp
@@ -12,13 +12,31 @@ void over_voltage_monitorImpl::init() {
 void over_voltage_monitorImpl::ready() {
 }
 
-void over_voltage_monitorImpl::handle_start(double& over_voltage_limit_V) {
-    EVLOG_info << "Over voltage monitoring: start with " << over_voltage_limit_V;
-    if (config.simulate_error) {
+void over_voltage_monitorImpl::handle_set_limits(double& emergency_over_voltage_limit_V,
+                                                 double& error_over_voltage_limit_V) {
+    error_threshold = error_over_voltage_limit_V;
+    emergency_threshold = emergency_over_voltage_limit_V;
+}
+
+void over_voltage_monitorImpl::handle_start() {
+    EVLOG_info << "Over voltage monitoring: starting with " << emergency_threshold << " (emergency) and "
+               << error_threshold << "(error)";
+    if (config.simulate_error_shutdown) {
         std::thread([this]() {
             std::this_thread::sleep_for(std::chrono::seconds(config.simulate_error_delay));
             auto err = error_factory->create_error("over_voltage_monitor/MREC5OverVoltage", "",
-                                                   "Simulated Over voltage error occurred.");
+                                                   "Simulated Over voltage error shutdown occurred.",
+                                                   Everest::error::Severity::Medium);
+            raise_error(err);
+        }).detach();
+    }
+
+    if (config.simulate_emergency_shutdown) {
+        std::thread([this]() {
+            std::this_thread::sleep_for(std::chrono::seconds(config.simulate_error_delay));
+            auto err = error_factory->create_error("over_voltage_monitor/MREC5OverVoltage", "",
+                                                   "Simulated Over voltage emergency shutdown occurred.",
+                                                   Everest::error::Severity::High);
             raise_error(err);
         }).detach();
     }

--- a/modules/Simulation/OVMSimulator/main/over_voltage_monitorImpl.hpp
+++ b/modules/Simulation/OVMSimulator/main/over_voltage_monitorImpl.hpp
@@ -20,7 +20,8 @@ namespace module {
 namespace main {
 
 struct Conf {
-    bool simulate_error;
+    bool simulate_error_shutdown;
+    bool simulate_emergency_shutdown;
     int simulate_error_delay;
 };
 
@@ -36,7 +37,8 @@ public:
 
 protected:
     // command handler functions (virtual)
-    virtual void handle_start(double& over_voltage_limit_V) override;
+    virtual void handle_set_limits(double& emergency_over_voltage_limit_V, double& error_over_voltage_limit_V) override;
+    virtual void handle_start() override;
     virtual void handle_stop() override;
     virtual void handle_reset_over_voltage_error() override;
 
@@ -53,6 +55,8 @@ private:
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here
+    double error_threshold{0.};
+    double emergency_threshold{0.};
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/Simulation/OVMSimulator/manifest.yaml
+++ b/modules/Simulation/OVMSimulator/manifest.yaml
@@ -4,8 +4,12 @@ provides:
     interface: over_voltage_monitor
     description: Main interface for the OVM
     config:
-      simulate_error:
-        description: Set to true to throw an over voltage error during charging
+      simulate_error_shutdown:
+        description: Set to true to simulate an error shutdown during charging
+        type: boolean
+        default: false
+      simulate_emergency_shutdown:
+        description: Set to true to simulate an emergency shutdown during charging
         type: boolean
         default: false
       simulate_error_delay:


### PR DESCRIPTION
## Describe your changes

Refactor over_voltage_monitoring interface with the following changes:

1. Add support for 6.3.1.106.3 (and not only 6.3.1.106.2) (lower speed over voltage error shutdown)
2. Use medium/high severity on errors to distiguish between error and emergency shutdown when an error is raised
3. Include MCS over voltage thresholds
4. Update voltage limits if they change during power transfer

All errors with medium/low severity are treated as error shutdowns from now on, and only errors with high severity  trigger an emergency shutdown.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

