### PR TITLE
PhyVersoBSP: BSP rework alongside new MCU firmware release 2.0.0

### DIFF
--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/PhyVersoBSP.cpp
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/PhyVersoBSP.cpp
@@ -22,23 +22,76 @@ void PhyVersoBSP::init() {
         return;
     }
 
+    serial.flush_buffers();
+
+    serial.signal_config_request.connect([&]() {
+        serial.send_config();
+        EVLOG_info << "Sent config packet to MCU";
+    });
+
+    serial.signal_connection_timeout.connect([this]() {
+        auto err = p_connector_1->error_factory->create_error("evse_board_support/CommunicationFault", "McuToEverest",
+                                                              "Serial connection to MCU timed out");
+        p_connector_1->raise_error(err);
+        err = p_connector_2->error_factory->create_error("evse_board_support/CommunicationFault", "McuToEverest",
+                                                         "Serial connection to MCU timed out");
+        p_connector_2->raise_error(err);
+    });
+
+    serial.signal_error_flags.connect([this](int connector, ErrorFlags error_flags) {
+        // heartbeat failure from Mcu side (not receiving packets) will be visible in both connector errors
+        if (error_flags.heartbeat_timeout != last_heartbeat_error) {
+            if (error_flags.heartbeat_timeout) {
+                auto err = p_connector_1->error_factory->create_error(
+                    "evse_board_support/CommunicationFault", "EverestToMcu", "MCU did not receive Everest heartbeat");
+                p_connector_1->raise_error(err);
+                err = p_connector_2->error_factory->create_error(
+                    "evse_board_support/CommunicationFault", "EverestToMcu", "MCU did not receive Everest heartbeat");
+                p_connector_2->raise_error(err);
+            } else {
+                p_connector_1->clear_error("evse_board_support/CommunicationFault", "EverestToMcu");
+                p_connector_2->clear_error("evse_board_support/CommunicationFault", "EverestToMcu");
+            }
+        }
+        last_heartbeat_error = error_flags.heartbeat_timeout;
+    });
+
+    serial.signal_keep_alive.connect([this](KeepAlive d) {
+        mcu_config_done = d.configuration_done;
+        p_connector_1->clear_error("evse_board_support/CommunicationFault", "McuToEverest");
+        p_connector_2->clear_error("evse_board_support/CommunicationFault", "McuToEverest");
+    });
+
+    serial.reset(1);
+
+    serial.run();
+    gpio.run();
+
+    // very sporadically multiple resets needed for MCU to respond -> retrying until we get MCU response in a
+    // configured, ready and running state
+    mcu_config_done = false;
+    uint16_t n_tries = 0;
+    while (!mcu_config_done) {
+        serial.keep_alive();
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        n_tries++;
+        if (n_tries > 20) {
+            EVLOG_info << "Trying reset again";
+            serial.flush_buffers();
+            serial.reset(1);
+            n_tries = 0;
+        }
+    }
+
     invoke_init(*p_connector_1);
     invoke_init(*p_connector_2);
     invoke_init(*p_rcd_1);
     invoke_init(*p_rcd_2);
     invoke_init(*p_connector_lock_1);
     invoke_init(*p_connector_lock_2);
