### PR TITLE
The charger can now pause the session if no energy is available

### DIFF
--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -110,6 +110,20 @@ cmds:
       pause:
         description: Set to true when to pause, set to false when to continue
         type: boolean
+  no_energy_pause_charging:
+    description: >-
+      Right now there is no power available for the charging process. According to
+      IEC61851-23:2023 CC3.5.3 the charger can pause the session before or after the cable check and
+      pre charge stage.
+    arguments:
+      mode:
+        description: >-
+          Set to different no energy pause modes. For PauseAfterPrecharge the charger should pause but
+          has power for cable check and pre charge. For PauseBeforeCableCheck the charger should pause
+          before cable check. For AllowEvToIgnorePause charger should ignore, that the ev will go to
+          CurrentDemand instead of pausing the session, this is against IEC61851-23:2023.
+        type: string
+        $ref: /iso15118#/NoEnergyPauseMode
 # Update physical values
   update_energy_transfer_modes:
     description: >-

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.cpp
@@ -17,11 +17,6 @@ void ISO15118_chargerImpl::handle_setup(types::iso15118::EVSEID& evse_id,
     // your code for cmd setup goes here
 }
 
-void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
-    std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
-    // your code for cmd update_energy_transfer_modes goes here
-}
-
 void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) {
     // your code for cmd set_charging_parameters goes here
 }
@@ -60,6 +55,15 @@ void ISO15118_chargerImpl::handle_stop_charging(bool& stop) {
 
 void ISO15118_chargerImpl::handle_pause_charging(bool& pause) {
     // your code for cmd pause_charging goes here
+}
+
+void ISO15118_chargerImpl::handle_no_energy_pause_charging(types::iso15118::NoEnergyPauseMode& mode) {
+    // your code for cmd no_energy_pause_charging goes here
+}
+
+void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
+    std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
+    // your code for cmd update_energy_transfer_modes goes here
 }
 
 void ISO15118_chargerImpl::handle_update_ac_max_current(double& max_current) {

--- a/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
+++ b/modules/DummyV2G/main/ISO15118_chargerImpl.hpp
@@ -47,6 +47,7 @@ protected:
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
     virtual void handle_pause_charging(bool& pause) override;
+    virtual void handle_no_energy_pause_charging(types::iso15118::NoEnergyPauseMode& mode) override;
     virtual void handle_update_energy_transfer_modes(
         std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) override;
     virtual void handle_update_ac_max_current(double& max_current) override;

--- a/modules/EvManager/main/car_simulation.hpp
+++ b/modules/EvManager/main/car_simulation.hpp
@@ -79,8 +79,8 @@ public:
         sim_data.iso_stopped = iso_stopped;
     }
 
