### PR TITLE
CMake: add tls by default

### DIFF
--- a/lib/staging/CMakeLists.txt
+++ b/lib/staging/CMakeLists.txt
@@ -3,10 +3,10 @@ add_subdirectory(external_energy_limits)
 add_subdirectory(helpers)
 add_subdirectory(run_application)
 add_subdirectory(util)
+add_subdirectory(tls)
 
 if(EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY)
     add_subdirectory(evse_security)
-    add_subdirectory(tls)
 endif()
 
 if(EVEREST_DEPENDENCY_ENABLED_LIBSLAC AND EVEREST_DEPENDENCY_ENABLED_LIBFSM)


### PR DESCRIPTION
## Describe your changes

The helpers are used by Auth, EvseManager and so on and now they depend on the tls - which is not compiled if evse-sec is not used. This fixes the issue
