### PR TITLE
Add RemoteCharging EVSE/EV modules 

### DIFF
--- a/modules/Misc/CMakeLists.txt
+++ b/modules/Misc/CMakeLists.txt
@@ -7,3 +7,5 @@ ev_add_module(Setup)
 ev_add_module(Store)
 ev_add_module(System)
 ev_add_module(YamlStore)
+
+add_subdirectory(RemoteCharging)

--- a/modules/Misc/RemoteCharging/CMakeLists.txt
+++ b/modules/Misc/RemoteCharging/CMakeLists.txt
@@ -1,0 +1,2 @@
+ev_add_module(RemoteChargingEV)
+ev_add_module(RemoteChargingEVSE)

--- a/modules/Misc/RemoteCharging/RemoteChargingEV/CMakeLists.txt
+++ b/modules/Misc/RemoteCharging/RemoteChargingEV/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+# template version 3
+#
+
+# module setup:
+#   - ${MODULE_NAME}: module name
+ev_setup_cpp_module()
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+# insert your custom targets and additional config variables here
+target_link_libraries(${MODULE_NAME}
+    PUBLIC
+        slac
+)
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+
+target_sources(${MODULE_NAME}
+    PRIVATE
+        "main/emptyImpl.cpp"
+)
+
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/Misc/RemoteCharging/RemoteChargingEV/RemoteChargingEV.cpp
+++ b/modules/Misc/RemoteCharging/RemoteChargingEV/RemoteChargingEV.cpp
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#include "RemoteChargingEV.hpp"
+
+#include "../common/slac_helper.hpp"
+#include "../common/tap_device.hpp"
+
+namespace module {
+
+static std::optional<types::ev_board_support::EvCpState> to_cp_state(const std::string cp) {
+    using CP = types::ev_board_support::EvCpState;
+    if (cp == "A") {
+        return CP::A;
+    } else if (cp == "B") {
+        return CP::B;
+    } else if (cp == "C") {
+        return CP::C;
+    } else if (cp == "D") {
+        return CP::D;
+    } else if (cp == "E") {
+        return CP::E;
+    } else {
+        EVLOG_error << "Cannot convert " << cp;
+        return {};
+    }
+}
+
+void RemoteChargingEV::init() {
+    invoke_init(*p_main);
+
+    // Bridge CP State
+    mqtt.subscribe(cp_state_topic(false), [this](const std::string& _cp) {
+        auto cp = to_cp_state(_cp);
+        if (cp.has_value()) {
+            EVLOG_info << "Remote: set CP " << cp.value();
+            r_bsp->call_set_cp_state(cp.value());
+        }
+    });
+
+    // Bridge CP PWM dutycycle
+    r_bsp->subscribe_bsp_measurement([this](types::board_support_common::BspMeasurement m) {
+        {
+            std::scoped_lock lock(mutex);
+            last_duty_cycle = std::to_string(m.cp_pwm_duty_cycle);
+            mqtt.publish(cp_pwm_duty_cycle_topic(true), last_duty_cycle);
+        }
+    });
+
+    // Bridge DC voltage
+    r_bsp_extended->subscribe_dc_voltage_event([this](double voltage) {
+        {
+            std::scoped_lock lock(mutex);
+            last_voltage = voltage;
+        }
+        mqtt.publish(dc_voltage_topic(true), std::to_string(voltage));
+    });
+
+    // ping pong
+    mqtt.subscribe(ping_topic(false),
+                   [this](const std::string& ping_time) { mqtt.publish(pong_topic(true), ping_time); });
+
+    // FIXME the EV side also needs to measure actual CP state as the real charger may set state F.
+    // In this case the direction is inverted, i.e. charger sets the state and EV has to follow here
+    // r_bsp->subscribe_bsp_event();
+
+    tap_fd = tap::open_devices(config.tap_device);
+
+    if (tap_fd <= 0) {
+        EVLOG_error << "Could not open TAP device: " << config.tap_device;
+    } else {
+        mqtt.subscribe(eth_ev_to_evse_topic(false), [this](const std::string& packet) {
+            auto _packet = packet.substr(0, packet.size() - 1500);
+            tap::send_eth_packet(tap_fd, _packet);
+        });
+
+        // set up bridge
+        system(fmt::format("ip link add name {} type bridge", config.bridge_device).c_str());
+        system(fmt::format("ip link set dev {} up", config.bridge_device).c_str());
+        system(fmt::format("ip link set dev {} master {}", config.plc_device, config.bridge_device).c_str());
+        system(fmt::format("ip link set dev {} master {}", config.tap_device, config.bridge_device).c_str());
+    }
+}
+
+void RemoteChargingEV::ready() {
+    invoke_ready(*p_main);
+
+    // Always allow to switch on the input relay (if any)
+    r_bsp->call_allow_power_on(true);
+
+    std::thread interval([this]() {
+        while (true) {
+            {
+                std::scoped_lock lock(mutex);
+                if (not last_duty_cycle.empty()) {
+                    mqtt.publish(cp_pwm_duty_cycle_topic(true), last_duty_cycle);
+                }
+                mqtt.publish(dc_voltage_topic(true), last_voltage);
+                for (int i = 0; i < 10; i++) {
+                    mqtt.publish("everest_api/" + this->info.id + "/var/datetime",
+                                 Everest::Date::to_rfc3339(date::utc_clock::now()));
+                }
+            }
+            r_bsp_extended->call_get_dc_data_instant();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+    });
+    interval.detach();
+
+    // Run loop to receive all ethernet packets
+    tap::run_receive_loop(tap_fd, [this](const std::string& packet) {
+        // Is it a Homeplug AV packet?
+        if (slac_helper::is_homeplug_protocol(packet)) {
+            auto msg = slac_helper::to_homeplug_msg(packet);
+
+            // capture set NMK key packages and set local key
+            if (slac_helper::is_cm_slac_match_cnf(msg)) {
+                EVLOG_info << "Received CM_SLAC_MATCH.CNF with NMK";
+                tap::send_eth_packet(tap_fd, slac_helper::set_nmk_key_from_match_cnf(msg));
+                // send NMK to EVSE peer
+                mqtt.publish(nmk_topic(true), packet);
+            }
+        }
+        auto _packet = packet;
+        _packet.append(1500, 'X');
+        mqtt.publish(eth_evse_to_ev_topic(true), _packet);
+    });
+}
+
+} // namespace module

--- a/modules/Misc/RemoteCharging/RemoteChargingEV/RemoteChargingEV.hpp
+++ b/modules/Misc/RemoteCharging/RemoteChargingEV/RemoteChargingEV.hpp
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#ifndef REMOTE_CHARGING_EV_HPP
+#define REMOTE_CHARGING_EV_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 2
+//
+
+#include "ld-ev.hpp"
+
+// headers for provided interface implementations
+#include <generated/interfaces/empty/Implementation.hpp>
+
+// headers for required interface implementations
+#include <generated/interfaces/ev_board_support/Interface.hpp>
+#include <generated/interfaces/ev_board_support_extended/Interface.hpp>
+
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+// insert your custom include headers here
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
+
+struct Conf {
+    std::string tap_device;
+    std::string plc_device;
+    std::string bridge_device;
+    std::string base_topic_sub;
+    std::string base_topic_pub;
+};
+
+class RemoteChargingEV : public Everest::ModuleBase {
+public:
+    RemoteChargingEV() = delete;
+    RemoteChargingEV(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider,
+                     std::unique_ptr<emptyImplBase> p_main, std::unique_ptr<ev_board_supportIntf> r_bsp,
+                     std::unique_ptr<ev_board_support_extendedIntf> r_bsp_extended, Conf& config) :
+        ModuleBase(info),
+        mqtt(mqtt_provider),
+        p_main(std::move(p_main)),
+        r_bsp(std::move(r_bsp)),
+        r_bsp_extended(std::move(r_bsp_extended)),
+        config(config){};
+
+    Everest::MqttProvider& mqtt;
+    const std::unique_ptr<emptyImplBase> p_main;
+    const std::unique_ptr<ev_board_supportIntf> r_bsp;
+    const std::unique_ptr<ev_board_support_extendedIntf> r_bsp_extended;
+    const Conf& config;
+
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+    // insert your public definitions here
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+
+protected:
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+    // insert your protected definitions here
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+
+private:
+    friend class LdEverest;
+    void init();
+    void ready();
+
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+    // insert your private definitions here
+    int tap_fd{0};
+    std::mutex mutex;
+    std::string last_duty_cycle;
+    double last_voltage{0.};
+
+    std::string cp_state_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/cp_state";
+    };
+    std::string cp_pwm_duty_cycle_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/cp_pwm_dc";
+    };
+    std::string eth_ev_to_evse_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/eth_ev_to_evse";
+    };
+    std::string eth_evse_to_ev_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/eth_evse_to_ev_topic";
+    };
+    std::string nmk_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/nmk";
+    };
+    std::string dc_voltage_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/dc_voltage";
+    };
+    std::string ping_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/ping";
+    };
+    std::string pong_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/pong";
+    };
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+};
+
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+// insert other definitions here
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+
+} // namespace module
+
+#endif // REMOTE_CHARGING_EV_HPP

