### PR TITLE
fix(EvseManager): Set the correct connector id in autocharge_token

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -43,7 +43,7 @@ inline static types::authorization::ProvidedIdToken create_autocharge_token(std:
     autocharge_token.authorization_type = types::authorization::AuthorizationType::Autocharge;
     trim_colons_from_string(token);
     autocharge_token.id_token = {"VID:" + token, types::authorization::IdTokenType::MacAddress};
-    autocharge_token.connectors.emplace(connector_id, 1);
+    autocharge_token.connectors.emplace({connector_id});
     return autocharge_token;
 }
 


### PR DESCRIPTION
## Describe your changes
Changed `emplace` in code.

## Issue ticket number and link
connector_ids were always one, even if several EvsManager connectors were defined when the autocharge_token was created. As a result, only connector 1 was authorized, but not the others

## Checklist before requesting a review
- [y] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

