### PR TITLE
Adding more utilities to lib 'util'

### DIFF
--- a/lib/everest/util/include/everest/util/async/async_wrapper.hpp
+++ b/lib/everest/util/include/everest/util/async/async_wrapper.hpp
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+/**
+ * @file Wrapping of a resource and serializing the access to the resource
+ * @brief The content is based on the conference talk 'Concurrency-and-Parallelism'
+ * held by Herb Sutter at C-and-Beyond-2012.
+ * The original pattern has been extend with exhaustive handling of corner cases and errors.
+ * Policies allow for the adaptation to common use cases.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <everest/util/queue/thread_safe_queue.hpp>
+#include <exception>
+#include <functional>
+#include <future>
+#include <memory>
+#include <thread>
+#include <type_traits>
+
+namespace everest::lib::util::testing_interface {
+//  Forward declaration of the test fixture used as a friend
+class AsyncWrapperTest;
+} // namespace everest::lib::util::testing_interface
+
+namespace everest::lib::util {
+
+// --- EXCEPTION POLICIES (Policy 1) ---
+
+/**
+ * @brief Policy that triggers a global shutdown if a user-supplied task throws an exception.
+ * @details Used for guarded resources where an exception implies resource corruption.
+ */
+struct GlobalFailurePolicy {
+    /**
+     * @brief Sets the global promise with the given exception pointer, permanently failing the executor.
+     */
+    static void handle_user_exception(std::shared_ptr<std::promise<void>> const& global_promise_ptr,
+                                      std::exception_ptr current_exception_ptr) {
+        try {
+            global_promise_ptr->set_exception(current_exception_ptr);
+        } catch (const std::future_error&) {
+            // Ignore: promise was already satisfied by an earlier thread/task
+        }
+    }
+};
+
+/**
+ * @brief Policy that contains a user-supplied exception locally (does not cause global failure).
+ * @details Used for background tasks where exceptions do not corrupt the resource state.
+ */
+struct LocalFailurePolicy {
+    /**
+     * @brief Handles the user exception by doing nothing to the global promise.
+     */
+    static void handle_user_exception([[maybe_unused]] std::shared_ptr<std::promise<void>> const& global_promise_ptr,
+                                      [[maybe_unused]] std::exception_ptr current_exception_ptr) {
+    }
+};
+
+// --- SHUTDOWN POLICIES (Policy 2) ---
+
+/**
+ * @brief Destructor policy that waits for all queued tasks to finish execution before joining the worker thread.
+ */
+struct WaitToFinishPolicy {
+    /**
+     * @brief Performs a graceful shutdown by pushing a sentinel task and joining.
+     */
+    template <typename QueueT, typename ThreadT>
+    static void shutdown(QueueT& queue, ThreadT& worker, std::atomic_bool& done_flag) {
+        // Push the final stop signal, which will be executed after all pending tasks.
+        queue.push([&done_flag] { done_flag = true; });
+        worker.join();
+    }
+};
+
+/**
+ * @brief Destructor policy that signals the worker to exit immediately, potentially dropping queued tasks.
+ */
+struct FastQuitPolicy {
+    /**
+     * @brief Performs an immediate shutdown by setting the flag and unblocking the thread.
+     */
+    template <typename QueueT, typename ThreadT>
+    static void shutdown(QueueT& queue, ThreadT& worker, std::atomic_bool& done_flag) {
+        // Signal termination immediately
+        done_flag = true;
+        // Send a dummy task to unblock the worker if it's currently blocking on pop()
+        queue.push([] {});
+        worker.join();
+    }
+};
+
+/**
+ * @brief A single-threaded asynchronous executor that serializes access to a resource T.
+ * @details All operations on T are performed sequentially on a dedicated worker thread. It uses two policies
+ * (ExceptionPolicy and ShutdownPolicy) and a QueueT template parameter to define its entire contract.
+ * @tparam T The resource type being wrapped.
+ * @tparam ExceptionPolicy Defines global failure behavior (e.g., GlobalFailurePolicy).
+ * @tparam ShutdownPolicy Defines destructor behavior (e.g., WaitToFinishPolicy).
+ * @tparam QueueT The underlying thread-safe queue implementation.
+ */
+template <typename T, typename ExceptionPolicy, typename ShutdownPolicy,
+          template <class> typename QueueT = thread_safe_queue>
+class async_wrapper_impl {
+public:
+    friend class everest::lib::util::testing_interface::AsyncWrapperTest; ///< Allows GTest fixture to access
+                                                                          ///< protected/private members for testing.
+
+    using ThisT = async_wrapper_impl<T, ExceptionPolicy, ShutdownPolicy, QueueT>;
+
+    /**
+     * @brief Constructs the wrapper, initializing the resource and starting the worker thread.
+     */
+    template <class... ArgsT>
+    explicit async_wrapper_impl(ArgsT&&... args) :
+        m_resource(std::forward<ArgsT>(args)...), m_global_promise(std::make_shared<std::promise<void>>()) {
+
+        m_global_future = m_global_promise->get_future();
+
+        m_worker = std::thread([this] {
+            while (not m_done) {
+                try {
+                    m_queue.pop()(); // Execute the task lambda
+                } catch (const std::exception& e) {
+
+                    // Critical infrastructure failure handling
+                    try {
+                        m_global_promise->set_exception(
+                            std::make_exception_ptr(std::runtime_error("Async worker infrastructure failure.")));
+                    } catch (const std::future_error&) {
+                        // Ignore: Promise was already set by a concurrent thread/user task
+                    }
+                    m_done = true; // Signal thread termination
+                } catch (...) {
+                    m_done = true; // Handle non-standard exceptions
+                }
+            }
+        });
+    }
+
+    // Rule of Five members
+    async_wrapper_impl(ThisT&& other) noexcept = default;
+    ThisT& operator=(ThisT&&) noexcept = default;
+    async_wrapper_impl(ThisT const& other) = delete;
+
+    /**
+     * @brief Destructor that shuts down the worker thread according to the ShutdownPolicy.
+     */
+    ~async_wrapper_impl() {
+        ShutdownPolicy::shutdown(m_queue, m_worker, m_done);
+    }
+
+private:
+    template <typename Fut, typename F> void promise_set_value(std::promise<Fut>& prom, F& f, T& t) const {
+        prom.set_value(f(t));
+    }
+
+    template <typename F> void promise_set_value(std::promise<void>& prom, F& f, T& t) const {
+        f(t);
+        prom.set_value();
+    }
+
+    bool is_global_failure_signaled() const {
+        return m_global_future.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+    }
+
+    template <typename F, typename R> void enqueue_task(F f, std::shared_ptr<std::promise<R>> prom) const {
+        auto global_promise_ptr = m_global_promise;
+
+        // --- SYNCHRONOUS FAILURE CHECK (Gatekeeper, executed on calling thread) ---
+        if (is_global_failure_signaled()) {
+            try {
+                m_global_future.get();
+            } catch (const std::exception&) {
+                prom->set_exception(std::current_exception());
+            }
+            return;
+        }
+
+        m_queue.push([=, this] {
+            // --- ASYNCHRONOUS FAILURE CHECK (Mandatory Final Gatekeeper) ---
+            if (is_global_failure_signaled()) {
+                try {
+                    m_global_future.get();
+                } catch (const std::exception&) {
+                    prom->set_exception(std::current_exception());
+                }
+                return;
+            }
+
+            try {
+                promise_set_value(*prom, f, m_resource);
+            } catch (...) {
+                prom->set_exception(std::current_exception());
+
+                ExceptionPolicy::handle_user_exception(global_promise_ptr, std::current_exception());
+            }
+        });
+    }
+
+    mutable T m_resource;
+    mutable QueueT<std::function<void()>> m_queue;
+    std::thread m_worker;
+    std::atomic_bool m_done{false};
+    std::shared_ptr<std::promise<void>> m_global_promise;
+    std::shared_future<void> m_global_future;
+
+public:
+    /**
+     * @brief Submits a function object to the worker thread and returns a future for the result.
+     * @details The function is guaranteed to be executed sequentially with respect to other tasks.
+     * It receives the managed resource as it's only parameter.
+     * @tparam F Function object callable with T&.
+     * @return std::future<R> where R is the return type of F. The future will contain an exception
+     * if the task fails or if a global failure signal has been set.
+     */
+    template <typename F> auto operator()(F f) const {
+        using ReturnT = decltype(f(m_resource));
+        auto prom = std::make_shared<std::promise<ReturnT>>();
+        auto fut = prom->get_future();
+
+        enqueue_task(f, prom);
+
+        return fut;
+    }
+
+    /**
+     * @brief Submits a function object to the worker thread without returning a future (fire-and-forget).
+     * @details This is equivalent to calling operator() and discarding the returned future. Exceptions
+     * are swallowed locally (in the future object) unless the policy dictates a global shutdown.
+     * @tparam F Function object callable with T&.
+     */
+    template <typename F> void run(F f) const {
+        (void)this->operator()(f);
+    }
+};
+
+// --- TYPEDEFS ---
+
+/** @brief Base alias for resources where a task failure causes GLOBAL corruption (Guarded). */
+template <typename T, typename ShutdownPolicy>
+using async_wrapper_guarded = async_wrapper_impl<T, GlobalFailurePolicy, ShutdownPolicy>;
+
+/** @brief Intermediate base alias for resources where a task failure is LOCALIZED (Background). */
+template <typename T, typename ShutdownPolicy>
+using async_wrapper_local = async_wrapper_impl<T, LocalFailurePolicy, ShutdownPolicy>;
+
+// Final Usage Types (Combine Exception Policy and Shutdown Policy)
+
+/** * @brief Primary default wrapper: Local Failure (Background) with Fast Quit.
+ * @tparam T The resource type.
+ */
+template <typename T> using async_wrapper = async_wrapper_local<T, FastQuitPolicy>;
+
+/** @brief Guarded resource with graceful (wait-to-finish) shutdown. */
+template <typename T> using async_wrapper_guarded_wait = async_wrapper_guarded<T, WaitToFinishPolicy>;
+/** @brief Local resource with graceful (wait-to-finish) shutdown. */
+template <typename T> using async_wrapper_wait = async_wrapper_local<T, WaitToFinishPolicy>;
+/** @brief Guarded resource with fast (potentially lossy) shutdown. */
+template <typename T> using async_wrapper_guarded_fast = async_wrapper_guarded<T, FastQuitPolicy>;
+/** @brief Local resource with fast (potentially lossy) shutdown. */
+template <typename T> using async_wrapper_fast = async_wrapper_local<T, FastQuitPolicy>;
+
+} // namespace everest::lib::util

