### PR TITLE
fix(Infypower_BEG1K075): Improve CAN reliability by retransmitting all

### DIFF
--- a/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/can_driver_acdc/CanDevice.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/can_driver_acdc/CanDevice.cpp
@@ -113,5 +113,6 @@ bool CanDevice::_tx(uint32_t can_id, const std::vector<uint8_t>& payload) {
         throw std::runtime_error(std::string("Failed to send can packet :") + strerror(errno));
         return false;
     }
+
     return true;
 }

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/can_driver_acdc/InfyCanDevice.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/can_driver_acdc/InfyCanDevice.hpp
@@ -89,6 +89,11 @@ private:
 
     bool tx(const uint8_t destination_address, const std::vector<uint8_t>& payload);
 
+    std::atomic<float> setpoint_voltage{0}, setpoint_current{0};
+    std::atomic_bool on;
+    std::atomic_bool walkin_enable;
+    std::atomic_bool inverter_mode;
+
     std::mutex settingsMutex;
 };
 

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower_BEG1K075G/main/power_supply_DCImpl.cpp
@@ -27,13 +27,10 @@ void power_supply_DCImpl::init() {
     caps.conversion_efficiency_import = 0.95;
 
     mod->acdc.signalVoltageCurrent.connect([this](float voltage, float current) {
-        static uint8_t throttle_cnt = 0;
-        if (throttle_cnt++ % 10 == 0) {
-            types::power_supply_DC::VoltageCurrent vc;
-            vc.current_A = current;
-            vc.voltage_V = voltage;
-            publish_voltage_current(vc);
-        }
+        types::power_supply_DC::VoltageCurrent vc;
+        vc.current_A = current;
+        vc.voltage_V = voltage;
+        publish_voltage_current(vc);
     });
 
     mod->acdc.signalModuleStatus.connect(


### PR DESCRIPTION
settings

The power module seems to be very sensitive if two commands come in short succession. This PR moves all TX in one thread with delays in between to avoid the problem that two commands are sent from different threads at the same time. Also it transmits the whole state every time to allow for hotplugging of the modules.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

