### PR TITLE
Trigger emergency shutdown when EV voltage limit < EV target voltage

### DIFF
--- a/modules/EvseManager/EvseManager.cpp
+++ b/modules/EvseManager/EvseManager.cpp
@@ -526,6 +526,20 @@ void EvseManager::ready() {
                 EVLOG_info << "Received EV maximum limits: " << l;
                 Everest::scoped_lock_timeout lock(ev_info_mutex,
                                                   Everest::MutexDescription::EVSE_subscribe_dc_ev_maximum_limits);
+
+                if (ev_info.present_voltage.has_value()) {
+                    const auto actual_voltage = ev_info.present_voltage.value();
+                    // IEC61851_23 CC.6.2:
+                    // The d.c. supply shall trigger a d.c. supply initiated emergency shutdown according to CC.3.4
+                    // in order to prevent overvoltage at the battery, if output voltage exceeds maximum voltage limit
+                    // sent by the vehicle
+                    if (actual_voltage > l.dc_ev_maximum_voltage_limit) {
+                        charger->set_hlc_error();
+                        r_hlc[0]->call_send_error(types::iso15118::EvseError::Error_EmergencyShutdown);
+                        return;
+                    }
+                }
+
                 ev_info.maximum_current_limit = l.dc_ev_maximum_current_limit;
                 ev_info.maximum_power_limit = l.dc_ev_maximum_power_limit;
                 ev_info.maximum_voltage_limit = l.dc_ev_maximum_voltage_limit;


### PR DESCRIPTION
## Describe your changes
According to IEC61851_23 CC.6.2 (reported here for ease):

**Protection against overvoltage of battery**
_The d.c. supply shall trigger a d.c. supply initiated emergency shutdown according to CC.3.4
in order to prevent overvoltage at the battery, if output voltage exceeds maximum voltage limit
sent by the vehicle for 400 ms. (See 6.4.3.107)._

We should trigger an emergency shutdown in this case. Without this change, it was not possible for us to pass functional tests at TUV Rheinland. What they do is basically the following:
- start DC charging with maximum voltage limit set to 500V
- set target voltage to 350V
- update the new limit voltage to 250V
- verify that the emergency shutdown is triggered according to CC.3.4

Instead currently the current target voltage is adjusted to the new limit. 

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

