### PR TITLE
Add configurable plug-in timeout behavior to Auth module 

### DIFF
--- a/modules/EVSE/Auth/Auth.cpp
+++ b/modules/EVSE/Auth/Auth.cpp
@@ -15,8 +15,9 @@ void Auth::init() {
 
     this->auth_handler = std::make_unique<AuthHandler>(
         string_to_selection_algorithm(this->config.selection_algorithm), this->config.connection_timeout,
-        this->config.prioritize_authorization_over_stopping_transaction, this->config.ignore_connector_faults,
-        this->info.id, (!this->r_kvs.empty() ? this->r_kvs.at(0).get() : nullptr));
+        this->config.plug_in_timeout_enabled, this->config.prioritize_authorization_over_stopping_transaction,
+        this->config.ignore_connector_faults, this->info.id,
+        (!this->r_kvs.empty() ? this->r_kvs.at(0).get() : nullptr));
 
     for (const auto& token_provider : this->r_token_provider) {
         token_provider->subscribe_provided_token([this](ProvidedIdToken provided_token) {

--- a/modules/EVSE/Auth/Auth.hpp
+++ b/modules/EVSE/Auth/Auth.hpp
@@ -37,6 +37,7 @@ struct Conf {
     std::string master_pass_group_id;
     bool prioritize_authorization_over_stopping_transaction;
     bool ignore_connector_faults;
+    bool plug_in_timeout_enabled;
 };
 
 class Auth : public Everest::ModuleBase {
@@ -55,8 +56,7 @@ public:
         r_token_validator(std::move(r_token_validator)),
         r_evse_manager(std::move(r_evse_manager)),
         r_kvs(std::move(r_kvs)),
-        config(config) {
-    }
+        config(config){};
 
     const std::unique_ptr<authImplBase> p_main;
     const std::unique_ptr<reservationImplBase> p_reservation;

--- a/modules/EVSE/Auth/include/AuthHandler.hpp
+++ b/modules/EVSE/Auth/include/AuthHandler.hpp
@@ -63,8 +63,8 @@ class AuthHandler {
 
 public:
     AuthHandler(const SelectionAlgorithm& selection_algorithm, const int connection_timeout,
-                bool prioritize_authorization_over_stopping_transaction, bool ignore_connector_faults,
-                const std::string& id, kvsIntf* store);
+                bool plug_in_timeout_enabled, bool prioritize_authorization_over_stopping_transaction,
+                bool ignore_connector_faults, const std::string& id, kvsIntf* store);
     virtual ~AuthHandler();
 
     /**
@@ -169,6 +169,13 @@ public:
     void set_connection_timeout(const int connection_timeout);
 
     /**
+     * @brief Set the plug in timeout enabled flag of the handler.
+     *
+     * @param plug_in_timeout_enabled
+     */
+    void set_plug_in_timeout_enabled(bool plug_in_timeout_enabled);
+
+    /**
      * @brief Set the master pass group id of the handler.
      *
      * @param master_pass_group_id
@@ -254,6 +261,7 @@ private:
 
     SelectionAlgorithm selection_algorithm;
     int connection_timeout;
+    bool plug_in_timeout_enabled;
     std::optional<std::string> master_pass_group_id;
     bool prioritize_authorization_over_stopping_transaction;
     bool ignore_faults;

--- a/modules/EVSE/Auth/manifest.yaml
+++ b/modules/EVSE/Auth/manifest.yaml
@@ -53,6 +53,22 @@ config:
       If false, faulty connectors are treated as not available and will not be authorized. This is a good setting for e.g. public chargers.
     type: boolean
     default: false
+  plug_in_timeout_enabled:
+    description: >-
+      This parameter is only used if the charging station has multiple EVSEs managed by this Auth module.
+
+      Controls the authorization-timeout behavior after a plug-in event. When enabled, an internal timer is started immediately after an EV
+      is detected as plugged in. During the time defined by connection_timeout, the user must present a valid authorization token.
+      
+      If no valid token is received within the specified connection_timeout, the authorization attempt is considered as timed out and a
+      re-plug by the user is required to start a new authorization process.
+      
+      This setting is particularly useful for charging stations with multiple EVSEs and a shared, non-EVSE-specific authorization interface
+      (e.g., a single RFID reader). It prevents authorization tokens from being incorrectly associated with an EVSE where an EV is
+      plugged in but has not been authorized, by ensuring that expired or ambiguous plug-ins are not considered for EVSE assignments
+      for future authorization attempts.
+    type: boolean
+    default: false
 provides:
   main:
     description: This implements the auth interface for EVerest

--- a/modules/EVSE/Auth/tests/auth_tests.cpp
+++ b/modules/EVSE/Auth/tests/auth_tests.cpp
@@ -82,8 +82,8 @@ protected:
         this->auth_receiver = std::make_unique<FakeAuthReceiver>(evse_indices);
 
         const std::string id = "auth_handler_test_id";
-        this->auth_handler = std::make_unique<AuthHandler>(SelectionAlgorithm::PlugEvents, CONNECTION_TIMEOUT, false,
-                                                           false, id, nullptr);
+        this->auth_handler = std::make_unique<AuthHandler>(SelectionAlgorithm::PlugEvents, CONNECTION_TIMEOUT, true,
+                                                           false, false, id, nullptr);
 
         this->auth_handler->register_notify_evse_callback([this](const int evse_index,
                                                                  const ProvidedIdToken& provided_token,
@@ -1645,6 +1645,34 @@ TEST_F(AuthTest, test_plug_in_time_out) {
     ASSERT_TRUE(result == TokenHandlingResult::NO_CONNECTOR_AVAILABLE);
 
     ASSERT_FALSE(this->auth_receiver->get_authorization(0));
+    ASSERT_FALSE(this->auth_receiver->get_authorization(1));
+}
+
+/// \brief Test that authorization is given to the EVSE afterwards if plug-in timeout is disabled
+TEST_F(AuthTest, test_plug_in_time_out_disabled) {
+    this->auth_handler->set_plug_in_timeout_enabled(false);
+    const SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
+    this->auth_handler->handle_session_event(1, session_event);
+
+    std::vector<int32_t> connectors{1};
+    ProvidedIdToken provided_token = get_provided_token(VALID_TOKEN_1, connectors);
+
+    std::this_thread::sleep_for(std::chrono::seconds(CONNECTION_TIMEOUT));
+
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Accepted));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::UsedToStart));
+
+    TokenHandlingResult result;
+    std::thread t1([this, provided_token, &result]() { result = this->auth_handler->on_token(provided_token); });
+    t1.join();
+
+    ASSERT_TRUE(result == TokenHandlingResult::USED_TO_START_TRANSACTION);
+
+    ASSERT_TRUE(this->auth_receiver->get_authorization(0));
     ASSERT_FALSE(this->auth_receiver->get_authorization(1));
 }
 


### PR DESCRIPTION
## Describe your changes

This PR adds a new configuration parameter `plug_in_timeout_enabled` to the Auth module, which controls the authorization-timeout behavior after a plug-in event.

When enabled, an internal timer is started immediately after an EV  is detected as plugged in. During the time defined by connection_timeout, the user must present a valid authorization token.

If no valid token is received within the specified connection_timeout, the authorization attempt is considered as timed out and a re-plug by the user is required to start a new authorization process.
      
This setting is particularly useful for charging stations with multiple EVSEs and a shared, non-EVSE-specific authorization interface (e.g., a single RFID reader). It prevents authorization tokens from being incorrectly associated with an EVSE where an EV is plugged in but has not been authorized, by ensuring that expired or ambiguous plug-ins are not considered for EVSE assignments for future authorization attempts.

So far the behavior was `plug_in_timeout_enabled` implicitly being set to true and no check how many EVSEs are present was performed. This is therefore a breaking change with `plug_in_timeout_enabled` defaulting to `false`.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

