### PR TITLE
EvseV2G: Prioritize SequenceError over UnknownSession errors

### DIFF
--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -75,6 +75,13 @@ static v2g_event iso_validate_response_code(iso2_responseCodeType* const v2g_res
         *v2g_response_code = iso2_responseCodeType_FAILED;
     }
 
+    /* [V2G2-460]: check whether the session id matches the expected one of the active session */
+    *v2g_response_code =
+        ((conn->ctx->current_v2g_msg != V2G_SESSION_SETUP_MSG) && (conn->ctx->ev_v2g_data.received_session_id != 0) &&
+         (conn->ctx->evse_v2g_data.session_id != conn->ctx->ev_v2g_data.received_session_id))
+            ? iso2_responseCodeType_FAILED_UnknownSession
+            : *v2g_response_code;
+
     /* [V2G-DC-390]: at this point we must check whether the given request is valid at this step;
      * the idea is that we catch this error in each function below to respond with a valid
      * encoded message; note, that the handler functions below must not access v2g_session in
@@ -84,13 +91,6 @@ static v2g_event iso_validate_response_code(iso2_responseCodeType* const v2g_res
         iso_validate_state(conn->ctx->state, conn->ctx->current_v2g_msg, conn->ctx->is_dc_charger); // [V2G2-538]
 
     *v2g_response_code = (response_code_tmp >= iso2_responseCodeType_FAILED) ? response_code_tmp : *v2g_response_code;
-
-    /* [V2G2-460]: check whether the session id matches the expected one of the active session */
-    *v2g_response_code =
-        ((conn->ctx->current_v2g_msg != V2G_SESSION_SETUP_MSG) && (conn->ctx->ev_v2g_data.received_session_id != 0) &&
-         (conn->ctx->evse_v2g_data.session_id != conn->ctx->ev_v2g_data.received_session_id))
-            ? iso2_responseCodeType_FAILED_UnknownSession
-            : *v2g_response_code;
 
     if ((conn->ctx->terminate_connection_on_failed_response == true) &&
         (*v2g_response_code >= iso2_responseCodeType_FAILED)) {


### PR DESCRIPTION
This bugfix solves test case TC_SECC_CMN_VTB_SessionSetup_002 of the ISO15118-4. It ensures that sequence errors are prioritized over UnknownSession errors when responding to V2G messages.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

