### PR TITLE
OpenSSL TPM2 configuration improvements

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -73,7 +73,7 @@ libcurl:
 # of libocpp and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: v0.9.8
+  git_tag: 63c209435d610caeeaac7eda7143c80e3e216999
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -73,7 +73,7 @@ libcurl:
 # of libocpp and would otherwise be overwritten by the version used there
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: 63c209435d610caeeaac7eda7143c80e3e216999
+  git_tag: bf5a015cfeacad72509c1620464460753e5a5bec
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_LIBEVSE_SECURITY"
 
 # OCPP

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -421,10 +421,6 @@ bool configure_ssl_ctx(bool is_server, SSL_CTX*& ctx, const char* ciphersuites, 
                        const tls::Server::certificate_config_t& cert_config, bool required) {
     bool result{true};
 
-    // TPM2 support is via the OpenSSL provider class OpenSSLProvider in
-    // libevse-security. This needs to be performed before
-    // SSL_CTX_use_PrivateKey_file() or configure_ssl_ctx()  is called
-
     if (is_server) {
         bool custom_key = false;
 
@@ -435,16 +431,8 @@ bool configure_ssl_ctx(bool is_server, SSL_CTX*& ctx, const char* ciphersuites, 
 
         OpenSSLProvider provider;
 
-        provider.set_global_mode(OpenSSLProvider::mode_t::default_provider);
-
-        if (custom_key) {
-            provider.set_tls_mode(OpenSSLProvider::mode_t::custom_provider);
-        } else {
-            provider.set_tls_mode(OpenSSLProvider::mode_t::default_provider);
-        }
-
         const SSL_METHOD* method = TLS_server_method();
-        ctx = SSL_CTX_new_ex(provider, provider.propquery_tls_str(), method);
+        ctx = SSL_CTX_new_ex(provider, provider.propquery_default(), method);
     } else {
         const SSL_METHOD* method = TLS_client_method();
         ctx = SSL_CTX_new(method);

--- a/third-party/bazel/extension.bzl
+++ b/third-party/bazel/extension.bzl
@@ -34,9 +34,9 @@ def _deps_impl(module_ctx):
     maybe(
         http_archive,
         name = "libevse-security",
-        url = "https://github.com/EVerest/libevse-security/archive/9f246bcca44ffe18212e919273bce281e07f3d7f.tar.gz",
-        sha256 = "80cedf260cbf4282ffc04516444019e66d2f624e29949a9a56a4caf9b0883a2c",
-        strip_prefix = "libevse-security-9f246bcca44ffe18212e919273bce281e07f3d7f",
+        url = "https://github.com/EVerest/libevse-security/archive/bf5a015cfeacad72509c1620464460753e5a5bec.tar.gz",
+        sha256 = "ddf1c033d3db9c81b14240efaa0b89845d493b253d69d5f5623eebed4fe4da10",
+        strip_prefix = "libevse-security-bf5a015cfeacad72509c1620464460753e5a5bec",
         build_file = "@everest-core//third-party/bazel:BUILD.libevse-security.bazel",
     )
 


### PR DESCRIPTION
## Describe your changes

Builds upon the changes in libevse-security
https://github.com/EVerest/libevse-security/pull/120

OpenSSLProvider is only used to ensure providers are loaded and to obtain the TLS context.

Note dependencies.yaml needs the correct hash once the libevse-security PR has been merged

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

