### PR TITLE
feat: SerialCommHub add read & write coils commands

### DIFF
--- a/interfaces/serial_communication_hub.yaml
+++ b/interfaces/serial_communication_hub.yaml
@@ -96,6 +96,52 @@ cmds:
       description: Status code of the transfer
       type: string
       $ref: /serial_comm_hub_requests#/StatusCodeEnum
+  modbus_read_coils:
+    description: >-
+      Send a Modbus RTU 'read coils' command via serial interface to the target
+      hardware. (return value: response)
+    arguments:
+      target_device_id:
+        description: ID (1 byte) of the device to send the commands to
+        type: integer
+        minimum: 0
+        maximum: 255
+      first_coil_address:
+        description: Start address for read operation (16 bit address)
+        type: integer
+        minimum: 0
+        maximum: 65535
+      num_coils_to_read:
+        description: Number of coils to read (1 bit each)
+        type: integer
+        minimum: 1
+        maximum: 65535
+    result:
+      description: Result of the transfer
+      type: object
+      $ref: /serial_comm_hub_requests#/ResultBool
+  modbus_write_single_coil:
+    description: >-
+      Send a Modbus RTU 'write single coil' command via serial interface to
+      the target hardware. (return value: response)
+    arguments:
+      target_device_id:
+        description: ID (1 byte) of the device to send the commands to
+        type: integer
+        minimum: 0
+        maximum: 255
+      coil_address:
+        description: Address of the coil to write to (16 bit address)
+        type: integer
+        minimum: 0
+        maximum: 65535
+      data:
+        description: Data content to be written to the selected coil
+        type: boolean
+    result:
+      description: Status code of the transfer
+      type: string
+      $ref: /serial_comm_hub_requests#/StatusCodeEnum
   nonstd_write:
     description: >-
       Non standard mode to write registers in read discrete input mode

--- a/modules/Misc/SerialCommHub/main/serial_communication_hubImpl.hpp
+++ b/modules/Misc/SerialCommHub/main/serial_communication_hubImpl.hpp
@@ -64,6 +64,10 @@ protected:
                                            types::serial_comm_hub_requests::VectorUint16& data_raw) override;
     virtual types::serial_comm_hub_requests::StatusCodeEnum
     handle_modbus_write_single_register(int& target_device_id, int& register_address, int& data) override;
+    virtual types::serial_comm_hub_requests::ResultBool
+    handle_modbus_read_coils(int& target_device_id, int& first_coil_address, int& num_coils_to_read) override;
+    virtual types::serial_comm_hub_requests::StatusCodeEnum
+    handle_modbus_write_single_coil(int& target_device_id, int& coil_address, bool& data) override;
     virtual void handle_nonstd_write(int& target_device_id, int& first_register_address,
                                      int& num_registers_to_read) override;
     virtual types::serial_comm_hub_requests::Result

--- a/modules/Misc/SerialCommHub/tiny_modbus_rtu.cpp
+++ b/modules/Misc/SerialCommHub/tiny_modbus_rtu.cpp
@@ -416,13 +416,13 @@ std::vector<uint16_t> TinyModbusRTU::txrx(uint8_t device_address, FunctionCode f
     return out;
 }
 
-std::vector<uint8_t> _make_single_write_request(uint8_t device_address, uint16_t register_address, bool wait_for_reply,
-                                                uint16_t data) {
+std::vector<uint8_t> _make_single_write_request(uint8_t device_address, FunctionCode function,
+                                                uint16_t register_address, bool wait_for_reply, uint16_t data) {
     const int req_len = 8;
     std::vector<uint8_t> req(req_len);
 
     req[DEVICE_ADDRESS_POS] = device_address;
-    req[FUNCTION_CODE_POS] = static_cast<uint8_t>(FunctionCode::WRITE_SINGLE_HOLDING_REGISTER);
+    req[FUNCTION_CODE_POS] = static_cast<uint8_t>(function);
 
     register_address = htobe16(register_address);
     data = htobe16(data);
@@ -479,8 +479,9 @@ std::vector<uint16_t> TinyModbusRTU::txrx_impl(uint8_t device_address, FunctionC
         }
 
         auto req =
-            function == FunctionCode::WRITE_SINGLE_HOLDING_REGISTER
-                ? _make_single_write_request(device_address, first_register_address, wait_for_reply, request.at(0))
+            function == FunctionCode::WRITE_SINGLE_HOLDING_REGISTER or function == FunctionCode::WRITE_SINGLE_COIL
+                ? _make_single_write_request(device_address, function, first_register_address, wait_for_reply,
+                                             request.at(0))
                 : _make_generic_request(device_address, function, first_register_address, register_quantity, request);
         // clear input and output buffer
         tcflush(fd, TCIOFLUSH);

--- a/types/serial_comm_hub_requests.yaml
+++ b/types/serial_comm_hub_requests.yaml
@@ -21,6 +21,19 @@ types:
           type: integer
           minimum: 0
           maximum: 65535
+  ResultBool:
+    description: Return type for IO transfer functions with boolean return values, e.g. for coil states
+    type: object
+    required:
+      - status_code
+    properties:
+      status_code:
+        type: string
+        $ref: /serial_comm_hub_requests#/StatusCodeEnum
+      value:
+        type: array
+        items:
+          type: boolean
   VectorUint16:
     description: Data content (raw data bytes)
     type: object


### PR DESCRIPTION
## Describe your changes

- adds `modbus_read_coils` and `modbus_write_single_coil` to the `serial_communication_hub` interface
- adds `ResultBool` to `serial_comm_hub_requests` types for boolean coils data
- adds implementations for added commands in `SerialCommHub` module
- fixes WriteSingleCoil request in tiny_modbus_rtu library

New commands have been manually tested against a pymodbus server

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

