### PR TITLE
Extended evse_manager_consumerAPI module with SessionInfo

### DIFF
--- a/doc/everest_api_specs/evse_manager_consumer_API/asyncapi.yaml
+++ b/doc/everest_api_specs/evse_manager_consumer_API/asyncapi.yaml
@@ -144,6 +144,11 @@ channels:
     messages:
       receive_car_manufacturer:
         $ref: '#/components/messages/receive_car_manufacturer'
+  receive_session_info:
+    address: 'e2m/session_info'
+    messages:
+      receive_session_info:
+        $ref: '#/components/messages/receive_session_info'
   # telemetry not implemented
   receive_powermeter:
     address: 'e2m/powermeter'
@@ -444,6 +449,11 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_car_manufacturer'
+  receive_session_info:
+    title: 'Receive session information'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_session_info'
   # telemetry not implemented
   receive_powermeter:
     title: 'Receive powermeter measured dataset'
@@ -882,6 +892,25 @@ components:
       contentType: application/json
       payload:
          $ref: '#/components/schemas/CarManufacturer'
+    receive_session_info:
+      name: receive_session_info
+      title: 'Receive session and transaction information'
+      summary: >-
+        Information about the current session and transaction.
+        During a session, data is published with a frequency of
+        ~1Hz. If no session is active, data is published on change.
+        
+        A session starts when the first user interaction occurs, 
+        e.g. plug in of an EV or authorization was provided. A 
+        session ends when the EV is unplugged or the authorization
+        has timed out.
+        
+        A transaction starts if an EV is plugged in and the user is 
+        authorized. A transaction ends when the EV is unplugged or 
+        the user is not authorized anymore.
+      contentType: application/json
+      payload:
+         $ref: '#/components/schemas/SessionInfo'
     # telemetry not implemented
     receive_powermeter:
       name: receive_powermeter
@@ -1100,6 +1129,102 @@ components:
         - VolkswagenGroup
         - Tesla
         - Unknown
+    EvseStateEnum:
+        description: |
+          State of the EVSE: 
+          - Unknown: Initial state when state is not known
+          - Unplugged: No EV is connected
+          - Disabled: EVSE is disabled on not available for energy transfer
+          - Preparing: First user interaction occured, e.g. plug in of EV or authorization has been received
+          - AuthRequired: EV is plugged in and EVSE is waiting for authorization
+          - WaitingForEnergy: EVSE is waiting for energy. Occurs at the start of the session or when no energy is available
+          - ChargingPausedEV: Session is paused by EV
+          - ChargingPausedEVSE: Session is paused by EVSE
+          - Charging: EV is charging
+          - AuthTimeout: EV has been plugged in but no authorization has been provided. A replug is required.
+          - Finished: Transaction is finished
+          - FinishedEVSE: Stop of transaction was initiated by EVSE e.g. by user request
+          - FinishedEV: Stopping of transaction was initiated by EV
+        type: string
+        enum:
+          - Unknown
+          - Unplugged
+          - Disabled
+          - Preparing
+          - Reserved
+          - AuthRequired
+          - WaitingForEnergy
+          - ChargingPausedEV
+          - ChargingPausedEVSE
+          - Charging
+          - AuthTimeout
+          - Finished
+          - FinishedEVSE
+          - FinishedEV
+    SessionInfo:
+      description: >-
+        Context for Session information
+      type: object
+      additionalProperties: false
+      required:
+        - state
+        - charged_energy_wh
+        - discharged_energy_wh
+        - latest_total_w
+        - session_duration_s
+        - timestamp
+      properties:
+        state:
+          description: Current session state
+          type: string
+          $ref: '#/components/schemas/EvseStateEnum'
+        charged_energy_wh:
+          description: Total charged energy in this session in Wh
+          type: integer
+          minimum: 0
+        discharged_energy_wh:
+          description: Total discharged energy in this session in Wh
+          type: integer
+          minimum: 0
+        latest_total_w:
+          description: Last power measurement in watts
+          type: integer
+        session_duration_s:
+          description: Total duration of the session in seconds
+          type: integer
+          minimum: 0
+        timestamp:
+          description: Timestamp of capturing session info
+          type: string
+          format: date-time
+        selected_protocol:
+          description: Selected protocol for charging. Only present during a session.
+          type: string
+          $ref: '#/components/schemas/SelectedProtocol'
+        transaction_duration_s:
+          description: >-
+            Total duration of the transaction in seconds. Only present and updated 
+            when a transaction is active.
+          type: integer
+          minimum: 0
+        session_start_time:
+          description: Timestamp of session start. Updated at each new session.
+          type: string
+          format: date-time
+        transaction_start_time:
+          description: >-
+            Timestamp of transaction start. Updated at each new transaction.
+          type: string
+          format: date-time
+        session_end_time:
+          description: Timestamp of session end. Updated at each session end.
+          type: string
+          format: date-time
+        transaction_end_time:
+          description: >-
+            Timestamp of transaction end. Updated at each transaction end.
+          type: string
+          format: date-time
     CertificateActionEnum:
       description: Specifies the type of a certificate request
       type: string

