### PR TITLE
feat(EvManager): It is now possible to register multiple SIL commands with the same name but different argument counts

### DIFF
--- a/config/config-sil-ac-d20.yaml
+++ b/config/config-sil-ac-d20.yaml
@@ -77,7 +77,7 @@ active_modules:
       connector_id: 1
       auto_enable: true
       auto_exec: false
-      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug
+      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug
     connections:
       ev_board_support:
         - module_id: connector_1_powerpath

--- a/config/config-sil-dc-d20.yaml
+++ b/config/config-sil-dc-d20.yaml
@@ -67,7 +67,7 @@ active_modules:
       connector_id: 1
       auto_enable: true
       auto_exec: false
-      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 15;iso_wait_v2g_session_stopped;unplug;
+      auto_exec_commands: sleep 3;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_dc_power_on;iso_wait_for_stop 15;iso_wait_v2g_session_stopped;unplug;
       dc_target_current: 20
       dc_target_voltage: 400
     connections:

--- a/modules/EV/EvManager/doc.rst
+++ b/modules/EV/EvManager/doc.rst
@@ -29,7 +29,7 @@ The module listens to the following MQTT topics:
     | Used to execute a charging session based on the semicolon separated provided command string.
     ::
 
-        "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;sleep 36000"
+        "sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;sleep 36000"
 
     | (For all available commands see: `Simulator Commands`_)
 

