### PR TITLE
Fix build issue in fusion_charger_lib/goose-lib unit tests with newer compiler

### DIFF
--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/goose-lib/libs/goose/tests/sender.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/goose-lib/libs/goose/tests/sender.cpp
@@ -2,7 +2,7 @@
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 #include <gtest/gtest.h>
 
-#inlcude <algorithm>
+#include <algorithm>
 
 #include <goose/sender.hpp>
 


### PR DESCRIPTION
## Describe your changes
See title

## Issue ticket number and link
Building the unit tests didnt work with gcc version 15+

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