--- a/modules/Misc/RemoteCharging/RemoteChargingEV/doc.rst
+++ b/modules/Misc/RemoteCharging/RemoteChargingEV/doc.rst
@@ -1,0 +1,22 @@
+.. _everest_modules_handwritten_RemoteChargingEV:
+
+..  This file is a placeholder for an optional single file
+    handwritten documentation for the RemoteChargingEV module.
+    Please decide whether you want to use this single file,
+    or a set of files in the doc/ directory.
+    In the latter case, you can delete this file.
+    In the former case, you can delete the doc/ directory.
+    
+..  This handwritten documentation is optional. In case
+    you do not want to write it, you can delete this file
+    and the doc/ directory.
+
+..  The documentation can be written in reStructuredText,
+    and will be converted to HTML and PDF by Sphinx.
+
+*******************************************
+RemoteChargingEV
+*******************************************
+
+:ref:`Link <everest_modules_RemoteChargingEV>` to the module's reference.
+Remote charging bridge for EV side (umwcar) - plugged in into a real charging station

--- a/modules/Misc/RemoteCharging/RemoteChargingEV/docs/index.rst
+++ b/modules/Misc/RemoteCharging/RemoteChargingEV/docs/index.rst
@@ -1,0 +1,23 @@
+.. _everest_modules_handwritten_RemoteChargingEV:
+
+..  This file is a placeholder for optional multiple files
+    handwritten documentation for the RemoteChargingEV module.
+    Please decide whether you want to use the doc.rst file
+    or a set of files in the doc/ directory.
+    In the latter case, you can delete the doc.rst file.
+    In the former case, you can delete the doc/ directory.
+    
+..  This handwritten documentation is optional. In case
+    you do not want to write it, you can delete this file
+    and the doc/ directory.
+
+..  The documentation can be written in reStructuredText,
+    and will be converted to HTML and PDF by Sphinx.
+    This index.rst file is the entry point for the module documentation.
+
+*******************************************
+RemoteChargingEV
+*******************************************
+
+:ref:`Link <everest_modules_RemoteChargingEV>` to the module's reference.
+Remote charging bridge for EV side (umwcar) - plugged in into a real charging station

