### PR TITLE
feat: huawei v100 telemetry data

### DIFF
--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/CHANGELOG.md
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## December 2025
+
+### Module
+
+- The module can now publish telemetry data on a specified mqtt base topic, set via the config option `telemetry_topic_prefix`. The concrete telemetry data is published only when the data changes to reduce mqtt traffic. The telemetry data is published as json objects per dispenser and per connector. See the module documentation for details.
+
 ## June 2025
 
 - Module

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/CMakeLists.txt
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/CMakeLists.txt
@@ -30,7 +30,10 @@ target_sources(${MODULE_NAME}
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
-target_sources(${MODULE_NAME} PRIVATE "connector_base/base.cpp")
+target_sources(${MODULE_NAME} PRIVATE
+    "connector_base/base.cpp"
+    "telemetry_publisher_everest.cpp"
+)
 add_subdirectory(fusion_charger_lib)
 
 ev_register_library_target(fusion_charger_dispenser)

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/Huawei_V100R023C10.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/Huawei_V100R023C10.hpp
@@ -21,6 +21,7 @@
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
+#include "telemetry_publisher_everest.hpp"
 #include <dispenser.hpp>
 #include <vector>
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
@@ -43,12 +44,14 @@ struct Conf {
     bool allow_insecure_goose;
     bool verify_secure_goose;
     std::string upstream_voltage_source;
+    std::string telemetry_topic_prefix;
 };
 
 class Huawei_V100R023C10 : public Everest::ModuleBase {
 public:
     Huawei_V100R023C10() = delete;
-    Huawei_V100R023C10(const ModuleInfo& info, std::unique_ptr<power_supply_DCImplBase> p_connector_1,
+    Huawei_V100R023C10(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider,
+                       std::unique_ptr<power_supply_DCImplBase> p_connector_1,
                        std::unique_ptr<power_supply_DCImplBase> p_connector_2,
                        std::unique_ptr<power_supply_DCImplBase> p_connector_3,
                        std::unique_ptr<power_supply_DCImplBase> p_connector_4,
@@ -57,6 +60,7 @@ public:
                        std::vector<std::unique_ptr<powermeterIntf>> r_carside_powermeter,
                        std::vector<std::unique_ptr<over_voltage_monitorIntf>> r_over_voltage_monitor, Conf& config) :
         ModuleBase(info),
+        mqtt(mqtt_provider),
         p_connector_1(std::move(p_connector_1)),
         p_connector_2(std::move(p_connector_2)),
         p_connector_3(std::move(p_connector_3)),
@@ -67,6 +71,7 @@ public:
         r_over_voltage_monitor(std::move(r_over_voltage_monitor)),
         config(config){};
 
+    Everest::MqttProvider& mqtt;
     const std::unique_ptr<power_supply_DCImplBase> p_connector_1;
     const std::unique_ptr<power_supply_DCImplBase> p_connector_2;
     const std::unique_ptr<power_supply_DCImplBase> p_connector_3;
@@ -99,6 +104,8 @@ public:
     };
     // PSU upstream voltage source
     UpstreamVoltageSource upstream_voltage_source;
+
+    std::shared_ptr<fusion_charger::telemetry::TelemetryPublisherBase> telemetry_publisher;
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/connector_base/base.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/connector_base/base.hpp
@@ -27,6 +27,17 @@ struct EverestConnectorConfig {
     }
 };
 
+namespace telemetry_datapoint_keys {
+static const std::string UPSTREAM_VOLTAGE = "upstream_voltage";
+static const std::string OUTPUT_VOLTAGE = "output_voltage";
+static const std::string OUTPUT_CURRENT = "output_current";
+static const std::string EXPORT_VOLTAGE = "export_voltage";
+static const std::string EXPORT_CURRENT = "export_current";
+static const std::string BSP_EVENT = "bsp_event";
+static const std::string EVEREST_MODE = "everest_mode";
+static const std::string EVEREST_PHASE = "everest_phase";
+}; // namespace telemetry_datapoint_keys
+
 class ConnectorBase {
 public:
     /**
@@ -89,6 +100,7 @@ private:
     void init_capabilities();
 
     std::string log_prefix;
+    std::string telemetry_subtopic;
 
     std::atomic<bool> module_placeholder_allocation_failure_raised;
 

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/doc.rst
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/doc.rst
@@ -22,6 +22,63 @@ For the everest measurements two options are available:
 - Using a carside powermeter (ideally the powermeter that is connected to the EvseManager's ``powermeter_car_side``)
 - Using a carside powermeter but during cable check using an ``OVM`` (see ``HACK_use_ovm_while_cable_check`` config option)
 
+Telemetry
+=========
+
+The module can publish telemetry data on a specified mqtt base topic, set via the config option ``telemetry_topic_prefix``.
+The concrete telemetry data is published only when the data changes to reduce mqtt traffic.
+
+The data published looks like this (example for base topic ``base_topic``):
+
+``base_topic/connector/1``
+
+.. code-block:: json
+
+    {
+      "max_rated_psu_current": 100.0,
+      "max_rated_psu_voltage": 1000.0,
+      "min_rated_psu_current": 1.0,
+      "min_rated_psu_voltage": 100.0,
+      "psu_port_available": "AVAILABLE",
+      "rated_output_power_psu": 60000.0
+    }
+
+``base_topic/connector/1/dispenser_to_psu``
+
+.. code-block:: json
+
+    {
+      "bsp_event": "PowerOn",
+      "everest_mode": "Export",
+      "everest_phase": "Charging",
+      "export_current": 20.0,
+      "export_voltage": 400.0,
+      "output_current": 0.0,
+      "output_voltage": 0.0,
+      "upstream_voltage": 0.0
+    }
+
+``base_topic/psu``
+
+.. code-block:: json
+
+    {
+      "ac_input_current_a": 10.0,
+      "ac_input_current_b": 10.5,
+      "ac_input_current_c": 9.5,
+      "ac_input_voltage_a": 230.0,
+      "ac_input_voltage_b": 231.0,
+      "ac_input_voltage_c": 229.0,
+      "psu_running_mode": "RUNNING",
+      "total_historic_input_energy": 100000.0
+    }
+
+The units are SI units (Amps, Volts, Watts, Watt-hours).
+
+.. note::
+
+    All telemetry values can be null, indicating that no value has been received or sent yet.
+
 Power Supply Mock
 ==================
 

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/include/configuration.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/include/configuration.hpp
@@ -8,6 +8,7 @@
 
 #include "callbacks.hpp"
 #include "fusion_charger/modbus/registers/raw.hpp"
+#include "telemetry.hpp"
 #include "tls_util.hpp"
 
 typedef fusion_charger::modbus_driver::raw_registers::ConnectorType ConnectorType;
@@ -40,6 +41,9 @@ struct DispenserConfig {
     std::optional<tls_util::MutualTlsClientConfig> tls_config;
 
     std::chrono::milliseconds module_placeholder_allocation_timeout;
+
+    std::shared_ptr<fusion_charger::telemetry::TelemetryPublisherBase> telemetry_publisher =
+        std::make_shared<fusion_charger::telemetry::TelemetryPublisherNull>();
 };
 
 struct ConnectorConfig {

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/include/dispenser.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/include/dispenser.hpp
@@ -22,6 +22,7 @@
 #include "connector.hpp"
 #include "connector_goose_sender.hpp"
 #include "state.hpp"
+#include "telemetry.hpp"
 
 using namespace fusion_charger::modbus_driver::raw_registers;
 using namespace fusion_charger::modbus_driver;

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/include/telemetry.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/include/telemetry.hpp
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <modbus-registers/data_provider.hpp>
+#include <string>
+
+namespace fusion_charger::telemetry {
+
+/**
+ * @brief Base interface class for fusion charger telemetry managers which are responsible for publishing telemetry
+ * datapoints
+ */
+class TelemetryPublisherBase {
+public:
+    virtual ~TelemetryPublisherBase() = default;
+    /**
+     * @brief Add a new subtopic for telemetry datapoints
+     * @param subtopic The subtopic name
+     */
+    virtual void add_subtopic(const std::string& subtopic) = 0;
+    /**
+     * @brief Notify that a datapoint for a subtopic has changed (string value)
+     * @param subtopic The subtopic name
+     * @param datapoint The datapoint name
+     * @param value The new value
+     */
+    virtual void datapoint_changed(const std::string& subtopic, const std::string& datapoint,
+                                   const std::string& value) = 0;
+    /**
+     * @brief Notify that a datapoint for a subtopic has changed (double value)
+     * @param subtopic The subtopic name
+     * @param datapoint The datapoint name
+     * @param value The new value
+     */
+    virtual void datapoint_changed(const std::string& subtopic, const std::string& datapoint, double value) = 0;
+
+    /**
+     * @brief Notify that a datapoint for a subtopic has changed (bool value)
+     * @param subtopic The subtopic name
+     * @param datapoint The datapoint name
+     * @param value The new value
+     */
+    virtual void datapoint_changed(const std::string& subtopic, const std::string& datapoint, bool value) = 0;
+
+    /**
+     * @brief Check if a datapoint exists for a subtopic
+     * @param subtopic The subtopic name
+     * @param datapoint The datapoint name
+     * @return true if the datapoint exists, false otherwise
+     */
+    virtual bool datapoint_exists(const std::string& subtopic, const std::string& datapoint) = 0;
+
+    /**
+     * @brief Initialize a datapoint for a subtopic with null
+     * @param subtopic The subtopic name
+     * @param datapoint The datapoint name
+     */
+    virtual void initialize_datapoint(const std::string& subtopic, const std::string& datapoint) = 0;
+
+    /**
+     * @brief Initialize a datapoint for a subtopic with a value
+     * @note Does nothing if the datapoint already exists
+     * @param subtopic The subtopic name
+     * @param datapoint The datapoint name
+     * @param value The initial value
+     */
+    template <typename T>
+    void initialize_datapoint(const std::string& subtopic, const std::string& datapoint, T value) {
+        if (!datapoint_exists(subtopic, datapoint)) {
+            datapoint_changed(subtopic, datapoint, value);
+        }
+    }
+
+    /**
+     * @brief Utility to add a callback to a holding complex register data provider that notifies the telemetry manager
+     * on value changes
+     * @tparam T The type of the data provider value
+     * @param subtopic The subtopic name
+     * @param datapoint The datapoint name
+     * @param data_provider The data provider to add the callback to
+     * @param conversion_func An optional conversion function to convert (e.g. to SI units) the value before sending it
+     * to the telemetry manager
+     */
+    template <typename T>
+    void
+    register_complex_register_data_provider(const std::string& subtopic, const std::string& datapoint,
+                                            modbus::registers::data_providers::DataProviderHolding<T>* data_provider,
+                                            std::function<T(const T&)> conversion_func = nullptr) {
+        initialize_datapoint(subtopic, datapoint);
+        data_provider->add_write_callback([this, subtopic, datapoint, conversion_func](T value) {
+            if (conversion_func) {
+                value = conversion_func(value);
+            }
+            this->datapoint_changed(subtopic, datapoint, value);
+        });
+    }
+
+    /**
+     * @brief Utility to add a callback to a holding complex register data provider that notifies the telemetry manager
+     * on value changes, converting the value to a string using the provided function
+     * @tparam T The type of the data provider value
+     * @param subtopic The subtopic name
+     * @param datapoint The datapoint name
+     * @param data_provider The data provider to add the callback to
+     * @param to_string_func The function to convert the value to a string
+     */
+    template <typename T>
+    void register_complex_register_data_provider_enum(
+        const std::string& subtopic, const std::string& datapoint,
+        modbus::registers::data_providers::DataProviderHolding<T>* data_provider,
+        std::function<std::string(const T&)> to_string_func) {
+        initialize_datapoint(subtopic, datapoint);
+        data_provider->add_write_callback([this, subtopic, datapoint, to_string_func](T value) {
+            this->datapoint_changed(subtopic, datapoint, to_string_func(value));
+        });
+    }
+};
+
+/**
+ * @brief Null implementation of the TelemetryPublisherBase that does nothing
+ */
+class TelemetryPublisherNull : public TelemetryPublisherBase {
+public:
+    void add_subtopic(const std::string& subtopic) override {
+    }
+    void datapoint_changed(const std::string& subtopic, const std::string& datapoint,
+                           const std::string& value) override {
+    }
+    void datapoint_changed(const std::string& subtopic, const std::string& datapoint, double value) override {
+    }
+    void datapoint_changed(const std::string& subtopic, const std::string& datapoint, bool value) override {
+    }
+    void initialize_datapoint(const std::string& subtopic, const std::string& datapoint) override {
+    }
+    bool datapoint_exists(const std::string& subtopic, const std::string& datapoint) override {
+        return true;
+    }
+};
+
+}; // namespace fusion_charger::telemetry

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/lib/connector.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/lib/connector.cpp
@@ -314,6 +314,26 @@ void Connector::start() {
     // todo: reset fsm?
 
     goose_sender.start();
+
+    std::string connector_telemetry_subtopic = "connector/" + std::to_string(connector_config.global_connector_number);
+    dispenser_config.telemetry_publisher->add_subtopic(connector_telemetry_subtopic);
+
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider(
+        connector_telemetry_subtopic, "max_rated_psu_current", &connector_registers.max_rated_psu_current);
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider(
+        connector_telemetry_subtopic, "min_rated_psu_current", &connector_registers.min_rated_psu_current);
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider(
+        connector_telemetry_subtopic, "max_rated_psu_voltage", &connector_registers.max_rated_psu_voltage);
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider(
+        connector_telemetry_subtopic, "min_rated_psu_voltage", &connector_registers.min_rated_psu_voltage);
+
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider<float>(
+        connector_telemetry_subtopic, "rated_output_power_psu", &connector_registers.rated_output_power_psu,
+        [](const float& kw) { return kw * 1000.0; });
+
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider_enum<PsuOutputPortAvailability>(
+        connector_telemetry_subtopic, "psu_port_available", &connector_registers.psu_port_available,
+        psu_output_port_availability_to_string);
 }
 
 void Connector::stop() {

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/lib/dispenser.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/lib/dispenser.cpp
@@ -436,6 +436,31 @@ void Dispenser::init() {
     modbus_unsolicitated_event_thread = std::thread([this]() { modbus_unsolicitated_event_thread_run(); });
 
     goose_receiver_thread = std::thread([this]() { goose_receiver_thread_run(); });
+
+    // add telemetry callbacks
+    dispenser_config.telemetry_publisher->add_subtopic("psu");
+
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider("psu", "ac_input_voltage_a",
+                                                                                  &psu_registers->ac_input_voltage_a);
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider("psu", "ac_input_voltage_b",
+                                                                                  &psu_registers->ac_input_voltage_b);
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider("psu", "ac_input_voltage_c",
+                                                                                  &psu_registers->ac_input_voltage_c);
+
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider("psu", "ac_input_current_a",
+                                                                                  &psu_registers->ac_input_current_a);
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider("psu", "ac_input_current_b",
+                                                                                  &psu_registers->ac_input_current_b);
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider("psu", "ac_input_current_c",
+                                                                                  &psu_registers->ac_input_current_c);
+
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider_enum<PSURunningMode>(
+        "psu", "psu_running_mode", &psu_registers->psu_running_mode,
+        [](const PSURunningMode& mode) { return SettingPowerUnitRegisters::psu_running_mode_to_string(mode); });
+
+    dispenser_config.telemetry_publisher->register_complex_register_data_provider<double>(
+        "psu", "total_historic_input_energy", &psu_registers->total_historic_input_energy,
+        [](const double& kwh) { return kwh * 1000.0; });
 }
 
 void Dispenser::update_psu_communication_state() {

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/power_stack_mock/include/power_stack_mock/power_stack_mock.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/power_stack_mock/include/power_stack_mock/power_stack_mock.hpp
@@ -91,6 +91,10 @@ public:
     void send_max_rated_voltage_of_output_port(float voltage, std::uint16_t local_connector_number);
     void send_min_rated_voltage_of_output_port(float voltage, std::uint16_t local_connector_number);
     void send_rated_power_of_output_port(float power, std::uint16_t local_connector_number);
+    void send_total_historical_ac_input_energy(double energy);
+    void send_ac_input_voltages_currents(float voltage_a, float voltage_b, float voltage_c, float current_a,
+                                         float current_b, float current_c);
+    void send_port_available(bool available, std::uint16_t local_connector_number);
 
     std::optional<fusion_charger::goose::PowerRequirementRequest>
     get_last_power_requirement_request(std::uint16_t global_connector_number);
@@ -101,6 +105,8 @@ public:
     fusion_charger::modbus_driver::raw_registers::ConnectionStatus
     get_connection_status(std::uint16_t local_connector_number);
     float get_maximum_rated_charge_current(std::uint16_t local_connector_number);
+    std::optional<fusion_charger::modbus_driver::raw_registers::WorkingStatus>
+    get_working_status(std::uint16_t local_connector_number);
     DispenserInformation get_dispenser_information();
     std::string get_dispenser_esn();
     std::uint32_t get_utc_time();
@@ -108,6 +114,12 @@ public:
     ConnectorCallbackResults get_connector_callback_values(std::uint16_t local_connector_number);
 
     void set_enable_answer_module_placeholder_allocation(bool enable);
+
+    /**
+     * @brief get the global connector number from the local connector number (range 1-4)
+     * @returns the global connector number or std::nullopt if not found / error reading
+     */
+    std::optional<int> get_global_connector_number_from_local(std::uint16_t local_connector_number);
 
 private:
     PowerStackMockConfig config;

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/power_stack_mock/include/power_stack_mock/util.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/power_stack_mock/include/power_stack_mock/util.hpp
@@ -23,6 +23,7 @@ float uint16_vec_to_float(std::vector<std::uint16_t> vec);
 std::vector<std::uint16_t> float_to_uint16_vec(float value);
 
 double uint16_vec_to_double(std::vector<std::uint16_t> vec);
+std::vector<std::uint16_t> double_to_uint16_vec(double value);
 
 std::uint32_t uint16_vec_to_uint32(std::vector<std::uint16_t> vec);
 

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/power_stack_mock/lib/util.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/fusion-charger-dispenser-library/power_stack_mock/lib/util.cpp
@@ -96,6 +96,18 @@ double uint16_vec_to_double(std::vector<std::uint16_t> vec) {
     return *((double*)v0);
 }
 
+std::vector<std::uint16_t> double_to_uint16_vec(double value) {
+    std::uint8_t* v = reinterpret_cast<std::uint8_t*>(&value);
+
+    std::vector<std::uint16_t> out;
+    out.push_back(static_cast<std::uint16_t>(v[7] << 8 | v[6]));
+    out.push_back(static_cast<std::uint16_t>(v[5] << 8 | v[4]));
+    out.push_back(static_cast<std::uint16_t>(v[3] << 8 | v[2]));
+    out.push_back(static_cast<std::uint16_t>(v[1] << 8 | v[0]));
+
+    return out;
+}
+
 std::uint32_t uint16_vec_to_uint32(std::vector<std::uint16_t> vec) {
     std::uint16_t v0[2] = {
         static_cast<std::uint16_t>(vec[1]),

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/huawei-fusioncharge-driver/libs/fusion_charger_modbus_driver/include/fusion_charger/modbus/registers/raw.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/huawei-fusioncharge-driver/libs/fusion_charger_modbus_driver/include/fusion_charger/modbus/registers/raw.hpp
@@ -129,6 +129,7 @@ enum class PsuOutputPortAvailability : std::uint16_t {
 };
 
 std::string working_status_to_string(const WorkingStatus& status);
+std::string psu_output_port_availability_to_string(const PsuOutputPortAvailability& availability);
 
 class CollectedConnectorRegisters : public ComplexRegisterSubregistry {
 public:

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/huawei-fusioncharge-driver/libs/fusion_charger_modbus_driver/src/raw.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/huawei-fusioncharge-driver/libs/fusion_charger_modbus_driver/src/raw.cpp
@@ -23,6 +23,18 @@ std::string fusion_charger::modbus_driver::raw_registers::working_status_to_stri
     }
 }
 
+std::string fusion_charger::modbus_driver::raw_registers::psu_output_port_availability_to_string(
+    const PsuOutputPortAvailability& availability) {
+    switch (availability) {
+    case PsuOutputPortAvailability::AVAILABLE:
+        return "AVAILABLE";
+    case PsuOutputPortAvailability::NOT_AVAILABLE:
+        return "NOT_AVAILABLE";
+    default:
+        return "UNKNOWN";
+    }
+}
+
 std::string fusion_charger::modbus_driver::raw_registers::SettingPowerUnitRegisters::psu_running_mode_to_string(
     const PSURunningMode& mode) {
     switch (mode) {

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/manifest.yaml
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/manifest.yaml
@@ -91,6 +91,12 @@ config:
       - IMD
       - OVM
     default: IMD
+  telemetry_topic_prefix:
+    description: |
+      MQTT Topic prefix for telemetry data published by this module.
+      Set to an empty string (default) to disable telemetry publishing.
+    type: string
+    default: ""
 provides:
   connector_1:
     description: Power supply interface for the first connector.
@@ -188,6 +194,7 @@ requires:
     interface: over_voltage_monitor
     min_connections: 0
     max_connections: 4
+enable_external_mqtt: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/telemetry_publisher_everest.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/telemetry_publisher_everest.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include "telemetry_publisher_everest.hpp"
+
+TelemetryPublisherEverest::TelemetryPublisherEverest(
+    std::function<void(const std::string&, const nlohmann::json&)> publish_func, const std::string& base_topic) :
+    publish_func(publish_func), base_topic(base_topic) {
+    publisher_thread = std::thread(&TelemetryPublisherEverest::publisher_thread_func, this);
+}
+
+TelemetryPublisherEverest::~TelemetryPublisherEverest() {
+    stop_publisher_thread = true;
+    if (publisher_thread.joinable()) {
+        subtopics_changed_cv.notify_all();
+        publisher_thread.join();
+    }
+}
+
+void TelemetryPublisherEverest::add_subtopic(const std::string& subtopic) {
+    std::lock_guard<std::mutex> lock(subtopics_mutex);
+    if (subtopics_data.find(subtopic) == subtopics_data.end()) {
+        SubtopicDataEntry entry;
+        subtopics_data[subtopic] = entry;
+    }
+}
+
+void TelemetryPublisherEverest::datapoint_changed(const std::string& subtopic, const std::string& datapoint,
+                                                  const std::string& value) {
+    datapoint_changed_internal(subtopic, datapoint, value);
+}
+
+void TelemetryPublisherEverest::datapoint_changed(const std::string& subtopic, const std::string& datapoint,
+                                                  double value) {
+    datapoint_changed_internal(subtopic, datapoint, value);
+}
+
+void TelemetryPublisherEverest::datapoint_changed(const std::string& subtopic, const std::string& datapoint,
+                                                  bool value) {
+    datapoint_changed_internal(subtopic, datapoint, value);
+}
+
+void TelemetryPublisherEverest::publisher_thread_func() {
+    for (;;) {
+        // await changes
+        {
+            std::unique_lock<std::mutex> lock(subtopics_mutex);
+            subtopics_changed_cv.wait(lock, [this]() {
+                if (stop_publisher_thread) {
+                    return true;
+                }
+                for (const auto& [subtopic, data_entry] : subtopics_data) {
+                    if (data_entry.has_changes) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+            if (stop_publisher_thread) {
+                return;
+            }
+        }
+
+        // wait for a few ms to batch changes
+        // Note: The PSU writes multiple registers in batches, which can trigger rapid
+        // bursts of datapoint value changes across different datapoints.
+        // This small delay helps batch those changes and prevents flooding the MQTT broker.
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+        // publish changed subtopics
+        {
+            std::lock_guard<std::mutex> lock(subtopics_mutex);
+            for (auto& [subtopic, subtopic_data_entry] : subtopics_data) {
+                if (subtopic_data_entry.has_changes) {
+                    publish_func(base_topic + "/" + subtopic, subtopic_data_entry.data_entries);
+                    subtopic_data_entry.has_changes = false;
+                }
+            }
+        }
+    }
+}
+
+bool TelemetryPublisherEverest::datapoint_exists(const std::string& subtopic, const std::string& datapoint) {
+    std::lock_guard<std::mutex> lock(subtopics_mutex);
+    if (subtopics_data.find(subtopic) != subtopics_data.end()) {
+        return subtopics_data[subtopic].data_entries.find(datapoint) != subtopics_data[subtopic].data_entries.end();
+    }
+
+    return false;
+}
+
+void TelemetryPublisherEverest::initialize_datapoint(const std::string& subtopic, const std::string& datapoint) {
+    std::lock_guard<std::mutex> lock(subtopics_mutex);
+    if (subtopics_data.find(subtopic) != subtopics_data.end()) {
+        if (subtopics_data[subtopic].data_entries.find(datapoint) == subtopics_data[subtopic].data_entries.end()) {
+            subtopics_data[subtopic].data_entries[datapoint] = nullptr;
+            subtopics_data[subtopic].has_changes = true;
+            subtopics_changed_cv.notify_one();
+        }
+    }
+}

--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/telemetry_publisher_everest.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/telemetry_publisher_everest.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <telemetry.hpp>
+
+#include <framework/ModuleAdapter.hpp>
+#include <map>
+#include <thread>
+
+class TelemetryPublisherEverest : public fusion_charger::telemetry::TelemetryPublisherBase {
+    std::function<void(const std::string&, const nlohmann::json&)> publish_func;
+    std::string base_topic;
+
+    struct SubtopicDataEntry {
+        nlohmann::json data_entries;
+        bool has_changes{false};
+    };
+
+    std::mutex subtopics_mutex;
+    std::condition_variable subtopics_changed_cv;
+
+    // key: subtopic, value: data entry
+    std::unordered_map<std::string, SubtopicDataEntry> subtopics_data;
+
+    std::thread publisher_thread;
+    std::atomic<bool> stop_publisher_thread{false};
+
+    void publisher_thread_func();
+
+    template <typename T>
+    void datapoint_changed_internal(const std::string& subtopic, const std::string& datapoint, T value) {
+        std::lock_guard<std::mutex> lock(subtopics_mutex);
+        if (subtopics_data.find(subtopic) != subtopics_data.end()) {
+
+            subtopics_data[subtopic].data_entries[datapoint] = value;
+            subtopics_data[subtopic].has_changes = true;
+
+            subtopics_changed_cv.notify_one();
+        }
+    }
+
+public:
+    TelemetryPublisherEverest(std::function<void(const std::string&, const nlohmann::json&)> publish_func,
+                              const std::string& base_topic);
+    ~TelemetryPublisherEverest() override;
+
+    void add_subtopic(const std::string& subtopic) override;
+    void datapoint_changed(const std::string& subtopic, const std::string& datapoint,
+                           const std::string& value) override;
+    void datapoint_changed(const std::string& subtopic, const std::string& datapoint, double value) override;
+    void datapoint_changed(const std::string& subtopic, const std::string& datapoint, bool value) override;
+    bool datapoint_exists(const std::string& subtopic, const std::string& datapoint) override;
+    void initialize_datapoint(const std::string& subtopic, const std::string& datapoint) override;
+};


### PR DESCRIPTION
## Describe your changes

- add a generic telemetry publisher interface to the fusion charger library
- fusion charger library now publishes different registers via said interface
- Everest module implements an Everest-specific implementation (`TelemetryPublisherEverest`) which publishes the data via Everests MqttProvider to a configurable mqtt base topic
- update the mock to publish a few more simulated registers
- Note that the TelementryPublisher can be replaced in the future once an Everest-wide telemetry system is implemented

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

