### PR TITLE
EvseManager: also propagate no. of phases changed at runtime via limits var

### DIFF
--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -505,6 +505,8 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
         if (limit > 1e-5 || limit < -1e-5)
             mod->charger->resume_charging_power_available();
 
+        mod->signalNrOfPhasesAvailable(mod->ac_nr_phases_active);
+
         if (mod->config.charge_mode == "DC") {
             // DC mode apply limit at the leave side, we get root side limits here from EnergyManager on ACDC!
             // FIXME: multiply by conversion_efficiency here!


### PR DESCRIPTION
This value in the limits var of the evse_manager interface was only being updated at init(), while the value in the limits of the energy interface was uptodate.

## Describe your changes
Propagate the change to the evse_manager interface when the internal value changes.
## Issue ticket number and link
This is a new request after incorrect closure of https://github.com/EVerest/everest-core/pull/1533.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
