### PR TITLE
Enable departure time

### DIFF
--- a/config/config-sil-ac-d20.yaml
+++ b/config/config-sil-ac-d20.yaml
@@ -77,7 +77,7 @@ active_modules:
       connector_id: 1
       auto_enable: true
       auto_exec: false
-      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug
+      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug
     connections:
       ev_board_support:
         - module_id: connector_1_powerpath

--- a/config/config-sil-dc-d20.yaml
+++ b/config/config-sil-dc-d20.yaml
@@ -67,7 +67,7 @@ active_modules:
       connector_id: 1
       auto_enable: true
       auto_exec: false
-      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 15;iso_wait_v2g_session_stopped;unplug;
+      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 15;iso_wait_v2g_session_stopped;unplug;
       dc_target_current: 20
       dc_target_voltage: 400
     connections:

--- a/config/nodered/config-sil-dc-bpt-flow.json
+++ b/config/nodered/config-sil-dc-bpt-flow.json
@@ -1789,7 +1789,7 @@
         "options": [
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
                 "type": "str"
             }
         ],
@@ -1859,7 +1859,7 @@
         "once": true,
         "onceDelay": "1",
         "topic": "sim_commands",
-        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
+        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
         "payloadType": "str",
         "x": 150,
         "y": 1180,

--- a/config/nodered/config-sil-dc-flow.json
+++ b/config/nodered/config-sil-dc-flow.json
@@ -1789,7 +1789,7 @@
         "options": [
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
                 "type": "str"
             }
         ],
@@ -1859,7 +1859,7 @@
         "once": true,
         "onceDelay": "1",
         "topic": "sim_commands",
-        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
+        "payload": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
         "payloadType": "str",
         "x": 150,
         "y": 1180,

--- a/config/nodered/config-sil-energy-management-flow.json
+++ b/config/nodered/config-sil-energy-management-flow.json
@@ -1792,12 +1792,12 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
                 "type": "str"
             },
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug",
                 "type": "str"
             }
         ],

--- a/config/nodered/config-sil-flow.json
+++ b/config/nodered/config-sil-flow.json
@@ -1867,7 +1867,7 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             }
         ],

--- a/config/nodered/config-sil-two-evse-flow.json
+++ b/config/nodered/config-sil-two-evse-flow.json
@@ -2136,12 +2136,12 @@
             },
             {
                 "label": "AC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;sleep 36000",
                 "type": "str"
             },
             {
                 "label": "DC ISO15118-2",
-                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
+                "value": "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 36000#iso_stop_charging;iso_wait_v2g_session_stopped;unplug#iso_pause_charging;iso_wait_for_resume#iso_start_bcb_toggle 3;iso_wait_pwm_is_running;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;sleep 36000;",
                 "type": "str"
             }
         ],

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -84,7 +84,7 @@ libocpp:
 # Josev
 Josev:
   git: https://github.com/EVerest/ext-switchev-iso15118.git
-  git_tag: 2025.9.0
+  git_tag: c31c4e7f8004dc63cec28ad113bd059cbabbe321
   cmake_condition: "EVEREST_ENABLE_PY_SUPPORT AND EVEREST_DEPENDENCY_ENABLED_JOSEV"
 # everest-testing and ev-dev-tools
 everest-utils:

--- a/interfaces/ISO15118_ev.yaml
+++ b/interfaces/ISO15118_ev.yaml
@@ -9,6 +9,14 @@ cmds:
           by the EVCC
         type: string
         $ref: /iso15118#/EnergyTransferMode
+      DepartureTime:
+        description: >-
+          The time when the EVCC wants to leave the charging station (in seconds)
+        type: number
+      EAmount:
+        description: >-
+          The amount of energy that the EVCC wants to charge (in kWh)
+        type: number
     result:
       description: Returns true if the evcc simulation started
       type: boolean

--- a/modules/EV/EvManager/EvManager.hpp
+++ b/modules/EV/EvManager/EvManager.hpp
@@ -48,6 +48,8 @@ struct Conf {
     int dc_discharge_v2g_minimal_soc;
     double max_current;
     bool three_phases;
+    int departure_time;
+    int e_amount;
     int soc;
     bool keep_cross_boot_plugin_state;
 };

--- a/modules/EV/EvManager/doc.rst
+++ b/modules/EV/EvManager/doc.rst
@@ -29,7 +29,7 @@ The module listens to the following MQTT topics:
     | Used to execute a charging session based on the semicolon separated provided command string.
     ::
 
-        "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC_extended;iso_wait_pwr_ready;sleep 36000"
+        "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;sleep 36000"
 
     | (For all available commands see: `Simulator Commands`_)
 

