### PR TITLE
EvseManager: slightly adjust warning about outstanding PP value

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -289,7 +289,7 @@ void Charger::run_state_machine() {
                 // retry if the value is not yet available. Some BSPs may take some time to measure the PP.
                 if (shared_context.max_current_cable == 0) {
                     if (not internal_context.pp_warning_printed) {
-                        EVLOG_warning << "PP ampacity is zero, still retrying to read PP ampacity...";
+                        EVLOG_warning << "PP ampacity is zero, still waiting for BSP to report it...";
                         internal_context.pp_warning_printed = true;
                     }
                     break;


### PR DESCRIPTION
## Describe your changes

Now that EvseManager does not actively tries to get/read the PP ampacity anymore, the wording can be adjusted to indicate that the board support package is in charge to report the value.

## Issue ticket number and link

none

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