--- a/modules/Misc/RemoteCharging/RemoteChargingEV/main/emptyImpl.cpp
+++ b/modules/Misc/RemoteCharging/RemoteChargingEV/main/emptyImpl.cpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include "emptyImpl.hpp"
+
+namespace module {
+namespace main {
+
+void emptyImpl::init() {
+}
+
+void emptyImpl::ready() {
+}
+
+} // namespace main
+} // namespace module

--- a/modules/Misc/RemoteCharging/RemoteChargingEV/main/emptyImpl.hpp
+++ b/modules/Misc/RemoteCharging/RemoteChargingEV/main/emptyImpl.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#ifndef MAIN_EMPTY_IMPL_HPP
+#define MAIN_EMPTY_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/empty/Implementation.hpp>
+
+#include "../RemoteChargingEV.hpp"
+
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+// insert your custom include headers here
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+
+namespace module {
+namespace main {
+
+struct Conf {};
+
+class emptyImpl : public emptyImplBase {
+public:
+    emptyImpl() = delete;
+    emptyImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<RemoteChargingEV>& mod, Conf& config) :
+        emptyImplBase(ev, "main"), mod(mod), config(config){};
+
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+    // insert your public definitions here
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+
+protected:
+    // no commands defined for this interface
+
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+    // insert your protected definitions here
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+
+private:
+    const Everest::PtrContainer<RemoteChargingEV>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+    // insert your private definitions here
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+};
+
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+// insert other definitions here
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+
+} // namespace main
+} // namespace module
+
+#endif // MAIN_EMPTY_IMPL_HPP

--- a/modules/Misc/RemoteCharging/RemoteChargingEV/manifest.yaml
+++ b/modules/Misc/RemoteCharging/RemoteChargingEV/manifest.yaml
@@ -1,0 +1,36 @@
+description: Remote charging bridge for EV side (umwcar) - plugged in into a real charging station 
+config:
+  tap_device:
+    description: Name of tap device
+    type: string
+    default: tap0
+  plc_device:
+    description: Name of PLC device
+    type: string
+    default: eth1
+  bridge_device:
+    description: Name of the bridge device
+    type: string
+    default: br0
+  base_topic_sub:
+    description: Base MQTT topic for subscriptions
+    type: string
+    default: everest/cloud/wormhole/sub
+  base_topic_pub:
+    description: Base MQTT topic for publishes
+    type: string
+    default: everest/cloud/wormhole/pub
+provides:
+  main:
+    interface: empty
+    description: Does not provide anything
+requires:
+  bsp:
+    interface: ev_board_support
+  bsp_extended:
+    interface: ev_board_support_extended
+enable_external_mqtt: true
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Cornelius Claussen, PIONIX GmbH