--- a/lib/everest/util/include/everest/util/queue/simple_queue.hpp
+++ b/lib/everest/util/include/everest/util/queue/simple_queue.hpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include <optional>
+#include <queue>
+
+namespace everest::lib::util {
+
+/**
+ * Simplified interface for a queue based
+ * on <a href="https://en.cppreference.com/w/cpp/container/queue">std::queue</a>
+ * @tparam T Datatype held by the queue
+ */
+template <class T> class simple_queue {
+public:
+    /**
+     * @var reference
+     * @brief Inherited type definition from STL
+     */
+    using reference = typename std::queue<T>::reference;
+
+    /**
+     * @var const_reference
+     * @brief Inherited type definition from STL
+     */
+    using const_reference = typename std::queue<T>::const_reference;
+
+    /**
+     * @var value_type
+     * @brief Inherited type definition from STL
+     */
+    using value_type = typename std::queue<T>::value_type;
+
+    /**
+     * @var size_type
+     * @brief Inherited type definition from STL
+     */
+    using size_type = typename std::queue<T>::size_type;
+
+    /**
+     * @brief Maps to std::queue::front()
+     */
+    const_reference front() const {
+        return m_queue.front();
+    }
+
+    /**
+     * Non-const front() is crucial for move semantics
+     **/
+    reference front() {
+        return m_queue.front();
+    }
+
+    /**
+     * @brief Maps to std::queue::back()
+     */
+    const_reference back() const {
+        return m_queue.back();
+    }
+
+    /**
+     * @brief Maps to std::queue::push(const value_type&)
+     */
+    void push(const value_type& value) {
+        m_queue.push(value);
+    }
+    /**
+     * @brief Maps to std::queue::push(value_type&&)
+     */
+    void push(value_type&& value) {
+        m_queue.push(std::forward<value_type>(value));
+    }
+
+    /**
+     * @brief Get the front element of the queue if available.
+     * @return Maybe the front element
+     */
+    std::optional<value_type> pop() {
+        if (m_queue.empty()) {
+            return std::nullopt;
+        }
+        value_type tmp = std::move(front());
+        m_queue.pop();
+        return tmp;
+    }
+
+    /**
+     * @brief Maps to std::queue::empty()
+     */
+    bool empty() const {
+        return m_queue.empty();
+    }
+
+    /**
+     * @brief Maps to std::queue::size()
+     */
+    size_type size() const {
+        return m_queue.size();
+    }
+
+private:
+    std::queue<T> m_queue;
+};
+
+} // namespace everest::lib::util

