### PR TITLE
EvseSecurity/ErrorHistory: adjust license url in manifests

### DIFF
--- a/modules/EVSE/EvseSecurity/manifest.yaml
+++ b/modules/EVSE/EvseSecurity/manifest.yaml
@@ -44,6 +44,6 @@ provides:
     interface: evse_security 
 enable_telemetry: false
 metadata:
-  license: https://spdx.org/licenses/Apache-2.0.html
+  license: https://opensource.org/licenses/Apache-2.0
   authors:
     - Piet Gömpel

--- a/modules/Misc/ErrorHistory/manifest.yaml
+++ b/modules/Misc/ErrorHistory/manifest.yaml
@@ -9,6 +9,6 @@ provides:
         description: Absolute path to the database file
 enable_global_errors: true
 metadata:
-  license: https://spdx.org/licenses/Apache-2.0.html
+  license: https://opensource.org/licenses/Apache-2.0
   authors:
     - Andreas Heinrich


### PR DESCRIPTION
## Describe your changes

Align the URL used in these two manifests with the other manifests.

## Issue ticket number and link

none

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