--- a/modules/Misc/RemoteCharging/RemoteChargingEVSE/CMakeLists.txt
+++ b/modules/Misc/RemoteCharging/RemoteChargingEVSE/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+# template version 3
+#
+
+# module setup:
+#   - ${MODULE_NAME}: module name
+ev_setup_cpp_module()
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+# insert your custom targets and additional config variables here
+target_link_libraries(${MODULE_NAME}
+    PUBLIC
+        slac
+)
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+
+target_sources(${MODULE_NAME}
+    PRIVATE
+        "main/emptyImpl.cpp"
+)
+
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/Misc/RemoteCharging/RemoteChargingEVSE/RemoteChargingEVSE.cpp
+++ b/modules/Misc/RemoteCharging/RemoteChargingEVSE/RemoteChargingEVSE.cpp
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#include "RemoteChargingEVSE.hpp"
+
+#include "../common/slac_helper.hpp"
+#include "../common/tap_device.hpp"
+
+namespace module {
+
+static std::optional<std::string> to_cp_state_str(const types::board_support_common::BspEvent event) {
+    using CP = types::board_support_common::Event;
+    switch (event.event) {
+    case CP::A:
+        return "A";
+    case CP::B:
+        return "B";
+    case CP::C:
+        return "C";
+    case CP::D:
+        return "D";
+    case CP::E:
+        return "E";
+    case CP::F:
+        return "F";
+    }
+    return {};
+}
+
+void RemoteChargingEVSE::init() {
+    invoke_init(*p_main);
+
+    // Bridge CP State
+    r_bsp->subscribe_event([this](const types::board_support_common::BspEvent event) {
+        const auto cp = to_cp_state_str(event);
+        if (cp.has_value()) {
+            {
+                std::scoped_lock lock(mutex);
+                last_cp_state = cp.value();
+            }
+            mqtt.publish(cp_state_topic(true), cp.value());
+            if (event.event == types::board_support_common::Event::C) {
+                // switch on relays whenever state C was detected
+                r_bsp->call_allow_power_on({true, types::evse_board_support::Reason::FullPowerCharging});
+                r_power_supply->call_setMode(types::power_supply_DC::Mode::Export,
+                                             types::power_supply_DC::ChargingPhase::Other);
+            } else {
+                r_bsp->call_allow_power_on({false, types::evse_board_support::Reason::PowerOff});
+                {
+                    std::scoped_lock lock(mutex);
+                    last_voltage = 0.;
+                }
+                r_power_supply->call_setMode(types::power_supply_DC::Mode::Off,
+                                             types::power_supply_DC::ChargingPhase::Other);
+                r_power_supply->call_setExportVoltageCurrent(0., 1.);
+            }
+        }
+    });
+
+    // Bridge CP PWM dutycycle
+    mqtt.subscribe(cp_pwm_duty_cycle_topic(false), [this](const std::string& _pwm) {
+        try {
+            float pwm = std::stof(_pwm);
+            if (pwm < 1.) {
+                // r_bsp->call_pwm_F();
+            } else if (pwm < 99.) {
+                r_bsp->call_pwm_on(pwm);
+            } else {
+                r_bsp->call_pwm_off();
+            }
+        } catch (...) {
+            // Just ignore if we cannot parse/forward the value
+            EVLOG_info << "Cannot parse PWM value: " << _pwm;
+        }
+    });
+
+    // Bridge DC voltage
+    mqtt.subscribe(dc_voltage_topic(false), [this](const std::string& _voltage) {
+        try {
+            double v = std::stod(_voltage);
+            {
+                std::scoped_lock lock(mutex);
+                last_voltage = v;
+            }
+            r_power_supply->call_setExportVoltageCurrent(v, 1);
+        } catch (...) {
+            // Just ignore if we cannot parse/forward the value
+            EVLOG_info << "Cannot parse Voltage value: " << _voltage;
+        }
+    });
+
+    // Bridge NMK (we do not get the SLAC_MATCH.CNF on this side without promiscuous mode)
+    mqtt.subscribe(nmk_topic(false), [this](const std::string& match_cnf_msg) {
+        auto msg = slac_helper::to_homeplug_msg(match_cnf_msg);
+        auto set_key_req = slac_helper::set_nmk_key_from_match_cnf(msg);
+        EVLOG_info << "Setting NMK key";
+        hlc_log("HLC", "", "Setting NMK key");
+        tap::send_eth_packet(tap_fd, set_key_req);
+    });
+
+    // ping pong
+    mqtt.subscribe(pong_topic(false), [this](const std::string& _ping_time) {
+        std::string ping_time = _ping_time.substr(0, _ping_time.size() - 1500);
+        EVLOG_info << ping_time;
+        auto start_time = Everest::Date::from_rfc3339(ping_time);
+        auto latency =
+            std::chrono::duration_cast<std::chrono::milliseconds>(date::utc_clock::now() - start_time).count();
+        EVLOG_info << "Round-trip time: " << latency;
+        hlc_log("SYS", "", fmt::format("Round-trip time: {}", latency));
+    });
+
+    tap_fd = tap::open_devices(config.tap_device);
+
+    if (tap_fd <= 0) {
+        EVLOG_error << "Could not open TAP device: " << config.tap_device;
+    } else {
+        mqtt.subscribe(eth_evse_to_ev_topic(false), [this](const std::string& packet) {
+            auto _packet = packet.substr(0, packet.size() - 1500);
+            tap::send_eth_packet(tap_fd, _packet);
+        });
+
+        // set up bridge
+        system(fmt::format("ip link add name {} type bridge", config.bridge_device).c_str());
+        system(fmt::format("ip link set dev {} up", config.bridge_device).c_str());
+        system(fmt::format("ip link set dev {} master {}", config.plc_device, config.bridge_device).c_str());
+        system(fmt::format("ip link set dev {} master {}", config.tap_device, config.bridge_device).c_str());
+    }
+}
+
+void RemoteChargingEVSE::ready() {
+    invoke_ready(*p_main);
+
+    std::thread interval([this]() {
+        int i = 0;
+        while (true) {
+            {
+                std::scoped_lock lock(mutex);
+                mqtt.publish(cp_state_topic(true), last_cp_state);
+            }
+            // for (int i = 0; i < 2; i++) {
+            const int ideal_size = 1500;
+            std::string s = Everest::Date::to_rfc3339(date::utc_clock::now());
+            s.append(1500, 'X');
+            mqtt.publish(ping_topic(true), s);
+            //}
+            mqtt.publish("everest_api/" + this->info.id + "/var/datetime",
+                         Everest::Date::to_rfc3339(date::utc_clock::now()));
+            session_info();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        }
+    });
+    interval.detach();
+
+    // Run loop to receive all ethernet packets
+    tap::run_receive_loop(tap_fd, [this](const std::string& packet) {
+        // Is it a Homeplug AV packet?
+        if (slac_helper::is_homeplug_protocol(packet)) {
+            auto msg = slac_helper::to_homeplug_msg(packet);
+
+            // The CM_ATTEN_PROFILE.IND is created by the PLC chip itself.
+            // Since we now have 4 PLC chips instead of 2, they would be duplicated.
+            // The real charger gets them from the PLC chip in the RemoteChargingEV,
+            // so we do not need to forward them via MQTT.
+            if (slac_helper::is_cm_atten_profile_ind(msg)) {
+                EVLOG_info << "Ignoring CM_ATTEN_PROFILE.IND";
+                return;
+            }
+        }
+
+        // Forward via MQTT
+        auto _packet = packet;
+        _packet.append(1500, 'X');
+        mqtt.publish(eth_ev_to_evse_topic(true), _packet);
+    });
+}
+
+} // namespace module

