### PR TITLE
GenericPowermeter: use exponent value instead of throwing it away

### DIFF
--- a/modules/HardwareDrivers/PowerMeters/GenericPowermeter/main/powermeterImpl.cpp
+++ b/modules/HardwareDrivers/PowerMeters/GenericPowermeter/main/powermeterImpl.cpp
@@ -429,7 +429,7 @@ bool powermeterImpl::process_response(
 
     int16_t exponent = 0;
     if (exponent_message) {
-        exponent_message->get().value.value()[0];
+        exponent = exponent_message->get().value.value().at(0);
     }
 
     if (register_data.type == ENERGY_WH_IMPORT_TOTAL) {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