--- a/lib/everest/util/include/everest/util/queue/thread_safe_queue.hpp
+++ b/lib/everest/util/include/everest/util/queue/thread_safe_queue.hpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include "simple_queue.hpp"
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+namespace everest::lib::util {
+
+/**
+ * A thread safe queue implemented on top of \ref queue::simple_queue. <br>
+ * The common resource \ref simple_queue is guarded by a mutex in every member function. A caller blocking on \p pop
+ * or \p try_pop will be unblocked when new data made available via \p push
+ * @tparam T Datatype held by the queue
+ */
+template <class T> class thread_safe_queue {
+public:
+    /**
+     * @var value_type
+     * @brief Inherited type definition.
+     */
+    using value_type = typename simple_queue<T>::value_type;
+
+    /**
+     * @brief Push new data into the queue
+     * @param[in] value data
+     */
+    void push(const value_type& value) {
+        std::unique_lock lock(m_mtx);
+        m_queue.push(value);
+        lock.unlock();
+        m_cv.notify_one();
+    }
+    /**
+     * @brief Push new data into the queue
+     * @param[in] value data
+     */
+    void push(value_type&& value) {
+        std::unique_lock lock(m_mtx);
+        m_queue.push(std::forward<value_type>(value));
+        lock.unlock();
+        m_cv.notify_one();
+    }
+
+    /**
+     * @brief Try to get an element from the queue.
+     * @details Returns immediately.
+     * @return An element from the queue, if one is available. \p std::nullopt otherwise
+     */
+    std::optional<value_type> try_pop() {
+        return pop_impl(0);
+    }
+
+    /**
+     * @brief Try to get an element from the queue.
+     * @details Returns as soon as data is availble or after timeout.
+     * @param[in] timeout as <a href="https://en.cppreference.com/w/cpp/chrono/duration">std::chrono::duration</a>.
+     * Smallest unit acceptable is milliseconds.
+     * @return An element from the queue, if one is available. \p std::nullopt otherwise
+     */
+    template <class Rep, class Period> std::optional<value_type> try_pop(std::chrono::duration<Rep, Period> timeout) {
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(timeout);
+        return pop_impl(ms.count());
+    }
+
+    /**
+     * @brief Get an element from the queue
+     * @details Only returns, when data is available
+     * @return An element from the queue.
+     */
+    value_type pop() {
+        return pop_impl(-1).value();
+    }
+
+private:
+    std::optional<value_type> pop_impl(int timeout_ms) {
+        std::unique_lock lock(m_mtx);
+        auto wait_predicate = [this]() { return not m_queue.empty(); };
+
+        if (timeout_ms < 0) {
+            m_cv.wait(lock, wait_predicate);
+        } else if (timeout_ms > 0) {
+            (void)m_cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), wait_predicate);
+        }
+
+        return m_queue.pop();
+    }
+
+    simple_queue<T> m_queue;
+    std::mutex m_mtx;
+    std::condition_variable m_cv;
+};
+
+} // namespace everest::lib::util