--- a/modules/EV/EvManager/main/car_simulation.cpp
+++ b/modules/EV/EvManager/main/car_simulation.cpp
@@ -295,19 +295,28 @@ bool CarSimulation::iso_dc_power_on(const CmdArguments& arguments) {
 }
 
 bool CarSimulation::iso_start_v2g_session(const CmdArguments& arguments, bool three_phases) {
+    // add departure time and eamount to arguments
+    // if have to provide but don't want to, use -1 as a flag to get default from config
     const auto& energy_mode = arguments[0];
+    const auto& departure_time = std::stoi(arguments[1]);
+    const auto& e_amount = std::stoi(arguments[2]);
+
+    EVLOG_debug << "energy mode: " << energy_mode << " departure time: " << departure_time << " eamount: " << e_amount
+                << " three phases: " << three_phases;
 
     if (energy_mode == constants::AC) {
         sim_data.energy_mode = EnergyMode::AC;
         if (three_phases == false) {
-            r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::AC_single_phase_core);
+            r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::AC_single_phase_core, departure_time,
+                                         e_amount);
             charge_mode = ChargeMode::AC;
         } else {
-            r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::AC_three_phase_core);
+            r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::AC_three_phase_core, departure_time,
+                                         e_amount);
             charge_mode = ChargeMode::ACThreePhase;
         }
     } else if (energy_mode == constants::DC) {
-        r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::DC_extended);
+        r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::DC_extended, departure_time, e_amount);
         sim_data.energy_mode = EnergyMode::DC;
         charge_mode = ChargeMode::DC;
     } else {

--- a/modules/EV/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EV/EvManager/main/car_simulatorImpl.cpp
@@ -200,8 +200,22 @@ void car_simulatorImpl::register_all_commands() {
         command_registry->register_command("iso_dc_power_on", 0, [this](const CmdArguments& arguments) {
             return this->car_simulation->iso_dc_power_on(arguments);
         });
-        command_registry->register_command("iso_start_v2g_session", 1, [this](const CmdArguments& arguments) {
-            return this->car_simulation->iso_start_v2g_session(arguments, mod->config.three_phases);
+        command_registry->register_command("iso_start_v2g_session", 3, [this](const CmdArguments& arguments) {
+            auto departure_time = std::stoi(arguments[1]);
+            auto e_amount = std::stoi(arguments[2]);
+            EVLOG_debug << "Before ladder departure time is " << departure_time << " and eamount is " << e_amount;
+            if (departure_time < 0) {
+                EVLOG_debug << "Using default departure time from config";
+                departure_time = mod->config.departure_time;
+            }
+            if (e_amount < 0) {
+                EVLOG_debug << "Using default eamount from config";
+                e_amount = mod->config.e_amount;
+            }
+            EVLOG_debug << "After ladder departure time is " << departure_time << " and eamount is " << e_amount;
+
+            CmdArguments args{arguments[0], std::to_string(departure_time), std::to_string(e_amount)};
+            return this->car_simulation->iso_start_v2g_session(args, mod->config.three_phases);
         });
         command_registry->register_command("iso_stop_charging", 0, [this](const CmdArguments& arguments) {
             return this->car_simulation->iso_stop_charging(arguments);

--- a/modules/EV/EvManager/manifest.yaml
+++ b/modules/EV/EvManager/manifest.yaml
@@ -80,6 +80,14 @@ config:
     description: Support three phase
     type: boolean
     default: true
+  departure_time:
+    description: Departure time in seconds after the session starts
+    type: integer
+    default: 86400
+  e_amount:
+    description: Energy amount in Wh that should be charged during the session
+    type: integer
+    default: 0
   soc:
     description: SoC at start of a simulated charging process
     type: integer

--- a/modules/EV/PyEvJosev/module.py
+++ b/modules/EV/PyEvJosev/module.py
@@ -100,6 +100,8 @@ class PyEVJosevModule():
 
     def _handler_start_charging(self, args) -> bool:
 
+        self._es.DepartureTime = args['DepartureTime']
+        self._es.EAmount_kWh = args['EAmount']
         self._es.EnergyTransferMode = args['EnergyTransferMode']
 
         self._ready_event.set()

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -1238,23 +1238,29 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
     res->EVSEChargeParameter_isUsed = 0;
     res->EVSEProcessing = (iso2_EVSEProcessingType)conn->ctx->evse_v2g_data.evse_processing[PHASE_PARAMETER];
 
+    int64_t pmax{0};
+
+    if (conn->ctx->is_dc_charger == false) {
+        /* Determin max current and nominal voltage */
+        /* Setup default params (before the departure time overrides) */
+        float max_current = conn->ctx->basic_config.evse_ac_current_limit;
+        int64_t voltage = conn->ctx->evse_v2g_data.evse_nominal_voltage.Value *
+                          pow(10, conn->ctx->evse_v2g_data.evse_nominal_voltage.Multiplier); /* nominal voltage */
+        pmax = max_current * voltage *
+               ((req->RequestedEnergyTransferMode == iso2_EnergyTransferModeType_AC_single_phase_core) ? 1 : 3);
+
+        dlog(DLOG_LEVEL_INFO,
+             "before adjusting for departure time, max_current %f, nom_voltage %d, pmax %d, departure_duration %d",
+             max_current, voltage, pmax, req->AC_EVChargeParameter.DepartureTime);
+    }
+
     /* Configure SA-schedules*/
     if (res->EVSEProcessing == iso2_EVSEProcessingType_Finished) {
         /* If processing is finished, configure SASchedule list */
         if (conn->ctx->evse_v2g_data.evse_sa_schedule_list_is_used == false) {
+            int64_t departure_time_duration = req->AC_EVChargeParameter.DepartureTime;
             /* If not configured, configure SA-schedule automatically for AC charging */
             if (conn->ctx->is_dc_charger == false) {
-                /* Determin max current and nominal voltage */
-                float max_current = conn->ctx->basic_config.evse_ac_current_limit;
-                int64_t nom_voltage =
-                    conn->ctx->evse_v2g_data.evse_nominal_voltage.Value *
-                    pow(10, conn->ctx->evse_v2g_data.evse_nominal_voltage.Multiplier); /* nominal voltage */
-
-                /* Calculate pmax based on max current, nominal voltage and phase count (which the car has selected
-                 * above) */
-                int64_t pmax =
-                    max_current * nom_voltage *
-                    ((req->RequestedEnergyTransferMode == iso2_EnergyTransferModeType_AC_single_phase_core) ? 1 : 3);
                 populate_physical_value(&conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                                              .PMaxSchedule.PMaxScheduleEntry.array[0]
                                              .PMax,
@@ -1263,6 +1269,9 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
                 conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                     .PMaxSchedule.PMaxScheduleEntry.array[0]
                     .PMax = conn->ctx->evse_v2g_data.evse_maximum_power_limit;
+            }
+            if (departure_time_duration == 0) {
+                departure_time_duration = SA_SCHEDULE_DURATION; // one day, per spec
             }
             conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                 .PMaxSchedule.PMaxScheduleEntry.array[0]
@@ -1275,7 +1284,7 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
             conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                 .PMaxSchedule.PMaxScheduleEntry.array[0]
                 .RelativeTimeInterval.duration = conn->ctx->evse_v2g_data.no_energy_pause == NoEnergyPauseStatus::None
-                                                     ? SA_SCHEDULE_DURATION
+                                                     ? departure_time_duration
                                                      : PAUSE_DURATION;
             conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                 .PMaxSchedule.PMaxScheduleEntry.arrayLen = 1;
@@ -1326,13 +1335,8 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
 
         /* Nominal voltage */
         res->AC_EVSEChargeParameter.EVSENominalVoltage = conn->ctx->evse_v2g_data.evse_nominal_voltage;
-        int64_t nom_voltage = conn->ctx->evse_v2g_data.evse_nominal_voltage.Value *
-                              pow(10, conn->ctx->evse_v2g_data.evse_nominal_voltage.Multiplier);
 
         /* Calculate pmax based on max current, nominal voltage and phase count (which the car has selected above) */
-        int64_t pmax = max_current * nom_voltage *
-                       ((iso2_EnergyTransferModeType_AC_single_phase_core == req->RequestedEnergyTransferMode) ? 1 : 3);
-
         /* Check the SASchedule */
         if (res->SAScheduleList_isUsed == (unsigned int)1) {
             for (uint8_t idx = 0; idx < res->SAScheduleList.SAScheduleTuple.arrayLen; idx++) {

--- a/tests/core_tests/startup_tests.py
+++ b/tests/core_tests/startup_tests.py
@@ -70,9 +70,9 @@ class ProbeModule:
         cmd = {}
 
         if mode == Mode.HlcAc:
-            cmd = {'value': 'sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug'}
+            cmd = {'value': 'sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug'}
         elif mode == Mode.HlcDc:
-            cmd = {'value': 'sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug'}
+            cmd = {'value': 'sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug'}
         else:
             cmd = {'value': 'sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 10;unplug'}
 


### PR DESCRIPTION
Departure Time and Energy Amount have defaults specified in the EvManager manifest.yaml file, which will be used unless other values are passed in as part of the iso_start_v2g_session command

-1 can be passed into the iso_start_v2g_session command in order to enforce use of the defaults

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

Due to time-lag and multiple merges from upstream, I was unable to squash my commits on #1201, this PR is clean.