### PR TITLE
Updates to everest-core to better support ycoto builds (meta-everest)

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -110,6 +110,7 @@ sdbus-cpp:
   git:  https://github.com/Kistler-Group/sdbus-cpp.git
   git_tag: v2.1.0
   cmake_condition: "EVEREST_DEPENDENCY_ENABLED_SDBUS_CPP"
+  options: ["CMAKE_POSITION_INDEPENDENT_CODE ON"]
 # unit testing
 gtest:
   # GoogleTest now follows the Abseil Live at Head philosophy. We recommend updating to the latest commit in the main branch as often as possible.

--- a/lib/3rd_party/nanopb/CMakeLists.txt
+++ b/lib/3rd_party/nanopb/CMakeLists.txt
@@ -28,7 +28,7 @@ set_target_properties(nanopb PROPERTIES OUTPUT_NAME "everest_nanopb")
 
 install(TARGETS nanopb
     EXPORT everest-core-targets
-    LIBRARY
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 install(

--- a/lib/everest/system/CMakeLists.txt
+++ b/lib/everest/system/CMakeLists.txt
@@ -33,6 +33,28 @@ target_compile_definitions(everest_system
         SDBUSCPP_MAJOR_VERSION=${sdbus-c++_VERSION_MAJOR}
 )
 
+set_target_properties(everest_system PROPERTIES EXPORT_NAME system)
+
+if (DISABLE_EDM)
+    install(
+        TARGETS everest_system
+        EXPORT everest_system-targets
+    )
+
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/everest
+        TYPE INCLUDE
+    )
+
+    evc_setup_package(
+        NAME everest-everest_system
+        NAMESPACE everest
+        EXPORT everest_system-targets
+        ADDITIONAL_CONTENT
+            "find_dependency(everest-log)"
+            "find_dependency(sdbus-c++)"
+    )
+endif()
+
 if (BUILD_TESTING)
     target_compile_definitions(everest_system PUBLIC EVEREST_COVERAGE_ENABLED)
     add_subdirectory(tests)

--- a/lib/everest/util/CMakeLists.txt
+++ b/lib/everest/util/CMakeLists.txt
@@ -7,6 +7,16 @@ target_include_directories(everest_util
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
+set_target_properties(everest_util
+    PROPERTIES
+        BUILD_INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/everest
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.hpp"
+)
+
 if (BUILD_TESTING)
     add_subdirectory(tests)
 endif()


### PR DESCRIPTION
## Describe your changes

fix: everest-utils header file only library now installed
fix: PIC code for sdbus-c++
fix: make header location available for header-only library everest_util
fix: adapt for multilib build (previously a yocto patch)

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

