### PR TITLE
lib/staging/external_energy_limits: fix int to string in throw

### DIFF
--- a/lib/staging/external_energy_limits/external_energy_limits.cpp
+++ b/lib/staging/external_energy_limits/external_energy_limits.cpp
@@ -35,7 +35,7 @@ get_evse_sink_by_evse_id(const std::vector<std::unique_ptr<external_energy_limit
             return *evse_sink;
         }
     }
-    throw std::runtime_error("No mapping configured for evse");
+    throw std::runtime_error("No mapping configured for evse_id: " + std::to_string(evse_id));
 }
 
 } // namespace external_energy_limits


### PR DESCRIPTION
## Describe your changes

Format the integer correctly in a string message in throw of `std::runtime_error`.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

