### PR TITLE
Module manifests: clean up external mqtt usage

### DIFF
--- a/modules/DummyBankSessionTokenProvider/manifest.yaml
+++ b/modules/DummyBankSessionTokenProvider/manifest.yaml
@@ -13,7 +13,6 @@ provides:
         type: boolean
         default: false
 requires: {}
-enable_external_mqtt: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/EnergyManager/manifest.yaml
+++ b/modules/EnergyManager/manifest.yaml
@@ -85,7 +85,6 @@ requires:
     interface: energy
     min_connections: 1
     max_connections: 1
-enable_external_mqtt: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/EnergyNode/manifest.yaml
+++ b/modules/EnergyNode/manifest.yaml
@@ -32,7 +32,6 @@ requires:
     interface: energy_price_information
     min_connections: 0
     max_connections: 1
-enable_external_mqtt: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/Evse15118D20/manifest.yaml
+++ b/modules/Evse15118D20/manifest.yaml
@@ -79,7 +79,6 @@ requires:
     interface: ISO15118_vas
     min_connections: 0
     max_connections: 128
-enable_external_mqtt: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/EvseSecurity/manifest.yaml
+++ b/modules/EvseSecurity/manifest.yaml
@@ -42,7 +42,6 @@ provides:
   main:
     description: Implementation of the evse_security interface
     interface: evse_security 
-enable_external_mqtt: false
 enable_telemetry: false
 metadata:
   license: https://spdx.org/licenses/Apache-2.0.html

