### PR TITLE
Fix error queueing of OCPP2.x at startup

### DIFF
--- a/modules/EVSE/OCPP201/OCPP201.hpp
+++ b/modules/EVSE/OCPP201/OCPP201.hpp
@@ -41,7 +41,7 @@
 
 using EventQueue =
     std::map<int32_t,
-             std::queue<std::variant<types::evse_manager::SessionEvent, ocpp::v2::EventData, ocpp::v2::MeterValue,
+             std::queue<std::variant<types::evse_manager::SessionEvent, Everest::error::Error, ocpp::v2::MeterValue,
                                      types::system::FirmwareUpdateStatus, types::system::LogStatus>>>;
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 


### PR DESCRIPTION
## Describe your changes
The OCPP201 module could call `on_faulted` or `on_faulted_cleared` even when the `charge_point` was not yet instantiated.

This change
* Correctly queue and process error events before startup
* Refactors event queuing to store Everest::error::Error objects instead of EventData.
* Adds helper for consistent component mapping (get_component_from_error)
* Ensures faulted and fault-cleared states are reported correctly.


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

