### PR TITLE
libiso15118: use integrated libcbv2g during standalone builds

### DIFF
--- a/lib/everest/iso15118/CMakeLists.txt
+++ b/lib/everest/iso15118/CMakeLists.txt
@@ -27,6 +27,10 @@ if (NOT everest-cmake_FOUND)
     include("${everest-cmake_SOURCE_DIR}/everest-cmake-config.cmake")
 endif()
 
+if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+    include(cmake/exported-build.cmake)
+endif()
+
 # options
 option(${PROJECT_NAME}_BUILD_TESTING "Build unit tests, used if included as dependency" OFF)
 option(BUILD_TESTING "Build unit tests, used if standalone project" OFF)

--- a/lib/everest/iso15118/cmake/exported-build.cmake
+++ b/lib/everest/iso15118/cmake/exported-build.cmake
@@ -1,0 +1,45 @@
+# download everest-core (source of libcbv2g)
+include(ExternalProject)
+ExternalProject_Add(
+    everest-core-src
+    DOWNLOAD_DIR "everest-core/src"
+    GIT_REPOSITORY "https://github.com/EVerest/everest-core.git"
+    GIT_TAG "61e97863fd2fc9f429f9cd2e4b689139e7d46981"
+    TIMEOUT 30
+    LOG_DOWNLOAD ON
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+)
+
+# build everest-core/lib/everest/cbv2g
+ExternalProject_Add(
+    cbv2g-src
+    DOWNLOAD_COMMAND ""
+    SOURCE_DIR "everest-core-src-prefix/src/everest-core-src/lib/everest/cbv2g"
+    PREFIX "everest-core"
+    INSTALL_COMMAND ""
+    LOG_CONFIGURE ON
+    LOG_BUILD ON
+    DEPENDS everest-core-src
+)
+ExternalProject_Get_Property(cbv2g-src SOURCE_DIR)
+ExternalProject_Get_Property(cbv2g-src BINARY_DIR)
+set(CBV2G_INCLUDE_DIR "${SOURCE_DIR}/include")
+set(CBV2G_LIB_DIR "${BINARY_DIR}/lib/cbv2g")
+
+# workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/15052
+# create CBV2G_INCLUDE_DIR since it will not exist in configure step
+file(MAKE_DIRECTORY ${CBV2G_INCLUDE_DIR})
+
+add_library(cbv2g_tp STATIC IMPORTED)
+add_library(cbv2g::tp ALIAS cbv2g_tp)
+set_property(TARGET cbv2g_tp PROPERTY IMPORTED_LOCATION ${CBV2G_LIB_DIR}/libcbv2g_tp.a)
+set_property(TARGET cbv2g_tp PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CBV2G_INCLUDE_DIR})
+add_dependencies(cbv2g_tp cbv2g-src)
+
+add_library(cbv2g_iso20 STATIC IMPORTED)
+add_library(cbv2g::iso20 ALIAS cbv2g_iso20)
+set_property(TARGET cbv2g_iso20 PROPERTY IMPORTED_LOCATION ${CBV2G_LIB_DIR}/libcbv2g_iso20.a)
+set_property(TARGET cbv2g_iso20 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CBV2G_INCLUDE_DIR})
+add_dependencies(cbv2g_iso20 cbv2g-src)

--- a/lib/everest/iso15118/dependencies.yaml
+++ b/lib/everest/iso15118/dependencies.yaml
@@ -3,7 +3,3 @@ catch2:
   git: https://github.com/catchorg/Catch2.git
   git_tag: v3.10.0
   cmake_condition: "ISO15118_BUILD_TESTING"
-libcbv2g:
-  git: https://github.com/EVerest/libcbv2g.git
-  git_tag: v0.3.2
-  cmake_condition: "${CMAKE_PROJECT_NAME} STREQUAL iso15118"


### PR DESCRIPTION
Add CMake code for using ExternalProject to use libcbv2g from everest-core when building libiso15118 standalone

note: in the future the everest-core hash used in the standalone build will be updated automatically when the library gets exported into another repository, for now it points to the import commit of libcbv2g

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

