### PR TITLE
feat(ocpp2): Add a reset stop delay config like v16

### DIFF
--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -524,6 +524,8 @@ void OCPP201::ready() {
 
         bool scheduled = type == ocpp::v2::ResetEnum::OnIdle;
 
+        // small delay before stopping the charge point to make sure all responses are received
+        std::this_thread::sleep_for(std::chrono::seconds(this->config.ResetStopDelay));
         try {
             this->r_system->call_reset(types::system::ResetType::NotSpecified, scheduled);
         } catch (std::out_of_range& e) {

--- a/modules/EVSE/OCPP201/OCPP201.hpp
+++ b/modules/EVSE/OCPP201/OCPP201.hpp
@@ -60,6 +60,7 @@ struct Conf {
     int RequestCompositeScheduleDurationS;
     std::string RequestCompositeScheduleUnit;
     int DelayOcppStart;
+    int ResetStopDelay;
 };
 
 class OCPP201 : public Everest::ModuleBase {

--- a/modules/EVSE/OCPP201/manifest.yaml
+++ b/modules/EVSE/OCPP201/manifest.yaml
@@ -65,6 +65,12 @@ config:
       This is only used to prevent issues from passing by availlable before preparing on a restart.
     type: integer
     default: 0
+  ResetStopDelay:
+    description: >-
+      Time (seconds) to delay the stopping of the charge point so that the CSMS has enough time to respond
+      to the charge point's last messages before resetting.
+    type: integer
+    default: 0
 provides:
   auth_validator:
     description: Validates the provided token using CSMS, AuthorizationList or AuthorizationCache


### PR DESCRIPTION
## Describe your changes

Unify some of the config between OCPP and OCPP201 modules.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

