### PR TITLE
YetiSimulator: fix params in drawPower silently being converted to int

### DIFF
--- a/modules/Simulation/YetiSimulator/YetiSimulator.cpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.cpp
@@ -641,7 +641,7 @@ void YetiSimulator::publish_keepalive() {
             .dump());
 }
 
-void YetiSimulator::drawPower(const int l1, const int l2, const int l3, const int n) const {
+void YetiSimulator::drawPower(const double l1, const double l2, const double l3, const double n) const {
     module_state->simdata_setting.currents.L1 = l1;
     module_state->simdata_setting.currents.L2 = l2;
     module_state->simdata_setting.currents.L3 = l3;

--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -91,7 +91,7 @@ private:
     void publish_powermeter();
     void publish_telemetry();
     void publish_keepalive();
-    void drawPower(int l1, int l2, int l3, int n) const;
+    void drawPower(const double l1, const double l2, const double l3, const double n) const;
     void powerOn();
     void powerOff();
     void reset_powermeter() const;


### PR DESCRIPTION
## Describe your changes
drawPower() is used with double values throughout the code and the datastructure these parameters are used in expects doubles as well

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

