### PR TITLE
Reset authorization to Ongoing in EvseV2G

### DIFF
--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -233,6 +233,10 @@ void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::Pay
         remove_service_from_service_list_if_exists(v2g_ctx, V2G_SERVICE_ID_CERTIFICATE);
     }
 
+    // Reset authorization that may have been provided after the TCP was closed, potentially causing
+    // authorization to be reused in the next session. Resetting it here prevents that.
+    v2g_ctx->evse_v2g_data.evse_processing[PHASE_AUTH] = (uint8_t)iso2_EVSEProcessingType_Ongoing;
+
     v2g_ctx->evse_v2g_data.central_contract_validation_allowed = central_contract_validation_allowed;
 }
 


### PR DESCRIPTION

## Describe your changes
Resetting authorization in handle_session_setup. Without this change, it can occur that authorization is provided after a TCP teardown (which resets authorization in the v2g_context). This could cause provided authorization to be reused in a subsequent session. Resetting the flag in handle_session_setup prevents this from happening

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

