### PR TITLE
EvseManager: Avoid PWM duty cycle glitches after T_step_EF

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -479,6 +479,9 @@ void Charger::run_state_machine() {
                 session_log.evse(false, "Exit T_step_EF");
                 if (internal_context.t_step_EF_return_pwm == 0.) {
                     pwm_off();
+                } else if (hlc_use_5percent_current_session) {
+                    update_pwm_now(PWM_5_PERCENT);
+                    internal_context.pwm_set_last_ampere = internal_context.t_step_EF_return_ampere;
                 } else {
                     update_pwm_now(internal_context.t_step_EF_return_pwm);
                     internal_context.pwm_set_last_ampere = internal_context.t_step_EF_return_ampere;


### PR DESCRIPTION
## Describe your changes
This pull request address the unexpected nominal duty cycle glitch after HLC T_step_EF.

Disclaimer: I'm not 100% sure, this is the right way (tm) to solve this issue.

## Issue ticket number and link
#1508

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

