### PR TITLE
Adding heartbeat counter to every API

### DIFF
--- a/doc/everest_api_specs/auth_consumer_API/asyncapi.yaml
+++ b/doc/everest_api_specs/auth_consumer_API/asyncapi.yaml
@@ -208,6 +208,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -449,3 +455,7 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"
+

--- a/doc/everest_api_specs/auth_token_provider_API/asyncapi.yaml
+++ b/doc/everest_api_specs/auth_token_provider_API/asyncapi.yaml
@@ -88,6 +88,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -105,3 +111,6 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/auth_token_validator_API/asyncapi.yaml
+++ b/doc/everest_api_specs/auth_token_validator_API/asyncapi.yaml
@@ -156,6 +156,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -293,3 +299,6 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/dc_external_derate_consumer_API/asyncapi.yaml
+++ b/doc/everest_api_specs/dc_external_derate_consumer_API/asyncapi.yaml
@@ -122,6 +122,12 @@ components:
       title: Receive heartbeat
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: Send communication check
@@ -161,3 +167,6 @@ components:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
 
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/display_message_API/asyncapi.yaml
+++ b/doc/everest_api_specs/display_message_API/asyncapi.yaml
@@ -242,6 +242,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -465,3 +471,6 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/error_history_consumer_API/asyncapi.yaml
+++ b/doc/everest_api_specs/error_history_consumer_API/asyncapi.yaml
@@ -201,6 +201,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -335,3 +341,6 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/evse_board_support_API/asyncapi.yaml
+++ b/doc/everest_api_specs/evse_board_support_API/asyncapi.yaml
@@ -572,6 +572,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -844,3 +850,6 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/evse_manager_consumer_API/asyncapi.yaml
+++ b/doc/everest_api_specs/evse_manager_consumer_API/asyncapi.yaml
@@ -1046,6 +1046,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -1758,3 +1764,6 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/external_energy_limits_consumer_API/asyncapi.yaml
+++ b/doc/everest_api_specs/external_energy_limits_consumer_API/asyncapi.yaml
@@ -240,6 +240,13 @@ components:
       name: receive_heartbeat
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -564,3 +571,6 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/generic_error_raiser_API/asyncapi.yaml
+++ b/doc/everest_api_specs/generic_error_raiser_API/asyncapi.yaml
@@ -111,6 +111,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -162,3 +168,7 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/isolation_monitor_API/asyncapi.yaml
+++ b/doc/everest_api_specs/isolation_monitor_API/asyncapi.yaml
@@ -221,6 +221,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -303,3 +309,7 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/ocpp_consumer_API/asyncapi.yaml
+++ b/doc/everest_api_specs/ocpp_consumer_API/asyncapi.yaml
@@ -405,6 +405,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -874,3 +880,7 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check"
+
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/over_voltage_monitor_API/asyncapi.yaml
+++ b/doc/everest_api_specs/over_voltage_monitor_API/asyncapi.yaml
@@ -248,6 +248,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -345,3 +351,6 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/power_supply_DC_API/asyncapi.yaml
+++ b/doc/everest_api_specs/power_supply_DC_API/asyncapi.yaml
@@ -255,6 +255,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -447,3 +453,7 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/powermeter_API/asyncapi.yaml
+++ b/doc/everest_api_specs/powermeter_API/asyncapi.yaml
@@ -281,6 +281,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -894,3 +900,7 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/session_cost_API/asyncapi.yaml
+++ b/doc/everest_api_specs/session_cost_API/asyncapi.yaml
@@ -101,6 +101,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -817,3 +823,7 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/doc/everest_api_specs/system_API/asyncapi.yaml
+++ b/doc/everest_api_specs/system_API/asyncapi.yaml
@@ -412,6 +412,12 @@ components:
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -677,3 +683,7 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached" 

