### PR TITLE
EvseV2G: Wait for peer FIN before closing TCP socket

### DIFF
--- a/modules/EVSE/EvseV2G/connection/connection.cpp
+++ b/modules/EVSE/EvseV2G/connection/connection.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <net/if.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,6 +31,7 @@
 #define DEFAULT_TCP_PORT              61341
 #define DEFAULT_TLS_PORT              64109
 #define ERROR_SESSION_ALREADY_STARTED 2
+#define CLIENT_FIN_TIMEOUT            3000
 
 /*!
  * \brief connection_create_socket This function creates a tcp/tls socket
@@ -392,12 +394,30 @@ void connection_teardown(struct v2g_connection* conn) {
     }
 }
 
+static void wait_for_peer_close(int fd, int timeout_ms) {
+    struct pollfd pfd = {};
+    pfd.fd = fd;
+    pfd.events = POLLIN | POLLHUP;
+
+    int rc = poll(&pfd, 1, timeout_ms);
+    if (rc <= 0) {
+        return;
+    }
+
+    if (pfd.revents & (POLLIN | POLLHUP)) {
+        char buf[64];
+        while (recv(fd, buf, sizeof(buf), MSG_DONTWAIT) > 0) {
+        }
+    }
+}
+
 /**
  * This is the 'main' function of a thread, which handles a TCP connection.
  */
 static void* connection_handle_tcp(void* data) {
     struct v2g_connection* conn = static_cast<struct v2g_connection*>(data);
     int rv = 0;
+    bool error_occurred{false};
 
     dlog(DLOG_LEVEL_INFO, "Started new TCP connection thread");
 
@@ -418,19 +438,25 @@ static void* connection_handle_tcp(void* data) {
     /* tear down connection gracefully */
     dlog(DLOG_LEVEL_INFO, "Closing TCP connection");
 
+    /* some EV's did not like the immediate shutdown. Therefore we sleep for 2 seconds */
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    if (shutdown(conn->conn.socket_fd, SHUT_RDWR) == -1) {
+    if (shutdown(conn->conn.socket_fd, SHUT_WR) == -1) {
         dlog(DLOG_LEVEL_ERROR, "shutdown() failed: %s", strerror(errno));
+        error_occurred = true;
     }
 
-    // Waiting for client closing the connection
-    std::this_thread::sleep_for(std::chrono::seconds(3));
+    /* wait briefly for peer FIN or timeout */
+    wait_for_peer_close(conn->conn.socket_fd, CLIENT_FIN_TIMEOUT);
 
     if (close(conn->conn.socket_fd) == -1) {
         dlog(DLOG_LEVEL_ERROR, "close() failed: %s", strerror(errno));
+        error_occurred = true;
     }
-    dlog(DLOG_LEVEL_INFO, "TCP connection closed gracefully");
+
+    if (not error_occurred) {
+        dlog(DLOG_LEVEL_INFO, "TCP connection closed gracefully");
+    }
 
     conn->ctx->connection_initiated = false;
 


### PR DESCRIPTION
## Describe your changes

- Send a half-close (SHUT_WR) instead of full SHUT_RDWR so the peer can still deliver its FIN.
- Poll the socket for up to 3 seconds and drain any remaining data/FIN before closing, reducing premature connection tear-down.

**How it was already tested:**

1. Established a TCP session with "socat -6 - TCP6:[IPv6 %eth0]:PORT,forever"
(Allowed the connection to idle until the timeout expired.)
3. Observed logs (Wireshark + EVerest) showing the client FIN after ~500 ms and the code waiting the same ~500 ms in wait_for_peer_close() before completing shutdown. 

Here is a EVerest log with additional debugging log messages for and after wait_for_peer_close() call with timestamps:

```shell
2025-12-02 08:29:56.271759 [INFO] iso15118_charge  :: v2g_handle_connection exited with -1
2025-12-02 08:29:56.271764 [INFO] iso15118_charge  :: Closing TCP connection
2025-12-02 08:29:58.272380 [INFO] iso15118_charge  :: Before wait_for_peer_close()
2025-12-02 08:29:58.773837 [INFO] iso15118_charge  :: After wait_for_peer_close()
2025-12-02 08:29:58.773922 [INFO] iso15118_charge  :: TCP connection closed gracefully
``` 

pcap trace:
<img width="1324" height="133" alt="grafik" src="https://github.com/user-attachments/assets/2676a2bf-1231-4225-bc80-384f6fe0029f" />


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

