### PR TITLE
refactor: Remove set_faulted command from evse_manager interface

### DIFF
--- a/interfaces/evse_manager.yaml
+++ b/interfaces/evse_manager.yaml
@@ -58,10 +58,6 @@ cmds:
       type: boolean
   cancel_reservation:
     description: Call to signal that EVSE is not reserved anymore
-  set_faulted:
-    description: >-
-      Sets the evse manager to faulted externally. It may also switch to
-      faulted itself if it detects an internal error.
   pause_charging:
     description: Call to signal EVSE to pause charging
     result:

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1670,11 +1670,6 @@ void Charger::enable_disable_source_table_update(const types::evse_manager::Enab
     }
 }
 
-void Charger::set_faulted() {
-    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_set_faulted);
-    shared_context.error_prevent_charging_flag = true;
-}
-
 std::string Charger::evse_state_to_string(EvseState s) {
     switch (s) {
     case EvseState::Disabled:

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -112,7 +112,6 @@ public:
     void enable_disable_initial_state_publish();
     bool enable_disable(int connector_id, const types::evse_manager::EnableDisableSource& source);
 
-    void set_faulted();
     void set_hlc_error();
 
     // Public interface during charging

--- a/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
@@ -55,9 +55,6 @@ void evse_managerImpl::init() {
                                                         types::evse_manager::Enable_state::Disable, 100});
                         });
 
-    mod->mqtt.subscribe(fmt::format("everest_external/nodered/{}/cmd/faulted", mod->config.connector_id),
-                        [&charger = mod->charger](const std::string& data) { charger->set_faulted(); });
-
     mod->mqtt.subscribe(
         fmt::format("everest_external/nodered/{}/cmd/switch_three_phases_while_charging", mod->config.connector_id),
         [&charger = mod->charger](const std::string& data) {
@@ -400,10 +397,6 @@ bool evse_managerImpl::handle_reserve(int& reservation_id) {
 
 void evse_managerImpl::handle_cancel_reservation() {
     mod->cancel_reservation(true);
-};
-
-void evse_managerImpl::handle_set_faulted() {
-    mod->charger->set_faulted();
 };
 
 bool evse_managerImpl::handle_pause_charging() {

--- a/modules/EVSE/EvseManager/evse/evse_managerImpl.hpp
+++ b/modules/EVSE/EvseManager/evse/evse_managerImpl.hpp
@@ -42,7 +42,6 @@ protected:
     virtual void handle_withdraw_authorization() override;
     virtual bool handle_reserve(int& reservation_id) override;
     virtual void handle_cancel_reservation() override;
-    virtual void handle_set_faulted() override;
     virtual bool handle_pause_charging() override;
     virtual bool handle_resume_charging() override;
     virtual bool handle_stop_transaction(types::evse_manager::StopTransactionRequest& request) override;

--- a/modules/EVSE/EvseManager/tests/EvseManagerStub.hpp
+++ b/modules/EVSE/EvseManager/tests/EvseManagerStub.hpp
@@ -41,8 +41,6 @@ struct evse_managerImplStub : public evse_managerImplBase {
     }
     virtual void handle_cancel_reservation() {
     }
-    virtual void handle_set_faulted() {
-    }
     virtual bool handle_pause_charging() {
         return true;
     }

--- a/tests/ocpp_tests/conftest.py
+++ b/tests/ocpp_tests/conftest.py
@@ -170,13 +170,6 @@ def probe_module(
         module,
         skip_implementation,
         "ProbeModuleConnectorA",
-        "set_faulted",
-        lambda arg: None,
-    )
-    implement_command(
-        module,
-        skip_implementation,
-        "ProbeModuleConnectorA",
         "pause_charging",
         lambda arg: True,
     )
@@ -269,13 +262,6 @@ def probe_module(
         skip_implementation,
         "ProbeModuleConnectorB",
         "cancel_reservation",
-        lambda arg: None,
-    )
-    implement_command(
-        module,
-        skip_implementation,
-        "ProbeModuleConnectorB",
-        "set_faulted",
         lambda arg: None,
     )
     implement_command(

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
@@ -91,8 +91,6 @@ async def _env(
         _add_pm_command_mock(
             evse_manager, "cancel_reservation", None, skip_implementation
         )
-        _add_pm_command_mock(evse_manager, "set_faulted",
-                             None, skip_implementation)
         _add_pm_command_mock(evse_manager, "pause_charging",
                              True, skip_implementation)
         _add_pm_command_mock(evse_manager, "resume_charging",


### PR DESCRIPTION
## Describe your changes
This PR removes the `set_faulted` command from evse_manager interface. It was not used by any other module in everest-core and it is interfering with the more generic error handling that was added some time ago

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

