### PR TITLE
OCPP: fix transaction stop message formatting

### DIFF
--- a/modules/EVSE/OCPP/OCPP.cpp
+++ b/modules/EVSE/OCPP/OCPP.cpp
@@ -928,7 +928,7 @@ void OCPP::ready() {
 
     this->charge_point->register_transaction_stopped_callback(
         [this](const int32_t connector, const std::string& session_id, const int32_t transaction_id) {
-            EVLOG_info << "Transaction stopped at connector: " << connector << "session_id: " << session_id;
+            EVLOG_info << "Transaction stopped at connector: " << connector << ", session_id: " << session_id;
             types::ocpp::OcppTransactionEvent tevent;
             tevent.transaction_event = types::ocpp::TransactionEvent::Ended;
             tevent.evse = {connector, 1};


### PR DESCRIPTION
## Describe your changes

Current style:
-8<-
...Transaction stopped at connector: 1session_id: 681b7f91...
-8<-

Let's add comma and a single white space:
--> ...connector: 1, session_id: ...

## Issue ticket number and link

none

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
