### PR TITLE
fix: detect musl-based systems and increase stack size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,16 +43,22 @@ endif()
 # test whether we are building on a musl based system.
 # On these we need to increase the stack size as it is very low by default
 find_program(LDD_EXECUTABLE ldd)
-if(LDD_EXECUTABLE)
-    # we use /bin/ls as it is very likely to exist on any system. ldd prints the dynamic linked libraries
+find_program(LS_EXECUTABLE ls)
+if(LDD_EXECUTABLE AND LS_EXECUTABLE)
+    # we use ls as a testing executable as it is very likely to exist on any system. ldd prints the dynamic linked libraries
     # of the given executable, if musl is used it will print it as a linked object
-    execute_process(COMMAND ${LDD_EXECUTABLE} /bin/ls OUTPUT_VARIABLE LDD_LS_OUTPUT ERROR_QUIET)
+    execute_process(COMMAND ${LDD_EXECUTABLE} ${LS_EXECUTABLE} OUTPUT_VARIABLE LDD_LS_OUTPUT ERROR_QUIET)
     if(LDD_LS_OUTPUT MATCHES "musl")
         message(STATUS "MUSL detected, increasing stack size to 8MiB")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,stack-size=8388608")
     endif()
 else()
-    message(WARNING "ldd not found, skipping musl detection")
+    if(NOT LDD_EXECUTABLE)
+        message(WARNING "ldd not found, skipping musl detection")
+    endif()
+    if(NOT LS_EXECUTABLE)
+        message(WARNING "ls not found, skipping musl detection")
+    endif()
 endif()
 
 option(CREATE_SYMLINKS "Create symlinks to javascript modules and auxillary files - for development purposes" OFF)


### PR DESCRIPTION
## Describe your changes

musl based systems have a default stack size that is far smaller that glibc based systems. This leads to stack overflows on some systems, including Alpine Linux.
This PR adds a check to the root `CMakeLists.txt` that adds a linker flag to increase the stack size to 8MiB if necessary.

This change has been tested on Alpine Linux 3.18 and Ubuntu 24.04

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

