### PR TITLE
Test: Extend existing OCPP e2e DefaultPriceText

### DIFF
--- a/tests/ocpp_tests/test_sets/ocpp16/california_pricing_ocpp16.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/california_pricing_ocpp16.py
@@ -1020,6 +1020,15 @@ class TestOcpp16CostAndPrice:
         response = await charge_point_v16.change_configuration_req(key="DefaultPriceText,de", value=json.dumps(price_text))
         assert response.status == "Accepted"
 
+        # Set price text for specific language.
+        price_text = {
+            "priceText": "€0.15 / kWh, Leerlaufgebühr nach dem Aufladen: 2 $/hr",
+            "priceTextOffline": "Die Station ist offline. Laden ist für €0,15/kWh möglich"
+        }
+
+        response = await charge_point_v16.change_configuration_req(key="DefaultPriceText,de", value=json.dumps(price_text))
+        assert response.status == "Accepted"
+
         # Get price text for specific language to check if it is set.
         response = await charge_point_v16.get_configuration_req(key=['DefaultPriceText,de'])
 


### PR DESCRIPTION
## Describe your changes
test: Extend existing ocpp16 e2e test by checking if an existing DefaultPriceText language key can be successfully overriden with a ChangeConfiguration.req

## Issue ticket number and link
Original PR: https://github.com/EVerest/everest-core/pull/1433
Requires https://github.com/EVerest/libocpp/pull/1147

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

