### PR TITLE
Various fixes to CMake's Rust support

### DIFF
--- a/cmake/everest-generate.cmake
+++ b/cmake/everest-generate.cmake
@@ -216,7 +216,7 @@ if (EVEREST_ENABLE_RS_SUPPORT)
             EVEREST_RS_FRAMEWORK_SOURCE_LOCATION="${everest-framework_SOURCE_DIR}"
             EVEREST_RS_FRAMEWORK_BINARY_LOCATION="${everest-framework_BINARY_DIR}"
             ${CARGO_EXECUTABLE} build
-            $<IF:$<STREQUAL:${CMAKE_BUILD_TYPE},Release>,--release,>
+            $<IF:$<STREQUAL:$<CONFIG>,Release>,--release,>
             # explicitly set the linker to match what we're using for C++ to avoid the following issue when cross compiling:
             # https://github.com/rust-lang/rust/issues/28924
             --config 'target.$<TARGET_PROPERTY:build_rust_modules,RUST_TARGET_TRIPLE>.linker = \"${CMAKE_CXX_COMPILER}\"'
@@ -287,12 +287,7 @@ if (EVEREST_ENABLE_RS_SUPPORT)
         add_dependencies(generate_rust rust_symlink_module_${MODULE_NAME})
 
         set(EVEREST_MODULE_INSTALL_PREFIX "${CMAKE_INSTALL_LIBEXECDIR}/everest/modules")
-
-        if (CMAKE_BUILD_TYPE STREQUAL "Release")
-            set(BIN_PREFIX "target/$<TARGET_PROPERTY:build_rust_modules,RUST_TARGET_TRIPLE>/release")
-        else ()
-            set(BIN_PREFIX "target/$<TARGET_PROPERTY:build_rust_modules,RUST_TARGET_TRIPLE>/debug")
-        endif ()
+        set(BIN_PREFIX "target/$<TARGET_PROPERTY:build_rust_modules,RUST_TARGET_TRIPLE>/$<IF:$<STREQUAL:$<CONFIG>,Release>,release,debug>")
 
         install(PROGRAMS ${RUST_WORKSPACE_DIR}/${BIN_PREFIX}/${MODULE_NAME}
             DESTINATION "${EVEREST_MODULE_INSTALL_PREFIX}/${MODULE_NAME}"


### PR DESCRIPTION
## Describe your changes
This PR fixes a few issues with the CMake-based Rust support:
* 1e1a4c740795a3a2c2c94da24eb11cae9902ddbb ensures that required variables are always set when calling `ev_add_rs_module()`, even when in different scopes.
* 53fa8143eef916869e214ed6903e3f7c4666675a makes the build work with multi-config generators (tested with Ninja).
* 33193bdd57eae867641149f59e02cb254902e0ef makes it possible to cross-compile Rust code. This works as expected except for one limitation: the target triple passed to Cargo currently assumes we're targeting glibc. I couldn't figure out a reliable way to detect if the C/C++ code is configured to use Musl, any suggestions are more than welcome.

See the commit descriptions for more details.

## Issue ticket number and link
Not applicable.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