--- a/modules/Misc/RemoteCharging/RemoteChargingEVSE/RemoteChargingEVSE.hpp
+++ b/modules/Misc/RemoteCharging/RemoteChargingEVSE/RemoteChargingEVSE.hpp
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#ifndef REMOTE_CHARGING_EVSE_HPP
+#define REMOTE_CHARGING_EVSE_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 2
+//
+
+#include "ld-ev.hpp"
+
+// headers for provided interface implementations
+#include <generated/interfaces/empty/Implementation.hpp>
+
+// headers for required interface implementations
+#include <generated/interfaces/evse_board_support/Interface.hpp>
+#include <generated/interfaces/power_supply_DC/Interface.hpp>
+
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+// insert your custom include headers here
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
+
+struct Conf {
+    std::string tap_device;
+    std::string plc_device;
+    std::string bridge_device;
+    std::string base_topic_sub;
+    std::string base_topic_pub;
+};
+
+class RemoteChargingEVSE : public Everest::ModuleBase {
+public:
+    RemoteChargingEVSE() = delete;
+    RemoteChargingEVSE(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider,
+                       std::unique_ptr<emptyImplBase> p_main, std::unique_ptr<evse_board_supportIntf> r_bsp,
+                       std::unique_ptr<power_supply_DCIntf> r_power_supply, Conf& config) :
+        ModuleBase(info),
+        mqtt(mqtt_provider),
+        p_main(std::move(p_main)),
+        r_bsp(std::move(r_bsp)),
+        r_power_supply(std::move(r_power_supply)),
+        config(config){};
+
+    Everest::MqttProvider& mqtt;
+    const std::unique_ptr<emptyImplBase> p_main;
+    const std::unique_ptr<evse_board_supportIntf> r_bsp;
+    const std::unique_ptr<power_supply_DCIntf> r_power_supply;
+    const Conf& config;
+
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+    // insert your public definitions here
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+
+protected:
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+    // insert your protected definitions here
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+
+private:
+    friend class LdEverest;
+    void init();
+    void ready();
+
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+    // insert your private definitions here
+    int tap_fd{0};
+    std::mutex mutex;
+    std::string last_cp_state;
+    double last_voltage{0.};
+
+    std::string cp_state_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/cp_state";
+    };
+    std::string cp_pwm_duty_cycle_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/cp_pwm_dc";
+    };
+    std::string eth_ev_to_evse_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/eth_ev_to_evse";
+    };
+    std::string eth_evse_to_ev_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/eth_evse_to_ev_topic";
+    };
+    std::string nmk_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/nmk";
+    };
+    std::string dc_voltage_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/dc_voltage";
+    };
+    std::string ping_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/ping";
+    };
+    std::string pong_topic(bool pub) {
+        return (pub ? config.base_topic_pub : config.base_topic_sub) + "/pong";
+    };
+
+    void hlc_log(const std::string& origin, const std::string& target, const std::string& msg) {
+        nlohmann::json data;
+        data["origin"] = origin;
+        data["target"] = target;
+        data["iso15118"] = false;
+        data["msg"] = msg;
+
+        std::string hlc_log_topic = "everest_api/" + this->info.id + "/var/hlc_log";
+        mqtt.publish(hlc_log_topic, data.dump());
+    };
+
+    void session_info() {
+
+        json info;
+        info["state"] = "Preparing";
+        info["datetime"] = Everest::Date::to_rfc3339(date::utc_clock::now());
+        mqtt.publish("everest_api/" + this->info.id + "/var/session_info", info.dump());
+        mqtt.publish("everest_api/evse_manager/var/session_info", info.dump());
+        /*
+        ### everest_api/evse_manager/var/session_info
+        This variable is published every second and contains a json object with information relating to the current
+        charging session in the following format:
+        ```json
+        {
+            "charged_energy_wh": 0,
+            "charging_duration_s": 84,
+            "datetime": "2022-10-11T16:48:35.747Z",
+            "discharged_energy_wh": 0,
+            "latest_total_w": 0.0,
+            "permanent_fault": false,
+            "state": "Unplugged",
+            "active_enable_disable_source": {
+                "source": "Unspecified",
+                "state": "Enable",
+                "priority": 5000
+            },
+            "uk_random_delay": {
+                "remaining_s": 34,
+                "current_limit_after_delay_A": 16.0,
+                "current_limit_during_delay_A": 0.0,
+                "start_time": "2024-02-28T14:11:11.129Z"
+            },
+            "last_enable_disable_source": "Unspecified"
+        }
+        */
+    };
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+};
+
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+// insert other definitions here
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+
+} // namespace module
+
+#endif // REMOTE_CHARGING_EVSE_HPP