--- a/modules/EvseV2G/EvseV2G.hpp
+++ b/modules/EvseV2G/EvseV2G.hpp
@@ -43,18 +43,15 @@ struct Conf {
 class EvseV2G : public Everest::ModuleBase {
 public:
     EvseV2G() = delete;
-    EvseV2G(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider,
-            std::unique_ptr<ISO15118_chargerImplBase> p_charger,
+    EvseV2G(const ModuleInfo& info, std::unique_ptr<ISO15118_chargerImplBase> p_charger,
             std::unique_ptr<iso15118_extensionsImplBase> p_extensions, std::unique_ptr<evse_securityIntf> r_security,
             Conf& config) :
         ModuleBase(info),
-        mqtt(mqtt_provider),
         p_charger(std::move(p_charger)),
         p_extensions(std::move(p_extensions)),
         r_security(std::move(r_security)),
         config(config){};
 
-    Everest::MqttProvider& mqtt;
     const std::unique_ptr<ISO15118_chargerImplBase> p_charger;
     const std::unique_ptr<iso15118_extensionsImplBase> p_extensions;
     const std::unique_ptr<evse_securityIntf> r_security;

--- a/modules/EvseV2G/manifest.yaml
+++ b/modules/EvseV2G/manifest.yaml
@@ -89,8 +89,6 @@ provides:
 requires:
   security:
     interface: evse_security
-
-enable_external_mqtt: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/PhyVersoBSP/PhyVersoBSP.hpp
+++ b/modules/PhyVersoBSP/PhyVersoBSP.hpp
@@ -65,14 +65,13 @@ struct Conf {
 class PhyVersoBSP : public Everest::ModuleBase {
 public:
     PhyVersoBSP() = delete;
-    PhyVersoBSP(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider, Everest::TelemetryProvider& telemetry,
+    PhyVersoBSP(const ModuleInfo& info, Everest::TelemetryProvider& telemetry,
                 std::unique_ptr<evse_board_supportImplBase> p_connector_1,
                 std::unique_ptr<evse_board_supportImplBase> p_connector_2, std::unique_ptr<ac_rcdImplBase> p_rcd_1,
                 std::unique_ptr<ac_rcdImplBase> p_rcd_2, std::unique_ptr<connector_lockImplBase> p_connector_lock_1,
                 std::unique_ptr<connector_lockImplBase> p_connector_lock_2,
                 std::unique_ptr<phyverso_mcu_temperatureImplBase> p_phyverso_mcu_temperature, Conf& config) :
         ModuleBase(info),
-        mqtt(mqtt_provider),
         telemetry(telemetry),
         p_connector_1(std::move(p_connector_1)),
         p_connector_2(std::move(p_connector_2)),
@@ -85,7 +84,6 @@ public:
         serial(verso_config),
         gpio(verso_config){};
 
-    Everest::MqttProvider& mqtt;
     Everest::TelemetryProvider& telemetry;
     const std::unique_ptr<evse_board_supportImplBase> p_connector_1;
     const std::unique_ptr<evse_board_supportImplBase> p_connector_2;

--- a/modules/PhyVersoBSP/manifest.yaml
+++ b/modules/PhyVersoBSP/manifest.yaml
@@ -194,7 +194,6 @@ provides:
   phyverso_mcu_temperature:
     interface: phyverso_mcu_temperature
     description: Temperatures from MCU
-enable_external_mqtt: true
 enable_telemetry: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0

--- a/modules/RsIskraMeter/manifest.yaml
+++ b/modules/RsIskraMeter/manifest.yaml
@@ -57,4 +57,3 @@ metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:
     - embedded@qwello.eu
-enable_external_mqtt: false

--- a/modules/RsPaymentTerminal/manifest.yaml
+++ b/modules/RsPaymentTerminal/manifest.yaml
@@ -62,7 +62,6 @@ provides:
   payment_terminal:
     interface: payment_terminal
     description: Provides all the commands specific for bank cards handling
-enable_external_mqtt: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/System/manifest.yaml
+++ b/modules/System/manifest.yaml
@@ -27,7 +27,6 @@ requires:
     interface: kvs
     min_connections: 0
     max_connections: 1
-enable_external_mqtt: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/YetiEvDriver/YetiEvDriver.hpp
+++ b/modules/YetiEvDriver/YetiEvDriver.hpp
@@ -29,15 +29,10 @@ struct Conf {
 class YetiEvDriver : public Everest::ModuleBase {
 public:
     YetiEvDriver() = delete;
-    YetiEvDriver(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider, Everest::TelemetryProvider& telemetry,
+    YetiEvDriver(const ModuleInfo& info, Everest::TelemetryProvider& telemetry,
                  std::unique_ptr<ev_board_supportImplBase> p_ev_board_support, Conf& config) :
-        ModuleBase(info),
-        mqtt(mqtt_provider),
-        telemetry(telemetry),
-        p_ev_board_support(std::move(p_ev_board_support)),
-        config(config){};
+        ModuleBase(info), telemetry(telemetry), p_ev_board_support(std::move(p_ev_board_support)), config(config){};
 
-    Everest::MqttProvider& mqtt;
     Everest::TelemetryProvider& telemetry;
     const std::unique_ptr<ev_board_supportImplBase> p_ev_board_support;
     const Conf& config;

--- a/modules/YetiEvDriver/manifest.yaml
+++ b/modules/YetiEvDriver/manifest.yaml
@@ -21,7 +21,6 @@ provides:
     interface: ev_board_support
     description: provides the board support Interface to low level control control pilot, relais, rcd
 enable_telemetry: true
-enable_external_mqtt: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/rust_examples/RsExample/manifest.yaml
+++ b/modules/rust_examples/RsExample/manifest.yaml
@@ -31,4 +31,4 @@ metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:
     - Holger Rapp
-enable_external_mqtt: false
+

--- a/modules/rust_examples/RsExampleUser/manifest.yaml
+++ b/modules/rust_examples/RsExampleUser/manifest.yaml
@@ -12,4 +12,3 @@ metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:
     - Holger Rapp
-enable_external_mqtt: false

--- a/modules/simulation/SlacSimulator/SlacSimulator.hpp
+++ b/modules/simulation/SlacSimulator/SlacSimulator.hpp
@@ -26,11 +26,10 @@ struct Conf {};
 class SlacSimulator : public Everest::ModuleBase {
 public:
     SlacSimulator() = delete;
-    SlacSimulator(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider, std::unique_ptr<slacImplBase> p_evse,
-                  std::unique_ptr<ev_slacImplBase> p_ev, Conf& config) :
-        ModuleBase(info), mqtt(mqtt_provider), p_evse(std::move(p_evse)), p_ev(std::move(p_ev)), config(config){};
+    SlacSimulator(const ModuleInfo& info, std::unique_ptr<slacImplBase> p_evse, std::unique_ptr<ev_slacImplBase> p_ev,
+                  Conf& config) :
+        ModuleBase(info), p_evse(std::move(p_evse)), p_ev(std::move(p_ev)), config(config){};
 
-    Everest::MqttProvider& mqtt;
     const std::unique_ptr<slacImplBase> p_evse;
     const std::unique_ptr<ev_slacImplBase> p_ev;
     const Conf& config;

--- a/modules/simulation/SlacSimulator/manifest.yaml
+++ b/modules/simulation/SlacSimulator/manifest.yaml
@@ -6,7 +6,6 @@ provides:
   ev:
     interface: ev_slac
     description: SLAC interface implementation for EV side
-enable_external_mqtt: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:


### PR DESCRIPTION
## Describe your changes

Remove useless and unused usages of `enable_external_mqtt` in manifests. A value of `false` is default, and `true` often not used.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

