### PR TITLE
fix(EvseV2G): The certificate service is now offered again

### DIFF
--- a/modules/EVSE/EvseV2G/connection/connection.cpp
+++ b/modules/EVSE/EvseV2G/connection/connection.cpp
@@ -401,6 +401,8 @@ static void* connection_handle_tcp(void* data) {
 
     dlog(DLOG_LEVEL_INFO, "Started new TCP connection thread");
 
+    remove_service_from_service_list_if_exists(conn->ctx, V2G_SERVICE_ID_CERTIFICATE);
+
     /* check if the v2g-session is already running in another thread, if not, handle v2g-connection */
     if (conn->ctx->state == 0) {
         int rv2 = v2g_handle_connection(conn);

--- a/modules/EVSE/EvseV2G/v2g_ctx.cpp
+++ b/modules/EVSE/EvseV2G/v2g_ctx.cpp
@@ -119,7 +119,6 @@ void v2g_ctx_init_charging_state(struct v2g_context* const ctx, bool is_connecti
     ctx->session.renegotiation_required = false;
     ctx->session.is_charging = false;
     ctx->evse_v2g_data.evse_notification = (uint8_t)0;
-    remove_service_from_service_list_if_exists(ctx, V2G_SERVICE_ID_CERTIFICATE);
 }
 
 void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
@@ -157,7 +156,6 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     }
     ctx->meter_info.meter_info_is_used = false;
 
-    ctx->evse_v2g_data.evse_service_list.clear();
     memset(&ctx->evse_v2g_data.service_parameter_list, 0,
            sizeof(struct iso2_ServiceParameterListType) * iso2_ServiceType_8_ARRAY_SIZE);
 
@@ -197,6 +195,7 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
         ctx->evse_v2g_data.payment_option_list[0] = iso2_paymentOptionType_ExternalPayment;
         ctx->evse_v2g_data.payment_option_list_len = (uint8_t)1; // One option must be set
 
+        ctx->evse_v2g_data.evse_service_list.clear();
         ctx->evse_v2g_data.evse_service_list.reserve(iso2_ServiceType_8_ARRAY_SIZE);
     }
 
@@ -267,6 +266,8 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     memset(ctx->session.gen_challenge, 0, sizeof(ctx->session.gen_challenge));
 
     ctx->session.authorization_rejected = false;
+
+    remove_service_from_service_list_if_exists(ctx, V2G_SERVICE_ID_CERTIFICATE);
 
     initialize_once = true;
 }


### PR DESCRIPTION
## Describe your changes
The certificate service is now offered again and will not be accidentally removed.
In addition, the certificate service will be removed when the car establishes a TCP connection

## Issue ticket number and link
The Certificate Service was accidentally deleted in an init function.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