--- a/modules/Misc/RemoteCharging/RemoteChargingEVSE/doc.rst
+++ b/modules/Misc/RemoteCharging/RemoteChargingEVSE/doc.rst
@@ -1,0 +1,24 @@
+.. _everest_modules_handwritten_RemoteChargingEVSE:
+
+..  This file is a placeholder for an optional single file
+    handwritten documentation for the RemoteChargingEVSE module.
+    Please decide whether you want to use this single file,
+    or a set of files in the doc/ directory.
+    In the latter case, you can delete this file.
+    In the former case, you can delete the doc/ directory.
+    
+..  This handwritten documentation is optional. In case
+    you do not want to write it, you can delete this file
+    and the doc/ directory.
+
+..  The documentation can be written in reStructuredText,
+    and will be converted to HTML and PDF by Sphinx.
+
+*******************************************
+RemoteChargingEVSE
+*******************************************
+
+:ref:`Link <everest_modules_RemoteChargingEVSE>` to the module's reference.
+Remote charging bridge for EVSE side (umwcharger) - plugged in into a real car
+
+This module bridges the Control Pilot signal and all PLC communication via MQTT to a RemoteChargingEV module.

--- a/modules/Misc/RemoteCharging/RemoteChargingEVSE/docs/index.rst
+++ b/modules/Misc/RemoteCharging/RemoteChargingEVSE/docs/index.rst
@@ -1,0 +1,23 @@
+.. _everest_modules_handwritten_RemoteChargingEVSE:
+
+..  This file is a placeholder for optional multiple files
+    handwritten documentation for the RemoteChargingEVSE module.
+    Please decide whether you want to use the doc.rst file
+    or a set of files in the doc/ directory.
+    In the latter case, you can delete the doc.rst file.
+    In the former case, you can delete the doc/ directory.
+    
+..  This handwritten documentation is optional. In case
+    you do not want to write it, you can delete this file
+    and the doc/ directory.
+
+..  The documentation can be written in reStructuredText,
+    and will be converted to HTML and PDF by Sphinx.
+    This index.rst file is the entry point for the module documentation.
+
+*******************************************
+RemoteChargingEVSE
+*******************************************
+
+:ref:`Link <everest_modules_RemoteChargingEVSE>` to the module's reference.
+Remote charging bridge for EVSE side (umwcharger) - plugged in into a real car

