### PR TITLE
Escape ISO authorize loop in case of Plug In Timeout 

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1501,6 +1501,8 @@ bool Charger::deauthorize_internal() {
                 if (config_context.raise_mrec9) {
                     error_handling->raise_authorization_timeout_error("No authorization was provided within timeout.");
                 }
+                // this will inform HLC about the timeout to escape the Authorize loop and stop the session
+                signal_hlc_plug_in_timeout();
                 return false;
             }
             shared_context.authorized = false;

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -168,6 +168,7 @@ public:
     sigslot::signal<> signal_hlc_stop_charging;
     sigslot::signal<> signal_hlc_pause_charging;
     sigslot::signal<types::iso15118::EvseError> signal_hlc_error;
+    sigslot::signal<> signal_hlc_plug_in_timeout;
 
     sigslot::signal<> signal_hlc_no_energy_available;
 

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -287,6 +287,10 @@ void EvseManager::ready() {
         // Ask HLC to stop charging session
         charger->signal_hlc_stop_charging.connect([this] { r_hlc[0]->call_stop_charging(true); });
         charger->signal_hlc_pause_charging.connect([this] { r_hlc[0]->call_pause_charging(true); });
+        charger->signal_hlc_plug_in_timeout.connect([this] {
+            r_hlc[0]->call_authorization_response(types::authorization::AuthorizationStatus::Unknown,
+                                                  types::authorization::CertificateStatus::NoCertificateAvailable);
+        });
 
         // Charger needs to inform ISO stack about emergency stop
         charger->signal_hlc_error.connect([this](types::iso15118::EvseError error) {

--- a/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
@@ -366,6 +366,8 @@ void evse_managerImpl::handle_authorize_response(types::authorization::ProvidedI
             mod->reserve(validation_result.reservation_id.value(), false);
         }
     } else if (pnc) {
+        // we only send authorization responses to the HLC for PnC rejections. In case of EIM we could
+        // still receive a successfull authorization later and therefore we don't inform the HLC
         this->mod->r_hlc[0]->call_authorization_response(
             validation_result.authorization_status,
             validation_result.certificate_status.value_or(types::authorization::CertificateStatus::Accepted));

--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -246,17 +246,14 @@ void ISO15118_chargerImpl::handle_authorization_response(
     types::authorization::AuthorizationStatus& authorization_status,
     types::authorization::CertificateStatus& certificate_status) {
 
-    if (v2g_ctx->session.iso_selected_payment_option == iso2_paymentOptionType_ExternalPayment) {
-        if (authorization_status == types::authorization::AuthorizationStatus::Accepted) {
-            v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = (uint8_t)iso2_EVSEProcessingType_Finished;
-        }
-    } else if (v2g_ctx->session.iso_selected_payment_option == iso2_paymentOptionType_Contract) {
-        v2g_ctx->session.certificate_status = certificate_status;
-        v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = static_cast<uint8_t>(iso2_EVSEProcessingType_Finished);
+    v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = static_cast<uint8_t>(iso2_EVSEProcessingType_Finished);
 
-        if (authorization_status != types::authorization::AuthorizationStatus::Accepted) {
-            v2g_ctx->session.authorization_rejected = true;
-        }
+    if (authorization_status != types::authorization::AuthorizationStatus::Accepted) {
+        v2g_ctx->session.authorization_rejected = true;
+    }
+
+    if (v2g_ctx->session.iso_selected_payment_option == iso2_paymentOptionType_Contract) {
+        v2g_ctx->session.certificate_status = certificate_status;
     }
 }
 

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -1186,7 +1186,8 @@ static enum v2g_event handle_iso_authorization(struct v2g_connection* conn) {
             conn->ctx->session.auth_start_timeout = getmonotonictime();
             res->ResponseCode = iso2_responseCodeType_FAILED;
         }
-    } else if (conn->ctx->session.authorization_rejected == true) {
+    } else if (conn->ctx->session.authorization_rejected == true and
+               (conn->ctx->session.iso_selected_payment_option == iso2_paymentOptionType_Contract)) {
         if (conn->ctx->session.certificate_status == types::authorization::CertificateStatus::CertificateRevoked) {
             res->ResponseCode = iso2_responseCodeType_FAILED_CertificateRevoked;
         } else {


### PR DESCRIPTION
## Describe your changes
The ISO15118 currently remains in the authorize loop even if the authorization process already signaled a PlugInTimeout. The (ISO15118) session can not recover from this without a replug, so the EV should be notified by responding with failed in the AuthorizeResponse. 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

