### PR TITLE
Slac: fix several conformance tests

### DIFF
--- a/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
+++ b/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
@@ -221,6 +221,7 @@ struct Context {
     void log_error(const std::string& text);
 
     ModemVendor modem_vendor{ModemVendor::Unknown};
+    uint8_t evse_mac[ETH_ALEN];
 
 private:
     const ContextCallbacks& callbacks;

--- a/lib/everest/slac/io/include/everest/slac/io.hpp
+++ b/lib/everest/slac/io/include/everest/slac/io.hpp
@@ -20,6 +20,9 @@ public:
     void send(slac::messages::HomeplugMessage& msg);
     void quit();
 
+    // cannot be const while libslac's SlacChannel::get_mac_addr() isn't const
+    const uint8_t* get_mac_addr() /* const */;
+
 private:
     void loop();
     slac::Channel slac_channel;

--- a/lib/everest/slac/io/src/io.cpp
+++ b/lib/everest/slac/io/src/io.cpp
@@ -42,3 +42,7 @@ void SlacIO::send(slac::messages::HomeplugMessage& msg) {
     // FIXME (aw): handle errors
     slac_channel.write(msg, 1);
 }
+
+const uint8_t* SlacIO::get_mac_addr() /* const */ {
+    return slac_channel.get_mac_addr();
+}

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -92,6 +92,8 @@ void slacImpl::run() {
 
     fsm_ctx.slac_config.generate_nmk();
 
+    memcpy(fsm_ctx.evse_mac, slac_io.get_mac_addr(), ETH_ALEN);
+
     fsm_ctrl = std::make_unique<FSMController>(fsm_ctx);
 
     slac_io.run([](slac::messages::HomeplugMessage& msg) { fsm_ctrl->signal_new_slac_message(msg); });


### PR DESCRIPTION
## Describe your changes
This fixes handling of a repeated CM_SLAC_MATCH.REQ (e.g. if the EV failed to receive or handle the EVSE's CM_SLAC_MATCH.CNF).

This also adds more strict SLAC MME content validations, to conform to ISO 15118-3 and the tests defined in ISO 15118-5. Most validations might be considered functionally useless, and only impose more strictness.

Fixes TC_SECC_CMN_VTB_AttenuationCharacterization_007/009/010.
Fixes TC_SECC_CMN_VTB_CmSlacMatch_003.
Fixes TC_SECC_CMN_VTB_CmSlacMatch_013/014.
Fixes TC_SECC_CMN_VTB_CmSlacMatch_015/016.
Fixes TC_SECC_CMN_VTB_CmSlacMatch_017/018.
Fixes TC_SECC_CMN_VTB_CmSlacMatch_019/020.
Fixes TC_SECC_CMN_VTB_CmSlacMatch_021/022.
## Issue ticket number and link
This is a new request after incorrect closure of https://github.com/EVerest/everest-core/pull/1487. See also the discussion there.
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
