### PR TITLE
EvseManager: Do not request bidi if bidi is not active, set current/p…

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -190,6 +190,7 @@ public:
                                   float max_current_export);
     bool update_max_watt_limit(types::energy::ExternalLimits& limits, float max_watt_export,
                                std::optional<float> max_watt_import);
+    void update_to_zero_discharge_limit(types::energy::ExternalLimits& limits);
     bool update_local_energy_limit(types::energy::ExternalLimits l);
     types::energy::ExternalLimits get_local_energy_limits();
 

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -628,8 +628,10 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
                             mod->is_actually_exporting_to_grid = true;
                         } else {
                             EVLOG_error << "Bidirectional export back to grid requested, but not supported.";
-                            // evse_max_limits.evse_maximum_power_limit = 0.;
-                            // evse_max_limits.evse_maximum_current_limit = 0.;
+                            evse_max_limits.evse_maximum_power_limit = 0.;
+                            evse_max_limits.evse_maximum_current_limit = 0.;
+                            evse_max_limits.evse_maximum_discharge_power_limit = 0.;
+                            evse_max_limits.evse_maximum_discharge_current_limit = 0.;
                         }
                     }
 


### PR DESCRIPTION
…ower to 0 if bidi is request but not supported

EvseManager requested bidi even if it is currently not supported by the session/car (no iso-20 bpt and no hack_bidi config option) as long as the PSU supported it.

This means once an external limit from ocpp reduced charging to 0 (but not discharging), energymanager switched to discharging. In enforced_limits(), the resulting current/power was not set to 0 but to charging with max_dc_power_supply_caps. 

This PR fixes the request from EvseManager as well as the handling if that should happen anyhow (input validation).

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