--- a/modules/Misc/RemoteCharging/RemoteChargingEVSE/main/emptyImpl.cpp
+++ b/modules/Misc/RemoteCharging/RemoteChargingEVSE/main/emptyImpl.cpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include "emptyImpl.hpp"
+
+namespace module {
+namespace main {
+
+void emptyImpl::init() {
+}
+
+void emptyImpl::ready() {
+}
+
+} // namespace main
+} // namespace module

--- a/modules/Misc/RemoteCharging/RemoteChargingEVSE/main/emptyImpl.hpp
+++ b/modules/Misc/RemoteCharging/RemoteChargingEVSE/main/emptyImpl.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#ifndef MAIN_EMPTY_IMPL_HPP
+#define MAIN_EMPTY_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/empty/Implementation.hpp>
+
+#include "../RemoteChargingEVSE.hpp"
+
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+// insert your custom include headers here
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+
+namespace module {
+namespace main {
+
+struct Conf {};
+
+class emptyImpl : public emptyImplBase {
+public:
+    emptyImpl() = delete;
+    emptyImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<RemoteChargingEVSE>& mod, Conf& config) :
+        emptyImplBase(ev, "main"), mod(mod), config(config){};
+
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+    // insert your public definitions here
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+
+protected:
+    // no commands defined for this interface
+
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+    // insert your protected definitions here
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+
+private:
+    const Everest::PtrContainer<RemoteChargingEVSE>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+    // insert your private definitions here
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+};
+
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+// insert other definitions here
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+
+} // namespace main
+} // namespace module
+
+#endif // MAIN_EMPTY_IMPL_HPP

--- a/modules/Misc/RemoteCharging/RemoteChargingEVSE/manifest.yaml
+++ b/modules/Misc/RemoteCharging/RemoteChargingEVSE/manifest.yaml
@@ -1,0 +1,36 @@
+description: Remote charging bridge for EVSE side (umwcharger) - plugged in into a real car 
+config:
+  tap_device:
+    description: Name of tap device
+    type: string
+    default: tap0
+  plc_device:
+    description: Name of PLC device
+    type: string
+    default: eth1
+  bridge_device:
+    description: Name of the bridge device
+    type: string
+    default: br0
+  base_topic_sub:
+    description: Base MQTT topic for subscriptions
+    type: string
+    default: everest/cloud/wormhole/sub
+  base_topic_pub:
+    description: Base MQTT topic for publishes
+    type: string
+    default: everest/cloud/wormhole/pub
+provides:
+  main:
+    interface: empty
+    description: Does not provide anything
+requires:
+  bsp:
+    interface: evse_board_support
+  power_supply:
+    interface: power_supply_DC
+enable_external_mqtt: true
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Cornelius Claussen, PIONIX GmbH

