### PR TITLE
DummyTokenProviderManual: drop unused config variables

### DIFF
--- a/modules/Testing/DummyTokenProviderManual/main/auth_token_providerImpl.hpp
+++ b/modules/Testing/DummyTokenProviderManual/main/auth_token_providerImpl.hpp
@@ -19,19 +19,14 @@
 namespace module {
 namespace main {
 
-struct Conf {
-    std::string token;
-    std::string type;
-    double timeout;
-};
+struct Conf {};
 
 class auth_token_providerImpl : public auth_token_providerImplBase {
 public:
     auth_token_providerImpl() = delete;
     auth_token_providerImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<DummyTokenProviderManual>& mod,
                             Conf& config) :
-        auth_token_providerImplBase(ev, "main"), mod(mod), config(config) {
-    }
+        auth_token_providerImplBase(ev, "main"), mod(mod), config(config){};
 
     // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
     // insert your public definitions here

--- a/modules/Testing/DummyTokenProviderManual/manifest.yaml
+++ b/modules/Testing/DummyTokenProviderManual/manifest.yaml
@@ -3,26 +3,6 @@ provides:
   main:
     description: Main implementation of dummy token provider always returning one configured token
     interface: auth_token_provider
-    config:
-      token:
-        description: Dummy token string to return
-        type: string
-        minLength: 1
-        maxLength: 20
-        default: DEADBEEF
-      type:
-        description: Type to report for our dummy token
-        type: string
-        minLength: 2
-        maxLength: 32
-        default: RFID
-      timeout:
-        description: Time our dummy token is valid (in s)
-        type: number
-        minimum: 0
-        maximum: 120
-        default: 10
-requires: {}
 enable_external_mqtt: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-078.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-078.yaml
@@ -72,11 +72,6 @@ active_modules:
         implementation_id: evse
   token_provider_manual:
     module: DummyTokenProviderManual
-    connections: {}
-    config_implementation:
-      main:
-        token: '123'
-        type: dummy
   energy_manager:
     module: EnergyManager
     connections:

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-security-profile-1.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-security-profile-1.yaml
@@ -72,11 +72,6 @@ active_modules:
         implementation_id: evse
   token_provider_manual:
     module: DummyTokenProviderManual
-    connections: {}
-    config_implementation:
-      main:
-        token: '123'
-        type: dummy
   energy_manager:
     module: EnergyManager
     connections:

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-security-profile-2.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-security-profile-2.yaml
@@ -72,11 +72,6 @@ active_modules:
         implementation_id: evse
   token_provider_manual:
     module: DummyTokenProviderManual
-    connections: {}
-    config_implementation:
-      main:
-        token: '123'
-        type: dummy
   energy_manager:
     module: EnergyManager
     connections:

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp-probe.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp-probe.yaml
@@ -82,11 +82,6 @@ active_modules:
         implementation_id: evse
   token_provider_manual:
     module: DummyTokenProviderManual
-    connections: {}
-    config_implementation:
-      main:
-        token: '123'
-        type: dummy
   energy_manager:
     module: EnergyManager
     connections:

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp.yaml
@@ -79,11 +79,6 @@ active_modules:
         implementation_id: evse
   token_provider_manual:
     module: DummyTokenProviderManual
-    connections: {}
-    config_implementation:
-      main:
-        token: '123'
-        type: dummy
   energy_manager:
     module: EnergyManager
     connections:


### PR DESCRIPTION
They gave the false impression that a fixed token could be configured.

## Describe your changes
Dropped config from `manifest.yaml` and re-created the code using `ev-cli`.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

