### PR TITLE
[yocto] config-tmux-run-script.cmake needs to be installed

### DIFF
--- a/cmake/everest-generate.cmake
+++ b/cmake/everest-generate.cmake
@@ -739,6 +739,7 @@ function(ev_install_project)
             ${EV_CORE_CMAKE_SCRIPT_DIR}/ev-targets.cmake
             ${EV_CORE_CMAKE_SCRIPT_DIR}/config-run-script.cmake
             ${EV_CORE_CMAKE_SCRIPT_DIR}/config-run-nodered-script.cmake
+            ${EV_CORE_CMAKE_SCRIPT_DIR}/config-tmux-run-script.cmake
         DESTINATION
             ${CMAKE_INSTALL_LIBDIR}/cmake/${LIBRARY_PACKAGE_NAME}
     )


### PR DESCRIPTION
## Describe your changes
Ensure that config-tmux-run-script.cmake is installed.

## Issue ticket number and link
For yocto builds certain files need to be available (installed) when everest-core is built.
    
A recent change to ev-project-bootstrap.cmake means that config-tmux-run-script.cmake is now required to be available.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

