### PR TITLE
Fix lib/everest/gpio header install

### DIFF
--- a/lib/everest/gpio/CMakeLists.txt
+++ b/lib/everest/gpio/CMakeLists.txt
@@ -24,7 +24,7 @@ install(TARGETS gpio
     INCLUDES DESTINATION include
 )
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DESTINATION include/everest
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/everest
+    DESTINATION include
     FILES_MATCHING PATTERN "*.hpp"
 )


### PR DESCRIPTION
## Describe your changes
During the recent move of headers from lib/staging #1319 this wasn't adapted and could lead to build errors in out-of-tree repositories in combination with yocto

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

