### PR TITLE
feat(Evse15118D20): Adding an option to convert the discharge limits to negative values if necessary

### DIFF
--- a/modules/EVSE/Evse15118D20/Evse15118D20.hpp
+++ b/modules/EVSE/Evse15118D20/Evse15118D20.hpp
@@ -37,6 +37,7 @@ struct Conf {
     bool supported_mobility_needs_mode_provided_by_secc;
     bool supported_scheduled_mode;
     std::string custom_protocol_namespace;
+    bool negative_bidirectional_limits;
 };
 
 class Evse15118D20 : public Everest::ModuleBase {

--- a/modules/EVSE/Evse15118D20/manifest.yaml
+++ b/modules/EVSE/Evse15118D20/manifest.yaml
@@ -62,6 +62,13 @@ config:
     description: Providing a custom protocol namespace.
     type: string
     default: ""
+  negative_bidirectional_limits:
+    description: >-
+      Some cars send or expect negative discharge limits. However, it is not clear from the standard
+      whether the discharge limits should be negative. Until this is clarified, the positive limits
+      can be converted using this option.
+    type: boolean
+    default: false
 provides:
   charger:
     interface: ISO15118_charger


### PR DESCRIPTION
## Describe your changes
Adding negative_bidirectional_limits config option to convert the discharge limits to negative values if necessary

## Issue ticket number and link
Some cars send or expect negative discharge limits. However, it is not clear from the standard whether the discharge limits should be negative. Until this is clarified, the positive limits can be converted using this option.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

