### PR TITLE
Slac: Fix Qualcomm firmware version & build date

### DIFF
--- a/lib/everest/slac/fsm/evse/src/states/others.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/others.cpp
@@ -361,9 +361,11 @@ static std::string get_qualcomm_device_info(slac::messages::qualcomm::op_attr_cn
     result += get_string_view(msg.hw_platform);
     result += "\n  SW Platform: ";
     result += get_string_view(msg.sw_platform);
-    result += "\n  Firmware: ";
-    result += ("\n  Build date: " + std::to_string(msg.version_major) + "." + std::to_string(msg.version_minor) + "." +
-               std::to_string(msg.version_pib) + "-" + std::to_string(msg.version_build));
+    result += ("\n  Firmware: " + std::to_string(msg.version_major) + "." + std::to_string(msg.version_minor) + "." +
+               std::to_string(msg.version_pib) + "." + std::to_string(msg.reserved) + "-" +
+               std::to_string(msg.version_build));
+    result += "\n  Build date: ";
+    result += get_string_view(msg.build_date);
 
     result += "\n  ZC signal: ";
 


### PR DESCRIPTION
## Describe your changes
The logging for the QCA7xxx firmware and build date was broken (e.g. MAC-QCA7000-3.4.0.36-00-20241008-CS). So let fix it.

````
BEFORE
2025-10-08T08:58:31.141276+0200 tarragon manager[27714]: [INFO] EvseSlac0:EvseS  :: Qualcomm PLC Device Attributes:
2025-10-08T08:58:31.141276+0200 tarragon manager[27714]:   HW Platform: QCA7000
2025-10-08T08:58:31.141276+0200 tarragon manager[27714]:   SW Platform: MAC
2025-10-08T08:58:31.141276+0200 tarragon manager[27714]:   Firmware:
2025-10-08T08:58:31.141276+0200 tarragon manager[27714]:   Build date: 3.4.0-0
2025-10-08T08:58:31.141276+0200 tarragon manager[27714]:   ZC signal: Missing
2025-10-08T08:58:31.141276+0200 tarragon manager[27714]:   Line frequency: 50Hz

AFTER
2025-10-08T15:00:37.881654+0200 tarragon manager[22835]: [INFO] EvseSlac0:EvseS  :: Qualcomm PLC Device Attributes:
2025-10-08T15:00:37.881654+0200 tarragon manager[22835]:   HW Platform: QCA7000
2025-10-08T15:00:37.881654+0200 tarragon manager[22835]:   SW Platform: MAC
2025-10-08T15:00:37.881654+0200 tarragon manager[22835]:   Firmware: 3.4.0.36-0
2025-10-08T15:00:37.881654+0200 tarragon manager[22835]:   Build date: 20241008
2025-10-08T15:00:37.881654+0200 tarragon manager[22835]:   ZC signal: Missing
2025-10-08T15:00:37.881654+0200 tarragon manager[22835]:   Line frequency: 50Hz
````

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

