### PR TITLE
EvseV2G: restore ISO 15118-2 supportedAppProtocolRes response code OK_SuccessfulNegotiation

### DIFF
--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -45,12 +45,14 @@
 
 #define ISO_15118_2013_MSG_DEF "urn:iso:15118:2:2013:MsgDef"
 #define ISO_15118_2013_MAJOR   2
+#define ISO_15118_2013_MINOR   0
 
 #define ISO_15118_2010_MSG_DEF "urn:iso:15118:2:2010:MsgDef"
 #define ISO_15118_2010_MAJOR   1
 
 #define DIN_70121_MSG_DEF "urn:din:70121:2012:MsgDef"
 #define DIN_70121_MAJOR   2
+#define DIN_70121_MINOR   0
 
 #define EVSE_LEAF_KEY_FILE_NAME "CPO_EVSE_LEAF.key"
 #define EVSE_PROV_KEY_FILE_NAME "PROV_LEAF.key"

--- a/modules/EVSE/EvseV2G/v2g_server.cpp
+++ b/modules/EVSE/EvseV2G/v2g_server.cpp
@@ -262,7 +262,9 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
             (strcmp(proto_ns, DIN_70121_MSG_DEF) == 0) && (app_proto->VersionNumberMajor == DIN_70121_MAJOR) &&
             (ev_app_priority >= app_proto->Priority)) {
             conn->handshake_resp.supportedAppProtocolRes.ResponseCode =
-                appHand_responseCodeType_OK_SuccessfulNegotiation;
+                (app_proto->VersionNumberMinor == DIN_70121_MINOR)
+                    ? appHand_responseCodeType_OK_SuccessfulNegotiation
+                    : appHand_responseCodeType_OK_SuccessfulNegotiationWithMinorDeviation;
             ev_app_priority = app_proto->Priority;
             conn->handshake_resp.supportedAppProtocolRes.SchemaID = app_proto->SchemaID;
             conn->ctx->selected_protocol = V2G_PROTO_DIN70121;
@@ -272,7 +274,9 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
                    (ev_app_priority >= app_proto->Priority)) {
 
             conn->handshake_resp.supportedAppProtocolRes.ResponseCode =
-                appHand_responseCodeType_OK_SuccessfulNegotiationWithMinorDeviation;
+                (app_proto->VersionNumberMinor == ISO_15118_2013_MINOR)
+                    ? appHand_responseCodeType_OK_SuccessfulNegotiation
+                    : appHand_responseCodeType_OK_SuccessfulNegotiationWithMinorDeviation;
             ev_app_priority = app_proto->Priority;
             conn->handshake_resp.supportedAppProtocolRes.SchemaID = app_proto->SchemaID;
             conn->ctx->selected_protocol = V2G_PROTO_ISO15118_2013;


### PR DESCRIPTION
Respond in supportedAppProtocolRes with response code `OK_SuccessfulNegotiationWithMinorDeviation` only when there is an actual deviation.


The ISO 15118-2 supportedAppProtocolRes response code was recently changed from `OK_SuccessfulNegotiation` to `OK_SuccessfulNegotiationWithMinorDeviation`, but even when there was no deviation.

This was done to satisfy ISO 15118-4 test cases TC_SECC_CMN_VTB_SupportedAppProtocol_*, which accept either, but does mandate `OK_SuccessfulNegotiationWithMinorDeviation` for a deviation.

## Describe your changes
Respond in supportedAppProtocolRes with response code `OK_SuccessfulNegotiationWithMinorDeviation` only when there is an actual deviation.

Fix this to actually check the EV's supported minor version, and issue `OK_SuccessfulNegotiationWithMinorDeviation` only when there is a deviation.

While at it, also introduce the same logic for DIN 70121, which has the same requirements.

## Issue ticket number and link
https://github.com/EVerest/everest-core/issues/1409

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

