### PR TITLE
fix: Prevent spamming handle_update_ac_present_power warning

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -918,7 +918,7 @@ void EvseManager::ready() {
             if (hlc_enabled) {
                 r_hlc[0]->call_update_meter_info(p);
 
-                if (p.power_W) {
+                if (p.power_W and selected_d20_energy_service.has_value()) {
                     r_hlc[0]->call_update_ac_present_power(p.power_W.value());
                 }
             }


### PR DESCRIPTION
## Describe your changes
See title

## Issue ticket number and link
After merging #1213 `handle_update_ac_present_power` warning was spammed if EvseV2G was used.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

