### PR TITLE
Bugfix: sanitize session logging path

### DIFF
--- a/lib/everest/helpers/include/everest/helpers/helpers.hpp
+++ b/lib/everest/helpers/include/everest/helpers/helpers.hpp
@@ -21,6 +21,10 @@ std::string redact(const std::string& token);
 
 types::authorization::ProvidedIdToken redact(const types::authorization::ProvidedIdToken& token);
 
+/// \brief Escapes various HTML characters
+/// \returns an escaped version of the provided html
+std::string escape_html(const std::string& html);
+
 /// \brief Compares two strings case-insensitively
 /// \returns true if the strings are equal, false otherwise
 bool is_equal_case_insensitive(const std::string& str1, const std::string& str2);

--- a/lib/everest/helpers/src/helpers.cpp
+++ b/lib/everest/helpers/src/helpers.cpp
@@ -29,6 +29,34 @@ types::authorization::ProvidedIdToken redact(const types::authorization::Provide
     return redacted_token;
 }
 
+std::string escape_html(const std::string& html) {
+    std::string escaped_html;
+    escaped_html.reserve(html.size());
+    for (const auto& character : html) {
+        switch (character) {
+        case '\"':
+            escaped_html.append("&quot;");
+            break;
+        case '\'':
+            escaped_html.append("&apos;");
+            break;
+        case '&':
+            escaped_html.append("&amp;");
+            break;
+        case '<':
+            escaped_html.append("&lt;");
+            break;
+        case '>':
+            escaped_html.append("&gt;");
+            break;
+        default:
+            escaped_html.push_back(character);
+            break;
+        }
+    }
+    return escaped_html;
+}
+
 bool is_equal_case_insensitive(const std::string& str1, const std::string& str2) {
     if (str1.length() != str2.length()) {
         return false;

--- a/modules/EVSE/EvseManager/SessionLog.cpp
+++ b/modules/EVSE/EvseManager/SessionLog.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <date/date.h>
 #include <date/tz.h>
+#include <everest/helpers/helpers.hpp>
 #include <filesystem>
 #include <optional>
 #include <utils/date.hpp>
@@ -92,7 +93,8 @@ std::optional<std::filesystem::path> SessionLog::startSession(const std::string&
             EVLOG_error << fmt::format("Cannot open {} of {} for writing", fn.string(), fnhtml.string());
             session_active = false;
         }
-        logfile_html << fmt::format("<html><head><title>EVerest log session {}</title>\n", suffix_string);
+        logfile_html << fmt::format("<html><head><title>EVerest log session {}</title>\n",
+                                    everest::helpers::escape_html(suffix_string));
         logfile_html << "<style>"
                         ".log {"
                         "  font-family: Arial, Helvetica, sans-serif;"

--- a/modules/EVSE/EvseManager/SessionLog.cpp
+++ b/modules/EVSE/EvseManager/SessionLog.cpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 #include "SessionLog.hpp"
 #include "everest/logging.hpp"
 #include "v2gMessage.hpp"
+
+#include <algorithm>
 #include <chrono>
 #include <date/date.h>
 #include <date/tz.h>
 #include <filesystem>
+#include <optional>
 #include <utils/date.hpp>
 
 #include <boost/algorithm/string.hpp>
@@ -29,7 +32,7 @@ SessionLog::~SessionLog() {
 }
 
 void SessionLog::setPath(const std::string& path) {
-    logpath_root = path;
+    logpath_root = std::filesystem::weakly_canonical(std::filesystem::path(path));
 }
 
 void SessionLog::setMqtt(const std::function<void(nlohmann::json data)>& mqtt_provider) {
@@ -40,35 +43,53 @@ void SessionLog::enable() {
     enabled = true;
 }
 
-std::optional<std::string> SessionLog::startSession(const std::string& suffix_string) {
+std::optional<std::filesystem::path> SessionLog::startSession(const std::string& suffix_string) {
     if (enabled) {
         if (session_active) {
             stopSession();
         }
 
         // create general log directory if it does not exist
-        if (!std::filesystem::exists(logpath_root))
-            std::filesystem::create_directories(logpath_root);
+        if (!std::filesystem::exists(logpath_root)) {
+            try {
+                std::filesystem::create_directories(logpath_root);
+            } catch (std::filesystem::filesystem_error& e) {
+                EVLOG_error << fmt::format("Cannot create logpath {}: {}", logpath_root.string(), e.what());
+                return std::nullopt;
+            }
+        }
 
         std::string ts = Everest::Date::to_rfc3339(date::utc_clock::now());
-        logpath = fmt::format("{}/{}-{}", logpath_root, ts, suffix_string);
+        auto ts_suffix_string = fmt::format("{}-{}", ts, suffix_string);
+        auto logpath_with_suffix = std::filesystem::weakly_canonical(logpath_root / ts_suffix_string);
+
+        const auto [root_it, suffix_ix] = std::mismatch(logpath_root.begin(), logpath_root.end(),
+                                                        logpath_with_suffix.begin(), logpath_with_suffix.end());
+        if (root_it != logpath_root.end()) {
+            EVLOG_error << fmt::format("Logpath with suffix ({}) is not a subdirectory of logpath root {}",
+                                       logpath_with_suffix.string(), logpath_root.string());
+            return std::nullopt;
+        }
+
+        logpath = logpath_with_suffix;
 
         // create sessionlog directory if it does not exist
-        if (!std::filesystem::exists(logpath))
+        if (!std::filesystem::exists(logpath)) {
             std::filesystem::create_directories(logpath);
+        }
 
         // open new file
-        fn = fmt::format("{}/incomplete-eventlog.csv", logpath);
-        fnhtml = fmt::format("{}/incomplete-eventlog.html", logpath);
-        fn_complete = fmt::format("{}/eventlog.csv", logpath);
-        fnhtml_complete = fmt::format("{}/eventlog.html", logpath);
+        fn = logpath / "incomplete-eventlog.csv";
+        fnhtml = logpath / "incomplete-eventlog.html";
+        fn_complete = logpath / "eventlog.csv";
+        fnhtml_complete = logpath / "eventlog.html";
 
         try {
             logfile_csv.open(fn);
             logfile_html.open(fnhtml);
             session_active = true;
         } catch (const std::ofstream::failure& e) {
-            EVLOG_error << fmt::format("Cannot open {} of {} for writing", fn, fnhtml);
+            EVLOG_error << fmt::format("Cannot open {} of {} for writing", fn.string(), fnhtml.string());
             session_active = false;
         }
         logfile_html << fmt::format("<html><head><title>EVerest log session {}</title>\n", suffix_string);
@@ -100,7 +121,7 @@ std::optional<std::string> SessionLog::startSession(const std::string& suffix_st
         return logpath;
     }
 
-    return std::string();
+    return std::nullopt;
 }
 
 void SessionLog::stopSession() {

--- a/modules/EVSE/EvseManager/SessionLog.hpp
+++ b/modules/EVSE/EvseManager/SessionLog.hpp
@@ -3,6 +3,7 @@
 #ifndef SESSION_LOG_HPP
 #define SESSION_LOG_HPP
 
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <nlohmann/json_fwd.hpp>
@@ -22,7 +23,7 @@ public:
     void setPath(const std::string& path);
     void setMqtt(const std::function<void(nlohmann::json data)>& mqtt_provider);
     void enable();
-    std::optional<std::string> startSession(const std::string& suffix_string);
+    std::optional<std::filesystem::path> startSession(const std::string& suffix_string);
     void stopSession();
 
     void car(bool iso15118, const std::string& msg);
@@ -44,9 +45,9 @@ private:
     bool xmloutput;
     bool session_active;
     bool enabled;
-    std::string logpath_root;
-    std::string logpath;
-    std::string fn, fnhtml, fn_complete, fnhtml_complete;
+    std::filesystem::path logpath_root;
+    std::filesystem::path logpath;
+    std::filesystem::path fn, fnhtml, fn_complete, fnhtml_complete;
 
     std::ofstream logfile_csv;
     std::ofstream logfile_html;

--- a/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
@@ -142,9 +142,12 @@ void evse_managerImpl::ready() {
                 }
             }
 
-            session_started.logging_path = session_log.startSession(
+            const auto logging_path = session_log.startSession(
                 mod->config.logfile_suffix == "session_uuid" ? session_uuid : mod->config.logfile_suffix);
 
+            if (logging_path.has_value()) {
+                session_started.logging_path = logging_path.value().string();
+            }
             session_log.evse(false, fmt::format("Session Started: {}",
                                                 types::evse_manager::start_session_reason_to_string(start_reason)));
 

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -793,7 +793,7 @@ void SessionLog::setMqtt(const std::function<void(nlohmann::json data)>& mqtt_pr
 }
 void SessionLog::enable() {
 }
-std::optional<std::string> SessionLog::startSession(const std::string& suffix_string) {
+std::optional<std::filesystem::path> SessionLog::startSession(const std::string& suffix_string) {
     return {};
 }
 void SessionLog::stopSession() {


### PR DESCRIPTION
## Describe your changes
Sanitize EvseManager logfile_suffix

This ensures that logfile_suffix stays in a subdirectory of session_logging_path to prevent possible path traversal issues

Escape reserved HTML characters in suffix_string used in HTML session log

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

