### PR TITLE
Remove find_package for everest-evse_security

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,6 @@ if(NOT DISABLE_EDM)
 else()
     find_package(everest-timer REQUIRED)
     find_package(everest-log REQUIRED)
-    find_package(everest-evse_security REQUIRED)
     find_package(everest-sqlite REQUIRED)
 
     find_package(PalSigslot REQUIRED)

--- a/lib/everest/ocpp/CMakeLists.txt
+++ b/lib/everest/ocpp/CMakeLists.txt
@@ -58,7 +58,6 @@ else()
     find_package(libwebsockets REQUIRED)
     find_package(everest-timer REQUIRED)
     find_package(everest-log REQUIRED)
-    find_package(everest-evse_security REQUIRED)
     find_package(everest-sqlite REQUIRED)
 endif()
 


### PR DESCRIPTION
This is not needed anymore now that libevse-security is integrated into everest-core

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