-    void set_iso_d20_paused(bool iso_d20_paused) {
-        sim_data.iso_d20_paused = iso_d20_paused;
+    void set_iso_charger_paused(bool iso_charger_paused) {
+        sim_data.iso_charger_paused = iso_charger_paused;
     }
 
     void set_v2g_finished(bool v2g_finished) {

--- a/modules/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EvManager/main/car_simulatorImpl.cpp
@@ -306,7 +306,7 @@ void car_simulatorImpl::subscribe_to_variables_on_init() {
         _ev->subscribe_stop_from_charger([this]() { car_simulation->set_iso_stopped(true); });
         _ev->subscribe_v2g_session_finished([this]() { car_simulation->set_v2g_finished(true); });
         _ev->subscribe_dc_power_on([this]() { car_simulation->set_dc_power_on(true); });
-        _ev->subscribe_pause_from_charger([this]() { car_simulation->set_iso_d20_paused(true); });
+        _ev->subscribe_pause_from_charger([this]() { car_simulation->set_iso_charger_paused(true); });
     }
 }
 

--- a/modules/EvManager/main/simulation_data.hpp
+++ b/modules/EvManager/main/simulation_data.hpp
@@ -41,7 +41,7 @@ struct SimulationData {
 
     bool v2g_finished{false};
     bool iso_stopped{false};
-    bool iso_d20_paused{false};
+    bool iso_charger_paused{false};
     size_t evse_maxcurrent{0};
     size_t max_current{0};
     std::string payment{"ExternalPayment"};

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -654,58 +654,6 @@ void ISO15118_chargerImpl::handle_setup(types::iso15118::EVSEID& evse_id,
     setup_steps_done.set(to_underlying_value(SetupStep::SETUP));
 }
 
-void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
-    std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
-
-    std::scoped_lock lock(GEL);
-
-    std::vector<dt::ServiceCategory> services;
-
-    for (const auto& mode : supported_energy_transfer_modes) {
-        switch (mode) {
-        case types::iso15118::EnergyTransferMode::AC_single_phase_core:
-        case types::iso15118::EnergyTransferMode::AC_two_phase:
-        case types::iso15118::EnergyTransferMode::AC_three_phase_core:
-            services.push_back(dt::ServiceCategory::AC);
-            break;
-        case types::iso15118::EnergyTransferMode::AC_BPT:
-        case types::iso15118::EnergyTransferMode::AC_BPT_DER:
-            services.push_back(dt::ServiceCategory::AC_BPT);
-            break;
-        case types::iso15118::EnergyTransferMode::AC_DER:
-            services.push_back(dt::ServiceCategory::AC_DER);
-            break;
-        case types::iso15118::EnergyTransferMode::DC:
-        case types::iso15118::EnergyTransferMode::DC_core:
-        case types::iso15118::EnergyTransferMode::DC_extended:
-        case types::iso15118::EnergyTransferMode::DC_combo_core:
-        case types::iso15118::EnergyTransferMode::DC_unique:
-            services.push_back(dt::ServiceCategory::DC);
-            break;
-        case types::iso15118::EnergyTransferMode::DC_BPT:
-            services.push_back(dt::ServiceCategory::DC_BPT);
-            break;
-        case types::iso15118::EnergyTransferMode::DC_ACDP:
-            services.push_back(dt::ServiceCategory::DC_ACDP);
-            break;
-        case types::iso15118::EnergyTransferMode::DC_ACDP_BPT:
-            services.push_back(dt::ServiceCategory::DC_ACDP_BPT);
-            break;
-        case types::iso15118::EnergyTransferMode::WPT:
-            services.push_back(dt::ServiceCategory::WPT);
-            break;
-        }
-    }
-
-    setup_config.supported_energy_services = services;
-
-    if (controller) {
-        controller->update_energy_modes(services);
-    }
-
-    setup_steps_done.set(to_underlying_value(SetupStep::ENERGY_SERVICE));
-}
-
 void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) {
     // your code for cmd set_charging_parameters goes here
 }
