### PR TITLE
Add command for setting SOC to the car simulator

### DIFF
--- a/modules/EV/EvManager/main/car_simulation.hpp
+++ b/modules/EV/EvManager/main/car_simulation.hpp
@@ -35,6 +35,13 @@ public:
         sim_data.battery_charge_wh = config.dc_energy_capacity * (soc / 100.0);
     }
 
+    void set_soc(double soc) {
+        if (soc < 0 || soc > 100) {
+            throw std::out_of_range("SoC value " + std::to_string(soc) + " is out of range (0-100)");
+        }
+        sim_data.battery_charge_wh = config.dc_energy_capacity * (soc / 100.0);
+    }
+
     const SimState& get_state() const {
         return sim_data.state;
     }

--- a/modules/EV/EvManager/main/car_simulatorImpl.cpp
+++ b/modules/EV/EvManager/main/car_simulatorImpl.cpp
@@ -189,6 +189,20 @@ void car_simulatorImpl::register_all_commands() {
         EVLOG_error << "plugin command called but \"plugin_commands\" config key not set";
         return true;
     });
+    command_registry->register_command("set_soc", 1, [this](const CmdArguments& arguments) {
+        try {
+            double soc = std::stod(arguments.at(0));
+            this->car_simulation->set_soc(soc);
+        } catch (const std::invalid_argument& e) {
+            EVLOG_error << "set_soc command called with invalid argument: " << arguments.at(0);
+            return true;
+        } catch (const std::out_of_range& e) {
+            EVLOG_error << "set_soc command called with out of range argument: " << arguments.at(0);
+            return true;
+        }
+
+        return true;
+    });
 
     if (!mod->r_slac.empty()) {
         command_registry->register_command("iso_wait_slac_matched", 0, [this](const CmdArguments& arguments) {


### PR DESCRIPTION
## Describe your changes

Extends the car simulator with a command that may be used to set the SOC to a custom value before plugging it in.
The command can be used with `set_soc <soc>`, where the `soc` argument is parsed as a floating point number that must be in the interval [0,100].

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

