### PR TITLE
Control IMDSimulator Resistence via MQTT

### DIFF
--- a/modules/Simulation/IMDSimulator/IMDSimulator.hpp
+++ b/modules/Simulation/IMDSimulator/IMDSimulator.hpp
@@ -24,9 +24,11 @@ struct Conf {};
 class IMDSimulator : public Everest::ModuleBase {
 public:
     IMDSimulator() = delete;
-    IMDSimulator(const ModuleInfo& info, std::unique_ptr<isolation_monitorImplBase> p_main, Conf& config) :
-        ModuleBase(info), p_main(std::move(p_main)), config(config){};
+    IMDSimulator(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider,
+                 std::unique_ptr<isolation_monitorImplBase> p_main, Conf& config) :
+        ModuleBase(info), mqtt(mqtt_provider), p_main(std::move(p_main)), config(config){};
 
+    Everest::MqttProvider& mqtt;
     const std::unique_ptr<isolation_monitorImplBase> p_main;
     const Conf& config;
 

--- a/modules/Simulation/IMDSimulator/doc.rst
+++ b/modules/Simulation/IMDSimulator/doc.rst
@@ -1,0 +1,15 @@
+.. _everest_modules_handwritten_IMDSimulator:
+
+############
+IMDSimulator
+############
+
+External MQTT Control
+=====================
+
+The IMDSimulator module supports setting the simulated isolation resistance via MQTT.
+To set the resistance, publish an integer value (in Ohms) to the following topic:
+
+.. code-block:: none
+
+    everest_api/<module_id>/cmd/set_resistance

--- a/modules/Simulation/IMDSimulator/main/isolation_monitorImpl.cpp
+++ b/modules/Simulation/IMDSimulator/main/isolation_monitorImpl.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <thread>
 namespace module {
+
 namespace main {
 
 void isolation_monitorImpl::init() {
@@ -13,6 +14,17 @@ void isolation_monitorImpl::init() {
     this->config_interval = this->config.interval;
 
     this->isolation_measurement_thread_handle = std::thread(&isolation_monitorImpl::isolation_measurement_worker, this);
+
+    const std::string RESISTANCE_TOPIC = "everest_api/" + this->mod->info.id + "/cmd/set_resistance";
+    this->mod->mqtt.subscribe(RESISTANCE_TOPIC, [this](const std::string& resistance_ohm) {
+        try {
+            int32_t _resistance_ohm = std::stoi(resistance_ohm);
+            EVLOG_info << "Setting simulated isolation resistance to " << _resistance_ohm << " Ohm via MQTT";
+            this->isolation_measurement.resistance_F_Ohm = _resistance_ohm;
+        } catch (const std::invalid_argument& e) {
+            EVLOG_error << "Failed to set isolation resistance via MQTT, invalid value: " << resistance_ohm;
+        }
+    });
 }
 
 void isolation_monitorImpl::ready() {

--- a/modules/Simulation/IMDSimulator/manifest.yaml
+++ b/modules/Simulation/IMDSimulator/manifest.yaml
@@ -16,6 +16,7 @@ provides:
         description: Set to true for successful self testing, false for fault
         type: boolean
         default: true
+enable_external_mqtt: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:


### PR DESCRIPTION

## Describe your changes
feat(IMDSimulator): Added support to set the resistance of the IMD via external MQTT.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