@@ -782,6 +730,62 @@ void ISO15118_chargerImpl::handle_pause_charging(bool& pause) {
     if (controller) {
         controller->send_control_event(iso15118::d20::PauseCharging{pause});
     }
+}
+
+void ISO15118_chargerImpl::handle_no_energy_pause_charging(types::iso15118::NoEnergyPauseMode& mode) {
+    // your code for cmd no_energy_pause_charging goes here
+}
+
+void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
+    std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
+
+    std::scoped_lock lock(GEL);
+
+    std::vector<dt::ServiceCategory> services;
+
+    for (const auto& mode : supported_energy_transfer_modes) {
+        switch (mode) {
+        case types::iso15118::EnergyTransferMode::AC_single_phase_core:
+        case types::iso15118::EnergyTransferMode::AC_two_phase:
+        case types::iso15118::EnergyTransferMode::AC_three_phase_core:
+            services.push_back(dt::ServiceCategory::AC);
+            break;
+        case types::iso15118::EnergyTransferMode::AC_BPT:
+        case types::iso15118::EnergyTransferMode::AC_BPT_DER:
+            services.push_back(dt::ServiceCategory::AC_BPT);
+            break;
+        case types::iso15118::EnergyTransferMode::AC_DER:
+            services.push_back(dt::ServiceCategory::AC_DER);
+            break;
+        case types::iso15118::EnergyTransferMode::DC:
+        case types::iso15118::EnergyTransferMode::DC_core:
+        case types::iso15118::EnergyTransferMode::DC_extended:
+        case types::iso15118::EnergyTransferMode::DC_combo_core:
+        case types::iso15118::EnergyTransferMode::DC_unique:
+            services.push_back(dt::ServiceCategory::DC);
+            break;
+        case types::iso15118::EnergyTransferMode::DC_BPT:
+            services.push_back(dt::ServiceCategory::DC_BPT);
+            break;
+        case types::iso15118::EnergyTransferMode::DC_ACDP:
+            services.push_back(dt::ServiceCategory::DC_ACDP);
+            break;
+        case types::iso15118::EnergyTransferMode::DC_ACDP_BPT:
+            services.push_back(dt::ServiceCategory::DC_ACDP_BPT);
+            break;
+        case types::iso15118::EnergyTransferMode::WPT:
+            services.push_back(dt::ServiceCategory::WPT);
+            break;
+        }
+    }
+
+    setup_config.supported_energy_services = services;
+
+    if (controller) {
+        controller->update_energy_modes(services);
+    }
+
+    setup_steps_done.set(to_underlying_value(SetupStep::ENERGY_SERVICE));
 }
 
 void ISO15118_chargerImpl::handle_update_ac_max_current(double& max_current) {

--- a/modules/Evse15118D20/charger/ISO15118_chargerImpl.hpp
+++ b/modules/Evse15118D20/charger/ISO15118_chargerImpl.hpp
@@ -53,6 +53,7 @@ protected:
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
     virtual void handle_pause_charging(bool& pause) override;
+    virtual void handle_no_energy_pause_charging(types::iso15118::NoEnergyPauseMode& mode) override;
     virtual void handle_update_energy_transfer_modes(
         std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) override;
     virtual void handle_update_ac_max_current(double& max_current) override;

--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -306,10 +306,11 @@ void Charger::run_state_machine() {
                 types::iso15118::DcEvseMaximumLimits evse_limit = shared_context.current_evse_max_limits;
                 if (not(evse_limit.evse_maximum_current_limit > 0 and evse_limit.evse_maximum_power_limit > 0)) {
                     if (not internal_context.no_energy_warning_printed) {
-                        EVLOG_warning << "No energy available, still retrying...";
+                        EVLOG_warning << "No energy available, still retrying... Some EVs dont like 0W and/or 0A in "
+                                         "ChargingParameterDiscoveryRes message";
                         internal_context.no_energy_warning_printed = true;
+                        signal_hlc_no_energy_available();
                     }
-                    break;
                 }
             }
 
@@ -516,6 +517,14 @@ void Charger::run_state_machine() {
             if (initialize_state) {
                 signal_simple_event(types::evse_manager::SessionEventEnum::PrepareCharging);
                 bcb_toggle_reset();
+
+                if (config_context.charge_mode == ChargeMode::DC) {
+                    // Create a copy of the atomic struct
+                    types::iso15118::DcEvseMaximumLimits evse_limit = shared_context.current_evse_max_limits;
+                    if (not(evse_limit.evse_maximum_current_limit > 0 and evse_limit.evse_maximum_power_limit > 0)) {
+                        signal_hlc_no_energy_available();
+                    }
+                }
             }
 
             if (config_context.charge_mode == ChargeMode::DC) {
@@ -896,6 +905,7 @@ void Charger::process_cp_events_state(CPEvent cp_event) {
         } else if (cp_event == CPEvent::CarRequestedStopPower) {
             shared_context.iec_allow_close_contactor = false;
             signal_dc_supply_off();
+            shared_context.current_state = EvseState::ChargingPausedEVSE;
         }
         break;
 

--- a/modules/EvseManager/Charger.hpp
+++ b/modules/EvseManager/Charger.hpp
@@ -172,6 +172,8 @@ public:
     sigslot::signal<> signal_hlc_pause_charging;
     sigslot::signal<types::iso15118::EvseError> signal_hlc_error;
 
+    sigslot::signal<> signal_hlc_no_energy_available;
+
     void process_event(CPEvent event);
 
     void run();

--- a/modules/EvseManager/EvseManager.hpp
+++ b/modules/EvseManager/EvseManager.hpp
@@ -110,6 +110,8 @@ struct Conf {
     bool contract_certificate_installation_enabled;
     bool inoperative_error_use_vendor_id;
     std::string session_id_type;
+    bool zero_power_ignore_pause;
+    bool zero_power_allow_ev_to_ignore_pause;
 };
 
 class EvseManager : public Everest::ModuleBase {

--- a/modules/EvseManager/manifest.yaml
+++ b/modules/EvseManager/manifest.yaml
@@ -338,6 +338,20 @@ config:
       - UUID_BASE64
       - SHORT_BASE64
     default: UUID
+  zero_power_ignore_pause:
+    description: >-
+      If no energy is available the charger can signal a pause to the car before cable check.
+      With this option the charger ignores that and continues as if energy were available.
+      This is not standard compliant!
+    type: boolean
+    default: false
+  zero_power_allow_ev_to_ignore_pause:
+    description: >-
+      If no energy is available the charger can signal a pause to the car before cable check.
+      With this option, the charger ignores that the ev goes to the energy phase instead of pausing
+      the session. This is not standard compliant!
+    type: boolean
+    default: false
 provides:
   evse:
     interface: evse_manager

--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.hpp
@@ -48,6 +48,7 @@ protected:
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
     virtual void handle_pause_charging(bool& pause) override;
+    virtual void handle_no_energy_pause_charging(types::iso15118::NoEnergyPauseMode& mode) override;
     virtual void handle_update_energy_transfer_modes(
         std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) override;
     virtual void handle_update_ac_max_current(double& max_current) override;

--- a/modules/EvseV2G/din_server.cpp
+++ b/modules/EvseV2G/din_server.cpp
@@ -578,8 +578,10 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
     } else {
         res->SAScheduleList.SAScheduleTuple.array[0].PMaxSchedule.PMaxScheduleEntry.array[0].PMax = SHRT_MAX;
     }
+    constexpr auto PAUSE_DURATION = 60 * 30;
     res->SAScheduleList.SAScheduleTuple.array[0].PMaxSchedule.PMaxScheduleEntry.array[0].RelativeTimeInterval.duration =
-        SA_SCHEDULE_DURATION; // Must cover 24 hours
+        conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::None ? SA_SCHEDULE_DURATION
+                                                                              : PAUSE_DURATION; // Must cover 24 hours
     res->SAScheduleList.SAScheduleTuple.array[0]
         .PMaxSchedule.PMaxScheduleEntry.array[0]
         .RelativeTimeInterval.duration_isUsed = 1; // Must be used in DIN
@@ -600,6 +602,12 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
     // res->SASchedules.noContent
     res->SASchedules_isUsed = (unsigned int)0;
 
+    if (res->EVSEProcessing == din_EVSEProcessingType_Finished and
+        conn->ctx->evse_v2g_data.no_energy_pause != NoEnergyPauseStatus::None) {
+        res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSENotification = din_EVSENotificationType_StopCharging;
+        res->DC_EVSEChargeParameter.DC_EVSEStatus.NotificationMaxDelay = 0;
+    }
+
     /* Check the current response code and check if no external error has occurred */
     nextEvent = utils::din_validate_response_code(&res->ResponseCode, conn);
 
@@ -609,7 +617,13 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
             dlog(DLOG_LEVEL_WARNING,
                  "EVSE wants to finish charge parameter phase, but status code is not set to 'ready' (1)");
         }
-        conn->ctx->state = WAIT_FOR_CABLECHECK; // [V2G-DC-453]
+        if (conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::BeforeCableCheck or
+            conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::AfterCableCheckPreCharge) {
+            conn->ctx->state = WAIT_FOR_SESSIONSTOP; // IEC61851-23:2023 CC.5.3.2
+        } else {
+            conn->ctx->state = WAIT_FOR_CABLECHECK; // [V2G-DC-453]
+        }
+
     } else {
         conn->ctx->state = WAIT_FOR_CHARGEPARAMETERDISCOVERY; // [V2G-DC-498]
     }

--- a/modules/EvseV2G/iso_server.cpp
+++ b/modules/EvseV2G/iso_server.cpp
@@ -1178,9 +1178,13 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
             conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                 .PMaxSchedule.PMaxScheduleEntry.array[0]
                 .RelativeTimeInterval.duration_isUsed = 1;
+
+            constexpr auto PAUSE_DURATION = 60 * 30;
             conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                 .PMaxSchedule.PMaxScheduleEntry.array[0]
-                .RelativeTimeInterval.duration = SA_SCHEDULE_DURATION;
+                .RelativeTimeInterval.duration = conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::None
+                                                     ? SA_SCHEDULE_DURATION
+                                                     : PAUSE_DURATION;
             conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                 .PMaxSchedule.PMaxScheduleEntry.arrayLen = 1;
             conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.arrayLen = 1;
@@ -1337,6 +1341,17 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
             ev_maximum_voltage_limit < evse_minimum_voltage_limit) {
             res->ResponseCode = iso2_responseCodeType_FAILED_WrongChargeParameter;
         }
