### PR TITLE
Bump everest-utils to 0.6.2 for removed staging namespace

### DIFF
--- a/cmake/ev-project-bootstrap.cmake
+++ b/cmake/ev-project-bootstrap.cmake
@@ -1,6 +1,6 @@
 set_property(
     GLOBAL
-    PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION "0.6.0"
+    PROPERTY EVEREST_REQUIRED_EV_CLI_VERSION "0.6.2"
 )
 
 # FIXME (aw): clean up this inclusion chain


### PR DESCRIPTION
In https://github.com/EVerest/everest-core/pull/1319, the staging namespace was removed from the EVerest helper libraries. The template in everest-utils adapted to this in v0.6.2, thus that version is required for proper generated code.

## Describe your changes

Bump the version requirement for the installed ev-cli.

Using `edm init` may give you the impression of updating your workspace but will leave your old ev-cli installed, as ev-cli is not automatically re-installed on update of everest-utils.

Note to self:
`(cd $EVEREST_WORKSPACE/everest-utils/ev-dev-tools/ && python3 -m pip install .)`

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