--- a/lib/everest/everest_api_types/include/everest_api_types/evse_manager/API.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/evse_manager/API.hpp
@@ -258,4 +258,35 @@ struct PlugAndChargeConfiguration {
     std::optional<bool> contract_certificate_installation_enabled;
 };
 
+enum class EvseStateEnum {
+    Unknown,
+    Unplugged,
+    Disabled,
+    Preparing,
+    AuthRequired,
+    WaitingForEnergy,
+    ChargingPausedEV,
+    ChargingPausedEVSE,
+    Charging,
+    AuthTimeout,
+    Finished,
+    FinishedEVSE,
+    FinishedEV
+};
+
+struct SessionInfo {
+    EvseStateEnum state;
+    int32_t charged_energy_wh;
+    int32_t discharged_energy_wh;
+    int32_t latest_total_w;
+    int64_t session_duration_s;
+    std::string timestamp;
+    std::optional<std::string> selected_protocol;
+    std::optional<int64_t> transaction_duration_s;
+    std::optional<std::string> session_start_time;
+    std::optional<std::string> transaction_start_time;
+    std::optional<std::string> session_end_time;
+    std::optional<std::string> transaction_end_time;
+};
+
 } // namespace everest::lib::API::V1_0::types::evse_manager

--- a/lib/everest/everest_api_types/include/everest_api_types/evse_manager/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/evse_manager/codec.hpp
@@ -35,6 +35,8 @@ std::string serialize(EnableDisableSource const& val) noexcept;
 std::string serialize(EnableDisableRequest const& val) noexcept;
 std::string serialize(AuthorizeResponseArgs const& val) noexcept;
 std::string serialize(PlugAndChargeConfiguration const& val) noexcept;
+std::string serialize(EvseStateEnum const& val) noexcept;
+std::string serialize(SessionInfo const& val) noexcept;
 
 std::ostream& operator<<(std::ostream& os, StopTransactionReason const& val);
 std::ostream& operator<<(std::ostream& os, StopTransactionRequest const& val);
@@ -63,6 +65,8 @@ std::ostream& operator<<(std::ostream& os, EnableDisableSource const& val);
 std::ostream& operator<<(std::ostream& os, EnableDisableRequest const& val);
 std::ostream& operator<<(std::ostream& os, AuthorizeResponseArgs const& val);
 std::ostream& operator<<(std::ostream& os, PlugAndChargeConfiguration const& val);
+std::ostream& operator<<(std::ostream& os, EvseStateEnum const& val);
+std::ostream& operator<<(std::ostream& os, SessionInfo const& val);
 
 template <class T> T deserialize(std::string const& val);
 template <class T> std::optional<T> try_deserialize(std::string const& val) noexcept {

--- a/lib/everest/everest_api_types/private_include/everest_api_types/evse_manager/json_codec.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/evse_manager/json_codec.hpp
@@ -91,4 +91,10 @@ void from_json(json const& j, AuthorizeResponseArgs& k);
 void to_json(json& j, PlugAndChargeConfiguration const& k) noexcept;
 void from_json(json const& j, PlugAndChargeConfiguration& k);
 
+void to_json(json& j, EvseStateEnum const& k) noexcept;
+void from_json(json const& j, EvseStateEnum& k);
+
+void to_json(json& j, SessionInfo const& k) noexcept;
+void from_json(json const& j, SessionInfo& k);
+
 } // namespace everest::lib::API::V1_0::types::evse_manager

