### PR TITLE
fix: updated cmake for everest_io and use of mqttc

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,6 +100,11 @@ ftxui:
   git: https://github.com/ArthurSonzogni/ftxui
   git_tag: v5.0.0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_FTXUI"
+# everest/io library
+mqttc:
+  git: https://github.com/LiamBindle/MQTT-C.git
+  git_tag: v1.1.6
+  options: ["MQTT_C_EXAMPLES OFF", "CMAKE_POSITION_INDEPENDENT_CODE ON"]
 # unit testing
 gtest:
   # GoogleTest now follows the Abseil Live at Head philosophy. We recommend updating to the latest commit in the main branch as often as possible.

--- a/lib/everest/io/CMakeLists.txt
+++ b/lib/everest/io/CMakeLists.txt
@@ -1,49 +1,9 @@
-cmake_minimum_required(VERSION 3.22)
-
-project(IO VERSION 0.1
-  DESCRIPTION "Event driven IO"
-  LANGUAGES CXX C
-)
-
-set(CMAKE_EXPORT_COMPILE_COMMANDS on)
-
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/dist" CACHE PATH "Install path prefix" FORCE)
-endif()
-
-# Add ccache support
-option(EVC_ENABLE_CCACHE "Enable ccache for faster compilation" OFF)
-if(EVC_ENABLE_CCACHE)
-    find_program(CCACHE_FOUND ccache)
-    if(CCACHE_FOUND)
-        message(STATUS "Using ccache: ${CCACHE_FOUND}")
-        set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_FOUND})
-        set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_FOUND})
-        set(CMAKE_CUDA_COMPILER_LAUNCHER ${CCACHE_FOUND})
-    else()
-        message(WARNING "ccache not found but EVC_ENABLE_CCACHE was enabled")
-    endif()
-endif()
-
-include(FetchContent)
-
-# Only fetch mqttc if it hasn't been fetched already
-if(NOT TARGET mqttc AND NOT DISABLE_EDM)
-  FetchContent_Declare(
-    mqttc
-    GIT_REPOSITORY https://github.com/LiamBindle/MQTT-C.git
-    GIT_TAG        v1.1.6
-  )
-  FetchContent_MakeAvailable(mqttc)
-endif()
-
 option(BUILD_DOC "Build documentation" OFF)
 option(BUILD_EXAMPLES "Build examples" OFF)
 
 add_subdirectory(src)
 
 if (BUILD_TESTING)
-    include(CTest)
     add_subdirectory(test)
 endif()
 

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -28,7 +28,7 @@ target_sources(everest_io
 
 target_include_directories(everest_io
     PUBLIC
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
         $<INSTALL_INTERFACE:include>
 )
 
@@ -58,16 +58,10 @@ set_target_properties(everest_io
 )
 
 install(
-  TARGETS everest_io mqttc
-  EXPORT everest_io-targets
+  TARGETS everest_io
 )
 
-evc_setup_package(
-  NAME everest-io
-  EXPORT everest_io-targets
-  NAMESPACE everest
-)
-
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/everest
     DESTINATION include
+    FILES_MATCHING PATTERN "*.hpp"
 )


### PR DESCRIPTION
## Describe your changes
The EVerest IO library was originally stand-alone and cmake configuration wasn't quite correct for inclusion in everest-core.

## Issue ticket number and link
Addresses issue #1379

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

