### PR TITLE
fix(ocpp2): Fix update of evcc id token from iso extensions interface

### DIFF
--- a/modules/OCPP201/OCPP201.cpp
+++ b/modules/OCPP201/OCPP201.cpp
@@ -1033,7 +1033,12 @@ void OCPP201::ready() {
 
         extension->subscribe_ev_info([this, extensions_id](const types::iso15118::EvInformation& ev_info) {
             // TODO(mlitre): Update device model
-            update_evcc_id_token(extensions_id, ev_info.evcc_id);
+            const auto& mapping = this->r_extensions_15118.at(extensions_id)->get_mapping();
+            if (mapping.has_value()) {
+                update_evcc_id_token(mapping->evse, ev_info.evcc_id);
+            } else {
+                EVLOG_warning << "ISO15118 Extension interface mapping not set! Not retrieving 'EV Info'!";
+            }
         });
 
         extensions_id++;


### PR DESCRIPTION
We would not use the correct value for the evse id from the iso15118 extensions interface.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

