### PR TITLE
Fix(EvseV2G): Resetting ISO15118 session states

### DIFF
--- a/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -156,7 +156,13 @@ void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::Pay
     const auto pnc_enabled = ((v2g_ctx->evse_v2g_data.payment_option_list[0] == iso2_paymentOptionType_Contract) or
                               (v2g_ctx->evse_v2g_data.payment_option_list[1] == iso2_paymentOptionType_Contract));
 
-    if (pnc_enabled and supported_certificate_service) {
+    using state_t = tls::Server::state_t;
+    const auto tls_server_state = v2g_ctx->tls_server->state();
+
+    const auto tls_server_available =
+        (tls_server_state == state_t::init_complete or tls_server_state == state_t::running);
+
+    if (pnc_enabled and supported_certificate_service and tls_server_available) {
         // For setting "Certificate" in ServiceList in ServiceDiscoveryRes
         struct iso2_ServiceType cert_service;
 
@@ -177,8 +183,6 @@ void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::Pay
 
         add_service_to_service_list(v2g_ctx, cert_service, cert_parameter_set_id,
                                     sizeof(cert_parameter_set_id) / sizeof(cert_parameter_set_id[0]));
-    } else {
-        remove_service_from_service_list_if_exists(v2g_ctx, V2G_SERVICE_ID_CERTIFICATE);
     }
 
     v2g_ctx->evse_v2g_data.central_contract_validation_allowed = central_contract_validation_allowed;

--- a/modules/EvseV2G/v2g_ctx.cpp
+++ b/modules/EvseV2G/v2g_ctx.cpp
@@ -118,6 +118,8 @@ void v2g_ctx_init_charging_state(struct v2g_context* const ctx, bool is_connecti
     ctx->selected_protocol = V2G_UNKNOWN_PROTOCOL;
     ctx->session.renegotiation_required = false;
     ctx->session.is_charging = false;
+    ctx->evse_v2g_data.evse_notification = (uint8_t)0;
+    remove_service_from_service_list_if_exists(ctx, V2G_SERVICE_ID_CERTIFICATE);
 }
 
 void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {


### PR DESCRIPTION

## Describe your changes
Resetting evse_notification and service_list in v2g_ctx_init_charging_state . This is called on every new ISO15118 connection, which is the desired behavior. The service list is only set in case we have a TLS session

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

