### PR TITLE
Correct asyncapi specifications for send_mode

### DIFF
--- a/doc/everest_api_specs/power_supply_DC_API/asyncapi.yaml
+++ b/doc/everest_api_specs/power_supply_DC_API/asyncapi.yaml
@@ -191,7 +191,7 @@ components:
       summary: 'Current mode of DC power supply.'
       contentType: application/json
       payload:
-        $ref: '#/components/schemas/ModeRequest'
+        $ref: '#/components/schemas/Mode'
       examples:   # Define examples here
         - summary: "Example 1 of sending voltage and current."
           payload:


### PR DESCRIPTION
The power_supply_DC_API incorrectly used the ModeRequest as payload for send_mode.
That also contains the charging phase. The payload type is changed to Mode.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

