### PR TITLE
EvseV2G/IsoMux: remove insecure cipher ECDH-ECDSA-AES128-SHA256

### DIFF
--- a/modules/EVSE/EvseV2G/connection/tls_connection.cpp
+++ b/modules/EVSE/EvseV2G/connection/tls_connection.cpp
@@ -267,7 +267,7 @@ bool build_config(tls::Server::config_t& config, struct v2g_context* ctx) {
 
     bool bResult{false};
 
-    config.cipher_list = "ECDHE-ECDSA-AES128-SHA256:ECDH-ECDSA-AES128-SHA256";
+    config.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
     config.ciphersuites = "";     // disable TLS 1.3
     config.verify_client = false; // contract certificate managed in-band in 15118-2
 

--- a/modules/EVSE/IsoMux/connection/tls_connection.cpp
+++ b/modules/EVSE/IsoMux/connection/tls_connection.cpp
@@ -275,7 +275,7 @@ bool build_config(tls::Server::config_t& config, struct v2g_context* ctx) {
 
     bool bResult{false};
 
-    config.cipher_list = "ECDHE-ECDSA-AES128-SHA256:ECDH-ECDSA-AES128-SHA256";
+    config.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
     config.ciphersuites = "";     // disable TLS 1.3
     config.verify_client = false; // contract certificate managed in-band in 15118-2
 


### PR DESCRIPTION
## Describe your changes

This cipher isn't supported by OpenSSL anymore anyway, so we can also just drop it from the cipher lists

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

