### PR TITLE
feat: Over-voltage monitor implementation in EVSEManager

### DIFF
--- a/errors/evse_manager.yaml
+++ b/errors/evse_manager.yaml
@@ -9,6 +9,8 @@ errors:
     description: Internal error of the state machine
   - name: MREC4OverCurrentFailure
     description: Over current event
+  - name: MREC5OverVoltage
+    description: Over voltage event
   - name: MREC9AuthorizationTimeout
     description: No authorization was provided within timeout after plugin
   - name: PowermeterTransactionStartFailed

--- a/modules/EVSE/EvseManager/BUILD.bazel
+++ b/modules/EVSE/EvseManager/BUILD.bazel
@@ -5,7 +5,8 @@ IMPLS = [
     "evse",
     "token_provider",
     "random_delay",
-    "dc_external_derate"
+    "dc_external_derate",
+    "over_voltage"
 ]
 
 cc_everest_module(

--- a/modules/EVSE/EvseManager/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(${MODULE_NAME}
         "token_provider/auth_token_providerImpl.cpp"
         "random_delay/uk_random_delayImpl.cpp"
         "dc_external_derate/dc_external_derateImpl.cpp"
+        "over_voltage/OverVoltageMonitor.cpp"
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/EVSE/EvseManager/ErrorHandling.cpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.cpp
@@ -126,6 +126,13 @@ void ErrorHandling::clear_overcurrent_error() {
     process_error();
 }
 
+void ErrorHandling::raise_over_voltage_error(Everest::error::Severity severity, const std::string& description) {
+    Everest::error::Error error_object =
+        p_evse->error_factory->create_error("evse_manager/MREC5OverVoltage", "", description, severity);
+    p_evse->raise_error(error_object);
+    process_error();
+}
+
 // Find out if the current error set is fatal to charging or not
 void ErrorHandling::process_error() {
     const auto fatal = errors_prevent_charging();

--- a/modules/EVSE/EvseManager/ErrorHandling.hpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.hpp
@@ -79,6 +79,8 @@ public:
     void raise_overcurrent_error(const std::string& description);
     void clear_overcurrent_error();
 
+    void raise_over_voltage_error(Everest::error::Severity severity, const std::string& description);
+
     void raise_internal_error(const std::string& description);
     void clear_internal_error();
 

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -47,6 +47,7 @@
 #include "PersistentStore.hpp"
 #include "SessionLog.hpp"
 #include "VarContainer.hpp"
+#include "over_voltage/OverVoltageMonitor.hpp"
 #include "scoped_lock_timeout.hpp"
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
@@ -74,6 +75,7 @@ struct Conf {
     bool ac_enforce_hlc;
     bool ac_with_soc;
     int dc_isolation_voltage_V;
+    int internal_over_voltage_duration_ms;
     bool dbg_hlc_auth_after_tstep;
     int hack_sleep_in_cable_check;
     int hack_sleep_in_cable_check_volkswagen;
@@ -324,6 +326,7 @@ private:
     VarContainer<types::isolation_monitor::IsolationMeasurement> isolation_measurement;
     VarContainer<types::power_supply_DC::VoltageCurrent> powersupply_measurement;
     VarContainer<bool> selftest_result;
+    std::unique_ptr<OverVoltageMonitor> internal_over_voltage_monitor;
 
     // Track voltage to earth failures for debouncing
     int voltage_to_earth_failure_count{0};

--- a/modules/EVSE/EvseManager/doc.rst
+++ b/modules/EVSE/EvseManager/doc.rst
@@ -62,6 +62,16 @@ In addition, on the DC side the following hardware modules can be connected:
   CableCheck, PreCharge and CurrentDemand steps.
 * DC power supply: This is the AC/DC converter that actually charges the car.
 
+Software over-voltage supervision is always active during DC charging. The configuration option
+``internal_over_voltage_duration_ms`` defines for how long the measured DC voltage
+must exceed the negotiated limit before EvseManager raises ``MREC5OverVoltage``.
+Set it to ``0`` to trigger immediately once the threshold is crossed.
+
+Software over-voltage supervision is always active during DC charging. The configuration option
+``internal_over_voltage_duration_ms`` defines for how long the measured DC voltage
+must exceed the negotiated limit before EvseManager raises ``MREC5OverVoltage``.
+Set it to ``0`` to trigger immediately once the threshold is crossed.
+
 Published variables
 ===================
 
@@ -281,7 +291,7 @@ Powermeter errors cause the EvseManager to become Inoperative, if fail_on_powerm
 
 * powermeter/CommunicationFault
 
-When a charging session is stopped because of an error, the EvseManager differentiates between **Emergency Shutdowns** and **Error Shutdowns**. The severity of the 
+When a charging session is stopped because of an error, the EvseManager differentiates between **Emergency Shutdowns** and **Error Shutdowns**. The severity of the
 error influences the type of the shudown. Emergency shutdowns are caused by errors with `Severity::High` and error shutdowns are caused by errors with `Severity::Medium` or `Severity::Low`.
 
 In case of an **Emergency Shutdown** the EvseManager will immediately:

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -98,6 +98,13 @@ config:
       Default is 0, which means the voltage will be determined according to IEC 61851-23 (2023) CC.4.1.2
     type: integer
     default: 0
+  internal_over_voltage_duration_ms:
+    description: >-
+      Time in milliseconds the internal software over voltage monitor waits before raising MREC5 once the measured
+      voltage exceeds the negotiated limit.
+    type: integer
+    minimum: 0
+    default: 400
   dbg_hlc_auth_after_tstep:
     description: >-
       Special mode: send HLC auth ok only after t_step_XX is finished (true) or directly when available (false)

--- a/modules/EVSE/EvseManager/over_voltage/OverVoltageMonitor.cpp
+++ b/modules/EVSE/EvseManager/over_voltage/OverVoltageMonitor.cpp
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "over_voltage/OverVoltageMonitor.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <fmt/core.h>
+#include <thread>
+
+namespace module {
+
+OverVoltageMonitor::OverVoltageMonitor(ErrorCallback callback, std::chrono::milliseconds duration) :
+    error_callback_(std::move(callback)), duration_(duration) {
+    timer_thread_ = std::thread(&OverVoltageMonitor::timer_thread_func, this);
+}
+
+OverVoltageMonitor::~OverVoltageMonitor() {
+    {
+        std::lock_guard<std::mutex> lock(timer_mutex_);
+        timer_thread_exit_ = true;
+        timer_armed_ = false;
+    }
+    timer_cv_.notify_one();
+    if (timer_thread_.joinable()) {
+        timer_thread_.join();
+    }
+}
+
+void OverVoltageMonitor::set_limits(double emergency_limit, double error_limit) {
+    emergency_limit_ = emergency_limit;
+    error_limit_ = error_limit;
+    limits_valid_ = true;
+}
+
+void OverVoltageMonitor::start_monitor() {
+    fault_latched_ = false;
+    cancel_error_timer();
+    running_ = true;
+}
+
+void OverVoltageMonitor::stop_monitor() {
+    running_ = false;
+    cancel_error_timer();
+}
+
+void OverVoltageMonitor::reset() {
+    fault_latched_ = false;
+    cancel_error_timer();
+}
+
+void OverVoltageMonitor::update_voltage(double voltage_v) {
+    if (!running_ || fault_latched_ || !limits_valid_) {
+        return;
+    }
+
+    if (voltage_v >= emergency_limit_) {
+        cancel_error_timer();
+        trigger_fault(FaultType::Emergency,
+                      fmt::format("Voltage {:.2f} V exceeded emergency limit {:.2f} V.", voltage_v, emergency_limit_));
+        return;
+    }
+
+    if (voltage_v >= error_limit_) {
+        arm_error_timer(voltage_v);
+    } else {
+        cancel_error_timer();
+    }
+}
+
+void OverVoltageMonitor::trigger_fault(FaultType type, const std::string& reason) {
+    fault_latched_ = true;
+    running_ = false;
+    cancel_error_timer();
+    if (error_callback_) {
+        error_callback_(type, reason);
+    }
+}
+
+void OverVoltageMonitor::arm_error_timer(double voltage_v) {
+    if (duration_.count() == 0) {
+        trigger_fault(FaultType::Error, fmt::format("Voltage {:.2f} V exceeded limit {:.2f} V for at least {} ms.",
+                                                    voltage_v, error_limit_, duration_.count()));
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(timer_mutex_);
+        if (timer_armed_) {
+            timer_voltage_snapshot_ = std::max(timer_voltage_snapshot_, voltage_v);
+            return;
+        }
+        timer_armed_ = true;
+        timer_voltage_snapshot_ = voltage_v;
+        timer_deadline_ = std::chrono::steady_clock::now() + duration_;
+    }
+    timer_cv_.notify_one();
+}
+
+void OverVoltageMonitor::cancel_error_timer() {
+    {
+        std::lock_guard<std::mutex> lock(timer_mutex_);
+        if (!timer_armed_) {
+            return;
+        }
+        timer_armed_ = false;
+    }
+    timer_cv_.notify_one();
+}
+
+void OverVoltageMonitor::timer_thread_func() {
+    std::unique_lock<std::mutex> lock(timer_mutex_);
+
+    while (!timer_thread_exit_) {
+        // Wait until a timer is armed or exit is requested
+        timer_cv_.wait(lock, [this] { return timer_thread_exit_ || timer_armed_; });
+        if (timer_thread_exit_) {
+            break;
+        }
+
+        // Capture the current deadline and wait until it expires or is cancelled/updated
+        auto deadline = timer_deadline_;
+        while (!timer_thread_exit_ && timer_armed_) {
+            if (timer_cv_.wait_until(lock, deadline) == std::cv_status::timeout) {
+                break;
+            }
+            // Woken up: check for exit, cancellation or re-arming with a new deadline
+            if (timer_thread_exit_ || !timer_armed_ || timer_deadline_ != deadline) {
+                break;
+            }
+        }
+
+        if (timer_thread_exit_) {
+            break;
+        }
+        if (!timer_armed_ || timer_deadline_ != deadline) {
+            // Timer was cancelled or re-armed; go back to waiting
+            continue;
+        }
+
+        // Timer expired with this deadline and is still armed
+        const double voltage = timer_voltage_snapshot_;
+        timer_armed_ = false;
+
+        // Release the lock while invoking the callback path
+        lock.unlock();
+        trigger_fault(FaultType::Error, fmt::format("Voltage {:.2f} V exceeded limit {:.2f} V for at least {} ms.",
+                                                    voltage, error_limit_, duration_.count()));
+        lock.lock();
+    }
+}
+
+} // namespace module

--- a/modules/EVSE/EvseManager/over_voltage/OverVoltageMonitor.hpp
+++ b/modules/EVSE/EvseManager/over_voltage/OverVoltageMonitor.hpp
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <limits>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace module {
+
+/// \brief Simple software over-voltage watchdog used by EvseManager.
+///
+/// The monitor observes a DC voltage and compares it against two thresholds:
+///
+/// - \ref FaultType::Emergency: if the measured voltage is greater than or equal to the
+///   configured emergency limit, an emergency fault is raised immediately.
+/// - \ref FaultType::Error: if the measured voltage is greater than or equal to the configured
+///   error limit continuously for at least the configured duration, an error fault is raised.
+///
+/// After a fault has been raised, it is latched until \ref reset() is called and monitoring
+/// is started again via \ref start_monitor().
+///
+/// Thread-safety:
+/// - Public APIs are intended to be called from EvseManager threads and from callbacks of the
+///   external over_voltage_monitor interface.
+/// - Internally, a dedicated background thread waits on an error timer condition and synchronizes
+///   access to timer-related state via an internal mutex and condition variable.
+class OverVoltageMonitor {
+public:
+    /// \brief Type of over-voltage fault.
+    ///
+    /// - Error: voltage above the error limit for at least the configured duration.
+    /// - Emergency: voltage above the emergency limit, triggers immediately.
+    enum class FaultType {
+        Error,
+        Emergency
+    };
+
+    /// \brief Callback type used to report detected faults.
+    ///
+    /// The callback is invoked from an internal monitoring context when a fault is detected.
+    /// It receives the fault type and a human-readable description.
+    using ErrorCallback = std::function<void(FaultType, const std::string&)>;
+
+    /// \brief Construct a new OverVoltageMonitor.
+    ///
+    /// \param callback  Function that will be called whenever a fault is detected.
+    /// \param duration  Duration for which the voltage must stay above the error limit before
+    ///                  an \ref FaultType::Error is raised. A duration of 0 ms means that an
+    ///                  error fault will be raised immediately when the error limit is exceeded.
+    OverVoltageMonitor(ErrorCallback callback, std::chrono::milliseconds duration);
+
+    /// \brief Destructor joins the internal timer thread before destroying the object.
+    ~OverVoltageMonitor();
+
+    /// \brief Configure the error and emergency voltage limits.
+    ///
+    /// This must be called before monitoring can become active. Calling this function marks
+    /// the limits as valid and enables evaluation in \ref update_voltage().
+    ///
+    /// \param emergency_limit  Emergency limit in volts; exceeding this immediately triggers an
+    ///                         \ref FaultType::Emergency.
+    /// \param error_limit      Error limit in volts; exceeding this for at least the configured
+    ///                         duration triggers an \ref FaultType::Error.
+    void set_limits(double emergency_limit, double error_limit);
+
+    /// \brief Start monitoring of incoming voltage samples.
+    ///
+    /// Clears any latched fault state and cancels a pending error timer, then enables
+    /// evaluation in \ref update_voltage().
+    void start_monitor();
+
+    /// \brief Stop monitoring of incoming voltage samples.
+    ///
+    /// Monitoring is disabled and any pending error timer is cancelled. Existing latched
+    /// faults remain active until \ref reset() is called.
+    void stop_monitor();
+
+    /// \brief Feed a new voltage sample to the monitor.
+    ///
+    /// If monitoring is active and limits have been configured, this function evaluates the
+    /// sample against the configured error and emergency limits and may:
+    ///
+    /// - Trigger an immediate emergency fault.
+    /// - Arm or update an error timer.
+    /// - Cancel an active error timer if the voltage falls back below the error limit.
+    ///
+    /// \param voltage_v  Measured DC voltage in volts.
+    void update_voltage(double voltage_v);
+
+    /// \brief Reset the internal fault latch and cancel timers.
+    ///
+    /// This clears any previously raised fault and stops the internal error timer. Monitoring
+    /// remains disabled until \ref start_monitor() is called again.
+    void reset();
+
+private:
+    void timer_thread_func();
+
+    void trigger_fault(FaultType type, const std::string& reason);
+    void arm_error_timer(double voltage_v);
+    void cancel_error_timer();
+
+    ErrorCallback error_callback_;
+    std::chrono::milliseconds duration_;
+    bool running_{false};
+    bool limits_valid_{false};
+    bool fault_latched_{false};
+    double emergency_limit_{std::numeric_limits<double>::infinity()};
+    double error_limit_{std::numeric_limits<double>::infinity()};
+
+    std::mutex timer_mutex_;
+    double timer_voltage_snapshot_{0.0};
+    std::chrono::steady_clock::time_point timer_deadline_{};
+    bool timer_armed_{false};
+    bool timer_thread_exit_{false};
+    std::condition_variable timer_cv_;
+    std::thread timer_thread_;
+};
+
+} // namespace module

--- a/modules/EVSE/EvseManager/tests/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/tests/CMakeLists.txt
@@ -18,9 +18,11 @@ target_sources(${TEST_TARGET_NAME} PRIVATE
     EventQueueTest.cpp
     ErrorHandlingTest.cpp
     IECStateMachineTest.cpp
+    OverVoltageMonitorTest.cpp
     ../ErrorHandling.cpp
     ../IECStateMachine.cpp
     ../backtrace.cpp
+    ../over_voltage/OverVoltageMonitor.cpp
 )
 
 target_compile_definitions(${TEST_TARGET_NAME} PRIVATE

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -755,6 +755,9 @@ void ErrorHandling::raise_overcurrent_error(const std::string& description) {
 void ErrorHandling::clear_overcurrent_error() {
 }
 
+void ErrorHandling::raise_over_voltage_error(Everest::error::Severity severity, const std::string& description) {
+}
+
 void ErrorHandling::raise_internal_error(const std::string& description) {
 }
 void ErrorHandling::clear_internal_error() {

--- a/modules/EVSE/EvseManager/tests/OverVoltageMonitorTest.cpp
+++ b/modules/EVSE/EvseManager/tests/OverVoltageMonitorTest.cpp
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include "over_voltage/OverVoltageMonitor.hpp"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+using namespace module;
+using namespace std::chrono_literals;
+
+class OverVoltageMonitorTest : public ::testing::Test {
+protected:
+    struct CallbackState {
+        std::mutex mtx;
+        std::condition_variable cv;
+        bool called{false};
+        OverVoltageMonitor::FaultType type;
+        std::string reason;
+    };
+
+    static OverVoltageMonitor make_monitor(CallbackState& state, std::chrono::milliseconds duration) {
+        return OverVoltageMonitor(
+            [&state](OverVoltageMonitor::FaultType type, const std::string& reason) {
+                std::lock_guard<std::mutex> lock(state.mtx);
+                state.called = true;
+                state.type = type;
+                state.reason = reason;
+                state.cv.notify_all();
+            },
+            duration);
+    }
+
+    static bool wait_for_callback(CallbackState& state, std::chrono::milliseconds timeout = 500ms) {
+        std::unique_lock<std::mutex> lock(state.mtx);
+        return state.cv.wait_for(lock, timeout, [&state] { return state.called; });
+    }
+};
+
+TEST_F(OverVoltageMonitorTest, no_fault_below_limits) {
+    CallbackState state;
+    auto monitor = make_monitor(state, 100ms);
+
+    monitor.set_limits(450.0, 420.0);
+    monitor.start_monitor();
+
+    monitor.update_voltage(400.0);
+    monitor.update_voltage(410.0);
+
+    EXPECT_FALSE(wait_for_callback(state));
+}
+
+TEST_F(OverVoltageMonitorTest, emergency_fault_triggers_immediately) {
+    CallbackState state;
+    auto monitor = make_monitor(state, 200ms);
+
+    monitor.set_limits(450.0, 420.0);
+    monitor.start_monitor();
+
+    monitor.update_voltage(460.0);
+
+    ASSERT_TRUE(wait_for_callback(state));
+    EXPECT_EQ(state.type, OverVoltageMonitor::FaultType::Emergency);
+}
+
+TEST_F(OverVoltageMonitorTest, error_fault_triggers_after_duration) {
+    CallbackState state;
+    auto monitor = make_monitor(state, 100ms);
+
+    monitor.set_limits(450.0, 420.0);
+    monitor.start_monitor();
+
+    monitor.update_voltage(430.0);
+
+    ASSERT_TRUE(wait_for_callback(state, 300ms));
+    EXPECT_EQ(state.type, OverVoltageMonitor::FaultType::Error);
+}
+
+TEST_F(OverVoltageMonitorTest, voltage_drop_cancels_error_timer) {
+    CallbackState state;
+    auto monitor = make_monitor(state, 150ms);
+
+    monitor.set_limits(450.0, 420.0);
+    monitor.start_monitor();
+
+    monitor.update_voltage(430.0); // above error limit
+    std::this_thread::sleep_for(50ms);
+    monitor.update_voltage(410.0); // below error limit
+
+    EXPECT_FALSE(wait_for_callback(state, 300ms));
+}
+
+TEST_F(OverVoltageMonitorTest, zero_duration_triggers_immediately) {
+    CallbackState state;
+    auto monitor = make_monitor(state, 0ms);
+
+    monitor.set_limits(450.0, 420.0);
+    monitor.start_monitor();
+
+    monitor.update_voltage(425.0);
+
+    ASSERT_TRUE(wait_for_callback(state));
+    EXPECT_EQ(state.type, OverVoltageMonitor::FaultType::Error);
+}
+
+TEST_F(OverVoltageMonitorTest, fault_is_latched) {
+    CallbackState state;
+    auto monitor = make_monitor(state, 50ms);
+
+    monitor.set_limits(450.0, 420.0);
+    monitor.start_monitor();
+
+    monitor.update_voltage(430.0);
+    ASSERT_TRUE(wait_for_callback(state));
+
+    {
+        std::lock_guard<std::mutex> lock(state.mtx);
+        state.called = false;
+    }
+
+    // Further voltage updates should not retrigger
+    monitor.update_voltage(460.0);
+    EXPECT_FALSE(wait_for_callback(state, 200ms));
+}
+
+TEST_F(OverVoltageMonitorTest, stop_monitor_suppresses_fault) {
+    CallbackState state;
+    auto monitor = make_monitor(state, 100ms);
+
+    monitor.set_limits(450.0, 420.0);
+    monitor.start_monitor();
+
+    monitor.update_voltage(430.0);
+    monitor.stop_monitor();
+
+    EXPECT_FALSE(wait_for_callback(state, 300ms));
+}
+
+TEST_F(OverVoltageMonitorTest, reset_clears_latched_fault_and_allows_retrigger) {
+    CallbackState state;
+    auto monitor = make_monitor(state, 50ms);
+
+    monitor.set_limits(450.0, 420.0);
+    monitor.start_monitor();
+
+    // First fault
+    monitor.update_voltage(430.0);
+    ASSERT_TRUE(wait_for_callback(state, 300ms));
+    EXPECT_EQ(state.type, OverVoltageMonitor::FaultType::Error);
+
+    // Clear callback state
+    {
+        std::lock_guard<std::mutex> lock(state.mtx);
+        state.called = false;
+    }
+
+    // Reset should clear latch and timers
+    monitor.reset();
+
+    // Must restart monitoring explicitly
+    monitor.start_monitor();
+
+    // Second fault should be possible again
+    monitor.update_voltage(430.0);
+    ASSERT_TRUE(wait_for_callback(state, 300ms));
+    EXPECT_EQ(state.type, OverVoltageMonitor::FaultType::Error);
+}
+
+TEST_F(OverVoltageMonitorTest, multiple_voltage_updates_update_timer_snapshot) {
+    CallbackState state;
+    auto monitor = make_monitor(state, 100ms);
+
+    monitor.set_limits(500.0, 420.0);
+    monitor.start_monitor();
+
+    // First update arms the timer
+    monitor.update_voltage(430.0);
+
+    // Subsequent updates while timer is active
+    monitor.update_voltage(435.0);
+    monitor.update_voltage(432.0);
+    monitor.update_voltage(440.0); // highest value
+
+    ASSERT_TRUE(wait_for_callback(state, 300ms));
+    EXPECT_EQ(state.type, OverVoltageMonitor::FaultType::Error);
+}

--- a/modules/EVSE/OCPP/error_mapping.hpp
+++ b/modules/EVSE/OCPP/error_mapping.hpp
@@ -35,6 +35,7 @@ const std::unordered_map<std::string, std::pair<ocpp::v16::ChargePointErrorCode,
     {"ac_rcd/MREC2GroundFailure", {ocpp::v16::ChargePointErrorCode::GroundFailure, "CX002"}},
     {"evse_manager/MREC22ResistanceFault", {ocpp::v16::ChargePointErrorCode::OtherError, "CX022"}},
     {"evse_manager/MREC11CableCheckFault", {ocpp::v16::ChargePointErrorCode::OtherError, "CX011"}},
+    {"evse_manager/MREC5OverVoltage", {ocpp::v16::ChargePointErrorCode::OverVoltage, "CX005"}},
 };
 
 // TODO: add other ChargePointErrorCode mappings

--- a/modules/EVSE/OCPP201/error_handling.hpp
+++ b/modules/EVSE/OCPP201/error_handling.hpp
@@ -33,6 +33,7 @@ const std::unordered_map<std::string, std::string> MREC_ERROR_MAP = {
     {"ac_rcd/MREC2GroundFailure", "CX002"},
     {"evse_manager/MREC22ResistanceFault", "CX022"},
     {"evse_manager/MREC11CableCheckFault", "CX011"},
+    {"evse_manager/MREC5OverVoltage", "CX005"},
 };
 
 const auto EVSE_MANAGER_INOPERATIVE_ERROR = "evse_manager/Inoperative";


### PR DESCRIPTION
## Describe your changes
Implementation of an internal over-voltage monitor on top of the external one. This is a safety mechanism that reads the measured values received from over-voltage monitor and raises the over voltage faults (in case the external one is not reacting correctly).
There 2 limits that can be set: an error and an emergency limit. 
In case of an voltage over the error limit, we are checking if this is just a very short peak or it will stay over 400ms (default value - configurable). If at the end of the 400ms we stayed above the error limit, we trigger the MREC50OverVoltage error.
In case of an voltage over the emergency error, we trigger ASAP the MREC50OverVoltage fault. 
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