--- a/lib/everest/util/tests/CMakeLists.txt
+++ b/lib/everest/util/tests/CMakeLists.txt
@@ -1,11 +1,14 @@
 add_executable(everest_util_tests
-    enum/EnumFlagsTest.cpp
-    enum/EnumFlagsTest_B.cpp
-    async/monitor_tests.cpp
+  async/monitor_tests.cpp
+  async/wrapper_tests.cpp
+  enum/EnumFlagsTest.cpp
+  enum/EnumFlagsTest_B.cpp
+  queue/simple_queue_tests.cpp
+  queue/thread_safe_queue_tests.cpp
 )
 
 target_link_libraries(everest_util_tests
-    PRIVATE
+  PRIVATE
         GTest::gtest_main
         everest::util
 )

--- a/lib/everest/util/tests/async/wrapper_tests.cpp
+++ b/lib/everest/util/tests/async/wrapper_tests.cpp
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include "gtest/gtest.h"
+#include <everest/util/async/async_wrapper.hpp>
+#include <exception>
+#include <future>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+struct Counter {
+    Counter(int v) : value(v) {
+    }
+    int value = 0;
+    std::thread::id worker_id;
+
+    // Mutator
+    void add(int v) {
+        value += v;
+        worker_id = std::this_thread::get_id();
+    }
+    // Accessor
+    int get() const {
+        return value;
+    }
+    // Thrower
+    int throw_if_equal(int v) {
+        if (value == v) {
+            throw std::runtime_error("User-defined fatal error.");
+        }
+        return value;
+    }
+};
+
+using namespace everest::lib::util;
+
+// --- GTEST FIXTURE ---
+namespace everest::lib::util::testing_interface {
+class AsyncWrapperTest : public ::testing::Test {
+public:
+    template <class T> std::shared_ptr<std::promise<void>> const& get_global_promise_for_test(T& wrapper) const {
+        return wrapper.m_global_promise;
+    }
+
+    template <class T> auto& get_queue_for_test(T& wrapper) {
+        return wrapper.m_queue;
+    }
+};
+} // namespace everest::lib::util::testing_interface
+
+using namespace everest::lib::util::testing_interface;
+
+template <class T> class TestQueue : public thread_safe_queue<T> {
+public:
+    using ThisT = thread_safe_queue<T>;
+    void push(T item) {
+        ThisT::push(item);
+    }
+
+    T pop() {
+        if (m_throw_on_next_pop) {
+            throw std::runtime_error("oh no");
+        }
+
+        auto tmp = ThisT::pop();
+
+        return tmp;
+    }
+
+    void force_throw_on_next_pop() {
+        m_throw_on_next_pop = true;
+        push([]() {});
+    }
+
+private:
+    bool m_throw_on_next_pop{false};
+};
+
+template <typename T>
+using async_guarded_testqueue = async_wrapper_impl<T, GlobalFailurePolicy, WaitToFinishPolicy, TestQueue>;
+
+// Test 1: Basic functionality and thread serialization (Background/WaitToFinish)
+TEST_F(AsyncWrapperTest, CoreFunctionality) {
+    async_wrapper_wait<Counter> wrapper(0);
+
+    // 1. Check asynchronous execution and result retrieval
+    auto fut1 = wrapper([](Counter& c) {
+        c.add(5);
+        return c.get();
+    });
+    auto fut2 = wrapper([](Counter& c) {
+        c.add(10);
+        return c.get();
+    });
+
+    EXPECT_EQ(fut1.get(), 5);
+    EXPECT_EQ(fut2.get(), 15);
+
+    // 2. Check side effect on resource
+    auto fut3 = wrapper([](Counter& c) { return c.get(); });
+    EXPECT_EQ(fut3.get(), 15);
+
+    // 3. Check 'run' (fire-and-forget)
+    wrapper.run([](Counter& c) { c.add(5); });
+
+    auto fut4 = wrapper([](Counter& c) { return c.get(); });
+    EXPECT_EQ(fut4.get(), 20);
+
+    // 4. Check thread ID
+    std::thread::id main_thread_id = std::this_thread::get_id();
+    auto fut_id = wrapper([](Counter& c) { return c.worker_id; });
+
+    EXPECT_NE(fut_id.get(), main_thread_id);
+}
+
+// Test 2: LocalFailurePolicy (Background) - User Exception is Isolated
+TEST_F(AsyncWrapperTest, LocalPolicy_UserExceptionIsContained) {
+    async_wrapper_wait<Counter> wrapper(5);
+
+    auto fut_a = wrapper([](Counter& c) { return c.throw_if_equal(5); });
+    auto fut_b = wrapper([](Counter& c) {
+        c.add(10);
+        return c.get();
+    });
+
+    fut_a.wait();
+    fut_b.wait();
+
+    ASSERT_THROW(fut_a.get(), std::runtime_error);
+
+    int received_value = 0;
+    EXPECT_NO_THROW(received_value = fut_b.get());
+    EXPECT_EQ(received_value, 15);
+
+    auto fut_c = wrapper([](Counter& c) { return c.get(); });
+    fut_c.wait();
+    EXPECT_EQ(fut_c.get(), 15);
+}
+
+// Test 3: GlobalFailurePolicy (Guarded) - User Exception Shuts Down Instance
+TEST_F(AsyncWrapperTest, GlobalPolicy_UserExceptionCausesShutdown) {
+    async_wrapper_guarded_wait<Counter> wrapper(5);
+
+    auto fut_a = wrapper([](Counter& c) { return c.throw_if_equal(5); });
+    auto fut_b = wrapper([](Counter& c) {
+        c.add(10);
+        return c.get();
+    });
+
+    fut_a.wait();
+    fut_b.wait();
+
+    ASSERT_THROW(fut_a.get(), std::runtime_error);
+    ASSERT_THROW(fut_b.get(), std::runtime_error);
+
+    auto fut_c = wrapper([](Counter& c) { return c.get(); });
+    fut_c.wait();
+    ASSERT_THROW(fut_c.get(), std::runtime_error);
+}
+
+// Test 4: GlobalFailureSignal_BlocksNewTasks (Tests signal effect)
+TEST_F(AsyncWrapperTest, GlobalFailureSignal_BlocksNewTasks) {
+    async_wrapper_guarded_wait<Counter> wrapper(0);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // 1. Manually set the Global Promise (simulating infrastructure or user failure)
+    try {
+        throw std::runtime_error("Simulated Global Signal Set.");
+    } catch (...) {
+        get_global_promise_for_test(wrapper)->set_exception(std::current_exception());
+    }
+
+    // 2. Submit a new task (Task B)
+    auto fut_b = wrapper([](Counter& c) {
+        c.add(50);
+        return c.get();
+    });
+
+    fut_b.wait();
+
+    // 3. Task B must immediately fail because the infrastructure flag is set
+    ASSERT_THROW(fut_b.get(), std::runtime_error);
+}
+
+// Test 5: Destructor Behavior - WaitToFinishPolicy vs FastQuitPolicy
+TEST_F(AsyncWrapperTest, DestructorShutdownPolicies) {
+    // Setup 1: Test WaitToFinishPolicy (Guaranteed execution of queued task)
+    int wait_result = 0;
+    {
+        async_wrapper_guarded_wait<Counter> wrapper(0);
+        auto fut = wrapper([&wait_result](Counter& c) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            wait_result = 1;
+            return c.get();
+        });
+        // Destructor runs here (WaitToFinishPolicy::shutdown), MUST wait 50ms.
+    }
+    // Result confirms the destructor waited for the task to finish.
+    EXPECT_EQ(wait_result, 1);
+
+    // Setup 2: Test FastQuitPolicy (Drops queued task, joins quickly)
+    int fast_result = 0;
+    {
+        async_wrapper_guarded_fast<Counter> wrapper(0);
+
+        // Push a task that hangs. FastQuitPolicy should try to abort before it runs.
+        wrapper.run([&fast_result](Counter& c) {
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+            fast_result = 2; // Should not reach here if quitting fast
+        });
+
+        // Destructor runs here (FastQuitPolicy::shutdown), should join almost immediately.
+        // It's non-deterministic if the task starts, but the join should not block for 1s.
+    }
+    // Note: Due to lack of deterministic queue clearing in this minimal implementation,
+    // we only check that the finalization flag wasn't active.
+    // A true test would use timing, which is unreliable in unit tests.
+    EXPECT_EQ(fast_result, 0); // Task should likely not have finished executing
+}
+
+// Test 6: Verify Worker's internal catch block works correctly
+TEST_F(AsyncWrapperTest, InfrastructureFailure_WorkerSetsSignalAndShutsDown) {
+    async_guarded_testqueue<Counter> wrapper(0); // Use the specialized TestQueue type
+
+    // 1. Ensure worker thread is blocked on pop()
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // 2. Force the queue to throw an exception, waking up the worker thread
+    get_queue_for_test(wrapper).force_throw_on_next_pop();
+
+    // 3. Give the worker time to execute the catch block and shut down.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // 4. Submit a new task (Task A). This hits the Synchronous Gatekeeper check.
+    auto fut_a = wrapper([](Counter& c) {
+        c.add(99);
+        return c.get();
+    });
+
+    fut_a.wait();
+
+    // 5. Task A must fail with the infrastructure exception
+    bool active_runtime_error = false;
+    std::string message = "";
+    try {
+        fut_a.get();
+    } catch (const std::runtime_error& e) {
+        message = e.what();
+        active_runtime_error = true;
+    }
+    EXPECT_TRUE(active_runtime_error);
+
+    EXPECT_EQ(message, "Async worker infrastructure failure.");
+}

