### PR TITLE
DummyTokenProviderManual: avoid crashing on invalid JSON via MQTT

### DIFF
--- a/modules/Testing/DummyTokenProviderManual/main/auth_token_providerImpl.cpp
+++ b/modules/Testing/DummyTokenProviderManual/main/auth_token_providerImpl.cpp
@@ -10,9 +10,13 @@ namespace main {
 
 void auth_token_providerImpl::init() {
     mod->mqtt.subscribe("everest_api/dummy_token_provider/cmd/provide", [this](const std::string& msg) {
-        types::authorization::ProvidedIdToken token = json::parse(msg);
-        EVLOG_info << "Publishing new dummy token: " << everest::helpers::redact(token);
-        publish_provided_token(token);
+        try {
+            types::authorization::ProvidedIdToken token = json::parse(msg);
+            EVLOG_info << "Publishing new dummy token: " << everest::helpers::redact(token);
+            publish_provided_token(token);
+        } catch (const nlohmann::json::exception& e) {
+            EVLOG_error << "Failed to handle JSON token from MQTT: " << e.what();
+        }
     });
 }
 


### PR DESCRIPTION
Now catches the exceptions.

When JSON is formatted incorrectly:
`[ERRO] token:DummyToke module::main::auth_token_providerImpl::init()::<lambda(const string&)> :: Failed to handle JSON token from MQTT: [json.exception.parse_error.101] parse error at line 1, column 169: syntax error while parsing object - unexpected end of input; expected '}'`

When the JSON cannot be mapped into an object of type authorization::ProvidedIdToken:
`[ERRO] token:DummyToke module::main::auth_token_providerImpl::init()::<lambda(const string&)> :: Failed to handle JSON token from MQTT: [json.exception.out_of_range.403] key 'id_token' not found`

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

