### PR TITLE
Add missing <algorithm> header include to goose sender test

### DIFF
--- a/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/goose-lib/libs/goose/tests/sender.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/Huawei_V100R023C10/fusion_charger_lib/goose-lib/libs/goose/tests/sender.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+#include <algorithm>
+
 #include <gtest/gtest.h>
 
 #include <goose/sender.hpp>


### PR DESCRIPTION
This would otherwise prevent the test from getting built on recent versions of GCC

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

