### PR TITLE
Rust module manifests: remove `enable_external_mqtt: false`

### DIFF
--- a/modules/RsIskraMeter/manifest.yaml
+++ b/modules/RsIskraMeter/manifest.yaml
@@ -57,4 +57,3 @@ metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:
     - embedded@qwello.eu
-enable_external_mqtt: false

--- a/modules/RsPaymentTerminal/manifest.yaml
+++ b/modules/RsPaymentTerminal/manifest.yaml
@@ -62,7 +62,6 @@ provides:
   payment_terminal:
     interface: payment_terminal
     description: Provides all the commands specific for bank cards handling
-enable_external_mqtt: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/rust_examples/RsExample/manifest.yaml
+++ b/modules/rust_examples/RsExample/manifest.yaml
@@ -31,4 +31,4 @@ metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:
     - Holger Rapp
-enable_external_mqtt: false
+

--- a/modules/rust_examples/RsExampleUser/manifest.yaml
+++ b/modules/rust_examples/RsExampleUser/manifest.yaml
@@ -12,4 +12,3 @@ metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:
     - Holger Rapp
-enable_external_mqtt: false


### PR DESCRIPTION
## Describe your changes
Rust manifests include the key/value pair `enable_external_mqtt: false`, which is used for nothing.

The [EVerest Rust docs say that external MQTT is accessed differently](https://github.com/EVerest/everest-framework/blob/v0.22.3/everestrs/everestrs/README.md?plain=1#L19-L24) anyway.

The key in the manifests is present only to fulfill [the Rust schema requirement](https://github.com/EVerest/everest-framework/blob/v0.22.3/everestrs/everestrs-build/src/schema/manifest.rs#L16-L19), yet the schema is there to tolerate the presence of the key.

This change implies changing the schema, to either make the key optional (if possible) or to drop it.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

