### PR TITLE
Fix test: test_cleanup_transaction_events_after_max_attempts_exhausted

### DIFF
--- a/tests/ocpp_tests/test_sets/ocpp201/transactions.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/transactions.py
@@ -293,6 +293,10 @@ async def test_cleanup_transaction_events_after_max_attempts_exhausted(
         validate_status_notification_201,
     )
 
+    # return a CALLERROR for the transaction event
+    central_system.mock.on_transaction_event.side_effect = [
+        NotImplementedError()]
+
     # swipe id tag to authorize
     test_controller.swipe(id_token.id_token)
 
@@ -307,10 +311,6 @@ async def test_cleanup_transaction_events_after_max_attempts_exhausted(
         {"eventType": "Started", "offline": False},
     )
     test_utility.validation_mode = ValidationMode.STRICT
-
-    # return a CALLERROR for the transaction event
-    central_system.mock.on_transaction_event.side_effect = [
-        NotImplementedError()]
 
     assert await wait_for_and_validate(
         test_utility,


### PR DESCRIPTION
## Describe your changes
Moved side effect to return CallError up, because it could happen that the CSMS properly responds to TransactionEvent(Started), which is not desired in this test case.


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

