### PR TITLE
EvseV2G: fix randomness of SessionID

### DIFF
--- a/modules/EVSE/EvseV2G/din_server.cpp
+++ b/modules/EVSE/EvseV2G/din_server.cpp
@@ -325,8 +325,7 @@ enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
     /* If the customer doesen't select a session id, generate one */
     srand((unsigned int)time(NULL));
     if (conn->ctx->evse_v2g_data.session_id == (uint64_t)0) {
-        conn->ctx->evse_v2g_data.session_id =
-            ((uint64_t)rand() << 48) | ((uint64_t)rand() << 32) | ((uint64_t)rand() << 16) | (uint64_t)rand();
+        generate_random_data(&conn->ctx->evse_v2g_data.session_id, 8);
         dlog(DLOG_LEVEL_INFO, "No session_id found. Generating random session id.");
     }
 

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -552,7 +552,7 @@ static enum v2g_event handle_iso_session_setup(struct v2g_connection* conn) {
     srand((unsigned int)time(NULL));
     if (conn->ctx->evse_v2g_data.session_id == (uint64_t)0 ||
         conn->ctx->evse_v2g_data.session_id != conn->ctx->ev_v2g_data.received_session_id) {
-        generate_random_data(&conn->ctx->evse_v2g_data.session_id, 4);
+        generate_random_data(&conn->ctx->evse_v2g_data.session_id, 8);
         dlog(
             DLOG_LEVEL_INFO,
             "No session_id found or not equal to the id from the preceding v2g session. Generating random session id.");


### PR DESCRIPTION
## Describe your changes
Give SessionID full 64-bit randomness.

Use the same code also for DIN 70121.

Also print SessionIDs correctly, i.e. in hexadecimal with "correct" byte order.

-----

While PR https://github.com/EVerest/everest-core/pull/1407 replaced multiple calls to `rand()` with a more generic and useful wrapper, the replacement only fetched 32 bits for a 64-bit value. (The previous `rand()`-based code also had its issues.) The change was furthermore only applied to ISO 15118-2, while DIN 70121 used the same original code. (libiso15118 again uses a different method.)
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

