### PR TITLE
Enable everestpy by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,9 @@ include(compatibility/boost)
 set(everest-framework_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lib/everest/framework)
 set(everest-framework_BINARY_DIR ${CMAKE_BINARY_DIR}/lib/everest/framework)
 set(EVEREST_SCHEMA_DIR ${everest-framework_SOURCE_DIR}/schemas)
+if(NOT DEFINED EVEREST_ENABLE_PY_SUPPORT)
+    set(EVEREST_ENABLE_PY_SUPPORT ON CACHE BOOL "Enable EVerest Python support" FORCE)
+endif()
 
 if(NOT DISABLE_EDM)
     # FIXME (aw): this implicit definition for child projects is hacky


### PR DESCRIPTION
This was usually set by everest-framework itself, but is not available early enough anymore However it is required to be set for the Python EV simulation and testing

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

