### PR TITLE
Set initial value of `can_id` to avoid `maybe-uninitialized` errors

### DIFF
--- a/lib/everest/io/src/can/socket_can_handler.cpp
+++ b/lib/everest/io/src/can/socket_can_handler.cpp
@@ -78,7 +78,8 @@ bool socket_can_handler::tx(can_dataset const& data) {
 bool socket_can_handler::rx(can_dataset& data) {
     uint32_t can_id = 0;
     auto status = rx(can_id, data.len8_dlc, data.payload);
-    if (status == 0) data.set_can_id_with_flags(can_id);
+    if (status == 0)
+        data.set_can_id_with_flags(can_id);
     return status == 0;
 }
 


### PR DESCRIPTION
## Describe your changes

Initialize `can_id` to avoid `maybe-uninitialized` error while compiling with `-Werror` enabled. In particular, give `can_id` an initial value of `0` and avoid modifying the given dataset if the receive operation was not successful.

## Issue ticket number and link

Fixes #1451.


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

