### PR TITLE
Fix EIM with PlugEvents and multiple EVSEs

### DIFF
--- a/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
@@ -365,9 +365,7 @@ void evse_managerImpl::handle_authorize_response(types::authorization::ProvidedI
             // As this is not a new reservation but an existing one, we don't signal a reservation event for this.
             mod->reserve(validation_result.reservation_id.value(), false);
         }
-    }
-
-    if (pnc) {
+    } else if (pnc) {
         this->mod->r_hlc[0]->call_authorization_response(
             validation_result.authorization_status,
             validation_result.certificate_status.value_or(types::authorization::CertificateStatus::Accepted));


### PR DESCRIPTION
## Describe your changes

Using Authorized event of EvseManager to `call_session_setup` at ISO15118 module to remove the contract payment option. 

This is required to fix Plug&Charge in case  multiple EVSEs. If a card is swiped, the EvseManager only receives authorization after a plug in is registered, but `call_session_setup` is called before the authorization is recieved. This leads to the fact that `call_session_setup` may be called including the payment option Contract. Using the Authorized event to `call_session_setup` again will remove this option so that the ISO15118 stack doesnt offer contract if authorization has been previously received

`call_session_setup` is not called on `SessionEvent::SessionFinished` anymore.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

