### PR TITLE
fix(ocpp16): websocket connection options after a security profile upgrade

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -79,7 +79,7 @@ libevse-security:
 # OCPP
 libocpp:
   git: https://github.com/EVerest/libocpp.git
-  git_tag: 617d71fbdba978c0e554401346ffc1c063cf48a8
+  git_tag: 7288e3fdea6553cb0315070b8fcebb0bb2fdf5f0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBOCPP"
 # Josev
 Josev:


### PR DESCRIPTION
## Describe your changes

Fixes websocket connection options after an OCPP16 security profile upgrade.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

