### PR TITLE
While testing MCS feature an authentication after plugged-in failed

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -940,7 +940,7 @@ void EvseManager::ready() {
         // Forward some events to HLC
         if (hlc_enabled) {
             // Reset HLC auth waiting flags on new session
-            if (event == CPEvent::CarPluggedIn) {
+            if (event == CPEvent::CarUnplugged) {
                 r_hlc[0]->call_reset_error();
                 r_hlc[0]->call_ac_contactor_closed(false);
                 r_hlc[0]->call_stop_charging(false);


### PR DESCRIPTION
## Describe your changes
After the car is plugged in and the authentication was done, Everest goes to state "prepare_charging", while the car stucks at authentication. The reason is that the car is never notified about authentication finished by the EVSE.
After debugging, a timing problem between HLC and bsp cp_event was determinated. When car was plugged, method hlc[0]->subscribe_require_auth_eim() is called milliseconds earlier than the bsp cp_event notifies about plug in event to evsemanager. This leads to a reset of variable "hlc_waiting_for_auth_eim" and avoidance of calling r_hlc[0]->call_authorization_response(...::Accepted,...). In MCS no Slac is used. In addition, ChargeSom based products from chargebyte are using a safetyController to set and read CP states. There are latencies in the communication with EVerest. Assuming that the code in CPEvent::CarPluggedIn should set a clean state at the car plugged in event. We can't imaging any usecase where variable "hlc_waiting_for_auth_eim" should be true when car is not plugged. This is why we tending to call the code in cp_event "CarUnplugged" rather than in "CarPluggedIn".

## Issue ticket number and link
Re-submission of https://github.com/EVerest/everest-core/pull/1514
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