--- a/lib/everest/everest_api_types/include/everest_api_types/generic/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/generic/codec.hpp
@@ -11,6 +11,7 @@ namespace everest::lib::API::V1_0::types::generic {
 
 std::string serialize(bool val) noexcept;
 std::string serialize(int val) noexcept;
+std::string serialize(size_t val) noexcept;
 std::string serialize(double val) noexcept;
 std::string serialize(float val) noexcept;
 std::string serialize(std::string const& val) noexcept;

--- a/lib/everest/everest_api_types/src/everest_api_types/generic/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/generic/codec.cpp
@@ -23,6 +23,11 @@ std::string serialize(int val) noexcept {
     return result.dump(json_indent);
 }
 
+std::string serialize(size_t val) noexcept {
+    json result = val;
+    return result.dump(json_indent);
+}
+
 std::string serialize(double val) noexcept {
     json result = val;
     return result.dump(json_indent);
@@ -77,6 +82,12 @@ template <> bool deserialize(std::string const& s) {
 template <> int deserialize(std::string const& s) {
     auto data = json::parse(s);
     int result = data;
+    return result;
+}
+
+template <> size_t deserialize(std::string const& s) {
+    auto data = json::parse(s);
+    size_t result = data;
     return result;
 }
 

--- a/modules/API/auth_consumer_API/auth_consumer_API.cpp
+++ b/modules/API/auth_consumer_API/auth_consumer_API.cpp
@@ -110,7 +110,7 @@ void auth_consumer_API::generate_api_var_communication_check() {
 void auth_consumer_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/auth_consumer_API/auth_consumer_API.hpp
+++ b/modules/API/auth_consumer_API/auth_consumer_API.hpp
@@ -84,6 +84,7 @@ private:
 
     ev_API::Topics topics;
     ev_API::CommCheckHandler<generic_errorImplBase> comm_check;
+    size_t hb_id{0};
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };

--- a/modules/API/auth_token_provider_API/auth_token_provider_API.cpp
+++ b/modules/API/auth_token_provider_API/auth_token_provider_API.cpp
@@ -14,6 +14,8 @@ namespace module {
 
 namespace API_types = ev_API::V1_0::types;
 namespace API_types_ext = API_types::auth;
+namespace API_generic = API_types::generic;
+
 using ev_API::deserialize;
 
 void auth_token_provider_API::init() {
@@ -58,7 +60,7 @@ void auth_token_provider_API::generate_api_var_communication_check() {
 void auth_token_provider_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/auth_token_provider_API/auth_token_provider_API.hpp
+++ b/modules/API/auth_token_provider_API/auth_token_provider_API.hpp
@@ -78,6 +78,7 @@ private:
     void setup_heartbeat_generator();
 
     ev_API::Topics topics;
+    size_t hb_id{0};
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };

--- a/modules/API/auth_token_validator_API/auth_token_validator_API.cpp
+++ b/modules/API/auth_token_validator_API/auth_token_validator_API.cpp
@@ -59,7 +59,7 @@ void auth_token_validator_API::generate_api_var_communication_check() {
 void auth_token_validator_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/auth_token_validator_API/auth_token_validator_API.hpp
+++ b/modules/API/auth_token_validator_API/auth_token_validator_API.hpp
@@ -80,7 +80,7 @@ private:
     void setup_heartbeat_generator();
 
     ev_API::Topics topics;
-
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/dc_external_derate_consumer_API/dc_external_derate_consumer_API.cpp
+++ b/modules/API/dc_external_derate_consumer_API/dc_external_derate_consumer_API.cpp
@@ -84,7 +84,7 @@ void dc_external_derate_consumer_API::generate_api_var_communication_check() {
 void dc_external_derate_consumer_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/dc_external_derate_consumer_API/dc_external_derate_consumer_API.hpp
+++ b/modules/API/dc_external_derate_consumer_API/dc_external_derate_consumer_API.hpp
@@ -77,6 +77,7 @@ private:
 
     ev_API::Topics topics;
     ev_API::CommCheckHandler<generic_errorImplBase> comm_check;
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/display_message_API/display_message_API.cpp
+++ b/modules/API/display_message_API/display_message_API.cpp
@@ -46,7 +46,7 @@ void display_message_API::generate_api_var_communication_check() {
 void display_message_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/display_message_API/display_message_API.hpp
+++ b/modules/API/display_message_API/display_message_API.hpp
@@ -81,7 +81,7 @@ private:
 
     void setup_heartbeat_generator();
     ev_API::Topics topics;
-
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/error_history_consumer_API/error_history_consumer_API.cpp
+++ b/modules/API/error_history_consumer_API/error_history_consumer_API.cpp
@@ -109,7 +109,7 @@ void error_history_consumer_API::generate_api_var_communication_check() {
 void error_history_consumer_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/error_history_consumer_API/error_history_consumer_API.hpp
+++ b/modules/API/error_history_consumer_API/error_history_consumer_API.hpp
@@ -85,7 +85,7 @@ private:
 
     ev_API::Topics topics;
     ev_API::CommCheckHandler<generic_errorImplBase> comm_check;
-
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/evse_board_support_API/evse_board_support_API.cpp
+++ b/modules/API/evse_board_support_API/evse_board_support_API.cpp
@@ -154,7 +154,7 @@ void evse_board_support_API::generate_api_var_communication_check() {
 void evse_board_support_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/evse_board_support_API/evse_board_support_API.hpp
+++ b/modules/API/evse_board_support_API/evse_board_support_API.hpp
@@ -103,7 +103,7 @@ private:
     void setup_heartbeat_generator();
 
     ev_API::Topics topics;
-
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/evse_manager_consumer_API/evse_manager_consumer_API.cpp
+++ b/modules/API/evse_manager_consumer_API/evse_manager_consumer_API.cpp
@@ -419,7 +419,7 @@ void evse_manager_consumer_API::generate_api_var_communication_check() {
 void evse_manager_consumer_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/evse_manager_consumer_API/evse_manager_consumer_API.hpp
+++ b/modules/API/evse_manager_consumer_API/evse_manager_consumer_API.hpp
@@ -147,7 +147,7 @@ private:
 
     ev_API::Topics topics;
     ev_API::CommCheckHandler<generic_errorImplBase> comm_check;
-
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/external_energy_limits_consumer_API/external_energy_limits_consumer_API.cpp
+++ b/modules/API/external_energy_limits_consumer_API/external_energy_limits_consumer_API.cpp
@@ -5,11 +5,14 @@
 #include <everest_api_types/energy/API.hpp>
 #include <everest_api_types/energy/codec.hpp>
 #include <everest_api_types/energy/wrapper.hpp>
+#include <everest_api_types/generic/codec.hpp>
 #include <everest_api_types/utilities/codec.hpp>
 
 namespace module {
 namespace API_types = everest::lib::API::V1_0::types;
 namespace API_types_ext = API_types::energy;
+namespace API_generic = API_types::generic;
+
 using ev_API::deserialize;
 
 void external_energy_limits_consumer_API::init() {
@@ -75,7 +78,7 @@ void external_energy_limits_consumer_API::generate_api_var_communication_check()
 void external_energy_limits_consumer_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/external_energy_limits_consumer_API/external_energy_limits_consumer_API.hpp
+++ b/modules/API/external_energy_limits_consumer_API/external_energy_limits_consumer_API.hpp
@@ -79,6 +79,7 @@ private:
 
     ev_API::Topics topics;
     ev_API::CommCheckHandler<generic_errorImplBase> comm_check;
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/generic_error_raiser_API/generic_error_raiser_API.cpp
+++ b/modules/API/generic_error_raiser_API/generic_error_raiser_API.cpp
@@ -11,6 +11,7 @@
 namespace module {
 
 using ev_API::deserialize;
+namespace API_generic = API_types::generic;
 
 void generic_error_raiser_API::init() {
     invoke_init(*p_main);
@@ -83,7 +84,7 @@ void generic_error_raiser_API::generate_api_var_communication_check() {
 void generic_error_raiser_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/generic_error_raiser_API/generic_error_raiser_API.hpp
+++ b/modules/API/generic_error_raiser_API/generic_error_raiser_API.hpp
@@ -80,6 +80,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/isolation_monitor_API/isolation_monitor_API.cpp
+++ b/modules/API/isolation_monitor_API/isolation_monitor_API.cpp
@@ -104,7 +104,7 @@ void isolation_monitor_API::generate_api_var_clear_error() {
 void isolation_monitor_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/isolation_monitor_API/isolation_monitor_API.hpp
+++ b/modules/API/isolation_monitor_API/isolation_monitor_API.hpp
@@ -81,6 +81,7 @@ private:
     void setup_heartbeat_generator();
 
     ev_API::Topics topics;
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/ocpp_consumer_API/ocpp_consumer_API.cpp
+++ b/modules/API/ocpp_consumer_API/ocpp_consumer_API.cpp
@@ -146,7 +146,7 @@ void ocpp_consumer_API::generate_api_var_communication_check() {
 void ocpp_consumer_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/ocpp_consumer_API/ocpp_consumer_API.hpp
+++ b/modules/API/ocpp_consumer_API/ocpp_consumer_API.hpp
@@ -64,8 +64,6 @@ public:
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     // insert your public definitions here
-    ev_API::CommCheckHandler<generic_errorImplBase> comm_check;
-
     const ev_API::Topics& get_topics() const;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
@@ -100,7 +98,9 @@ private:
     void setup_heartbeat_generator();
 
     ev_API::Topics topics;
+    ev_API::CommCheckHandler<generic_errorImplBase> comm_check;
 
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/over_voltage_monitor_API/over_voltage_monitor_API.cpp
+++ b/modules/API/over_voltage_monitor_API/over_voltage_monitor_API.cpp
@@ -114,7 +114,7 @@ void over_voltage_monitor_API::generate_api_var_communication_check() {
 void over_voltage_monitor_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/over_voltage_monitor_API/over_voltage_monitor_API.hpp
+++ b/modules/API/over_voltage_monitor_API/over_voltage_monitor_API.hpp
@@ -83,7 +83,7 @@ private:
 
     void setup_heartbeat_generator();
     ev_API::Topics topics;
-
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/power_supply_DC_API/power_supply_DC_API.cpp
+++ b/modules/API/power_supply_DC_API/power_supply_DC_API.cpp
@@ -126,7 +126,7 @@ void power_supply_DC_API::generate_api_var_communication_check() {
 void power_supply_DC_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/power_supply_DC_API/power_supply_DC_API.hpp
+++ b/modules/API/power_supply_DC_API/power_supply_DC_API.hpp
@@ -85,6 +85,7 @@ private:
 
     ev_API::Topics topics;
     ev_API::CommCheckHandler<power_supply_DCImplBase> comm_check;
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/powermeter_API/powermeter_API.cpp
+++ b/modules/API/powermeter_API/powermeter_API.cpp
@@ -75,7 +75,7 @@ void powermeter_API::generate_api_var_communication_check() {
 void powermeter_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/powermeter_API/powermeter_API.hpp
+++ b/modules/API/powermeter_API/powermeter_API.hpp
@@ -78,6 +78,7 @@ private:
     void setup_heartbeat_generator();
 
     ev_API::Topics topics;
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/session_cost_API/session_cost_API.cpp
+++ b/modules/API/session_cost_API/session_cost_API.cpp
@@ -3,6 +3,7 @@
 
 #include "session_cost_API.hpp"
 
+#include <everest_api_types/generic/codec.hpp>
 #include <everest_api_types/session_cost/API.hpp>
 #include <everest_api_types/session_cost/codec.hpp>
 #include <everest_api_types/session_cost/wrapper.hpp>
@@ -14,6 +15,7 @@ namespace module {
 
 namespace API_types = ev_API::V1_0::types;
 namespace API_types_ext = API_types::session_cost;
+namespace API_generic = API_types::generic;
 using ev_API::deserialize;
 
 void session_cost_API::init() {
@@ -72,7 +74,7 @@ void session_cost_API::generate_api_var_communication_check() {
 void session_cost_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/session_cost_API/session_cost_API.hpp
+++ b/modules/API/session_cost_API/session_cost_API.hpp
@@ -84,7 +84,7 @@ private:
     void setup_heartbeat_generator();
 
     ev_API::Topics topics;
-
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/API/system_API/system_API.cpp
+++ b/modules/API/system_API/system_API.cpp
@@ -72,7 +72,7 @@ void system_API::generate_api_var_communication_check() {
 void system_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/system_API/system_API.hpp
+++ b/modules/API/system_API/system_API.hpp
@@ -81,6 +81,7 @@ private:
     void setup_heartbeat_generator();
 
     ev_API::Topics topics;
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 


### PR DESCRIPTION
## Describe your changes
This adds an increasing ID to the payload of all the hearbeat messages. It can be used to verify, that no messages have been lost.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

