### PR TITLE
Fix inconsistent everest_API namespace

### DIFF
--- a/lib/everest/everest_api_types/include/everest_api_types/utilities/AsyncApiRequestReply.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/utilities/AsyncApiRequestReply.hpp
@@ -14,7 +14,9 @@
 #include <optional>
 #include <utility>
 
-namespace everest::lib::companion {
+#include <everest_api_types/utilities/Topics.hpp>
+
+namespace everest::lib::API {
 
 namespace internal {
 template <class T> T to_internal_api(T x) {
@@ -99,4 +101,4 @@ auto request_reply_handler(Everest::MqttProvider& mqtt, Topics const& topic_gene
     return request_reply_handler<ReplyT>(mqtt, topic_generator, internal::empty_payload, topic, timeout_s);
 }
 
-} // namespace everest::lib::companion
+} // namespace everest::lib::API

--- a/lib/everest/everest_api_types/include/everest_api_types/utilities/Topics.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/utilities/Topics.hpp
@@ -12,7 +12,7 @@ public:
     Topics() = default;
     Topics(const std::string& target_module_id);
 
-    void setTargetApiModuleID(const std::string& target_moduel_id, const std::string& api_type);
+    void setTargetApiModuleID(const std::string& target_module_id, const std::string& api_type);
 
     std::string everest_to_extern(const std::string& var) const;
     std::string extern_to_everest(const std::string& var) const;


### PR DESCRIPTION
## Fix inconsistent namespace in everest API lib

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