--- a/lib/everest/util/tests/queue/simple_queue_tests.cpp
+++ b/lib/everest/util/tests/queue/simple_queue_tests.cpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include "gtest/gtest.h"
+#include <everest/util/queue/simple_queue.hpp>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+using namespace everest::lib::util;
+
+// =================================================================
+// 2. Test Fixture Setup
+// =================================================================
+
+template <typename T> class SimpleQueueTest : public ::testing::Test {
+protected:
+    simple_queue<T> queue;
+};
+
+// Typed Test Suite for standard types
+using QueueTypes = ::testing::Types<int, std::string>;
+TYPED_TEST_SUITE(SimpleQueueTest, QueueTypes);
+
+// =================================================================
+// A. Basic Functionality Tests (FIFO & Empty Checks)
+// =================================================================
+
+TYPED_TEST(SimpleQueueTest, InitialStateIsEmpty) {
+    ASSERT_TRUE(this->queue.empty());
+    ASSERT_EQ(this->queue.size(), 0);
+    ASSERT_FALSE(this->queue.pop().has_value());
+}
+
+TYPED_TEST(SimpleQueueTest, PushAndEmptyCheck) {
+    TypeParam value;
+
+    // Use if constexpr to initialize value correctly
+    if constexpr (std::is_same_v<TypeParam, int>) {
+        value = 10;
+    } else if constexpr (std::is_same_v<TypeParam, std::string>) {
+        value = "Test_10";
+    } else {
+        return;
+    }
+
+    this->queue.push(value);
+
+    ASSERT_FALSE(this->queue.empty());
+    ASSERT_EQ(this->queue.size(), 1);
+}
+
+TYPED_TEST(SimpleQueueTest, PushPopAndEmptyCheck) {
+    TypeParam expected_value;
+
+    // Use if constexpr to initialize value correctly
+    if constexpr (std::is_same_v<TypeParam, int>) {
+        expected_value = 42;
+    } else if constexpr (std::is_same_v<TypeParam, std::string>) {
+        expected_value = "Test_42";
+    } else {
+        return;
+    }
+
+    this->queue.push(expected_value);
+
+    std::optional<TypeParam> result = this->queue.pop();
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value(), expected_value);
+    ASSERT_TRUE(this->queue.empty());
+    ASSERT_EQ(this->queue.size(), 0);
+}
+
+TYPED_TEST(SimpleQueueTest, MultiplePushAndPopOrder) {
+    const int count = 3;
+
+    // Push elements (0, 1, 2)
+    for (int i = 0; i < count; ++i) {
+        if constexpr (std::is_same_v<TypeParam, int>) {
+            this->queue.push(i);
+        } else {
+            this->queue.push(std::to_string(i));
+        }
+    }
+
+    // Pop elements and verify FIFO order (0, 1, 2)
+    for (int i = 0; i < count; ++i) {
+        std::optional<TypeParam> result = this->queue.pop();
+        TypeParam expected_value;
+        if constexpr (std::is_same_v<TypeParam, int>) {
+            expected_value = i;
+        } else {
+            expected_value = std::to_string(i);
+        }
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_EQ(result.value(), expected_value) << "Element popped out of FIFO order.";
+    }
+
+    ASSERT_TRUE(this->queue.empty());
+}
+
+// =================================================================
+// B. Reference Tests (front() and back())
+// =================================================================
+
+TYPED_TEST(SimpleQueueTest, FrontAndBackReferences) {
+    TypeParam val1, val2;
+
+    if constexpr (std::is_same_v<TypeParam, int>) {
+        val1 = 100;
+        val2 = 200;
+    } else if constexpr (std::is_same_v<TypeParam, std::string>) {
+        val1 = "Front";
+        val2 = "Back";
+    } else {
+        return;
+    }
+
+    this->queue.push(val1);
+    this->queue.push(val2);
+
+    // Verify front()
+    ASSERT_EQ(this->queue.front(), val1);
+
+    // Verify back()
+    ASSERT_EQ(this->queue.back(), val2);
+
+    // After pop, front should change
+    this->queue.pop();
+    ASSERT_EQ(this->queue.front(), val2);
+    ASSERT_EQ(this->queue.back(), val2);
+}
+
+// =================================================================
+// C. Move-Only Type Compatibility Test (Verifying the pop() fix)
+// =================================================================
+
+// Test suite for std::unique_ptr<int> (a move-only type)
+class SimpleQueueMoveOnlyTest : public ::testing::Test {
+protected:
+    simple_queue<std::unique_ptr<int>> queue;
+};
+
+TEST_F(SimpleQueueMoveOnlyTest, PushAndPopMoveOnlyType) {
+    const int value1 = 10;
+    const int value2 = 20;
+
+    // Push: Requires the r-value push overload
+    this->queue.push(std::make_unique<int>(value1));
+    this->queue.push(std::make_unique<int>(value2));
+
+    ASSERT_EQ(this->queue.size(), 2);
+
+    // Pop: Requires the fixed move-based pop()
+    std::optional<std::unique_ptr<int>> opt_result1 = this->queue.pop();
+
+    // Verify the value was retrieved
+    ASSERT_TRUE(opt_result1.has_value());
+    ASSERT_NE(opt_result1.value(), nullptr);
+    ASSERT_EQ(*opt_result1.value(), value1);
+
+    // Pop the second item
+    std::optional<std::unique_ptr<int>> opt_result2 = this->queue.pop();
+    ASSERT_TRUE(opt_result2.has_value());
+    ASSERT_EQ(*opt_result2.value(), value2);
+
+    ASSERT_TRUE(this->queue.empty());
+}