+
+        if (res->EVSEProcessing == iso2_EVSEProcessingType_Finished and
+            conn->ctx->evse_v2g_data.no_energy_pause != NoEnergyPauseStatus::None) {
+            res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSENotification = iso2_EVSENotificationType_StopCharging;
+
+            constexpr auto PAUSE_NOTIFICATION_DELAY = 300;
+            res->DC_EVSEChargeParameter.DC_EVSEStatus.NotificationMaxDelay =
+                conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::BeforeCableCheck
+                    ? 0
+                    : PAUSE_NOTIFICATION_DELAY;
+        }
     }
 
     /* Check the current response code and check if no external error has occurred */
@@ -1344,9 +1359,13 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
 
     /* Set next expected req msg */
     if (conn->ctx->is_dc_charger == true) {
-        conn->ctx->state = (iso2_EVSEProcessingType_Finished == res->EVSEProcessing)
-                               ? (int)iso_dc_state_id::WAIT_FOR_CABLECHECK
-                               : (int)iso_dc_state_id::WAIT_FOR_CHARGEPARAMETERDISCOVERY; // [V2G-582], [V2G-688]
+        if (conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::BeforeCableCheck) {
+            conn->ctx->state = (int)iso_dc_state_id::WAIT_FOR_PRECHARGE_POWERDELIVERY; // IEC6185-1:2023 CC.3.5.2
+        } else {
+            conn->ctx->state = (iso2_EVSEProcessingType_Finished == res->EVSEProcessing)
+                                   ? (int)iso_dc_state_id::WAIT_FOR_CABLECHECK
+                                   : (int)iso_dc_state_id::WAIT_FOR_CHARGEPARAMETERDISCOVERY; // [V2G-582], [V2G-688]
+        }
     } else {
         conn->ctx->state = (iso2_EVSEProcessingType_Finished == res->EVSEProcessing)
                                ? (int)iso_ac_state_id::WAIT_FOR_POWERDELIVERY
@@ -1380,6 +1399,10 @@ static enum v2g_event handle_iso_power_delivery(struct v2g_connection* conn) {
 
     /* At first, publish the received EV request message to the MQTT interface */
     publish_iso_power_delivery_req(conn->ctx, req);
+
+    const auto ev_should_pause =
+        conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::AfterCableCheckPreCharge or
+        conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::BeforeCableCheck;
 
     /* build up response */
     res->ResponseCode = iso2_responseCodeType_OK;
@@ -1418,6 +1441,13 @@ static enum v2g_event handle_iso_power_delivery(struct v2g_connection* conn) {
                     pthread_mutex_unlock(&conn->ctx->mqtt_lock);
                 }
             }
+        } else if (ev_should_pause) {
+
+            dlog(DLOG_LEVEL_ERROR, "The EV did not pause the session even EVSE signaled the EV that no energy is "
+                                   "available. Abort the session");
+            res->ResponseCode = iso2_responseCodeType_FAILED;
+            conn->ctx->session.is_charging = false;
+            conn->ctx->p_charger->publish_dc_open_contactor(nullptr);
         }
         break;
 

