### PR TITLE
Fix unexpected d-link action in case of an error

### DIFF
--- a/modules/EVSE/EvseV2G/connection/connection.cpp
+++ b/modules/EVSE/EvseV2G/connection/connection.cpp
@@ -377,15 +377,12 @@ void connection_teardown(struct v2g_connection* conn) {
     v2g_ctx_init_charging_session(conn->ctx, true);
 
     /* print dlink status */
-    switch (conn->dlink_action) {
-    case MQTT_DLINK_ACTION_ERROR:
-        dlog(DLOG_LEVEL_TRACE, "d_link/error");
-        break;
-    case MQTT_DLINK_ACTION_TERMINATE:
+    switch (conn->d_link_action) {
+    case dLinkAction::D_LINK_ACTION_TERMINATE:
         conn->ctx->p_charger->publish_dlink_terminate(nullptr);
         dlog(DLOG_LEVEL_TRACE, "d_link/terminate");
         break;
-    case MQTT_DLINK_ACTION_PAUSE:
+    case dLinkAction::D_LINK_ACTION_PAUSE:
         conn->ctx->p_charger->publish_dlink_pause(nullptr);
         dlog(DLOG_LEVEL_TRACE, "d_link/pause");
         break;

--- a/modules/EVSE/EvseV2G/din_server.cpp
+++ b/modules/EVSE/EvseV2G/din_server.cpp
@@ -919,7 +919,7 @@ static enum v2g_event handle_din_session_stop(struct v2g_connection* conn) {
     utils::din_validate_response_code(&res->ResponseCode, conn);
 
     /* Setuo dlink action */
-    conn->dlink_action = MQTT_DLINK_ACTION_TERMINATE;
+    conn->d_link_action = dLinkAction::D_LINK_ACTION_TERMINATE;
 
     /* Set next expected req msg */
     conn->ctx->state = WAIT_FOR_TERMINATED_SESSION; // [V2G-DC-451]

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -2147,7 +2147,7 @@ static enum v2g_event handle_iso_session_stop(struct v2g_connection* conn) {
     /* Set the next charging state */
     switch (req->ChargingSession) {
     case iso2_chargingSessionType_Terminate:
-        conn->dlink_action = MQTT_DLINK_ACTION_TERMINATE;
+        conn->d_link_action = dLinkAction::D_LINK_ACTION_TERMINATE;
         conn->ctx->hlc_pause_active = false;
         /* Set next expected req msg */
         conn->ctx->state = (int)iso_dc_state_id::WAIT_FOR_TERMINATED_SESSION;
@@ -2158,13 +2158,13 @@ static enum v2g_event handle_iso_session_stop(struct v2g_connection* conn) {
         /* Check if the EV is allowed to request the sleep mode. TODO: Remove "true" if sleep mode is supported */
         if (((conn->ctx->last_v2g_msg != V2G_POWER_DELIVERY_MSG) &&
              (conn->ctx->last_v2g_msg != V2G_WELDING_DETECTION_MSG))) {
-            conn->dlink_action = MQTT_DLINK_ACTION_TERMINATE;
+            conn->d_link_action = dLinkAction::D_LINK_ACTION_TERMINATE;
             res->ResponseCode = iso2_responseCodeType_FAILED;
             conn->ctx->hlc_pause_active = false;
             conn->ctx->state = (int)iso_dc_state_id::WAIT_FOR_TERMINATED_SESSION;
         } else {
             /* Init sleep mode for the EV */
-            conn->dlink_action = MQTT_DLINK_ACTION_PAUSE;
+            conn->d_link_action = dLinkAction::D_LINK_ACTION_PAUSE;
             conn->ctx->hlc_pause_active = true;
             conn->ctx->state = (int)iso_dc_state_id::WAIT_FOR_SESSIONSETUP;
         }
@@ -2172,7 +2172,7 @@ static enum v2g_event handle_iso_session_stop(struct v2g_connection* conn) {
 
     default:
         /* Set next expected req msg */
-        conn->dlink_action = MQTT_DLINK_ACTION_TERMINATE;
+        conn->d_link_action = dLinkAction::D_LINK_ACTION_TERMINATE;
         conn->ctx->state = (int)iso_dc_state_id::WAIT_FOR_TERMINATED_SESSION;
     }
 

--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -366,10 +366,9 @@ struct v2g_context {
     bool connection_initiated;
 };
 
-enum mqtt_dlink_action {
-    MQTT_DLINK_ACTION_ERROR,
-    MQTT_DLINK_ACTION_TERMINATE,
-    MQTT_DLINK_ACTION_PAUSE,
+enum class dLinkAction {
+    D_LINK_ACTION_TERMINATE,
+    D_LINK_ACTION_PAUSE
 };
 
 /**
@@ -410,7 +409,7 @@ struct v2g_connection {
         struct iso2_exiDocument* iso2EXIDocument;
     } exi_out;
 
-    enum mqtt_dlink_action dlink_action; /* signaled action after connection is closed */
+    dLinkAction d_link_action; /* signaled data-link action after connection is closed */
 };
 
 #endif /* V2G_H */

--- a/modules/EVSE/EvseV2G/v2g_server.cpp
+++ b/modules/EVSE/EvseV2G/v2g_server.cpp
@@ -373,7 +373,7 @@ int v2g_handle_connection(struct v2g_connection* conn) {
 
     /* Here is a good point to wait until the customer is ready for a resumed session,
      * because we are waiting for the incoming message of the ev */
-    if (conn->dlink_action == MQTT_DLINK_ACTION_PAUSE) {
+    if (conn->d_link_action == dLinkAction::D_LINK_ACTION_PAUSE) {
         // TODO: D_LINK pause
     }
 


### PR DESCRIPTION
## Describe your changes

Currently, as soon as V2G communication is unexpectedly terminated by a failed response code and the EV does not send a SessionStopReq, the dlink action parameter is incorrectly left at the initial value "dlink_error". This means that a connected EvseManager is not notified when V2G communication is terminated in this error case. However, the enum value dlink_error does not make sense within the EvseV2G module, as a data-link error cannot be detected by this module.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
