### PR TITLE
Bump libevse-security dependency to 0.9.8

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -73,7 +73,7 @@ libcurl:
 # of libocpp and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: v0.9.7
+  git_tag: v0.9.8
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP


### PR DESCRIPTION
## Describe your changes

Update libevse-security dependency to 0.9.8.

## Issue ticket number and link

https://github.com/EVerest/libevse-security/pull/119

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

