### PR TITLE
Reset hlc authorize flags after unplug

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -926,6 +926,8 @@ void EvseManager::ready() {
                 if (unmatched_on_unplug) {
                     r_slac[0]->call_reset(false);
                 }
+                hlc_waiting_for_auth_pnc = false;
+                hlc_waiting_for_auth_eim = false;
             }
         }
 


### PR DESCRIPTION

## Describe your changes
fix(EvseManager): Reset flags to wait for authorize pnc or eim. The changes could persist through multiple session if we don't reset them on unplug

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