--- a/lib/everest/everest_api_types/src/everest_api_types/evse_manager/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/evse_manager/codec.cpp
@@ -145,6 +145,16 @@ std::string serialize(PlugAndChargeConfiguration const& val) noexcept {
     return result.dump(json_indent);
 }
 
+std::string serialize(EvseStateEnum const& val) noexcept {
+    json result = val;
+    return result.dump(json_indent);
+}
+
+std::string serialize(SessionInfo const& val) noexcept {
+    json result = val;
+    return result.dump(json_indent);
+}
+
 std::ostream& operator<<(std::ostream& os, StopTransactionReason const& val) {
     os << serialize(val);
     return os;
@@ -275,6 +285,16 @@ std::ostream& operator<<(std::ostream& os, AuthorizeResponseArgs const& val) {
     return os;
 }
 std::ostream& operator<<(std::ostream& os, PlugAndChargeConfiguration const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, EvseStateEnum const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, SessionInfo const& val) {
     os << serialize(val);
     return os;
 }
@@ -438,6 +458,18 @@ template <> AuthorizeResponseArgs deserialize(std::string const& s) {
 template <> PlugAndChargeConfiguration deserialize(std::string const& s) {
     auto data = json::parse(s);
     PlugAndChargeConfiguration result = data;
+    return result;
+}
+
+template <> EvseStateEnum deserialize(std::string const& s) {
+    auto data = json::parse(s);
+    EvseStateEnum result = data;
+    return result;
+}
+
+template <> SessionInfo deserialize(std::string const& s) {
+    auto data = json::parse(s);
+    SessionInfo result = data;
     return result;
 }
 

--- a/lib/everest/everest_api_types/src/everest_api_types/evse_manager/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/evse_manager/json_codec.cpp
@@ -1213,4 +1213,164 @@ void from_json(json const& j, PlugAndChargeConfiguration& k) {
     }
 }
 
+void to_json(json& j, EvseStateEnum const& k) noexcept {
+    switch (k) {
+    case EvseStateEnum::Unknown:
+        j = "Unknown";
+        return;
+    case EvseStateEnum::Unplugged:
+        j = "Unplugged";
+        return;
+    case EvseStateEnum::Disabled:
+        j = "Disabled";
+        return;
+    case EvseStateEnum::Preparing:
+        j = "Preparing";
+        return;
+    case EvseStateEnum::AuthRequired:
+        j = "AuthRequired";
+        return;
+    case EvseStateEnum::WaitingForEnergy:
+        j = "WaitingForEnergy";
+        return;
+    case EvseStateEnum::ChargingPausedEV:
+        j = "ChargingPausedEV";
+        return;
+    case EvseStateEnum::ChargingPausedEVSE:
+        j = "ChargingPausedEVSE";
+        return;
+    case EvseStateEnum::Charging:
+        j = "Charging";
+        return;
+    case EvseStateEnum::AuthTimeout:
+        j = "AuthTimeout";
+        return;
+    case EvseStateEnum::Finished:
+        j = "Finished";
+        return;
+    case EvseStateEnum::FinishedEVSE:
+        j = "FinishedEVSE";
+        return;
+    case EvseStateEnum::FinishedEV:
+        j = "FinishedEV";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::evse_manger::EvseStateEnum";
+}
+
+void from_json(json const& j, EvseStateEnum& k) {
+    std::string s = j;
+    if (s == "Unknown") {
+        k = EvseStateEnum::Unknown;
+        return;
+    }
+    if (s == "Unplugged") {
+        k = EvseStateEnum::Unplugged;
+        return;
+    }
+    if (s == "Disabled") {
+        k = EvseStateEnum::Disabled;
+        return;
+    }
+    if (s == "Preparing") {
+        k = EvseStateEnum::Preparing;
+        return;
+    }
+    if (s == "AuthRequired") {
+        k = EvseStateEnum::AuthRequired;
+        return;
+    }
+    if (s == "WaitingForEnergy") {
+        k = EvseStateEnum::WaitingForEnergy;
+        return;
+    }
+    if (s == "ChargingPausedEV") {
+        k = EvseStateEnum::ChargingPausedEV;
+        return;
+    }
+    if (s == "ChargingPausedEVSE") {
+        k = EvseStateEnum::ChargingPausedEVSE;
+        return;
+    }
+    if (s == "Charging") {
+        k = EvseStateEnum::Charging;
+        return;
+    }
+    if (s == "AuthTimeout") {
+        k = EvseStateEnum::AuthTimeout;
+        return;
+    }
+    if (s == "Finished") {
+        k = EvseStateEnum::Finished;
+        return;
+    }
+    if (s == "FinishedEVSE") {
+        k = EvseStateEnum::FinishedEVSE;
+        return;
+    }
+    if (s == "FinishedEV") {
+        k = EvseStateEnum::FinishedEV;
+        return;
+    }
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type API_V1_0_TYPES_EVSE_MANAGER_EvseStateEnum");
+}
+
+void to_json(json& j, SessionInfo const& k) noexcept {
+    j = json{
+        {"state", k.state},
+        {"charged_energy_wh", k.charged_energy_wh},
+        {"discharged_energy_wh", k.discharged_energy_wh},
+        {"session_duration_s", k.session_duration_s},
+        {"latest_total_w", k.latest_total_w},
+        {"timestamp", k.timestamp},
+    };
+
+    if (k.selected_protocol.has_value()) {
+        j["selected_protocol"] = k.selected_protocol.value();
+    }
+    if (k.transaction_duration_s.has_value()) {
+        j["transaction_duration_s"] = k.transaction_duration_s.value();
+    }
+    if (k.session_start_time.has_value()) {
+        j["session_start_time"] = k.session_start_time.value();
+    }
+    if (k.session_end_time.has_value()) {
+        j["session_end_time"] = k.session_end_time.value();
+    }
+    if (k.transaction_start_time.has_value()) {
+        j["transaction_start_time"] = k.transaction_start_time.value();
+    }
+    if (k.transaction_end_time.has_value()) {
+        j["transaction_end_time"] = k.transaction_end_time.value();
+    }
+}
+
+void from_json(json const& j, SessionInfo& k) {
+    k.state = j.at("state");
+    k.charged_energy_wh = j.at("charged_energy_wh");
+    k.discharged_energy_wh = j.at("discharged_energy_wh");
+    k.session_duration_s = j.at("session_duration_s");
+    k.latest_total_w = j.at("latest_total_w");
+    k.timestamp = j.at("timestamp");
+
+    if (j.contains("selected_protocol")) {
+        k.selected_protocol = j.at("selected_protocol");
+    }
+    if (j.contains("transaction_duration_s")) {
+        k.transaction_duration_s = j.at("transaction_duration_s");
+    }
+    if (j.contains("session_start_time")) {
+        k.session_start_time = j.at("session_start_time");
+    }
+    if (j.contains("session_end_time")) {
+        k.session_end_time = j.at("session_end_time");
+    }
+    if (j.contains("transaction_start_time")) {
+        k.transaction_start_time = j.at("transaction_start_time");
+    }
+    if (j.contains("transaction_end_time")) {
+        k.transaction_end_time = j.at("transaction_end_time");
+    }
+}
 } // namespace everest::lib::API::V1_0::types::evse_manager

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/filetestgenerator.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/filetestgenerator.py
@@ -82,7 +82,7 @@ class FileTestGenerator:
         test_code = self.get_code_test()
         if test_code[0] != "" and with_warning:
             raise NotImplementedError("The generation of a struct could not be done automatically, it needs to be supplied manually.\n" +
-                                      "The suplying of manual helpers is not fully implemented. The imports need to be added and the manual helpers need to be registered with the accross file generator. \n" +
+                                      "The supplying of manual helpers is not fully implemented. The imports need to be added and the manual helpers need to be registered with the accross file generator. \n" +
                                       "The problematic struct is probably related to: " + test_code[0])
         code = (
             self.license_header

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/valuegenerator.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/valuegenerator.py
@@ -105,7 +105,7 @@ def get_vector_variable_name(variable_name_suffix=""):
 
 class ValueGenerator:
     manual_generator = ManualGenerator()
-    base_types = ["int32_t", "float", "std::string", "bool"]
+    base_types = ["int32_t", "int64_t", "float", "std::string", "bool"]
 
     def __init__(self, struct_name, struct_namespace, enum_map, across_file_struct_generator=None):
         if (across_file_struct_generator is None):
@@ -168,6 +168,10 @@ class ValueGenerator:
         match type_string_cleaned:
             case "int32_t":
                 s = ((2 ** 32) - 1) / 2
+                value_string = random.randint(
+                    math.floor(-s), math.floor(s)).__str__()
+            case "int64_t":
+                s = ((2 ** 64) - 1) / 2
                 value_string = random.randint(
                     math.floor(-s), math.floor(s)).__str__()
             case "float":

--- a/modules/API/evse_manager_consumer_API/CMakeLists.txt
+++ b/modules/API/evse_manager_consumer_API/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(${MODULE_NAME}
   PRIVATE
     atomic
     everest::everest_api_types
+    everest::util
 )
 
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
@@ -24,6 +25,8 @@ target_link_libraries(${MODULE_NAME}
 target_sources(${MODULE_NAME}
   PRIVATE
     "main/generic_errorImpl.cpp"
+    "evse_manager_consumer_API.cpp"
+    "session_info.cpp"
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/API/evse_manager_consumer_API/doc.rst
+++ b/modules/API/evse_manager_consumer_API/doc.rst
@@ -7,3 +7,10 @@ evse_manager_consumer_API
 :ref:`Link <everest_modules_evse_manager_consumer_API>` to the module's reference.
 
 See ``doc/everest_api_specs/evse_manager_consumer_API/asyncapi.yaml`` for a full AsycAPI specification.
+
+Session Info
+=============
+
+This API module additionally provides a ``SessionInfo`` class to represent information about EVSE sessions.
+The data for ``SessionInfo`` is not simply forwared from the internal EVerest representation. The internal
+represenation is processed and converted to the external API representation.

--- a/modules/API/evse_manager_consumer_API/evse_manager_consumer_API.hpp
+++ b/modules/API/evse_manager_consumer_API/evse_manager_consumer_API.hpp
@@ -29,8 +29,11 @@
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
+#include <everest/util/async/monitor.hpp>
 #include <everest_api_types/utilities/CommCheckHandler.hpp>
 #include <everest_api_types/utilities/Topics.hpp>
+
+#include "session_info.hpp"
 
 namespace ev_API = everest::lib::API;
 
@@ -119,6 +122,7 @@ private:
     void generate_api_cmd_random_delay_set_duration_s();
 
     void generate_api_var_session_event();
+    void generate_api_var_session_info();
     void generate_api_var_limits();
     void generate_api_var_ev_info();
     void generate_api_var_car_manufacturer();
@@ -148,6 +152,8 @@ private:
     ev_API::Topics topics;
     ev_API::CommCheckHandler<generic_errorImplBase> comm_check;
     size_t hb_id{0};
+    everest::lib::util::monitor<SessionInfo> session_info;
+
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/evse_manager_consumer_API/session_info.cpp
+++ b/modules/API/evse_manager_consumer_API/session_info.cpp
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include "session_info.hpp"
+#include <everest/logging.hpp>
+#include <utils/date.hpp>
+namespace module {
+
+using namespace everest::lib::API::V1_0::types::evse_manager;
+
+SessionInfo::SessionInfo() :
+    publish_cb([](auto) {}),
+    start_energy_import_wh(0),
+    end_energy_import_wh(0),
+    start_energy_export_wh(0),
+    end_energy_export_wh(0) {
+    this->session_start_time_point = date::utc_clock::now();
+    this->session_end_time_point = this->session_start_time_point;
+    this->transaction_start_time_point = this->session_start_time_point;
+    this->transaction_end_time_point = this->session_start_time_point;
+}
+
+void SessionInfo::set_publish_callback(PublishCallback cb) {
+    this->publish_cb = [cb](everest::lib::API::V1_0::types::evse_manager::SessionInfo ext) {
+        ext.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
+        cb(ext);
+    };
+}
+
+void SessionInfo::update_state(const types::evse_manager::SessionEvent& session_event) {
+    using Event = types::evse_manager::SessionEventEnum;
+
+    try {
+        switch (session_event.event) {
+        case Event::Enabled:
+            this->ext.state = EvseStateEnum::Unplugged;
+            break;
+        case Event::Disabled:
+            this->ext.state = EvseStateEnum::Disabled;
+            break;
+        case Event::AuthRequired:
+            this->ext.state = EvseStateEnum::AuthRequired;
+            break;
+        case Event::SessionStarted:
+            this->handle_session_started(session_event);
+            this->ext.state = EvseStateEnum::Preparing;
+            break;
+        case Event::PrepareCharging:
+            this->ext.state = EvseStateEnum::Preparing;
+            break;
+        case Event::TransactionStarted:
+            this->handle_transaction_started(session_event);
+            break;
+        case Event::ChargingResumed:
+        case Event::ChargingStarted:
+            this->ext.state = EvseStateEnum::Charging;
+            break;
+        case Event::ChargingPausedEV:
+            this->ext.state = EvseStateEnum::ChargingPausedEV;
+            break;
+        case Event::ChargingPausedEVSE:
+            this->ext.state = EvseStateEnum::ChargingPausedEVSE;
+            break;
+        case Event::WaitingForEnergy:
+            this->ext.state = EvseStateEnum::WaitingForEnergy;
+            break;
+        case Event::ChargingFinished:
+            this->ext.state = EvseStateEnum::Finished;
+            break;
+        case Event::StoppingCharging:
+            this->ext.state = EvseStateEnum::FinishedEV;
+            break;
+        case Event::TransactionFinished: {
+            this->handle_transaction_finished(session_event);
+            break;
+        }
+        case Event::PluginTimeout:
+            this->ext.state = EvseStateEnum::AuthTimeout;
+            break;
+        case Event::SessionFinished:
+            this->handle_session_finished(session_event);
+            break;
+        case Event::ReservationStart:
+        case Event::ReservationEnd:
+        case Event::ReplugStarted:
+        case Event::ReplugFinished:
+        default:
+            break;
+        }
+        publish_cb(this->ext);
+    } catch (const std::exception& e) {
+        EVLOG_warning << "Session event handling failed with -> " << e.what();
+    }
+}
+
+void SessionInfo::update_powermeter(const types::powermeter::Powermeter& powermeter) {
+    try {
+        this->set_latest_energy_import_wh(powermeter.energy_Wh_import.total);
+        if (powermeter.energy_Wh_export.has_value()) {
+            this->set_latest_energy_export_wh(powermeter.energy_Wh_export.value().total);
+        }
+
+        if (powermeter.power_W.has_value()) {
+            this->ext.latest_total_w = powermeter.power_W.value().total;
+        }
+
+        if (this->is_session_running()) {
+            publish_cb(this->ext);
+        }
+    } catch (const std::exception& e) {
+        EVLOG_warning << "Powermeter update handling failed with -> " << e.what();
+    }
+}
+
+void SessionInfo::update_selected_protocol(const std::string& protocol) {
+    try {
+        this->ext.selected_protocol = protocol;
+        if (this->is_session_running()) {
+            publish_cb(this->ext);
+        }
+    } catch (const std::exception& e) {
+        EVLOG_warning << "Selected protocol update handling failed with -> " << e.what();
+    }
+}
+
+void SessionInfo::handle_session_started(const types::evse_manager::SessionEvent& session_event) {
+    this->session_start_time_point = Everest::Date::from_rfc3339(session_event.timestamp);
+    this->session_end_time_point = this->session_start_time_point;
+    this->start_energy_import_wh = this->end_energy_import_wh;
+    this->start_energy_export_wh = this->end_energy_export_wh;
+
+    this->ext.state = EvseStateEnum::Unknown;
+    this->ext.charged_energy_wh = 0;
+    this->ext.discharged_energy_wh = 0;
+    this->ext.session_duration_s = 0;
+    this->ext.transaction_duration_s.reset();
+    this->ext.latest_total_w = 0;
+    this->ext.selected_protocol.reset();
+    this->ext.transaction_start_time.reset();
+    this->ext.transaction_end_time.reset();
+    this->ext.session_end_time.reset();
+    this->ext.session_start_time = Everest::Date::to_rfc3339(this->session_start_time_point);
+}
+
+void SessionInfo::handle_session_finished(const types::evse_manager::SessionEvent& session_event) {
+    this->ext.session_end_time = session_event.timestamp;
+    this->ext.state = EvseStateEnum::Unplugged;
+}
+
+void SessionInfo::handle_transaction_started(const types::evse_manager::SessionEvent& session_event) {
+    this->ext.state = EvseStateEnum::Preparing;
+    this->transaction_running = true;
+
+    if (!session_event.transaction_started.has_value()) {
+        return;
+    }
+
+    auto transaction_started = session_event.transaction_started.value();
+    this->transaction_start_time_point = Everest::Date::from_rfc3339(session_event.timestamp);
+    this->transaction_end_time_point = this->transaction_start_time_point;
+    this->start_energy_import_wh = transaction_started.meter_value.energy_Wh_import.total;
+
+    this->end_energy_import_wh = this->start_energy_import_wh;
+    this->transaction_end_time_point = this->transaction_start_time_point;
+
+    if (transaction_started.meter_value.energy_Wh_export.has_value()) {
+        auto energy_Wh_export = transaction_started.meter_value.energy_Wh_export.value().total;
+        this->start_energy_export_wh = energy_Wh_export;
+        this->end_energy_export_wh = energy_Wh_export;
+        this->start_energy_export_wh_was_set = true;
+    } else {
+        this->start_energy_export_wh_was_set = false;
+    }
+
+    this->ext.transaction_start_time = Everest::Date::to_rfc3339(this->transaction_start_time_point);
+}
+
+void SessionInfo::handle_transaction_finished(const types::evse_manager::SessionEvent& session_event) {
+    this->ext.state = EvseStateEnum::Finished;
+
+    if (!session_event.transaction_finished.has_value()) {
+        return;
+    }
+
+    auto transaction_finished = session_event.transaction_finished.value();
+
+    if (transaction_finished.reason == types::evse_manager::StopTransactionReason::Local) {
+        this->ext.state = EvseStateEnum::FinishedEVSE;
+    }
+
+    auto energy_Wh_import = transaction_finished.meter_value.energy_Wh_import.total;
+    this->end_energy_import_wh = energy_Wh_import;
+    this->transaction_end_time_point = Everest::Date::from_rfc3339(session_event.timestamp);
+    this->transaction_running = false;
+
+    if (transaction_finished.meter_value.energy_Wh_export.has_value()) {
+        auto energy_Wh_export = transaction_finished.meter_value.energy_Wh_export.value().total;
+        this->end_energy_export_wh = energy_Wh_export;
+        this->end_energy_export_wh_was_set = true;
+    } else {
+        this->end_energy_export_wh_was_set = false;
+    }
+
+    this->ext.transaction_end_time = Everest::Date::to_rfc3339(this->transaction_end_time_point);
+}
+
+void SessionInfo::set_latest_energy_import_wh(int32_t latest_energy_wh_import) {
+    this->ext.charged_energy_wh = this->end_energy_import_wh - this->start_energy_import_wh;
+    if (this->start_energy_export_wh_was_set && this->end_energy_export_wh_was_set) {
+        this->ext.discharged_energy_wh = this->end_energy_export_wh - this->start_energy_export_wh;
+    }
+
+    this->ext.session_duration_s =
+        std::chrono::duration_cast<std::chrono::seconds>(this->session_end_time_point - this->session_start_time_point)
+            .count();
+    this->session_end_time_point = date::utc_clock::now();
+
+    if (transaction_running) {
+        this->ext.transaction_duration_s = std::chrono::duration_cast<std::chrono::seconds>(
+                                               this->transaction_end_time_point - this->transaction_start_time_point)
+                                               .count();
+        this->transaction_end_time_point = this->session_end_time_point;
+        this->end_energy_import_wh = latest_energy_wh_import;
+    }
+}
+
+void SessionInfo::set_latest_energy_export_wh(int32_t latest_export_energy_wh) {
+    this->end_energy_export_wh = latest_export_energy_wh;
+    this->end_energy_export_wh_was_set = true;
+}
+
+bool SessionInfo::is_session_running() {
+    return this->ext.state != EvseStateEnum::Unplugged && this->ext.state != EvseStateEnum::Disabled and
+           this->ext.state != EvseStateEnum::Unknown;
+}
+
+} // namespace module

--- a/modules/API/evse_manager_consumer_API/session_info.hpp
+++ b/modules/API/evse_manager_consumer_API/session_info.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <chrono>
+#include <date/date.h>
+#include <date/tz.h>
+#include <mutex>
+#include <string>
+
+#include <everest_api_types/evse_manager/API.hpp>
+#include <generated/types/evse_manager.hpp>
+namespace module {
+
+/// \brief Session and transaction information for EVSE
+class SessionInfo {
+public:
+    using PublishCallback = std::function<void(everest::lib::API::V1_0::types::evse_manager::SessionInfo)>;
+    SessionInfo();
+
+    void set_publish_callback(PublishCallback cb);
+
+    void update_state(const types::evse_manager::SessionEvent& session_event);
+    void update_powermeter(const types::powermeter::Powermeter& powermeter);
+    void update_selected_protocol(const std::string& protocol);
+
+private:
+    PublishCallback publish_cb;
+    /// \brief External API representation
+    everest::lib::API::V1_0::types::evse_manager::SessionInfo ext;
+
+    bool start_energy_export_wh_was_set{
+        false}; ///< Indicate if start export energy value (optional) has been received or not
+    bool end_energy_export_wh_was_set{
+        false}; ///< Indicate if end export energy value (optional) has been received or not
+    bool transaction_running{false};
+
+    int32_t start_energy_import_wh; ///< Energy reading (import) at the beginning of this charging session in Wh
+    int32_t end_energy_import_wh;   ///< Energy reading (import) at the end of this charging session in Wh
+    int32_t start_energy_export_wh; ///< Energy reading (export) at the beginning of this charging session in Wh
+    int32_t end_energy_export_wh;   ///< Energy reading (export) at the end of this charging session in Wh
+    std::chrono::time_point<date::utc_clock> session_start_time_point;     ///< Start of the charging session
+    std::chrono::time_point<date::utc_clock> session_end_time_point;       ///< End of the charging session
+    std::chrono::time_point<date::utc_clock> transaction_start_time_point; ///< Start of the transaction
+    std::chrono::time_point<date::utc_clock> transaction_end_time_point;   ///< End of the transaction
+
+    void handle_session_started(const types::evse_manager::SessionEvent& session_event);
+    void handle_session_finished(const types::evse_manager::SessionEvent& session_event);
+    void handle_transaction_started(const types::evse_manager::SessionEvent& session_event);
+    void handle_transaction_finished(const types::evse_manager::SessionEvent& session_event);
+    void set_latest_energy_import_wh(int32_t latest_energy_wh_import);
+    void set_latest_energy_export_wh(int32_t latest_export_energy_wh);
+    bool is_session_running();
+};
+
+} // namespace module


### PR DESCRIPTION

## Describe your changes
Extended evse_manager_consumerAPI module with SessionInfo:
* Additional route e2m/session_info was added that contains information about a charging session
* Data of e2m/session_info is not simply forwared from internal APIs. The data from internal APIs is processed and converted into the external API format This requires a small state machine to track the EVSE status and meter values

Note: The implementation is based on the implementation of SessionInfo in the [API module](https://github.com/EVerest/everest-core/tree/main/modules/API/API). Some parts were reused and modified.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