--- a/modules/EV/EvManager/main/car_simulation.cpp
+++ b/modules/EV/EvManager/main/car_simulation.cpp
@@ -295,18 +295,13 @@ bool CarSimulation::iso_dc_power_on(const CmdArguments& arguments) {
 }
 
 bool CarSimulation::iso_start_v2g_session(const CmdArguments& arguments, bool three_phases) {
-    // add departure time and eamount to arguments
-    // if have to provide but don't want to, use -1 as a flag to get default from config
     const auto& energy_mode = arguments[0];
     const auto& departure_time = std::stoi(arguments[1]);
     const auto& e_amount = std::stoi(arguments[2]);
 
-    EVLOG_debug << "energy mode: " << energy_mode << " departure time: " << departure_time << " eamount: " << e_amount
-                << " three phases: " << three_phases;
-
     if (energy_mode == constants::AC) {
         sim_data.energy_mode = EnergyMode::AC;
-        if (three_phases == false) {
+        if (not three_phases) {
             r_ev[0]->call_start_charging(types::iso15118::EnergyTransferMode::AC_single_phase_core, departure_time,
                                          e_amount);
             charge_mode = ChargeMode::AC;

--- a/modules/EV/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EV/EvManager/main/car_simulatorImpl.cpp
@@ -208,22 +208,17 @@ void car_simulatorImpl::register_all_commands() {
         command_registry->register_command("iso_dc_power_on", 0, [this](const CmdArguments& arguments) {
             return this->car_simulation->iso_dc_power_on(arguments);
         });
-        command_registry->register_command("iso_start_v2g_session", 3, [this](const CmdArguments& arguments) {
-            auto departure_time = std::stoi(arguments[1]);
-            auto e_amount = std::stoi(arguments[2]);
-            EVLOG_debug << "Before ladder departure time is " << departure_time << " and eamount is " << e_amount;
-            if (departure_time < 0) {
-                EVLOG_debug << "Using default departure time from config";
-                departure_time = mod->config.departure_time;
-            }
-            if (e_amount < 0) {
-                EVLOG_debug << "Using default eamount from config";
-                e_amount = mod->config.e_amount;
-            }
-            EVLOG_debug << "After ladder departure time is " << departure_time << " and eamount is " << e_amount;
-
-            CmdArguments args{arguments[0], std::to_string(departure_time), std::to_string(e_amount)};
+        command_registry->register_command("iso_start_v2g_session", 1, [this](const CmdArguments& arguments) {
+            EVLOG_debug << "Using default departure time and eamount";
+            CmdArguments args{arguments[0], std::to_string(mod->config.departure_time),
+                              std::to_string(mod->config.e_amount)};
             return this->car_simulation->iso_start_v2g_session(args, mod->config.three_phases);
+        });
+        command_registry->register_command("iso_start_v2g_session", 3, [this](const CmdArguments& arguments) {
+            // 1. Argument: EnergyMode
+            // 2. Argument: DepartureTime
+            // 3. Argument: EAmount
+            return this->car_simulation->iso_start_v2g_session(arguments, mod->config.three_phases);
         });
         command_registry->register_command("iso_stop_charging", 0, [this](const CmdArguments& arguments) {
             return this->car_simulation->iso_stop_charging(arguments);

--- a/modules/EV/EvManager/main/simulation_command.cpp
+++ b/modules/EV/EvManager/main/simulation_command.cpp
@@ -83,7 +83,7 @@ std::queue<SimulationCommand> SimulationCommand::compile_commands(CommandsWithAr
     auto compiled_commands = std::queue<SimulationCommand>{};
 
     for (auto& [command, arguments] : commands_with_arguments) {
-        compiled_commands.emplace(&command_registry.get_registered_command(command), arguments);
+        compiled_commands.emplace(&command_registry.get_registered_command(command, arguments.size()), arguments);
     }
 
     return compiled_commands;

--- a/modules/EV/EvManager/tests/CommandRegistryTest.cpp
+++ b/modules/EV/EvManager/tests/CommandRegistryTest.cpp
@@ -18,7 +18,7 @@ SCENARIO("Commands can be registered", "[RegisteredCommand]") {
             command_registry.register_command(command_name, argument_count, test_comand_0_function);
 
             THEN("The command can be retrieved") {
-                const auto& registered_command = command_registry.get_registered_command(command_name);
+                const auto& registered_command = command_registry.get_registered_command(command_name, 0);
                 THEN("The command can be executed") {
                     CHECK(registered_command({}) == true);
                 }
@@ -47,7 +47,7 @@ SCENARIO("Commands can be registered", "[RegisteredCommand]") {
             command_registry.register_command(command_name, argument_count, test_comand_1_function);
 
             THEN("The command can be retrieved") {
-                const auto& registered_command = command_registry.get_registered_command(command_name);
+                const auto& registered_command = command_registry.get_registered_command(command_name, 1);
                 THEN("The command can be executed") {
                     CHECK(registered_command({"arg1"}) == true);
                 }
@@ -73,7 +73,7 @@ SCENARIO("Commands can be registered", "[RegisteredCommand]") {
             command_registry.register_command(command_name, argument_count, test_comand_2_function);
 
             THEN("The command can be retrieved") {
-                const auto& registered_command = command_registry.get_registered_command(command_name);
+                const auto& registered_command = command_registry.get_registered_command(command_name, 2);
                 THEN("The command can be executed") {
                     CHECK(registered_command({"arg1", "arg2"}) == true);
                 }
@@ -85,6 +85,44 @@ SCENARIO("Commands can be registered", "[RegisteredCommand]") {
                     CHECK_THROWS_WITH(registered_command({"arg1", "arg2", "arg3"}),
                                       "Invalid number of arguments for: test_command2 expected 2 got 3");
                 }
+            }
+        }
+    }
+
+    GIVEN("Two identical commands with different arguments") {
+        auto command_registry = CommandRegistry();
+        const std::string command_name = std::string{"test_command"};
+        const auto test_command_1_function = [](const std::vector<std::string>& arguments) {
+            return arguments.size() == 1;
+        };
+        const auto test_command_2_function = [](const std::vector<std::string>& arguments) {
+            return arguments.size() == 2;
+        };
+
+        WHEN("The command is registered") {
+            command_registry.register_command(command_name, 1, test_command_1_function);
+            command_registry.register_command(command_name, 2, test_command_2_function);
+
+            THEN("The command can be retrieved") {
+                const auto& registered_command1 = command_registry.get_registered_command(command_name, 1);
+                const auto& registered_command2 = command_registry.get_registered_command(command_name, 2);
+
+                THEN("The command can be executed") {
+                    CHECK(registered_command1({"arg1"}) == true);
+                    CHECK(registered_command2({"arg1", "arg2"}) == true);
+                }
+                THEN("The command throws when the number of arguments is invalid") {
+                    CHECK_THROWS_WITH(registered_command1({}),
+                                      "Invalid number of arguments for: test_command expected 1 got 0");
+                    CHECK_THROWS_WITH(registered_command1({"arg1", "arg2"}),
+                                      "Invalid number of arguments for: test_command expected 1 got 2");
+                }
+            }
+            THEN("The wrong commands can not be retrieved") {
+                CHECK_THROWS_WITH(command_registry.get_registered_command(command_name, 0),
+                                  "Command not found: test_command");
+                CHECK_THROWS_WITH(command_registry.get_registered_command(command_name, 4),
+                                  "Command not found: test_command");
             }
         }
     }

--- a/modules/EV/EvManager/tests/SimCommandTest.cpp
+++ b/modules/EV/EvManager/tests/SimCommandTest.cpp
@@ -17,7 +17,7 @@ SCENARIO("SimCommands can be created", "[SimCommand]") {
         command_registry.register_command(command_name, argument_count, test_command_function);
 
         WHEN("The SimCommand is created") {
-            const auto sim_command = SimulationCommand{&command_registry.get_registered_command(command_name), {}};
+            const auto sim_command = SimulationCommand{&command_registry.get_registered_command(command_name, 0), {}};
 
             THEN("The command can be executed") {
                 CHECK(sim_command.execute() == true);
@@ -26,7 +26,7 @@ SCENARIO("SimCommands can be created", "[SimCommand]") {
 
         WHEN("The SimCommand is created with the wrong number of arguments") {
             const auto sim_command =
-                SimulationCommand{&command_registry.get_registered_command(command_name), {"arg1"}};
+                SimulationCommand{&command_registry.get_registered_command(command_name, 1), {"arg1"}};
 
             THEN("The command throws") {
                 CHECK_THROWS_WITH(sim_command.execute(),

--- a/tests/core_tests/startup_tests.py
+++ b/tests/core_tests/startup_tests.py
@@ -70,9 +70,9 @@ class ProbeModule:
         cmd = {}
 
         if mode == Mode.HlcAc:
-            cmd = {'value': 'sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC 86400 0;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug'}
+            cmd = {'value': 'sleep 1;iso_wait_slac_matched;iso_start_v2g_session AC;iso_wait_pwr_ready;iso_draw_power_regulated 16,3;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug'}
         elif mode == Mode.HlcDc:
-            cmd = {'value': 'sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC 86400 0;iso_wait_pwr_ready;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug'}
+            cmd = {'value': 'sleep 1;iso_wait_slac_matched;iso_start_v2g_session DC;iso_wait_pwr_ready;iso_wait_for_stop 20;iso_wait_v2g_session_stopped;unplug'}
         else:
             cmd = {'value': 'sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 10;unplug'}
 


### PR DESCRIPTION
## Describe your changes
It is now possible to register multiple SIL commands with the same name but different argument counts. This is helpful, for example, with the `iso_start_v2g_session` command. If some arguments are not set, these values can be set as default values via the config. It is no longer necessary to check in the argument values whether the config value should be used or not.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

