### PR TITLE
Change links in dev env docs to reference monorepo

### DIFF
--- a/applications/dev-environment/README.md
+++ b/applications/dev-environment/README.md
@@ -56,18 +56,18 @@ Here are the steps required:
    **One-liner:**
 
    ```bash
-   curl -s https://raw.githubusercontent.com/EVerest/everest-dev-environment/main/devcontainer/template/setup-container > setup-container && chmod +x setup-container && ./setup-container
+   curl -s https://raw.githubusercontent.com/EVerest/everest-core/refs/heads/main/applications/dev-environment/devcontainer/setup-container > setup-container && chmod +x setup-container && ./setup-container
    ```
 
    **Manual clone (if curl fails):**
 
    ```bash
-   git clone git@github.com:EVerest/everest-dev-environment.git
-   cp everest-dev-environment/devcontainer/template/setup-container setup-container
+   git clone git@github.com:EVerest/everest-core.git
+   cp everest-core/applications/dev-environment/devcontainer/setup-container setup-container
    chmod +x setup-container
    ./setup-container
-   # you can delete the everest-dev-environment folder, it is not needed anymore
-   rm -rf everest-dev-environment
+   # you can delete the everest-core folder, it is not needed anymore
+   rm -rf everest-core
    ```
 
    The script will ask you for:


### PR DESCRIPTION
The everest-dev-environment repo is now archived so documentation should refer to the scripts in the
main repo.

Following the current instructions results in a 404 error when running the curl command

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

