### PR TITLE
fix(Auth): Case-Insensitive comparison of tokens

### DIFF
--- a/lib/staging/helpers/include/everest/staging/helpers/helpers.hpp
+++ b/lib/staging/helpers/include/everest/staging/helpers/helpers.hpp
@@ -4,11 +4,14 @@
 #ifndef EVEREST_STAGING_HELPERS_HPP
 #define EVEREST_STAGING_HELPERS_HPP
 
+#include <algorithm>
+#include <cctype>
 #include <string>
 
 namespace types::authorization {
 struct ProvidedIdToken;
-}
+struct IdToken;
+} // namespace types::authorization
 
 namespace everest::staging::helpers {
 
@@ -17,6 +20,22 @@ namespace everest::staging::helpers {
 std::string redact(const std::string& token);
 
 types::authorization::ProvidedIdToken redact(const types::authorization::ProvidedIdToken& token);
+
+/// \brief Compares two strings case-insensitively
+/// \returns true if the strings are equal, false otherwise
+bool is_equal_case_insensitive(const std::string& str1, const std::string& str2);
+
+/// \brief Compares two IdTokens case-insensitively
+/// \returns true if the IdTokens are equal, false otherwise
+/// \note This function compares the value and type of the IdTokens
+bool is_equal_case_insensitive(const types::authorization::IdToken& token1,
+                               const types::authorization::IdToken& token2);
+
+/// \brief Compares two ProvidedIdTokens case-insensitively
+/// \returns true if the ProvidedIdTokens are equal, false otherwise
+/// \note This function compares the id_token and type of the ProvidedIdTokens
+bool is_equal_case_insensitive(const types::authorization::ProvidedIdToken& token1,
+                               const types::authorization::ProvidedIdToken& token2);
 
 /// \brief Provide a UUID
 /// \returns a UUID string. This UUID is 36 characters long

--- a/lib/staging/helpers/lib/helpers.cpp
+++ b/lib/staging/helpers/lib/helpers.cpp
@@ -29,6 +29,25 @@ types::authorization::ProvidedIdToken redact(const types::authorization::Provide
     return redacted_token;
 }
 
+bool is_equal_case_insensitive(const std::string& str1, const std::string& str2) {
+    if (str1.length() != str2.length()) {
+        return false;
+    }
+    return std::equal(str1.begin(), str1.end(), str2.begin(),
+                      [](char a, char b) { return std::tolower(a) == std::tolower(b); });
+}
+
+bool is_equal_case_insensitive(const types::authorization::IdToken& token1,
+                               const types::authorization::IdToken& token2) {
+    return is_equal_case_insensitive(token1.value, token2.value) && token1.type == token2.type;
+}
+
+bool is_equal_case_insensitive(const types::authorization::ProvidedIdToken& token1,
+                               const types::authorization::ProvidedIdToken& token2) {
+    return is_equal_case_insensitive(token1.id_token.value, token2.id_token.value) &&
+           token1.id_token.type == token2.id_token.type;
+}
+
 std::string get_uuid() {
     return boost::uuids::to_string(boost::uuids::random_generator()()); // 36 characters
 }

--- a/modules/Auth/lib/ReservationHandler.cpp
+++ b/modules/Auth/lib/ReservationHandler.cpp
@@ -9,6 +9,8 @@
 #include <generated/interfaces/kvs/Interface.hpp>
 #include <utils/date.hpp>
 
+using everest::staging::helpers::is_equal_case_insensitive;
+
 namespace module {
 
 static types::reservation::ReservationResult
@@ -356,9 +358,9 @@ std::optional<int32_t> ReservationHandler::matches_reserved_identifier(const std
     if (evse_id.has_value()) {
         if (this->evse_reservations.count(evse_id.value())) {
             const types::reservation::Reservation& reservation = this->evse_reservations[evse_id.value()];
-            if (reservation.id_token == id_token ||
+            if (is_equal_case_insensitive(reservation.id_token, id_token) ||
                 (parent_id_token.has_value() && reservation.parent_id_token.has_value() &&
-                 parent_id_token.value() == reservation.parent_id_token.value())) {
+                 is_equal_case_insensitive(parent_id_token.value(), reservation.parent_id_token.value()))) {
                 EVLOG_debug << "There is a reservation (" << reservation.reservation_id << ") for evse "
                             << evse_id.value() << " and the token matches";
                 return reservation.reservation_id;
@@ -372,9 +374,9 @@ std::optional<int32_t> ReservationHandler::matches_reserved_identifier(const std
     // If evse_id == 0 or there is no reservation found with the given evse id, search globally for reservation with
     // this token.
     for (const auto& reservation : global_reservations) {
-        if (reservation.id_token == id_token ||
+        if (is_equal_case_insensitive(reservation.id_token, id_token) ||
             (parent_id_token.has_value() && reservation.parent_id_token.has_value() &&
-             parent_id_token.value() == reservation.parent_id_token.value())) {
+             is_equal_case_insensitive(parent_id_token.value(), reservation.parent_id_token.value()))) {
             EVLOG_debug << "There is a reservation for the token, reservation id: " << reservation.reservation_id;
             return reservation.reservation_id;
         }


### PR DESCRIPTION
## Describe your changes
Auth module now implements case insensitive comparison of tokens throughout reservations, stopping transaction and parent/group id processing

## Issue ticket number and link
https://github.com/EVerest/everest-core/issues/566

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

