### PR TITLE
Update ftxui dependency to 6.1.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ else()
     find_package(ryml REQUIRED)
     find_package(nlohmann_json REQUIRED)
 
-    find_package(ftxui 5 QUIET) # optional, if not available BringUp module will not be built
+    find_package(ftxui 6 QUIET) # optional, if not available BringUp module will not be built
 
     find_package(sdbus-c++ REQUIRED)
 endif()

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -98,7 +98,7 @@ libnfc-nci:
 # UI library for BringUp modules
 ftxui:
   git: https://github.com/ArthurSonzogni/ftxui
-  git_tag: v5.0.0
+  git_tag: v6.1.9
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_FTXUI"
 # everest/io library
 mqttc:

--- a/modules/BringUp/BUDisplayMessage/BUDisplayMessage.cpp
+++ b/modules/BringUp/BUDisplayMessage/BUDisplayMessage.cpp
@@ -240,7 +240,7 @@ public:
     }
 
     // Override the Render method to display label and input together.
-    Element Render() override {
+    Element OnRender() override {
         return vbox({
             text(m_heading) | inverted,
             hbox(text(" Message         : ") | bold, m_msg_input->Render()),


### PR DESCRIPTION
This requires a small change in the BUDisplayMessage module overriding the new OnRender method instead of the old Render method

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

