### PR TITLE
Bugfix/harden ocpp modules

### DIFF
--- a/modules/EVSE/OCPP/OCPP.hpp
+++ b/modules/EVSE/OCPP/OCPP.hpp
@@ -50,8 +50,8 @@
 using EvseConnectorMap = std::map<int32_t, std::map<int32_t, int32_t>>;
 using ClearedErrorId = std::string;
 using EventQueue =
-    std::map<int32_t,
-             std::queue<std::variant<types::evse_manager::SessionEvent, ocpp::v16::ErrorInfo, ClearedErrorId>>>;
+    std::map<int32_t, std::queue<std::variant<types::evse_manager::SessionEvent, ocpp::v16::ErrorInfo, ClearedErrorId,
+                                              types::system::LogStatus, types::system::FirmwareUpdateStatus>>>;
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {

--- a/modules/EVSE/OCPP/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/EVSE/OCPP/auth_validator/auth_token_validatorImpl.cpp
@@ -19,6 +19,13 @@ void auth_token_validatorImpl::ready() {
 types::authorization::ValidationResult
 auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedIdToken& provided_token) {
 
+    if (this->mod->charge_point == nullptr) {
+        EVLOG_warning << "ChargePoint not initialized, cannot handle validate token command";
+        types::authorization::ValidationResult result;
+        result.authorization_status = types::authorization::AuthorizationStatus::Unknown;
+        return result;
+    }
+
     if (provided_token.authorization_type == types::authorization::AuthorizationType::PlugAndCharge) {
         return validate_pnc_request(provided_token);
     } else {

--- a/modules/EVSE/OCPP/data_transfer/ocpp_data_transferImpl.cpp
+++ b/modules/EVSE/OCPP/data_transfer/ocpp_data_transferImpl.cpp
@@ -29,6 +29,13 @@ types::ocpp::DataTransferStatus to_everest(ocpp::v16::DataTransferStatus status)
 
 types::ocpp::DataTransferResponse
 ocpp_data_transferImpl::handle_data_transfer(types::ocpp::DataTransferRequest& request) {
+    if (this->mod->charge_point == nullptr) {
+        EVLOG_warning << "ChargePoint not initialized, cannot handle data transfer command";
+        types::ocpp::DataTransferResponse response;
+        response.status = types::ocpp::DataTransferStatus::Offline;
+        return response;
+    }
+
     auto ocpp_response = mod->charge_point->data_transfer(request.vendor_id, request.message_id, request.data);
     types::ocpp::DataTransferResponse response;
     if (ocpp_response.has_value()) {

--- a/modules/EVSE/OCPP201/OCPP201.hpp
+++ b/modules/EVSE/OCPP201/OCPP201.hpp
@@ -41,7 +41,8 @@
 
 using EventQueue =
     std::map<int32_t,
-             std::queue<std::variant<types::evse_manager::SessionEvent, ocpp::v2::EventData, ocpp::v2::MeterValue>>>;
+             std::queue<std::variant<types::evse_manager::SessionEvent, ocpp::v2::EventData, ocpp::v2::MeterValue,
+                                     types::system::FirmwareUpdateStatus, types::system::LogStatus>>>;
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {

--- a/modules/EVSE/OCPP201/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/EVSE/OCPP201/auth_validator/auth_token_validatorImpl.cpp
@@ -18,6 +18,14 @@ void auth_token_validatorImpl::ready() {
 
 types::authorization::ValidationResult
 auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedIdToken& provided_token) {
+
+    if (this->mod->charge_point == nullptr) {
+        EVLOG_warning << "ChargePoint not initialized, cannot handle validate token command";
+        types::authorization::ValidationResult validation_result;
+        validation_result.authorization_status = types::authorization::AuthorizationStatus::Unknown;
+        return validation_result;
+    }
+
     types::authorization::ValidationResult validation_result;
     try {
         const auto id_token = conversions::to_ocpp_id_token(provided_token.id_token);

--- a/modules/EVSE/OCPP201/data_transfer/ocpp_data_transferImpl.cpp
+++ b/modules/EVSE/OCPP201/data_transfer/ocpp_data_transferImpl.cpp
@@ -16,6 +16,14 @@ void ocpp_data_transferImpl::ready() {
 
 types::ocpp::DataTransferResponse
 ocpp_data_transferImpl::handle_data_transfer(types::ocpp::DataTransferRequest& request) {
+
+    if (this->mod->charge_point == nullptr) {
+        EVLOG_warning << "ChargePoint not initialized, cannot data transfer command";
+        types::ocpp::DataTransferResponse response;
+        response.status = types::ocpp::DataTransferStatus::Offline;
+        return response;
+    }
+
     ocpp::v2::DataTransferRequest ocpp_request = conversions::to_ocpp_data_transfer_request(request);
     auto ocpp_response = mod->charge_point->data_transfer_req(ocpp_request);
 

--- a/modules/EVSE/OCPP201/ocpp_generic/ocppImpl.cpp
+++ b/modules/EVSE/OCPP201/ocpp_generic/ocppImpl.cpp
@@ -25,6 +25,11 @@ bool ocppImpl::handle_restart() {
 }
 
 void ocppImpl::handle_security_event(types::ocpp::SecurityEvent& event) {
+    if (this->mod->charge_point == nullptr) {
+        EVLOG_warning << "ChargePoint not yet initialized. Cannot handle security event.";
+        return;
+    }
+
     std::optional<ocpp::DateTime> timestamp;
     if (event.timestamp.has_value()) {
         timestamp = ocpp_conversions::to_ocpp_datetime_or_now(event.timestamp.value());
@@ -34,6 +39,20 @@ void ocppImpl::handle_security_event(types::ocpp::SecurityEvent& event) {
 
 std::vector<types::ocpp::GetVariableResult>
 ocppImpl::handle_get_variables(std::vector<types::ocpp::GetVariableRequest>& requests) {
+    if (this->mod->charge_point == nullptr) {
+        EVLOG_warning << "ChargePoint not yet initialized. Cannot handle get variables request.";
+        std::vector<types::ocpp::GetVariableResult> results;
+        for (const auto& req : requests) {
+            types::ocpp::GetVariableResult result;
+            result.status = types::ocpp::GetVariableStatusEnumType::Rejected;
+            result.component_variable.component = req.component_variable.component;
+            result.component_variable.variable = req.component_variable.variable;
+            result.attribute_type = req.attribute_type;
+            results.push_back(result);
+        }
+        return results;
+    }
+
     const auto _requests = conversions::to_ocpp_get_variable_data_vector(requests);
     const auto response = this->mod->charge_point->get_variables(_requests);
     return conversions::to_everest_get_variable_result_vector(response);
@@ -41,6 +60,20 @@ ocppImpl::handle_get_variables(std::vector<types::ocpp::GetVariableRequest>& req
 
 std::vector<types::ocpp::SetVariableResult>
 ocppImpl::handle_set_variables(std::vector<types::ocpp::SetVariableRequest>& requests, std::string& source) {
+    if (this->mod->charge_point == nullptr) {
+        EVLOG_warning << "ChargePoint not yet initialized. Cannot handle set variables request.";
+        std::vector<types::ocpp::SetVariableResult> results;
+        for (const auto& req : requests) {
+            types::ocpp::SetVariableResult result;
+            result.status = types::ocpp::SetVariableStatusEnumType ::Rejected;
+            result.component_variable.component = req.component_variable.component;
+            result.component_variable.variable = req.component_variable.variable;
+            result.attribute_type = req.attribute_type;
+            results.push_back(result);
+        }
+        return results;
+    }
+
     const auto _requests = conversions::to_ocpp_set_variable_data_vector(requests);
     const auto response_map = this->mod->charge_point->set_variables(_requests, source);
     std::vector<ocpp::v2::SetVariableResult> response;


### PR DESCRIPTION
## Describe your changes

Some EVerest commands are processed by the OCPP modules without verifying if `charge_point` has been initialized. This PR adds checks in each command handler to defensively check if `charge_point == nullptr` and returns appropriate responses in that case.

- [x] Move subscribe of FW update and Log upload status in OCPP module

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