--- a/modules/EvseV2G/tests/ISO15118_chargerImplStub.hpp
+++ b/modules/EvseV2G/tests/ISO15118_chargerImplStub.hpp
@@ -60,6 +60,9 @@ struct ISO15118_chargerImplStub : public ISO15118_chargerImplBase {
     virtual void handle_pause_charging(bool& pause) {
         std::cout << "ISO15118_chargerImplBase::handle_pause_charging called" << std::endl;
     }
+    virtual void handle_no_energy_pause_charging(types::iso15118::NoEnergyPauseMode& mode) {
+        std::cout << "ISO15118_chargerImplBase::handle_no_energy_pause_charging called" << std::endl;
+    }
     virtual void handle_update_ac_max_current(double& max_current) {
         std::cout << "ISO15118_chargerImplBase::handle_update_ac_max_current called" << std::endl;
     }

--- a/modules/EvseV2G/v2g.hpp
+++ b/modules/EvseV2G/v2g.hpp
@@ -163,6 +163,13 @@ struct SAE_Bidi_Data {
     bool discharging;
 };
 
+enum NoEnergyPauseStatus {
+    None,
+    AllowEvToIgnorePause,
+    AfterCableCheckPreCharge,
+    BeforeCableCheck,
+};
+
 /**
  * Abstracts a charging port, i.e. a power outlet in this daemon.
  *
@@ -294,6 +301,9 @@ struct v2g_context {
 
         // Specific SAE J2847 bidi values
         struct SAE_Bidi_Data sae_bidi_data;
+
+        // No energy pause IEC61851-23:2023
+        NoEnergyPauseStatus no_energy_pause{NoEnergyPauseStatus::None};
 
     } evse_v2g_data;
 

--- a/modules/EvseV2G/v2g_ctx.cpp
+++ b/modules/EvseV2G/v2g_ctx.cpp
@@ -250,6 +250,8 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     ctx->evse_v2g_data.sae_bidi_data.sae_v2h_minimal_soc = 20;
     ctx->evse_v2g_data.sae_bidi_data.discharging = false;
 
+    ctx->evse_v2g_data.no_energy_pause = NoEnergyPauseStatus::None;
+
     // Init EV received v2g-data to an invalid state
     memset(&ctx->ev_v2g_data, 0xff, sizeof(ctx->ev_v2g_data));
 

--- a/modules/IsoMux/charger/ISO15118_chargerImpl.cpp
+++ b/modules/IsoMux/charger/ISO15118_chargerImpl.cpp
@@ -476,12 +476,6 @@ void ISO15118_chargerImpl::handle_setup(types::iso15118::EVSEID& evse_id,
     mod->r_iso2->call_setup(evse_id, sae_j2847_mode, debug_mode);
 }
 
-void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
-    std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
-    mod->r_iso20->call_update_energy_transfer_modes(supported_energy_transfer_modes);
-    mod->r_iso2->call_update_energy_transfer_modes(supported_energy_transfer_modes);
-}
-
 void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::SetupPhysicalValues& physical_values) {
     mod->r_iso20->call_set_charging_parameters(physical_values);
     mod->r_iso2->call_set_charging_parameters(physical_values);
@@ -549,6 +543,20 @@ void ISO15118_chargerImpl::handle_pause_charging(bool& pause) {
     } else {
         mod->r_iso2->call_pause_charging(pause);
     }
+}
+
+void ISO15118_chargerImpl::handle_no_energy_pause_charging(types::iso15118::NoEnergyPauseMode& mode) {
+    if (mod->selected_iso20()) {
+        mod->r_iso20->call_no_energy_pause_charging(mode);
+    } else {
+        mod->r_iso2->call_no_energy_pause_charging(mode);
+    }
+}
+
+void ISO15118_chargerImpl::handle_update_energy_transfer_modes(
+    std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
+    mod->r_iso20->call_update_energy_transfer_modes(supported_energy_transfer_modes);
+    mod->r_iso2->call_update_energy_transfer_modes(supported_energy_transfer_modes);
 }
 
 void ISO15118_chargerImpl::handle_update_ac_max_current(double& max_current) {

--- a/modules/IsoMux/charger/ISO15118_chargerImpl.hpp
+++ b/modules/IsoMux/charger/ISO15118_chargerImpl.hpp
@@ -48,6 +48,7 @@ protected:
     virtual void handle_receipt_is_required(bool& receipt_required) override;
     virtual void handle_stop_charging(bool& stop) override;
     virtual void handle_pause_charging(bool& pause) override;
+    virtual void handle_no_energy_pause_charging(types::iso15118::NoEnergyPauseMode& mode) override;
     virtual void handle_update_energy_transfer_modes(
         std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) override;
     virtual void handle_update_ac_max_current(double& max_current) override;

--- a/types/iso15118.yaml
+++ b/types/iso15118.yaml
@@ -145,6 +145,17 @@ types:
     enum:
       - Install
       - Update
+  NoEnergyPauseMode:
+    description: >-
+      PauseAfterPrecharge the charger should pause but has power for cable check and pre charge.
+      PauseBeforeCableCheck the charger should pause before cable check.
+      AllowEvToIgnorePause charger should ignore, that the ev will go to CurrentDemand instead
+      of pausing the session, this is against IEC61851-23:2023.
+    type: string
+    enum:
+      - PauseAfterPrecharge
+      - PauseBeforeCableCheck
+      - AllowEvToIgnorePause
   EVSEID:
     description: >-
       An ID that uniquely identifies the EVSE and the power outlet the


### PR DESCRIPTION
## Describe your changes
In IEC61851-23:2023 (CC.3.5.2 & CC.3.5.3) the charger has the opportunity to pause the session if no energy is available. In addition, two configuration options have been added that allow you to ignore the pause and enable the charger to ignore the fact that the EV is not entering a pause. However, neither option is standard-compliant

## Issue ticket number and link
The EvseManager was a little too cautious. Because some cars do not accept 0W and 0A as the maximum limit.
With IEC61851-23:2023, it is now also possible to pause the session from the charger with ISO15118

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

