### PR TITLE
fix(EvseV2G): Set Responsecode to FAULT if auth times out

### DIFF
--- a/modules/EVSE/EvseV2G/din_server.cpp
+++ b/modules/EVSE/EvseV2G/din_server.cpp
@@ -454,7 +454,11 @@ enum v2g_event states::handle_din_contract_authentication(struct v2g_connection*
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
     /* Fill the EVSE response message */
-    res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
+    if (conn->ctx->session.authorization_rejected == true) {
+        res->ResponseCode = din_responseCodeType_FAILED;
+    } else {
+        res->ResponseCode = din_responseCodeType_OK; // [V2G-DC-388]
+    }
     res->EVSEProcessing = (conn->ctx->evse_v2g_data.evse_processing[PHASE_AUTH] == (uint8_t)0)
                               ? din_EVSEProcessingType_Finished
                               : din_EVSEProcessingType_Ongoing;

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -1187,6 +1187,8 @@ static enum v2g_event handle_iso_authorization(struct v2g_connection* conn) {
         } else {
             res->ResponseCode = iso2_responseCodeType_FAILED;
         }
+    } else if (conn->ctx->session.authorization_rejected == true) {
+        res->ResponseCode = iso2_responseCodeType_FAILED;
     }
 
 error_out:


### PR DESCRIPTION
## Describe your changes

If auth is revoked e.g. due to a plugin timeout, set the ISO-2/DIN response code to FAILED instead of OK.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

