### PR TITLE
TLS server key type check is no longer required

### DIFF
--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -422,13 +422,6 @@ bool configure_ssl_ctx(bool is_server, SSL_CTX*& ctx, const char* ciphersuites, 
     bool result{true};
 
     if (is_server) {
-        bool custom_key = false;
-
-        if (cert_config.private_key_file != nullptr) {
-            fs::path keyfile{std::string(cert_config.private_key_file)};
-            custom_key = evse_security::is_custom_private_key_file(keyfile);
-        }
-
         OpenSSLProvider provider;
 
         const SSL_METHOD* method = TLS_server_method();


### PR DESCRIPTION
## Describe your changes

The recent change to the default provider strings mean that knowing the key type is no longer required.
This commit removes the redundant code. 

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

