### PR TITLE
Add openssl-devel-engine package to fedora dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sudo dnf install make automake gcc gcc-c++ kernel-devel python3-pip \
   python3-devel git rsync wget cmake doxygen graphviz clang-tools-extra \
   cppcheck java-21-openjdk java-21-openjdk-devel boost-devel nodejs \
   nodejs-devel npm openssl openssl-devel libsqlite3x-devel curl rfkill \
-  libpcap-devel libevent-devel libcap-devel systemd-devel
+  libpcap-devel libevent-devel libcap-devel systemd-devel openssl-devel-engine
 ```
 
 ## Build & Install


### PR DESCRIPTION
## Describe your changes
See title

## Issue ticket number and link
The current everest-core can not be built. With the new package installed it builds again
`fatal error: openssl/engine.h: No such file or directory`

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