-
-    serial.signal_config_request.connect([&]() {
-        serial.send_config();
-        EVLOG_info << "Sent config packet to MCU";
-    });
 }
 
 void PhyVersoBSP::ready() {
-    serial.run();
-    gpio.run();
-
     invoke_ready(*p_connector_1);
     invoke_ready(*p_connector_2);
     invoke_ready(*p_rcd_1);
@@ -58,6 +111,36 @@ void PhyVersoBSP::ready() {
 
 // fills evConfig bridge with config values from manifest/everest config
 void PhyVersoBSP::everest_config_to_verso_config() {
+    // if a port is configured to be AC and has a socket, a motor lock type specification/usage is mandatory
+    if ((this->config.conn1_disable_port == false) && (this->config.conn1_dc == false) &&
+        (this->config.conn1_has_socket == true) && (this->config.conn1_motor_lock_type < 1)) {
+        EVLOG_critical << "Motor lock type for connector 1 has to be specified when using connector 1 as AC charging "
+                          "port with a socket/detachable charging cable!";
+        throw std::runtime_error("Motor lock type for connector 1 has to be specified when using connector 1 as AC "
+                                 "charging port with a socket/detachable charging cable!");
+    }
+    if ((this->config.conn2_disable_port == false) && (this->config.conn2_dc == false) &&
+        (this->config.conn2_has_socket == true) && (this->config.conn2_motor_lock_type < 1)) {
+        EVLOG_critical << "Motor lock type for connector 2 has to be specified when using connector 2 as AC charging "
+                          "port with a socket/detachable charging cable!";
+        throw std::runtime_error("Motor lock type for connector 2 has to be specified when using connector 2 as AC "
+                                 "charging port with a socket/detachable charging cable!");
+    }
+
+    if ((this->config.conn1_feedback_pull < 0) || (this->config.conn1_feedback_pull > 2)) {
+        EVLOG_error << "conn1_feedback_pull out of range! Falling back to default: 2";
+        verso_config.conf.conn1_feedback_pull = 2;
+    } else {
+        verso_config.conf.conn1_feedback_pull = this->config.conn1_feedback_pull;
+    }
+
+    if ((this->config.conn2_feedback_pull < 0) || (this->config.conn2_feedback_pull > 2)) {
+        EVLOG_error << "conn2_feedback_pull out of range! Falling back to default: 2";
+        verso_config.conf.conn2_feedback_pull = 2;
+    } else {
+        verso_config.conf.conn2_feedback_pull = this->config.conn2_feedback_pull;
+    }
+
     verso_config.conf.serial_port = this->config.serial_port;
     verso_config.conf.baud_rate = this->config.baud_rate;
     verso_config.conf.reset_gpio_bank = this->config.reset_gpio_bank;
@@ -72,6 +155,12 @@ void PhyVersoBSP::everest_config_to_verso_config() {
     verso_config.conf.conn2_gpio_stop_button_bank = this->config.conn2_gpio_stop_button_bank;
     verso_config.conf.conn2_gpio_stop_button_pin = this->config.conn2_gpio_stop_button_pin;
     verso_config.conf.conn2_gpio_stop_button_invert = this->config.conn2_gpio_stop_button_invert;
+    verso_config.conf.conn1_disable_port = this->config.conn1_disable_port;
+    verso_config.conf.conn2_disable_port = this->config.conn2_disable_port;
+    verso_config.conf.conn1_feedback_active_low = this->config.conn1_feedback_active_low;
+    verso_config.conf.conn2_feedback_active_low = this->config.conn2_feedback_active_low;
+    verso_config.conf.conn1_dc = this->config.conn1_dc;
+    verso_config.conf.conn2_dc = this->config.conn2_dc;
 }
 
 } // namespace module

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/PhyVersoBSP.hpp
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/PhyVersoBSP.hpp
@@ -59,6 +59,12 @@ struct Conf {
     std::string conn2_gpio_stop_button_bank;
     int conn2_gpio_stop_button_pin;
     bool conn2_gpio_stop_button_invert;
+    bool conn1_disable_port;
+    bool conn2_disable_port;
+    bool conn1_feedback_active_low;
+    bool conn2_feedback_active_low;
+    int conn1_feedback_pull;
+    int conn2_feedback_pull;
 };
 
 class PhyVersoBSP : public Everest::ModuleBase {
@@ -110,6 +116,8 @@ private:
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
     void everest_config_to_verso_config();
+    bool last_heartbeat_error;
+    bool mcu_config_done = false;
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/cli_config_hella_lock.json
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/cli_config_hella_lock.json
@@ -1,0 +1,5 @@
+{
+    "conn1_motor_lock_type": 1,
+    "conn2_motor_lock_type": 1,
+    "reset_gpio_bank": 2
+}

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/cli_config_potentiometer_lock.json
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/cli_config_potentiometer_lock.json
@@ -1,5 +1,5 @@
 {
     "conn1_motor_lock_type": 2,
-    "conn2_motor_lock_type": 1,
+    "conn2_motor_lock_type": 2,
     "reset_gpio_bank": 2
 }

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/connector_1/evse_board_supportImpl.cpp
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/connector_1/evse_board_supportImpl.cpp
@@ -50,8 +50,8 @@ void evse_board_supportImpl::init() {
 
     mod->serial.signal_pp_state.connect([this](int connector, PpState s) {
         if (connector == 1) {
-            EVLOG_info << "[1] PpState " << s;
             if (last_pp_state != s) {
+                EVLOG_info << "[1] PpState " << s;
                 publish_ac_pp_ampacity(to_pp_ampacity(s));
             }
             last_pp_state = s;
@@ -65,6 +65,47 @@ void evse_board_supportImpl::init() {
             this->publish_request_stop_transaction(request);
             EVLOG_info << "[1] Request stop button state: " << (state ? "PUSHED" : "RELEASED");
             last_stop_button_state = state;
+        }
+    });
+
+    mod->serial.signal_error_flags.connect([this](int connector, ErrorFlags error_flags) {
+        if (connector == 1) {
+            // Contactor feedback divergence
+            if (error_flags.coil_feedback_diverges != last_error_flags.coil_feedback_diverges) {
+                if (error_flags.coil_feedback_diverges) {
+                    Everest::error::Error error_object = this->error_factory->create_error(
+                        "evse_board_support/MREC17EVSEContactorFault", "",
+                        "Port 1 contactor feedback diverges from target state", Everest::error::Severity::High);
+                    this->raise_error(error_object);
+                } else {
+                    this->clear_error("evse_board_support/MREC17EVSEContactorFault");
+                }
+            }
+
+            // Diode fault
+            if (error_flags.diode_fault != last_error_flags.diode_fault) {
+                if (error_flags.diode_fault) {
+                    Everest::error::Error error_object = this->error_factory->create_error(
+                        "evse_board_support/DiodeFault", "", "Port 1 diode fault", Everest::error::Severity::High);
+                    this->raise_error(error_object);
+                } else {
+                    this->clear_error("evse_board_support/DiodeFault");
+                }
+            }
+
+            // PP fault
+            if (error_flags.pp_signal_fault != last_error_flags.pp_signal_fault) {
+                if (error_flags.pp_signal_fault) {
+                    Everest::error::Error error_object =
+                        this->error_factory->create_error("evse_board_support/MREC23ProximityFault", "",
+                                                          "Port 1 PP signal fault", Everest::error::Severity::High);
+                    this->raise_error(error_object);
+                } else {
+                    this->clear_error("evse_board_support/MREC23ProximityFault");
+                }
+            }
+
+            last_error_flags = error_flags;
         }
     });
 }
@@ -101,14 +142,13 @@ void evse_board_supportImpl::handle_pwm_F() {
 }
 
 void evse_board_supportImpl::handle_allow_power_on(types::evse_board_support::PowerOnOff& value) {
+    if (mod->config.conn1_disable_port) {
+        EVLOG_error << "[1] Port disabled; Cannot set power_on!";
+        return;
+    }
+
     if (mod->config.conn1_dc) {
         mod->serial.set_coil_state_request(1, CoilType_COIL_DC1, value.allow_power_on);
-        // FIXME: implement in MCU with feedback
-        if (value.allow_power_on) {
-            publish_event({types::board_support_common::Event::PowerOn});
-        } else {
-            publish_event({types::board_support_common::Event::PowerOff});
-        }
     } else {
         mod->serial.set_coil_state_request(1, CoilType_COIL_AC, value.allow_power_on);
     }

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/connector_1/evse_board_supportImpl.hpp
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/connector_1/evse_board_supportImpl.hpp
@@ -62,6 +62,7 @@ private:
     CpState last_cp_state;
     PpState last_pp_state; ///< The last pp state received from the MCU.
     bool last_stop_button_state;
+    ErrorFlags last_error_flags;
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/connector_2/evse_board_supportImpl.hpp
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/connector_2/evse_board_supportImpl.hpp
@@ -61,6 +61,7 @@ private:
     CpState last_cp_state;
     PpState last_pp_state; ///< The last pp state received from the MCU.
     bool last_stop_button_state;
+    ErrorFlags last_error_flags;
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/example_config_pionix.json
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/example_config_pionix.json
@@ -1,4 +1,0 @@
-{
-    "conn1_motor_lock_type": 2,
-    "conn2_motor_lock_type": 2
-}

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/example_config_qwello.json
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/example_config_qwello.json
@@ -1,4 +1,0 @@
-{
-    "conn1_motor_lock_type": 1,
-    "conn2_motor_lock_type": 1
-}

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/manifest.yaml
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/manifest.yaml
@@ -133,13 +133,25 @@ config:
     type: integer
     default: 23
   conn1_motor_lock_type:
-    description: Connector 1 motor lock type; 1 == Hella Style time-based lock, 2 == Valeo potentiometer feedback based
+    description: >
+      Connector 1 motor lock type; 
+        -1 == no Lock
+         1 == Hella Style time-based lock, 
+         2 == Valeo potentiometer feedback based; 
+
+      If charging port has a socket and is AC charging, it will need a lock specified
     type: integer
-    default: 2
+    default: -1
   conn2_motor_lock_type:
-    description: Connector 2 motor lock type; 1 == Hella Style time-based lock, 2 == Valeo potentiometer feedback based
+    description: >
+      Connector 2 motor lock type; 
+        -1 == no Lock
+         1 == Hella Style time-based lock, 
+         2 == Valeo potentiometer feedback based; 
+
+      If charging port has a socket and is AC charging, it will need a lock specified
     type: integer
-    default: 2
+    default: -1
   conn1_gpio_stop_button_enabled:
     description: Set to true to enable external charging stop button for connector 1 on a GPIO connected to the SOM
     type: boolean
@@ -172,6 +184,31 @@ config:
     description: Set to true to invert pin logic
     type: boolean
     default: false
+  conn1_disable_port:
+    description: Set to true if port 1 is neither used for AC nor DC charging (will overwrite conn1_dc parameter)
+    type: boolean
+    default: false
+  conn2_disable_port:
+    description: Set to true if port 2 is neither used for AC nor DC charging (will overwrite conn2_dc parameter)
+    type: boolean
+    default: false
+  conn1_feedback_active_low:
+    description: Set to true if relay mirror contact on port 1 feedback is active LOW, false if active HIGH; don't change for AC port config
+    type: boolean
+    default: true
+  conn2_feedback_active_low:
+    description: Set to true if relay mirror contact on port 2 feedback is active LOW, false if active HIGH; don't change for AC port config
+    type: boolean
+    default: true
+  conn1_feedback_pull:
+    description: DC port config only - specify which way internal pull resistors will work; 0 -> None, 1 -> PullUp, 2 -> PullDown (default=PD)
+    type: integer
+    default: 2
+  conn2_feedback_pull:
+    description: DC port config only - specify which way internal pull resistors will work; 0 -> None, 1 -> PullUp, 2 -> PullDown (default=PD)
+    type: integer
+    default: 2
+    
 provides:
   connector_1:
     interface: evse_board_support
@@ -181,10 +218,10 @@ provides:
     description: provides the board support interface to low level control the proximity and control pilots, relais and motor lock
   rcd_1:
     interface: ac_rcd
-    description: RCD interface of the onboard RCD
+    description: RCD interface for an external RDC-MD
   rcd_2:
     interface: ac_rcd
-    description: RCD interface of the onboard RCD
+    description: RCD interface of the onboard RDC-MD
   connector_lock_1:
     interface: connector_lock
     description: Lock interface
@@ -196,4 +233,5 @@ metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:
     - Cornelius Claussen
+    - Jonas Rockstroh
 

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_cli/main.cpp
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_cli/main.cpp
@@ -154,6 +154,12 @@ int main(int argc, char* argv[]) {
             case LockState_UNLOCKED:
                 printf(">> Connector %i: Lock State Unlocked\n", connector);
                 break;
+            case LockState_LOCKING:
+                printf(">> Connector %i: Lock State Locking\n", connector);
+                break;
+            case LockState_UNLOCKING:
+                printf(">> Connector %i: Lock State Unlocking\n", connector);
+                break;
             }
         });
 
@@ -165,6 +171,9 @@ int main(int argc, char* argv[]) {
             printf("\tventilation_not_available: %d\n", error_flags.ventilation_not_available);
             printf("\tconnector_lock_failed: %d\n", error_flags.connector_lock_failed);
             printf("\tcp_signal_fault: %d\n", error_flags.cp_signal_fault);
+            printf("\theartbeat_timeout: %d\n", error_flags.heartbeat_timeout);
+            printf("\tcoil_feedback_diverges_ac: %d\n", error_flags.coil_feedback_diverges);
+            printf("\tpp_signal_fault: %d\n", error_flags.pp_signal_fault);
             printf("------------\n");
         });
 
@@ -291,6 +300,7 @@ int main(int argc, char* argv[]) {
                 p.reset_rcd(selected_connector, true);
                 break;
             }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
     return 0;

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/evConfig.h
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/evConfig.h
@@ -41,8 +41,8 @@ public:
         bool conn2_dc = false;
         int reset_gpio_bank = 1;
         int reset_gpio_pin = 23;
-        int conn1_motor_lock_type = 2;
-        int conn2_motor_lock_type = 2;
+        int conn1_motor_lock_type = -1;
+        int conn2_motor_lock_type = -1;
         bool conn1_gpio_stop_button_enabled = false;
         std::string conn1_gpio_stop_button_bank = "gpiochip1";
         int conn1_gpio_stop_button_pin = 36;
@@ -51,6 +51,12 @@ public:
         std::string conn2_gpio_stop_button_bank = "gpiochip1";
         int conn2_gpio_stop_button_pin = 37;
         bool conn2_gpio_stop_button_invert = false;
+        bool conn1_disable_port = false;
+        bool conn2_disable_port = false;
+        bool conn1_feedback_active_low = true;
+        bool conn2_feedback_active_low = true;
+        int conn1_feedback_pull = 2;
+        int conn2_feedback_pull = 2;
     } conf;
 
     evConfig();

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/evSerial.h
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/evSerial.h
@@ -28,6 +28,7 @@ public:
     bool is_open() {
         return fd > 0;
     };
+    void flush_buffers();
 
     void read_thread();
     void run();

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/protobuf/phyverso.options
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/protobuf/phyverso.options
@@ -1,3 +1,5 @@
 KeepAlive.sw_version_string max_length:50
 FanState.fan_id int_size:IS_8
 FanState.rpm int_size:IS_16
+BootConfigResponse.chargeport_config max_count:2
+BootConfigResponse.chargeport_config fixed_count:true

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/protobuf/phyverso.pb.c
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/protobuf/phyverso.pb.c
@@ -33,10 +33,15 @@ PB_BIND(BootConfigRequest, BootConfigRequest, AUTO)
 PB_BIND(BootConfigResponse, BootConfigResponse, AUTO)
 
 
+PB_BIND(ChargePortConfig, ChargePortConfig, AUTO)
+
+
 PB_BIND(ConfigMotorLockType, ConfigMotorLockType, AUTO)
 
 
 PB_BIND(RcdCommand, RcdCommand, AUTO)
+
+
 
 
 

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/protobuf/phyverso.proto
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/phyverso_mcu_comms/protobuf/phyverso.proto
@@ -53,6 +53,9 @@ message ErrorFlags {
   bool ventilation_not_available = 4;
   bool connector_lock_failed = 5;
   bool cp_signal_fault = 6;
+  bool heartbeat_timeout = 7;
+  bool coil_feedback_diverges = 8;
+  bool pp_signal_fault = 9;
 }
 
 enum ResetReason {
@@ -65,6 +68,7 @@ message KeepAlive {
   uint32 hw_type = 2;
   uint32 hw_revision = 3;
   string sw_version_string = 6;
+  bool configuration_done = 7;
 }
 
 message Telemetry {
@@ -92,6 +96,8 @@ enum LockState {
   UNDEFINED = 0;
   UNLOCKED = 1;
   LOCKED = 2;
+  LOCKING = 3;
+  UNLOCKING = 4;
 }
 
 message CoilState {
@@ -114,12 +120,33 @@ message BootConfigRequest {
 
 message BootConfigResponse {
   ConfigHardwareRevision hw_rev = 1;
-  ConfigMotorLockType lock_1 = 2;
-  ConfigMotorLockType lock_2 = 3;
+  repeated ChargePortConfig chargeport_config = 6;
+}
+
+message ChargePortConfig {
+  ChargePortType type = 1;
+  bool feedback_active_low = 2;
+  GpioPull feedback_pull = 3;
+  ConfigMotorLockType lock = 4;
+  bool has_socket = 5;
+}
+
+enum ChargePortType {
+  DISABLED = 0;
+  AC = 1;
+  DC = 2;
+}
+
+enum GpioPull {
+  NONE = 0;
+  UP = 1;
+  DOWN = 2;
 }
 
 message ConfigMotorLockType {
   MotorLockType type = 1;
+  // additional lock specific options could be added here later
+  // will still keep this in place even if it only holds the type enum at the moment
 }
 
 enum ConfigHardwareRevision {
@@ -130,8 +157,10 @@ enum ConfigHardwareRevision {
 
 enum MotorLockType {
   MOTOR_LOCK_UNKNOWN = 0;
-  MOTOR_LOCK_QWELLO = 1;
+  MOTOR_LOCK_HELLA = 1;
   MOTOR_LOCK_DEBUG_VALEO_HVAC = 2;
+  // add additional locks here
+  MOTOR_LOCK_NONE = -1;
 }
 
 message RcdCommand {

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/rcd_1/ac_rcdImpl.hpp
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/rcd_1/ac_rcdImpl.hpp
@@ -49,7 +49,7 @@ private:
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here
-    ErrorFlags last_error_flags;
+    ErrorFlags last_error_flags{false};
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/HardwareDrivers/EVSE/PhyVersoBSP/rcd_2/ac_rcdImpl.hpp
+++ b/modules/HardwareDrivers/EVSE/PhyVersoBSP/rcd_2/ac_rcdImpl.hpp
@@ -49,7 +49,7 @@ private:
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here
-    ErrorFlags last_error_flags;
+    ErrorFlags last_error_flags{false};
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 


### PR DESCRIPTION
* MCU<>Everest protobuf extension/rework
    * Config structure for a charging port has changed -> more info under its own bullet point below
    * motor locking states locking/unlocking added, not only endstates (but not really usable at the moment as motor lock interface definition does not have lock state vars where we could communicate state to other modules)
    * KeepAlive packet has added configuration_done flag that signals everest the MCU has successfully been configured, booted and is in normal run mode
    * added error flags for PP fault, coil/relay feedback divergence from target state, heartbeat timeout

* Config extension
    * coil/relay feedback active high/low and pull directions can be configured
    * motor lock type defaults to no motor lock (as is the case for DC charging or AC charging without socket/detachable charging cable)
    * has_socket defines if we have a socketed charging port (with detachable cable)
    * if configuring a port for AC charging with a socket, critical errors will be thrown on everest/MCU side when not specifying motor lock type
    * Motor lock type only enforced on socketed AC ports
    * possible to completely disable charging port to do one charging port configs only
    * phyverso_cli parameters via json mirror whole everest module parameter set now
    * renamed cli_config_*.json files for more clarity where they could be used (phyverso_cli use only, no real-world application)

* Error handling
    * Bidirectional serial communication timeouts will be reported and throw respective errors / will get cleared after normal communcation resumes
    * new errors thrown on everest side that will also have already lead to an emergency stop on MCU side
        * PP fault
        * coil/relay feedback diverges from target * heartbeat timeout (connection to/from Everest lost) * diode fault

* Misc.
    * PP state logging fixed, was constantly spamming EVLOG with info messages when receiving periodic updates from MCU
    * sometimes serial communication gets completely mangled, leading to Everest not receiving config request packets -> MCU will not get config packets and will hang in boot loop
        * BSP will wait for MCU reporting that it is properly configured -> otherwise reset MCU / serial after some time and wait for new config request packet until MCU reports properly configured MCU, boot mode exit and normal operation
    * increased hard-reset nRST low time
    * added small delay in phyverso_cli input polling loop to not use 100% CPU

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

