### PR TITLE
Remove two functions from Auth Consumer API

### DIFF
--- a/doc/everest_api_specs/auth_consumer_API/asyncapi.yaml
+++ b/doc/everest_api_specs/auth_consumer_API/asyncapi.yaml
@@ -26,16 +26,6 @@ defaultContentType: application/json
 
 
 channels:
-  send_set_connection_timeout:
-    address: 'm2e/set_connection_timeout'
-    messages:
-      send_set_connection_timeout:
-        $ref: '#/components/messages/send_set_connection_timeout'
-  send_set_master_pass_group_id:
-    address: 'm2e/set_connection_timeout'
-    messages:
-      send_set_master_pass_group_id:
-        $ref: '#/components/messages/send_set_master_pass_group_id'
   send_request_withdraw_authorization:
     address: 'm2e/withdraw_authorization'
     messages:
@@ -68,21 +58,6 @@ channels:
 
 
 operations:
-  send_set_connection_timeout:
-    title: 'Set the connection timeout.'
-    action: send
-    channel:
-      $ref: '#/channels/send_set_connection_timeout'
-  send_set_master_pass_group_id:
-    title: 'Set the master group ID.'
-    action: send
-    channel:
-      $ref: '#/channels/send_set_master_pass_group_id'
-    description: >-
-      Sets the master pass group id. IdTokens that have this id as parent_id_token belong to the Master Pass Group. 
-      This means they can stop any ongoing transaction, but cannot start transactions. This can, for example, be used by
-      law enforcement personal to stop any ongoing transaction when an EV has to be towed away. If master_pass_group_id 
-      is an empty string, it is not used.
   send_request_withdraw_authorization:
     title: 'Withdraw granted authorization.'
     action: send
@@ -128,28 +103,6 @@ operations:
 
 components:
   messages:
-    send_set_connection_timeout:
-      name: send_set_connection_timeout
-      title: 'Set the connection timeout.'
-      summary: 'Set the connection timeout.'
-      contentType: application/json
-      payload:
-        $ref: '#/components/schemas/SetConnectionTimeoutRequest'
-      examples:
-        - summary: ""
-          payload:
-            15
-    send_set_master_pass_group_id:
-      name: send_set_master_pass_group_id
-      title: 'Set the master group ID.'
-      summary: 'Set the master group ID.'
-      contentType: application/json
-      payload:
-        $ref: '#/components/schemas/SetMasterPassGroupId'
-      examples:
-        - summary: ""
-          payload:
-            "dDxDam6mt4qyOnFKnSp6O0KYRJK9NFb0"
     send_request_withdraw_authorization:
       name: send_request_withdraw_authorization
       title: 'Withdraw granted authorization'
@@ -172,21 +125,12 @@ components:
             headers:
               replyTo: everest_api/1.0/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
             payload: {
-              "token": {
-              "request_id": 0,
               "id_token": {
                 "value": "string",
                 "type": "Central",
-                "additional_info": [
-                  {
-                    "value": "string",
-                    "type": "string"
-                  }
-                ]
               },
-              },
-              "status": "Processing"
-              }
+              "evse_id": 1
+            }
     receive_reply_withdraw_authorization:
       name: receive_reply_withdraw_authorization
       title: 'Reply to request to withdraw authorization'
@@ -194,6 +138,9 @@ components:
       contentType: application/json
       payload:
          $ref: '#/components/schemas/WithdrawAuthorizationResult'
+      examples:
+        - summary: ""
+          payload: "Accepted"
 
     receive_token_validation_status:
       name: receive_token_validation_status
@@ -379,15 +326,6 @@ components:
             $ref: '#/components/schemas/CertificateHashDataInfo'
           minItems: 1
           maxItems: 4
-    SetConnectionTimeoutRequest:
-      description: Connection timeout in seconds
-      type: integer
-      minimum: 10
-      maximum: 300
-    SetMasterPassGroupId:
-      description: The master pass group id
-      type: string
-      maxLength: 36
     TokenValidationStatus:
       description: |
         Ongoing token validation status

--- a/modules/API/auth_consumer_API/auth_consumer_API.cpp
+++ b/modules/API/auth_consumer_API/auth_consumer_API.cpp
@@ -27,8 +27,6 @@ void auth_consumer_API::init() {
 void auth_consumer_API::ready() {
     invoke_ready(*p_main);
 
-    generate_api_cmd_set_connection_timeout();
-    generate_api_cmd_set_master_pass_group_id();
     generate_api_cmd_withdraw_authorization();
     generate_api_var_token_validation_status();
 
@@ -52,28 +50,6 @@ auto auth_consumer_API::forward_api_var(std::string const& var) {
             EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
         }
     };
-}
-
-void auth_consumer_API::generate_api_cmd_set_connection_timeout() {
-    subscribe_api_topic("set_connection_timeout", [this](std::string const& data) {
-        int connection_timeout = 0;
-        if (deserialize(data, connection_timeout)) {
-            r_auth->call_set_connection_timeout(connection_timeout);
-            return true;
-        }
-        return false;
-    });
-}
-
-void auth_consumer_API::generate_api_cmd_set_master_pass_group_id() {
-    subscribe_api_topic("set_master_pass_group_id", [this](std::string const& data) {
-        std::string master_pass_group_id;
-        if (deserialize(data, master_pass_group_id)) {
-            r_auth->call_set_master_pass_group_id(std::move(master_pass_group_id));
-            return true;
-        }
-        return false;
-    });
 }
 
 void auth_consumer_API::generate_api_cmd_withdraw_authorization() {

--- a/modules/API/auth_consumer_API/auth_consumer_API.hpp
+++ b/modules/API/auth_consumer_API/auth_consumer_API.hpp
@@ -73,8 +73,6 @@ private:
     using ParseAndPublishFtor = std::function<bool(std::string const&)>;
     void subscribe_api_topic(std::string const& var, ParseAndPublishFtor const& parse_and_publish);
 
-    void generate_api_cmd_set_connection_timeout();
-    void generate_api_cmd_set_master_pass_group_id();
     void generate_api_cmd_withdraw_authorization();
 
     void generate_api_var_token_validation_status();


### PR DESCRIPTION

## Describe your changes
Remove two functions from Auth Consumer API:
* set_connection_timeout
* set_master_pass_group_id

The function are supposed to be used for internal module communication only

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

