### PR TITLE
EvseV2G: Create session id with generate_random_data() instead of rand()

### DIFF
--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -558,8 +558,7 @@ static enum v2g_event handle_iso_session_setup(struct v2g_connection* conn) {
     srand((unsigned int)time(NULL));
     if (conn->ctx->evse_v2g_data.session_id == (uint64_t)0 ||
         conn->ctx->evse_v2g_data.session_id != conn->ctx->ev_v2g_data.received_session_id) {
-        conn->ctx->evse_v2g_data.session_id =
-            ((uint64_t)rand() << 48) | ((uint64_t)rand() << 32) | ((uint64_t)rand() << 16) | (uint64_t)rand();
+        generate_random_data(&conn->ctx->evse_v2g_data.session_id, 4);
         dlog(
             DLOG_LEVEL_INFO,
             "No session_id found or not equal to the id from the preceding v2g session. Generating random session id.");


### PR DESCRIPTION
## Describe your changes
Since this relies on /dev/urandom this should result in a random session id with higher entropy than multiple calls ro rand()

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

