### PR TITLE
Remove contract service from ServiceDiscoveryResponse if PNC is not available

### DIFF
--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -217,6 +217,9 @@ void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::Pay
 
         add_service_to_service_list(v2g_ctx, cert_service, cert_parameter_set_id,
                                     sizeof(cert_parameter_set_id) / sizeof(cert_parameter_set_id[0]));
+    } else {
+        // Make sure Certificate service is not in ServiceList when pnc is not possible
+        remove_service_from_service_list_if_exists(v2g_ctx, V2G_SERVICE_ID_CERTIFICATE);
     }
 
     v2g_ctx->evse_v2g_data.central_contract_validation_allowed = central_contract_validation_allowed;


### PR DESCRIPTION

## Describe your changes
fix(EvseV2G): Remove certificate service in session setup handler if pnc is not available. Without this change, the ServiceDiscoveryResponse may still over the contract service, even if plug&charge has been disabled or no TLS is available.
The issue was likely introduced with https://github.com/EVerest/everest-core/commit/5f780ecce6b5020037d53912401ced5638da5dc8

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

