### PR TITLE
EvseV2G: change terminate_connection_on_failed_response default to true

### DIFF
--- a/modules/EVSE/EvseV2G/manifest.yaml
+++ b/modules/EVSE/EvseV2G/manifest.yaml
@@ -31,7 +31,7 @@ config:
       V2G connection is terminated immediately on a failed response code, otherwise
       the EV is responsible for closing of the V2G communication session with SessionStop.
     type: boolean
-    default: false
+    default: true
   tls_key_logging:
     description: >-
       Enable/Disable the export of TLS session keys (pre-master-secret)


### PR DESCRIPTION
This is very likely a safer default behavior since it keeps control of the V2G connection at the EVSE

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

