### PR TITLE
EvseManager: wait 5s for energy in DC charging before stopping Charge…

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -301,6 +301,13 @@ void Charger::run_state_machine() {
                 // Create a copy of the atomic struct
                 types::iso15118::DcEvseMaximumLimits evse_limit = shared_context.current_evse_max_limits;
                 if (not(evse_limit.evse_maximum_current_limit > 0 and evse_limit.evse_maximum_power_limit > 0)) {
+
+                    // Wait some time here in this state to see if we get energy from the EnergyManager...
+                    if (time_in_current_state < WAIT_FOR_ENERGY_IN_AUTHLOOP_TIMEOUT_MS) {
+                        break;
+                    }
+
+                    // If still no energy is available after the timeout, assume we will not get any for this session.
                     if (not internal_context.no_energy_warning_printed) {
                         EVLOG_warning << "No energy available, still retrying... Some EVs dont like 0W and/or 0A in "
                                          "ChargingParameterDiscoveryRes message";

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -430,6 +430,7 @@ private:
     // This is not required by IEC61851-1, but it is allowed by the IEC. It helps some older EVs to start charging
     // after the wake-up sequence.
     static constexpr int STAY_IN_X1_AFTER_TSTEP_EF_MS = 750;
+    static constexpr int WAIT_FOR_ENERGY_IN_AUTHLOOP_TIMEOUT_MS = 5000;
 
     types::evse_manager::EnableDisableSource active_enable_disable_source{
         types::evse_manager::Enable_source::Unspecified, types::evse_manager::Enable_state::Unassigned, 10000};


### PR DESCRIPTION
…ParameterDiscovery

When using request_zero_power_in_idle to allow energy management with multiple connectors in DC charging, it may happen that we stop in ChargeParameterDiscovery with "StopCharging" from EVSE since no power is available at that point. This is a wanted feature for cases where charging should be delayed to a later time. However in cases where energy is inprinciple available but the Energy management is a little slow to distribute that energy, we want to wait a small timeout to see if we get an energy budget before we signal to the EV that we don't have any.

Set to a fixed 5s because evse manager already has way too many config options and it won't really help to make that adjustable.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