--- a/modules/Misc/RemoteCharging/common/slac_helper.hpp
+++ b/modules/Misc/RemoteCharging/common/slac_helper.hpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#ifndef REMOTE_CHARGING_SLAC_HELPER_HPP
+#define REMOTE_CHARGING_SLAC_HELPER_HPP
+
+#include <arpa/inet.h>
+#include <functional>
+#include <net/ethernet.h>
+#include <string>
+
+#include <everest/logging.hpp>
+#include <slac/slac.hpp>
+
+namespace slac_helper {
+
+uint8_t plc_mac[ETH_ALEN] = {0x00, 0xB0, 0x52, 0x00, 0x00, 0x01};
+
+template <typename SlacMessageType> struct MMTYPE;
+
+template <> struct MMTYPE<slac::messages::cm_set_key_req> {
+    static const uint16_t value = slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_REQ;
+};
+
+template <typename SlacMessageType> struct MMV {
+    // this is the default value for homeplug av 2.0 messages, which are
+    // backward compatible with homeplug av 1.1 messages
+    // non-backward (to 1.1) compatible message are CM_CHAN_EST,
+    // CM_AMP_MAP and CM_NW_STATS, these need to use AV_2_0
+    // older av 1.0 message need to use AV_1_0
+    static constexpr auto value = slac::defs::MMV::AV_1_1;
+};
+
+bool is_homeplug_protocol(std::string packet) {
+    uint16_t type = reinterpret_cast<struct ether_header*>(packet.data())->ether_type;
+    return htons(type) == 0x88E1;
+}
+
+slac::messages::HomeplugMessage to_homeplug_msg(const std::string& packet) {
+    // create home plug message
+    slac::messages::HomeplugMessage msg;
+    int size = packet.size();
+
+    if (size > sizeof(slac::messages::homeplug_message)) {
+        size = sizeof(slac::messages::homeplug_message);
+    }
+
+    memcpy(msg.get_raw_message_ptr(), packet.data(), size);
+
+    return msg;
+}
+
+bool is_cm_atten_profile_ind(const slac::messages::HomeplugMessage& msg) {
+    return msg.get_mmtype() == (slac::defs::MMTYPE_CM_ATTEN_PROFILE | slac::defs::MMTYPE_MODE_IND);
+}
+
+bool is_cm_slac_match_cnf(const slac::messages::HomeplugMessage& msg) {
+    return msg.get_mmtype() == (slac::defs::MMTYPE_CM_SLAC_MATCH | slac::defs::MMTYPE_MODE_CNF);
+}
+
+template <typename SlacMessageType>
+std::string create_slac_message(const uint8_t* dest_mac, SlacMessageType const& message) {
+    slac::messages::HomeplugMessage hp_message;
+
+    // FIXME this needs to be the actual MAC adress
+    uint8_t src_mac[ETH_ALEN] = {0x2A, 0x8F, 0x03, 0xC4, 0x2E, 0xA2};
+
+    hp_message.setup_ethernet_header(dest_mac, src_mac);
+    hp_message.setup_payload(&message, sizeof(message), MMTYPE<SlacMessageType>::value, MMV<SlacMessageType>::value);
+
+    return std::string(reinterpret_cast<char*>(hp_message.get_raw_message_ptr()), hp_message.get_raw_msg_len());
+    ;
+}
+
+std::string set_nmk_key_from_match_cnf(slac::messages::HomeplugMessage& msg_in) {
+    auto nmk = msg_in.get_payload<slac::messages::cm_slac_match_cnf>().nmk;
+    slac::messages::cm_set_key_req msg;
+    msg.key_type = slac::defs::CM_SET_KEY_REQ_KEY_TYPE_NMK;
+    msg.my_nonce = 0xAAAAAAAA;
+    msg.your_nonce = 0x00000000;
+    msg.pid = slac::defs::CM_SET_KEY_REQ_PID_HLE;
+    msg.prn = htole16(slac::defs::CM_SET_KEY_REQ_PRN_UNUSED);
+    msg.pmn = slac::defs::CM_SET_KEY_REQ_PMN_UNUSED;
+    msg.cco_capability = slac::defs::CM_SET_KEY_REQ_CCO_CAP_NONE;
+    slac::utils::generate_nid_from_nmk(msg.nid, nmk);
+    msg.new_eks = slac::defs::CM_SET_KEY_REQ_PEKS_NMK_KNOWN_TO_STA;
+    memcpy(msg.new_key, nmk, sizeof(msg.new_key));
+
+    return create_slac_message(plc_mac, msg);
+}
+
+} // namespace slac_helper
+
+#endif

--- a/modules/Misc/RemoteCharging/common/tap_device.hpp
+++ b/modules/Misc/RemoteCharging/common/tap_device.hpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#ifndef REMOTE_CHARGING_TAP_DEVICE_HPP
+#define REMOTE_CHARGING_TAP_DEVICE_HPP
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/if_ether.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <fcntl.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+
+#include <everest/logging.hpp>
+#include <functional>
+#include <string>
+
+namespace tap {
+
+int open_devices(const std::string& eth_device) {
+    // open the clone device
+    int fd = open("/dev/net/tun", O_RDWR);
+    if (fd < 0) {
+        return fd;
+    }
+
+    // preparation of the paramter struct ifr
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+    strncpy(ifr.ifr_name, eth_device.c_str(), IFNAMSIZ);
+
+    // create the actual device
+    int err = ioctl(fd, TUNSETIFF, (void*)&ifr);
+    if (err < 0) {
+        close(fd);
+        return err;
+    }
+
+    return fd;
+}
+
+inline void send_eth_packet(int fd, const std::string& packet) {
+    write(fd, packet.data(), packet.size());
+}
+
+inline void run_receive_loop(int fd, std::function<void(std::string packet)> rx_callback) {
+    char packet[2048];
+
+    while (true) {
+        // Read one packet
+        int nread = read(fd, packet, sizeof(packet));
+        if (nread < 0) {
+            perror("Reading from interface");
+            close(fd);
+            return;
+        }
+
+        // call callback
+        rx_callback(std::string(packet, nread));
+    }
+}
+
+} // namespace tap
+
+#endif


### PR DESCRIPTION
This PR adds modules for establishing a bridged, remote charging session between a real EV connected to an EVSE (uMWCharger) and a real EVSE connected to an EVerest-based EV hardware simulator (uMWCar).

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

