### PR TITLE
Feat/async util

### DIFF
--- a/lib/everest/tls/include/everest/tls/tls_types.hpp
+++ b/lib/everest/tls/include/everest/tls/tls_types.hpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 
-#include <everest/util/EnumFlags.hpp>
+#include <everest/util/enum/EnumFlags.hpp>
 
 struct ocsp_response_st;
 struct ssl_ctx_st;
@@ -26,7 +26,7 @@ private:
         last = trusted_ca_keys,
     };
 
-    everest::util::AtomicEnumFlags<flags_t> flags;
+    everest::lib::util::AtomicEnumFlags<flags_t> flags;
 
 public:
     void status_request_received() {

--- a/lib/everest/tls/tests/tls_connection_test.hpp
+++ b/lib/everest/tls/tests/tls_connection_test.hpp
@@ -17,7 +17,7 @@
 #include <thread>
 #include <unistd.h>
 
-#include <everest/util/EnumFlags.hpp>
+#include <everest/util/enum/EnumFlags.hpp>
 
 using namespace std::chrono_literals;
 
@@ -36,10 +36,10 @@ struct ClientStatusRequestV2Test : public ClientStatusRequestV2 {
         last = connected,
     };
 
-    everest::util::AtomicEnumFlags<flags_t>& flags;
+    everest::lib::util::AtomicEnumFlags<flags_t>& flags;
 
     ClientStatusRequestV2Test() = delete;
-    explicit ClientStatusRequestV2Test(everest::util::AtomicEnumFlags<flags_t>& flag_ref) : flags(flag_ref) {
+    explicit ClientStatusRequestV2Test(everest::lib::util::AtomicEnumFlags<flags_t>& flag_ref) : flags(flag_ref) {
     }
 
     int status_request_cb(tls::Ssl* ctx) override {
@@ -97,7 +97,7 @@ struct ClientStatusRequestV2Test : public ClientStatusRequestV2 {
 
 struct ClientTest : public tls::Client {
     using flags_t = ClientStatusRequestV2Test::flags_t;
-    everest::util::AtomicEnumFlags<flags_t> flags;
+    everest::lib::util::AtomicEnumFlags<flags_t> flags;
 
     ClientTest() : tls::Client(std::unique_ptr<ClientStatusRequestV2>(new ClientStatusRequestV2Test(flags))) {
     }

--- a/lib/everest/util/CMakeLists.txt
+++ b/lib/everest/util/CMakeLists.txt
@@ -2,6 +2,11 @@ add_library(everest_util INTERFACE)
 add_library(everest::util ALIAS everest_util)
 ev_register_library_target(everest_helpers)
 
+set_target_properties(everest_util PROPERTIES
+  VERSION 0.0.1
+)
+
+
 target_include_directories(everest_util
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/lib/everest/util/include/everest/util/async/monitor.hpp
+++ b/lib/everest/util/include/everest/util/async/monitor.hpp
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+/**
+ * @file monitor.hpp
+ * @brief Provides a generic RAII Monitor pattern implementation for thread-safe access to a shared resource.
+ *
+ * The Monitor pattern bundles shared data with a synchronization mechanism (mutex and condition variable)
+ * to ensure only one thread can access the data at any given time, and provides tools for thread
+ * coordination (waiting and signaling).
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+namespace everest::lib::util {
+
+template <typename T, typename = void> struct has_arrow_operator : std::false_type {};
+
+template <typename T>
+struct has_arrow_operator<T, std::void_t<decltype(std::declval<T>().operator->())>> : std::true_type {};
+
+template <typename T> inline constexpr bool has_arrow_operator_v = has_arrow_operator<T>::value;
+
+/**
+ * @brief The RAII guard that provides locked access to the shared data T.
+ * * This object is non-copyable but movable. Its existence guarantees that the
+ * underlying mutex in the parent monitor object is held. When this handle
+ * goes out of scope, the lock is automatically released.
+ *
+ * @tparam T The type of the protected resource.
+ * @tparam MTX The mutex type used for locking (e.g., std::mutex, std::recursive_mutex).
+ */
+template <class T, class MTX> class monitor_handle {
+public:
+    /**
+     * @brief Constructs the monitor handle and takes ownership of the acquired lock.
+     * @param obj Reference to the protected resource within the monitor.
+     * @param mtx R-value reference to the acquired unique lock, ownership is moved.
+     * @param cv Reference to the condition variable in the monitor.
+     */
+    monitor_handle(T& obj, std::unique_lock<MTX>&& mtx, std::condition_variable& cv) :
+        m_obj(obj), m_lock(std::move(mtx)), m_cv(cv) {
+    }
+
+    // Monitor handles should not be copied, as that would duplicate a unique lock.
+    monitor_handle(monitor_handle<T, MTX> const& other) = delete;
+    monitor_handle<T, MTX>& operator=(monitor_handle<T, MTX> const& rhs) = delete;
+
+    // Defaulted move operations allow the handle to be moved (e.g., returned from monitor::handle).
+    /** @brief generated default move constructor*/
+    monitor_handle(monitor_handle<T, MTX>&& other) = default;
+    /** @brief generated default move assignment*/
+    monitor_handle<T, MTX>& operator=(monitor_handle<T, MTX>&& rhs) = default;
+
+    /**
+     * @brief Destructor. Automatically releases the lock held by m_lock.
+     */
+    ~monitor_handle() = default;
+
+    /**
+     * @brief Overloads the dereference operator to allow reference access to the protected object.
+     * * This provides direct reference access to the guarded object T (or the wrapper T, e.g., std::unique_ptr<...>&).
+     * The lock is held during the access.
+     *
+     * @return Reference to the protected object T.
+     */
+    T& operator*() {
+        return m_obj;
+    }
+
+    /**
+     * @brief Overloads the arrow operator to provide unified pointer-like access to the protected object.
+     * * This implementation uses C++17's `if constexpr` to support three primary access patterns:
+     * 1. **Chaining (Returns T&):** Used when T is a pointer-like wrapper (e.g., std::unique_ptr<T>) or a raw pointer
+     * (T*). This allows the compiler's built-in chaining mechanism to continue indirection until the final object is
+     * reached.
+     * 2. **Direct Pointer Access (Returns T*):** Used when T is the final object type (e.g., a simple struct or class).
+     * This terminates the chain immediately with a pointer to the object.
+     * * @note This method holds the mutex lock for the duration of the access.
+     *
+     * @return `decltype(auto)` returns T& for chaining/pointers, or T* for direct access.
+     */
+    decltype(auto) operator->() {
+        if constexpr (has_arrow_operator_v<T> || std::is_pointer_v<T>) {
+            return m_obj;
+        } else {
+            return &m_obj;
+        }
+    }
+
+    /**
+     * @brief Blocks the thread until the provided predicate returns true.
+     * @details This function atomically releases the lock (allowing other threads to acquire it)
+     * and waits for a notification on the condition variable. When woken, it re-acquires
+     * the lock and re-checks the predicate.
+     * * @note This method is only available when MTX is std::mutex.
+     * @tparam Predicate The callable type (e.g., lambda) that returns a boolean.
+     * @param pred The condition that must become true to stop waiting.
+     */
+    template <class Predicate, class U = MTX, std::enable_if_t<std::is_same_v<U, std::mutex>>* = nullptr>
+    void wait(Predicate&& pred) {
+        m_cv.wait(m_lock, std::forward<Predicate>(pred));
+    }
+
+    /**
+     * @brief Blocks the thread until the predicate returns true or the timeout expires.
+     * @note This method is only available when MTX is std::mutex.
+     * @tparam Rep The type representing the duration count (e.g., int, long).
+     * @tparam Period The type representing the duration period (e.g., std::milli, std::ratio<1>).
+     * @tparam Predicate The callable type (e.g., lambda) that returns a boolean.
+     * @param pred The condition that must become true to stop waiting.
+     * @param timeout The maximum time to wait for the condition to become true.
+     * @return true if the predicate became true, false if the timeout expired.
+     */
+    template <class Rep, class Period, class Predicate, class U = MTX,
+              std::enable_if_t<std::is_same_v<U, std::mutex>>* = nullptr>
+    bool wait_for(Predicate&& pred, std::chrono::duration<Rep, Period> timeout) {
+        return m_cv.wait_for(m_lock, timeout, std::forward<Predicate>(pred));
+    }
+
+    /**
+     * @brief Blocks the thread until the predicate returns true or the absolute time point is reached.
+     * * If the predicate is false, the lock is atomically released, and the thread sleeps until
+     * a notification is received or abs_time is reached. When woken, the lock is re-acquired
+     * and the predicate is re-checked.
+     * @note This method is only available when MTX is std::mutex.
+     * @tparam Clock The clock type used for the time point (e.g., std::system_clock, std::steady_clock).
+     * @tparam Duration The duration type used for the time point.
+     * @tparam Predicate The callable type (e.g., lambda) that returns a boolean.
+     * @param abs_time The absolute time point at which the wait will cease, regardless of predicate state.
+     * @param pred The condition that must become true to stop waiting.
+     * @return true if the predicate became true, false if the absolute time was reached.
+     */
+    template <class Clock, class Duration, class Predicate, class U = MTX,
+              std::enable_if_t<std::is_same_v<U, std::mutex>>* = nullptr>
+    bool wait_until(std::chrono::time_point<Clock, Duration> const& abs_time, Predicate&& pred) {
+        return m_cv.wait_until(m_lock, abs_time, std::forward<Predicate>(pred));
+    }
+
+private:
+    T& m_obj;                      ///< Reference to the protected resource.
+    std::unique_lock<MTX> m_lock;  ///< The unique lock, holding the mutex during the handle's lifetime.
+    std::condition_variable& m_cv; ///< Reference to the monitor's condition variable.
+};
+
+/**
+ * @brief A generic monitor class that manages RAII access to its resource T.
+ * * Provides thread-safe data encapsulation using a mutex and thread coordination
+ * via a condition variable. Access to the internal resource T is only possible
+ * by obtaining a monitor_handle.
+ *
+ * @tparam T The type of the resource being protected.
+ * @tparam MTX The mutex type to use, defaults to std::mutex.
+ */
+template <class T, class MTX = std::mutex> class monitor {
+public:
+    monitor() = default;
+    /**
+     * @brief Constructs the internal object T using move construction.
+     */
+    explicit monitor(T&& obj) : m_obj(std::move(obj)) {
+    }
+
+    /**
+     * @brief Constructs the internal object T using perfect forwarding.
+     * @tparam ArgsT Types of arguments used to construct T.
+     * @param args Arguments passed to the constructor of T.
+     */
+    template <class... ArgsT> explicit monitor(ArgsT&&... args) : m_obj(std::forward<ArgsT>(args)...) {
+    }
+
+    ~monitor() = default;
+
+    // Monitors should not be copied.
+    monitor(monitor<T, MTX> const& other) = delete;
+    monitor<T, MTX>& operator=(monitor<T, MTX> const& rhs) = delete;
+
+    /**
+     * @brief Thread-safe move constructor. Locks the source mutex before swapping.
+     */
+    monitor(monitor<T, MTX>&& other) {
+        // Lock the source monitor's mutex before moving its data to ensure thread safety
+        std::unique_lock lock(other.m_mtx);
+        std::swap(m_obj, other.m_obj);
+        // Note: m_mtx and m_cv are not swapped; they remain tied to the current object.
+    }
+
+    /**
+     * @brief Thread-safe move assignment operator. Locks the source mutex before swapping.
+     * @return Reference to the current object.
+     */
+    monitor<T, MTX>& operator=(monitor<T, MTX>&& rhs) {
+        // Lock the source monitor's mutex before moving its data to ensure thread safety
+        std::unique_lock lock(rhs.m_mtx);
+        std::swap(m_obj, rhs.m_obj);
+        return *this;
+    }
+
+    /**
+     * @brief Blocks indefinitely to acquire the lock and return a handle.
+     * @return monitor_handle<T, MTX> with ownership of the acquired lock.
+     */
+    monitor_handle<T, MTX> handle() {
+        std::unique_lock lock(m_mtx);
+        return monitor_handle<T, MTX>(m_obj, std::move(lock), m_cv);
+    }
+
+    /**
+     * @brief Attempts to acquire the lock within the specified timeout duration.
+     * @note This method is only available when MTX is std::timed_mutex.
+     * @tparam Rep The type representing the duration count.
+     * @tparam Period The type representing the duration period.
+     * @param timeout The maximum time to wait for the lock.
+     * @return An optional handle: contains the handle if the lock was acquired, std::nullopt otherwise.
+     */
+    template <class Rep, class Period, class U = MTX, std::enable_if_t<std::is_same_v<U, std::timed_mutex>>* = nullptr>
+    std::optional<monitor_handle<T, MTX>> handle(std::chrono::duration<Rep, Period> timeout) {
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+
+        std::unique_lock lock(m_mtx, std::defer_lock);
+        if (not lock.try_lock_until(deadline)) {
+            return std::nullopt;
+        }
+
+        return monitor_handle<T, MTX>(m_obj, std::move(lock), m_cv);
+    }
+
+    /**
+     * @brief Wakes up one thread currently waiting on the monitor's condition variable.
+     * @note This method is only available when MTX is std::mutex.
+     */
+    template <class U = MTX, std::enable_if_t<std::is_same_v<U, std::mutex>>* = nullptr> void notify_one() {
+        m_cv.notify_one();
+    }
+
+    /**
+     * @brief Wakes up all threads currently waiting on the monitor's condition variable.
+     * @note This method is only available when MTX is std::mutex.
+     */
+    template <class U = MTX, std::enable_if_t<std::is_same_v<U, std::mutex>>* = nullptr> void notify_all() {
+        m_cv.notify_all();
+    }
+
+private:
+    MTX m_mtx;                    ///< The mutex protecting the resource T.
+    T m_obj;                      ///< The protected resource.
+    std::condition_variable m_cv; ///< The condition variable for thread coordination.
+};
+
+} // namespace everest::lib::util

--- a/lib/everest/util/include/everest/util/enum/EnumFlags.hpp
+++ b/lib/everest/util/include/everest/util/enum/EnumFlags.hpp
@@ -14,7 +14,7 @@
 #include <limits>
 #include <type_traits>
 
-namespace everest::util {
+namespace everest::lib::util {
 
 /**
  * \brief templated class to use an enumeration as bit flags
@@ -239,6 +239,6 @@ template <typename T> struct EnumFlags : public EnumFlagsBase<T, SelectedUInt<T>
 
 template <typename T> struct AtomicEnumFlags : public EnumFlagsBase<T, std::atomic<SelectedUInt<T>>> {};
 
-} // namespace everest::util
+} // namespace everest::lib::util
 
 #endif

--- a/lib/everest/util/tests/CMakeLists.txt
+++ b/lib/everest/util/tests/CMakeLists.txt
@@ -1,13 +1,14 @@
-add_executable(EnumFlagsTest
-    EnumFlagsTest.cpp
-    EnumFlagsTest_B.cpp
+add_executable(everest_util_tests
+    enum/EnumFlagsTest.cpp
+    enum/EnumFlagsTest_B.cpp
+    async/monitor_tests.cpp
 )
 
-target_link_libraries(EnumFlagsTest
+target_link_libraries(everest_util_tests
     PRIVATE
         GTest::gtest_main
         everest::util
 )
 
 include(GoogleTest)
-gtest_discover_tests(EnumFlagsTest)
+gtest_discover_tests(everest_util_tests)

--- a/lib/everest/util/tests/async/monitor_tests.cpp
+++ b/lib/everest/util/tests/async/monitor_tests.cpp
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include "gtest/gtest.h"
+#include <everest/util/async/monitor.hpp>
+#include <future>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+struct SharedData {
+    int value = 0;
+    std::string name = "initial";
+};
+
+using namespace everest::lib::util;
+
+class MonitorTest : public ::testing::Test {
+protected:
+    monitor<SharedData> simple_monitor_;
+    monitor<std::unique_ptr<SharedData>> ptr_monitor_;
+    // A timed mutex enabled monitor::handle(timeout)
+    monitor<SharedData, std::timed_mutex> timed_mtx_monitor_;
+};
+
+TEST_F(MonitorTest, SingleThreadedAccess) {
+    // Block 1: Access and Modify (Lock acquired by handle, then released)
+    {
+        // Acquire the handle (locks the mutex)
+        auto handle = simple_monitor_.handle();
+
+        // Access and modify the data using operator->
+        handle->value = 100;
+        handle->name = "updated";
+
+        // When 'handle' goes out of scope here, the lock is released (RAII).
+    }
+
+    // Block 2: Verify changes (Lock acquired, then released)
+    {
+        // Now acquiring the lock succeeds because it was released above.
+        auto handle_check = simple_monitor_.handle();
+
+        // Verify
+        EXPECT_EQ(100, handle_check->value);
+        EXPECT_EQ("updated", handle_check->name);
+    }
+}
+
+TEST_F(MonitorTest, PointerLikeAccessChaining) {
+    // Block 1: Initialization (Ensures the unique_ptr is created)
+    {
+        auto h = ptr_monitor_.handle();
+        *h = std::make_unique<SharedData>();
+    } // h is destroyed, lock released.
+
+    // Block 2: Access and Modify (Lock acquired by handle, then released)
+    {
+        // Acquire lock
+        auto handle = ptr_monitor_.handle();
+
+        // Access via chaining (T=unique_ptr<SharedData>)
+        handle->value = 42;
+        handle->name = "chained";
+    } // handle is destroyed, lock released.
+
+    // Block 3: Verify (Lock acquired, then released)
+    {
+        // Acquire lock
+        auto handle_check = ptr_monitor_.handle();
+
+        // Access via chaining
+        EXPECT_EQ(42, handle_check->value);
+        EXPECT_EQ("chained", handle_check->name);
+    }
+}
+
+TEST_F(MonitorTest, ThreadSafeIncrement) {
+    const int num_threads = 10;
+    const int increments_per_thread = 1000;
+    std::vector<std::thread> threads;
+
+    // Set initial value to 0
+    simple_monitor_.handle()->value = 0;
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&] {
+            for (int j = 0; j < increments_per_thread; ++j) {
+                // Handle scope ensures RAII locking on every single increment
+                auto handle = simple_monitor_.handle();
+                handle->value++;
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Verify the final value is correct
+    auto final_handle = simple_monitor_.handle();
+    EXPECT_EQ(num_threads * increments_per_thread, final_handle->value);
+}
+
+TEST_F(MonitorTest, ConditionVariableWaitNotify) {
+    bool done = false;
+
+    // Future/Promise pair 1: Waiter signals it is ready to wait
+    std::promise<void> waiter_ready_promise;
+    std::future<void> waiter_ready_future = waiter_ready_promise.get_future();
+
+    std::thread waiter([&] {
+        // Acquire handle
+        auto handle = simple_monitor_.handle();
+
+        // Signal that we are holding the lock and about to wait
+        waiter_ready_promise.set_value();
+
+        // Wait until 'done' is true.
+        handle.wait([&] { return done; });
+
+        EXPECT_EQ(99, handle->value);
+    });
+
+    // Main thread waits until the waiter has acquired the lock and set the promise
+    waiter_ready_future.get();
+
+    // Notifier thread operation (guaranteed to happen after waiter has locked/signaled)
+    {
+        // Acquire lock
+        auto handle = simple_monitor_.handle();
+        handle->value = 99;
+        done = true;
+    }
+
+    // Notify the waiting thread
+    simple_monitor_.notify_one();
+
+    waiter.join();
+}
+
+// --------------------------------------------------------------------------------
+
+TEST_F(MonitorTest, TryLockHandleTimeout) {
+    // Future/Promise pair 1: Blocker signals it has acquired the lock
+    std::promise<void> blocker_locked_promise;
+    std::future<void> blocker_locked_future = blocker_locked_promise.get_future();
+
+    // The shared object is used as the resource for the lock
+
+    std::thread blocker([&] {
+        // Acquire the lock
+        auto handle = timed_mtx_monitor_.handle(); // 🔒 Lock acquired
+
+        // Signal to the main thread that the lock is held
+        blocker_locked_promise.set_value();
+
+        // Hold the lock for a specified duration
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+        // Lock released when handle goes out of scope 🔓
+    });
+
+    // Main thread waits until the blocker explicitly confirms it is holding the lock
+    blocker_locked_future.get();
+
+    // Test 1: Try to acquire the lock with a short timeout (Expected to FAIL)
+    auto handle_opt = timed_mtx_monitor_.handle(std::chrono::milliseconds(10));
+    EXPECT_FALSE(handle_opt.has_value());
+
+    // Test 2: Try to acquire the lock with a long timeout (Expected to SUCCEED eventually)
+    // Note: The total wait time will be about 300ms, which is sufficient for the blocker to finish.
+    auto handle_long_opt = timed_mtx_monitor_.handle(std::chrono::milliseconds(300));
+    EXPECT_TRUE(handle_long_opt.has_value());
+
+    blocker.join();
+}
+
+TEST_F(MonitorTest, TimedMutexLockAcquisition) {
+    // Synchronization barriers
+    std::promise<void> blocker_locked_promise;
+    std::future<void> blocker_locked_future = blocker_locked_promise.get_future();
+    std::promise<void> start_waiting_promise;
+    std::future<void> start_waiting_future = start_waiting_promise.get_future();
+
+    std::chrono::milliseconds hold_time(100);
+    std::chrono::milliseconds short_wait(10);
+    std::chrono::milliseconds long_wait(200);
+
+    // THREAD A: The Blocker (Holds the lock on timed_mtx_monitor_)
+    std::thread blocker([&] {
+        // 1. Acquire lock
+        auto handle = timed_mtx_monitor_.handle();
+        blocker_locked_promise.set_value(); // Signal: Lock is now held
+
+        // 3. Wait for the main thread to start waiting/timing
+        start_waiting_future.get();
+
+        // 4. Hold the lock for the required duration
+        std::this_thread::sleep_for(hold_time);
+
+        // Lock released when handle goes out of scope
+    });
+
+    // 2. Main thread waits until the lock is actively held
+    blocker_locked_future.get();
+
+    // --- Test 1: Fail Case (Wait is shorter than remaining lock time) ---
+    // The previous timing logic was adequate here, as failure should be fast.
+    auto fail_handle = timed_mtx_monitor_.handle(short_wait);
+    EXPECT_FALSE(fail_handle.has_value());
+
+    // --- Test 2: Success Case (Wait is longer than remaining lock time) ---
+    // We now start the timer precisely when the blocker starts its hold duration.
+    auto start_success = std::chrono::steady_clock::now();
+
+    // Signal the blocker to start its sleep/hold time
+    start_waiting_promise.set_value();
+
+    // Acquire the lock with a sufficient timeout (this call blocks and times the wait)
+    auto success_handle = timed_mtx_monitor_.handle(long_wait);
+
+    // Calculate duration from the point the blocker started holding the lock
+    auto duration_success = std::chrono::steady_clock::now() - start_success;
+
+    // Must succeed acquisition
+    EXPECT_TRUE(success_handle.has_value());
+
+    // The time waited MUST be greater than or equal to the hold_time
+    // We use EXPECT_GE (Greater than or Equal to) for robustness against scheduler timing
+    EXPECT_GE(duration_success, hold_time);
+
+    blocker.join();
+}
+
+TEST_F(MonitorTest, ConditionVariableAtomicity) {
+    bool predicate_was_checked = false;
+    bool notification_sent = false;
+
+    // THREAD A: The Waiter
+    std::thread waiter([&] {
+        // Use simple_monitor_ (std::mutex) for CV operations
+        auto handle = simple_monitor_.handle();
+
+        // Waiter signals that it is holding the lock and about to enter the wait state
+        // (This part is simplified here to focus on the CV logic itself)
+
+        // Predicate check: Ensure 'notification_sent' is only true IF the lock is reacquired
+        handle.wait([&] {
+            predicate_was_checked = true;
+            return notification_sent;
+        });
+
+        // After waking up, the lock is held. Verify the resource state.
+        EXPECT_EQ(1, handle->value);
+    });
+
+    // Give the waiter time to acquire the lock and block on the CV
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // THREAD B: The Notifier (This thread modifies the state and notifies)
+    {
+        // Must acquire the lock. This proves the waiter released it.
+        auto handle = simple_monitor_.handle();
+
+        // 1. Modify the resource while holding the lock
+        handle->value = 1;
+
+        // 2. Set the wait condition *after* modification
+        notification_sent = true;
+
+        // 3. Ensure the predicate has NOT been checked since the wait began (it will be checked on wake)
+        // This is tricky to assert safely without more barriers, but the logic holds:
+        // The first successful predicate check occurs only after the notify/wake.
+    } // Lock released, waiter is notified
+
+    simple_monitor_.notify_one();
+
+    waiter.join();
+
+    // Final verification that the CV logic executed properly
+    EXPECT_TRUE(predicate_was_checked);
+}
+
+TEST_F(MonitorTest, ThreadSafeMoveOperations) {
+    // Setup: Monitor m1 is the source, initialized with a value
+    monitor<SharedData> m1;
+    m1.handle()->value = 10;
+
+    std::promise<void> blocker_locked_promise;
+    std::future<void> blocker_locked_future = blocker_locked_promise.get_future();
+
+    // THREAD A: The Blocker (Holds the lock on m1 to force the move operation to wait)
+    std::thread blocker([&] {
+        auto handle = m1.handle(); // Lock m1
+        blocker_locked_promise.set_value();
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    });
+
+    // Main thread waits until m1 is locked by the blocker
+    blocker_locked_future.get();
+
+    // --- Move Assignment Test ---
+    monitor<SharedData> m2;
+
+    // Move m1 to m2. This operation MUST wait for the blocker thread to release m1's lock
+    // because the move assignment operator correctly acquires a unique_lock on the source (m1) mutex.
+    auto start_move = std::chrono::steady_clock::now();
+    m2 = std::move(m1); // Should block here until blocker releases m1's lock
+    auto duration_move = std::chrono::steady_clock::now() - start_move;
+
+    // Verify the move blocked until the blocker thread finished (duration > hold time)
+    EXPECT_GT(duration_move, std::chrono::milliseconds(100));
+
+    // Verify data transfer (m2 should now have the data)
+    EXPECT_EQ(10, m2.handle()->value);
+
+    blocker.join();
+}

--- a/lib/everest/util/tests/enum/EnumFlagsTest.cpp
+++ b/lib/everest/util/tests/enum/EnumFlagsTest.cpp
@@ -2,7 +2,7 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #include <gtest/gtest.h>
 
-#include <everest/util/EnumFlags.hpp>
+#include <everest/util/enum/EnumFlags.hpp>
 
 enum class ErrorHandlingFlags : std::uint8_t {
     prevent_charging,
@@ -36,7 +36,7 @@ enum class BspErrors : std::uint8_t {
     last = VendorError
 };
 
-using namespace everest::util;
+using namespace everest::lib::util;
 
 TEST(AtomicEnumFlagsTest, init) {
     AtomicEnumFlags<ErrorHandlingFlags> flags;

--- a/lib/everest/util/tests/enum/EnumFlagsTest_B.cpp
+++ b/lib/everest/util/tests/enum/EnumFlagsTest_B.cpp
@@ -2,10 +2,10 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #include <gtest/gtest.h>
 
-#include <everest/util/EnumFlags.hpp>
+#include <everest/util/enum/EnumFlags.hpp>
 
 namespace {
-using namespace everest::util;
+using namespace everest::lib::util;
 
 // needs an 8-bit value
 enum class small : std::uint8_t {


### PR DESCRIPTION
## Describe your changes
This adds a new monitor class template to everest/lib/util implementing the monitor pattern

The monitor wraps up some data structure and give pointer like access via a handle, that ensures exclusive access.

Depending on the used mutex type additional features, like getting the handle with a timeout (std::timed_mutex) or conditional wait (std::mutex) are available.

See the included doxygen documentation and the testcases for details


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

