### PR TITLE
Fix: unchecked json conversions in EVerest API lib

### DIFF
--- a/lib/everest/everest_api_types/src/everest_api_types/generic/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/generic/json_codec.cpp
@@ -21,11 +21,12 @@ void to_json(json& j, RequestReply const& k) {
 }
 
 void from_json(json const& j, RequestReply& k) {
-    k.replyTo = j["headers"]["replyTo"];
+    k.replyTo = j.at("headers").at("replyTo");
     if (j.contains("payload")) {
         k.payload = j["payload"].dump();
-    } else
+    } else {
         k.payload = "";
+    }
 }
 
 void to_json(json& j, ErrorEnum const& k) noexcept {

--- a/lib/everest/everest_api_types/src/everest_api_types/ocpp/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/ocpp/json_codec.cpp
@@ -553,8 +553,8 @@ void to_json(json& j, SetVariablesArgs const& k) noexcept {
 }
 
 void from_json(const json& j, SetVariablesArgs& k) {
-    k.variables = j["variables"];
-    k.source = j["source"];
+    k.variables = j.at("variables");
+    k.source = j.at("source");
 }
 
 void to_json(json& j, SecurityEvent const& k) noexcept {


### PR DESCRIPTION
## Describe your changes
Fix: Access json fields always with at() in the EVerest API lib

## Issue ticket number and link
This bug allowed crashing an API module via malformed messages.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