--- a/lib/everest/util/tests/queue/thread_safe_queue_tests.cpp
+++ b/lib/everest/util/tests/queue/thread_safe_queue_tests.cpp
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include "gtest/gtest.h"
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <everest/util/queue/thread_safe_queue.hpp>
+#include <memory> // For std::unique_ptr
+#include <numeric>
+#include <optional>
+#include <set>
+#include <thread>
+#include <type_traits> // For std::is_same_v
+#include <vector>
+
+// Note: Add includes for your simple_queue and thread_safe_queue here
+// #include "simple_queue.h"
+// #include "thread_safe_queue.h"
+
+using namespace std::chrono_literals;
+using namespace everest::lib::util;
+
+// =================================================================
+// 1. Test Fixture Setup
+// =================================================================
+
+// Helper to initialize TypeParam correctly in typed tests
+template <typename T> T initialize_value(int id) {
+    if constexpr (std::is_same_v<T, int>) {
+        return id;
+    } else if constexpr (std::is_same_v<T, std::string>) {
+        return "Value_" + std::to_string(id);
+    } else {
+        // Fallback for other non-tested types
+        return T{};
+    }
+}
+
+// Test Fixture
+template <typename T> class ThreadSafeQueueTest : public ::testing::Test {
+protected:
+    thread_safe_queue<T> queue;
+};
+
+// Typed Test Suite for int and std::string
+using QueueTypes = ::testing::Types<int, std::string>;
+TYPED_TEST_SUITE(ThreadSafeQueueTest, QueueTypes);
+
+// Define a test suite specifically for concurrency checks (using int)
+using ThreadSafeQueueIntTest = ThreadSafeQueueTest<int>;
+
+// =================================================================
+// 2. Basic Functionality Tests (Single Thread)
+// =================================================================
+
+TYPED_TEST(ThreadSafeQueueTest, PushAndPopSimple) {
+    TypeParam expected_value = initialize_value<TypeParam>(42);
+
+    this->queue.push(expected_value);
+
+    // Test the non-blocking pop
+    std::optional<TypeParam> result = this->queue.try_pop();
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value(), expected_value);
+    ASSERT_FALSE(this->queue.try_pop().has_value());
+}
+
+TYPED_TEST(ThreadSafeQueueTest, MultiplePushAndPopOrder) {
+    const int count = 5;
+    for (int i = 0; i < count; ++i) {
+        this->queue.push(initialize_value<TypeParam>(i));
+    }
+
+    for (int i = 0; i < count; ++i) {
+        TypeParam expected_value = initialize_value<TypeParam>(i);
+        std::optional<TypeParam> result = this->queue.try_pop();
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_EQ(result.value(), expected_value);
+    }
+    ASSERT_FALSE(this->queue.try_pop().has_value());
+}
+
+// =================================================================
+// 3. Time-Based Functionality Tests
+// =================================================================
+
+TYPED_TEST(ThreadSafeQueueTest, TryPopWithTimeout_Timeout) {
+    auto start = std::chrono::steady_clock::now();
+
+    // Try to pop with a short timeout
+    std::optional<TypeParam> result = this->queue.try_pop(10ms);
+
+    auto end = std::chrono::steady_clock::now();
+
+    ASSERT_FALSE(result.has_value());
+
+    auto elapsed = end - start;
+    ASSERT_GE(elapsed, 9ms);
+    ASSERT_LE(elapsed, 50ms);
+}
+
+TYPED_TEST(ThreadSafeQueueTest, TryPopWithTimeout_ImmediateSuccess) {
+    TypeParam value = initialize_value<TypeParam>(101);
+    this->queue.push(value);
+
+    auto start = std::chrono::steady_clock::now();
+    std::optional<TypeParam> result = this->queue.try_pop(10s);
+    auto end = std::chrono::steady_clock::now();
+
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value(), value);
+
+    ASSERT_LT(end - start, 5ms);
+}
+
+// =================================================================
+// 4. Synchronization and Blocking Tests
+// =================================================================
+
+TEST_F(ThreadSafeQueueIntTest, BlockingPopUnblocksOnPush) {
+    const int expected_value = 123;
+    std::atomic<int> result = 0;
+
+    std::thread consumer([this, &result] {
+        // Blocking pop() call
+        result = this->queue.pop();
+    });
+
+    std::this_thread::sleep_for(100ms);
+
+    this->queue.push(expected_value);
+
+    consumer.join();
+    ASSERT_EQ(result.load(), expected_value);
+}
+
+TEST_F(ThreadSafeQueueIntTest, MultipleWaitersUnblockedSequentially) {
+    const int num_waiters = 5;
+    std::vector<std::thread> consumers;
+    std::atomic<int> pops_received = 0;
+
+    for (int i = 0; i < num_waiters; ++i) {
+        consumers.emplace_back([this, &pops_received] {
+            this->queue.pop();
+            pops_received++;
+        });
+    }
+
+    std::this_thread::sleep_for(100ms);
+
+    // Push exactly the number of waiters—only one waiter should be released per push
+    for (int i = 0; i < num_waiters; ++i) {
+        this->queue.push(i);
+    }
+
+    for (auto& t : consumers) {
+        t.join();
+    }
+
+    ASSERT_EQ(pops_received.load(), num_waiters);
+}
+
+// =================================================================
+// 5. Stress and Race Condition Tests
+// =================================================================
+
+TEST_F(ThreadSafeQueueIntTest, ConcurrentPushConsistency) {
+    const int num_producers = 10;
+    const int items_per_producer = 1000;
+    const int total_items = num_producers * items_per_producer;
+
+    std::vector<std::thread> producers;
+    std::set<int> expected_values;
+
+    for (int i = 0; i < num_producers; ++i) {
+        producers.emplace_back([this, i, items_per_producer] {
+            int start_value = i * items_per_producer;
+            for (int j = 0; j < items_per_producer; ++j) {
+                this->queue.push(start_value + j);
+            }
+        });
+        int start_value = i * items_per_producer;
+        for (int j = 0; j < items_per_producer; ++j) {
+            expected_values.insert(start_value + j);
+        }
+    }
+
+    for (auto& t : producers) {
+        t.join();
+    }
+
+    // Drain the queue and check for consistency
+    std::set<int> retrieved_values;
+    for (int i = 0; i < total_items; ++i) {
+        auto val = this->queue.pop();
+        retrieved_values.insert(val);
+    }
+
+    ASSERT_EQ(retrieved_values.size(), total_items);
+    ASSERT_EQ(retrieved_values, expected_values);
+}
+
+TEST_F(ThreadSafeQueueIntTest, ConcurrentPopNoDuplicate) {
+    const int total_items = 10000;
+    const int num_consumers = 10;
+
+    // Producer pushes all items
+    for (int i = 0; i < total_items; ++i) {
+        this->queue.push(i);
+    }
+
+    // Consumers pop concurrently
+    std::vector<std::thread> consumers;
+    std::mutex result_mtx;
+    std::set<int> retrieved_values;
+    std::atomic<int> pop_count = 0;
+
+    for (int i = 0; i < num_consumers; ++i) {
+        consumers.emplace_back([this, &result_mtx, &retrieved_values, &pop_count, total_items] {
+            while (pop_count.load() < total_items) {
+                // Use try_pop so threads don't block indefinitely waiting for a push
+                // that won't come until the other threads finish.
+                if (auto val = this->queue.try_pop(); val.has_value()) {
+                    std::lock_guard lock(result_mtx);
+                    retrieved_values.insert(val.value());
+                    pop_count++;
+                }
+                std::this_thread::yield();
+            }
+        });
+    }
+
+    for (auto& t : consumers) {
+        t.join();
+    }
+
+    // Check consistency
+    ASSERT_EQ(pop_count.load(), total_items) << "Total pops do not match total pushed items.";
+    ASSERT_EQ(retrieved_values.size(), total_items) << "Duplicate items were retrieved.";
+}
+
+// =================================================================
+// 6. Move-Only Type Compatibility Test (Verifying the push/pop fix)
+// =================================================================
+
+// Test fixture for std::unique_ptr<int> (a move-only type)
+class ThreadSafeQueueMoveOnlyTest : public ::testing::Test {
+protected:
+    thread_safe_queue<std::unique_ptr<int>> queue;
+};
+
+TEST_F(ThreadSafeQueueMoveOnlyTest, HandlesConcurrentMoveOnlyTypes) {
+    const int total_items = 1000;
+    const int num_threads = 5;
+
+    std::vector<std::thread> threads;
+    std::atomic<int> pop_count = 0;
+
+    // Producer/Consumer set for unique ownership verification
+    std::set<int> retrieved_values;
+    std::mutex result_mtx;
+
+    // Start 5 threads: 3 producers, 2 consumers
+    for (int i = 0; i < num_threads; ++i) {
+        if (i < 3) { // Producers
+            threads.emplace_back([this, i, total_items] {
+                int start_value = i * total_items;
+                for (int j = 0; j < total_items; ++j) {
+                    // Requires thread_safe_queue::push(T&&)
+                    this->queue.push(std::make_unique<int>(start_value + j));
+                }
+            });
+        } else { // Consumers
+            threads.emplace_back([this, &pop_count, &result_mtx, &retrieved_values, total_items] {
+                int pops = 0;
+                while (pops < total_items * 3 / 2) { // Try to pop 1500 times
+                    // Requires thread_safe_queue::try_pop()
+                    if (auto opt_ptr = this->queue.try_pop(); opt_ptr.has_value()) {
+                        std::lock_guard lock(result_mtx);
+                        retrieved_values.insert(*opt_ptr.value());
+                        pop_count++;
+                        pops++;
+                    }
+                    std::this_thread::yield();
+                }
+            });
+        }
+    }
+
+    for (auto& t : threads) {
+        if (t.joinable()) {
+            t.join();
+        }
+    }
+
+    // Drain any remaining items in the main thread (should be few/none)
+    while (auto opt_ptr = this->queue.try_pop()) {
+        std::lock_guard lock(result_mtx);
+        retrieved_values.insert(*opt_ptr.value());
+        pop_count++;
+    }
+
+    const int total_expected = total_items * 3; // 3 producers * 1000 items
+
+    ASSERT_EQ(pop_count.load(), total_expected) << "Total items popped does not match total pushed.";
+    ASSERT_EQ(retrieved_values.size(), total_expected)
+        << "Duplicate pointers/values were retrieved, indicating a race condition failure or a failed move.";
+}


### PR DESCRIPTION
This adds more utilities to the header only 'util' library

## Describe your changes
New templates for concurrency

* simple_queue
  * A simple wrapper around std::queue with a more convenient interface
* thread_safe_queue
  * A thread safe queue, especially for producer/consumer scenarios
* async_wrapper
  * Wrapping up a resource for serialized access. The resource has it's own associated thread and all access is performed in that thread in order. 

For details refer to the doxygen documentation and the unit tests. Both are fairly exhaustive

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

