### PR TITLE
fix(EvseManager): Use mutexes to raise/clear errors

### DIFF
--- a/modules/EVSE/EvseManager/ErrorHandling.hpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.hpp
@@ -102,6 +102,8 @@ private:
     void clear_inoperative_error();
     std::optional<Everest::error::Error> errors_prevent_charging();
 
+    std::mutex error_mutex;
+
     const std::unique_ptr<evse_board_supportIntf>& r_bsp;
     const std::vector<std::unique_ptr<ISO15118_chargerIntf>>& r_hlc;
     const std::vector<std::unique_ptr<connector_lockIntf>>& r_connector_lock;


### PR DESCRIPTION
## Describe your changes

The error framework is not thread safe. EvseManager raises errors from multiple threads, this can lead to concurrent writeaccess on the error database. Added mutexes to prevent that.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

