### PR TITLE
Updating everest-utils to v0.7.3

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -89,7 +89,7 @@ Josev:
 # everest-testing and ev-dev-tools
 everest-utils:
   git: https://github.com/EVerest/everest-utils.git
-  git_tag: v0.7.2
+  git_tag: v0.7.3
 # linux_libnfc-nci for RFID
 libnfc-nci:
   git: https://github.com/EVerest/linux_libnfc-nci.git


### PR DESCRIPTION
## Describe your changes
See title

## Issue ticket number and link
ISO15118 e2e tests did not work anymore after merging  #1468. With updating everest-utils the tests should work again.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

