### PR TITLE
FIX: Changing DC capabilities for 'current' not applied

### DIFF
--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -112,6 +112,7 @@ void energyImpl::clear_request_schedules() {
 
 void energyImpl::ready() {
     hw_caps = mod->get_hw_capabilities();
+    last_powersupply_capabilities = mod->get_powersupply_capabilities();
     clear_request_schedules();
 
     // request energy now
@@ -317,6 +318,36 @@ static bool almost_eq(float a, float b) {
     return a > b - 0.1 and a < b + 0.1;
 }
 
+static bool almost_eq(std::optional<float> const& a, std::optional<float> const& b) {
+    if (a.has_value() and b.has_value()) {
+        return almost_eq(a.value(), b.value());
+    }
+    if (not a.has_value() and not b.has_value()) {
+        return true;
+    }
+    return false;
+}
+
+static bool almost_eq(types::power_supply_DC::Capabilities const& lhs,
+                      types::power_supply_DC::Capabilities const& rhs) {
+    bool result = lhs.bidirectional == rhs.bidirectional and
+                  almost_eq(lhs.current_regulation_tolerance_A, rhs.current_regulation_tolerance_A) and
+                  almost_eq(lhs.peak_current_ripple_A, rhs.peak_current_ripple_A) and
+                  almost_eq(lhs.max_export_voltage_V, rhs.max_export_voltage_V) and
+                  almost_eq(lhs.min_export_voltage_V, rhs.min_export_voltage_V) and
+                  almost_eq(lhs.max_export_current_A, rhs.max_export_current_A) and
+                  almost_eq(lhs.min_export_current_A, rhs.min_export_current_A) and
+                  almost_eq(lhs.max_export_power_W, rhs.max_export_power_W) and
+                  almost_eq(lhs.max_import_voltage_V, rhs.max_import_voltage_V) and
+                  almost_eq(lhs.min_import_voltage_V, rhs.min_import_voltage_V) and
+                  almost_eq(lhs.max_import_current_A, rhs.max_import_current_A) and
+                  almost_eq(lhs.min_import_current_A, rhs.min_import_current_A) and
+                  almost_eq(lhs.max_import_power_W, rhs.max_import_power_W) and
+                  almost_eq(lhs.conversion_efficiency_import, rhs.conversion_efficiency_import) and
+                  almost_eq(lhs.conversion_efficiency_export, rhs.conversion_efficiency_export);
+    return result;
+}
+
 // This is the decision logic when limits are changing.
 bool energyImpl::random_delay_needed(float last_limit, float limit) {
 
@@ -484,12 +515,14 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
                 float actual_voltage = ev_info.present_voltage.value_or(0.);
 
                 bool values_changed = true;
+                auto powersupply_capabilities = mod->get_powersupply_capabilities();
 
                 // did the values change since the last call?
                 if (almost_eq(last_enforced_limits_watt, watt_leave_side) and
                     almost_eq(last_enforced_limits_ampere, ampere_root_side) and
                     almost_eq(target_voltage, last_target_voltage) and
-                    not voltage_changed(actual_voltage, last_actual_voltage)) {
+                    not voltage_changed(actual_voltage, last_actual_voltage) and
+                    almost_eq(powersupply_capabilities, last_powersupply_capabilities)) {
                     values_changed = false;
                 }
 
@@ -498,8 +531,7 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
                     last_enforced_limits_watt = watt_leave_side;
                     last_target_voltage = target_voltage;
                     last_actual_voltage = actual_voltage;
-
-                    auto powersupply_capabilities = mod->get_powersupply_capabilities();
+                    last_powersupply_capabilities = powersupply_capabilities;
 
                     // tell car our new limits
                     types::iso15118::DcEvseMaximumLimits evse_max_limits;

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.hpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.hpp
@@ -56,6 +56,7 @@ private:
     float last_enforced_limits_watt{-9999};
     float last_target_voltage{-9999};
     float last_actual_voltage{-9999};
+    types::power_supply_DC::Capabilities last_powersupply_capabilities;
     void clear_import_request_schedule();
     void clear_export_request_schedule();
     void clear_request_schedules();


### PR DESCRIPTION
## Describe your changes
Updated capabilities for a DC power supply were not always taken into account. Especially changing only current capabilities during a charging session, did not transition to into the capabilities reported to the car.


## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ - ] I have made corresponding changes to the documentation
- [ x ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

