### PR TITLE
refactor(OCPP): Introduce DeviceModelInterface abstraction layer

### DIFF
--- a/lib/everest/ocpp/doc/message_dispatching.md
+++ b/lib/everest/ocpp/doc/message_dispatching.md
@@ -17,7 +17,7 @@ class v16_MessageDispatcher {
 
 class v2_MessageDispatcher {
     - MessageQueue& message_queue
-    - DeviceModel& device_model
+    - DeviceModelAbstract& device_model
     - ConnectivityManager& connectivity_manager
     - RegistrationStatusEnum& registration_status
 }

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
@@ -47,7 +47,7 @@ class TransactionInterface;
 class BidirectionalInterface;
 
 class DatabaseHandler;
-class DeviceModel;
+class DeviceModelAbstract;
 class DeviceModelStorageInterface;
 class EvseManager;
 
@@ -343,7 +343,7 @@ public:
 class ChargePoint : public ChargePointInterface, private ocpp::ChargingStationBase {
 
 private:
-    std::shared_ptr<DeviceModel> device_model;
+    std::shared_ptr<DeviceModelAbstract> device_model;
     std::unique_ptr<EvseManager> evse_manager;
     std::unique_ptr<ConnectivityManager> connectivity_manager;
 
@@ -474,7 +474,7 @@ public:
     /// \param evse_security Pointer to evse_security that manages security related operations
     /// \param callbacks Callbacks that will be registered for ChargePoint
     ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connector_structure,
-                std::shared_ptr<DeviceModel> device_model, std::shared_ptr<DatabaseHandler> database_handler,
+                std::shared_ptr<DeviceModelAbstract> device_model, std::shared_ptr<DatabaseHandler> database_handler,
                 std::shared_ptr<MessageQueue<v2::MessageType>> message_queue, const std::string& message_log_path,
                 const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks);
 

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point_callbacks.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point_callbacks.hpp
@@ -36,7 +36,7 @@ struct Callbacks {
     ///
     /// \retval false if any of the normal callbacks are nullptr or any of the optional ones are filled with a nullptr
     ///        true otherwise
-    bool all_callbacks_valid(std::shared_ptr<DeviceModel> device_model,
+    bool all_callbacks_valid(std::shared_ptr<DeviceModelAbstract> device_model,
                              const std::map<std::int32_t, std::int32_t>& evse_connector_structure) const;
 
     ///

--- a/lib/everest/ocpp/include/ocpp/v2/connectivity_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/connectivity_manager.hpp
@@ -13,7 +13,7 @@
 namespace ocpp {
 namespace v2 {
 
-class DeviceModel;
+class DeviceModelAbstract;
 
 /// \brief The result of a configuration of a network profile.
 struct ConfigNetworkResult {
@@ -120,7 +120,7 @@ public:
 class ConnectivityManager : public ConnectivityManagerInterface {
 private:
     /// \brief Reference to the device model
-    DeviceModel& device_model;
+    DeviceModelAbstract& device_model;
     /// \brief Pointer to the evse security class
     std::shared_ptr<EvseSecurity> evse_security;
     /// \brief Pointer to the logger
@@ -150,7 +150,7 @@ private:
     OcppProtocolVersion connected_ocpp_version;
 
 public:
-    ConnectivityManager(DeviceModel& device_model, std::shared_ptr<EvseSecurity> evse_security,
+    ConnectivityManager(DeviceModelAbstract& device_model, std::shared_ptr<EvseSecurity> evse_security,
                         std::shared_ptr<MessageLogging> logging,
                         const std::function<void(const std::string& message)>& message_callback);
 

--- a/lib/everest/ocpp/include/ocpp/v2/device_model_abstract.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model_abstract.hpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <ocpp/v2/device_model_base.hpp>
+#include <ocpp/v2/device_model_interface.hpp>
+
+namespace ocpp {
+namespace v2 {
+
+class DeviceModelAbstract : public DeviceModelBase, public DeviceModelInterface {};
+
+} // namespace v2
+} // namespace ocpp

--- a/lib/everest/ocpp/include/ocpp/v2/device_model_base.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model_base.hpp
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <everest/logging.hpp>
+
+#include <ocpp/common/utils.hpp>
+#include <ocpp/v2/comparators.hpp>
+#include <ocpp/v2/device_model_interface.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+namespace ocpp {
+namespace v2 {
+
+/// \brief Response to requesting a value from the device model
+/// \tparam T
+template <typename T> struct RequestDeviceModelResponse {
+    GetVariableStatusEnum status;
+    std::optional<T> value;
+};
+
+template <typename T> T to_specific_type(const std::string& value) {
+    static_assert(std::is_same_v<T, std::string> || std::is_same_v<T, int> || std::is_same_v<T, double> ||
+                      std::is_same_v<T, size_t> || std::is_same_v<T, DateTime> || std::is_same_v<T, bool> ||
+                      std::is_same_v<T, std::uint64_t>,
+                  "Requested unknown datatype");
+
+    if constexpr (std::is_same_v<T, std::string>) {
+        return value;
+    } else if constexpr (std::is_same_v<T, int>) {
+        return std::stoi(value);
+    } else if constexpr (std::is_same_v<T, double>) {
+        return std::stod(value);
+    } else if constexpr (std::is_same_v<T, std::size_t>) {
+        const std::size_t res = std::stoul(value);
+        return res;
+    } else if constexpr (std::is_same_v<T, DateTime>) {
+        return DateTime(value);
+    } else if constexpr (std::is_same_v<T, bool>) {
+        if (!is_boolean(value)) {
+            throw std::invalid_argument("Invalid boolean value: " + value);
+        }
+        return ocpp::conversions::string_to_bool(value);
+    } else if constexpr (std::is_same_v<T, std::uint64_t>) {
+        return std::stoull(value);
+    }
+}
+
+template <DataEnum T> auto to_specific_type_auto(const std::string& value) {
+    static_assert(T == DataEnum::string || T == DataEnum::integer || T == DataEnum::decimal ||
+                      T == DataEnum::dateTime || T == DataEnum::boolean,
+                  "Requested unknown datatype");
+
+    if constexpr (T == DataEnum::string) {
+        return to_specific_type<std::string>(value);
+    } else if constexpr (T == DataEnum::integer) {
+        return to_specific_type<int>(value);
+    } else if constexpr (T == DataEnum::decimal) {
+        return to_specific_type<double>(value);
+    } else if constexpr (T == DataEnum::dateTime) {
+        return to_specific_type<DateTime>(value);
+    } else if constexpr (T == DataEnum::boolean) {
+        return to_specific_type<bool>(value);
+    }
+}
+
+template <DataEnum T> bool is_type_numeric() {
+    static_assert(T == DataEnum::string || T == DataEnum::integer || T == DataEnum::decimal ||
+                      T == DataEnum::dateTime || T == DataEnum::boolean || T == DataEnum::OptionList ||
+                      T == DataEnum::SequenceList || T == DataEnum::MemberList,
+                  "Requested unknown datatype");
+
+    if constexpr (T == DataEnum::integer || T == DataEnum::decimal) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/// \brief Base class for device model implementations, provides templated getters for variable attribute values
+class DeviceModelBase {
+
+public:
+    // ============================================================================
+    // Value getters
+    // ============================================================================
+
+    /// \brief Retrieves a variable attribute value
+    /// \tparam T The target type (must be: std::string, int, double, size_t, DateTime, bool, or uint64_t)
+    /// \param component_id The component
+    /// \param variable_id The variable
+    /// \param attribute_enum The attribute
+    /// \return The requested value
+    template <typename T>
+    T get_value(const Component& component_id, const Variable& variable_id,
+                const AttributeEnum& attribute_enum = AttributeEnum::Actual) const {
+        std::string value;
+        const auto status = request_value_internal(component_id, variable_id, attribute_enum, value, true);
+
+        if (status != GetVariableStatusEnum::Accepted) {
+            EVLOG_critical << "Required value " << variable_id.name << " of component " << component_id.name
+                           << " could not be retrieved";
+            EVLOG_AND_THROW(std::runtime_error("Required value not available"));
+        }
+
+        return to_specific_type<T>(value);
+    }
+
+    /// \brief Retrieves a variable attribute value
+    /// \tparam T The target type (must be: std::string, int, double, size_t, DateTime, bool, or uint64_t)
+    /// \param component_variable The component and variable
+    /// \param attribute_enum The attribute
+    /// \return The requested value
+    template <typename T>
+    T get_value(const ComponentVariable& component_variable,
+                const AttributeEnum& attribute_enum = AttributeEnum::Actual) const {
+        if (!component_variable.variable.has_value()) {
+            EVLOG_critical << "ComponentVariable has no variable set for component: " << component_variable.component;
+            EVLOG_AND_THROW(std::runtime_error("ComponentVariable has no variable set"));
+        }
+        return get_value<T>(component_variable.component, component_variable.variable.value(), attribute_enum);
+    }
+
+    /// \brief Retrieves an optional variable attribute value
+    /// \tparam T The target type (must be: std::string, int, double, size_t, DateTime, bool, or uint64_t)
+    /// \param component_id The component
+    /// \param variable_id The variable
+    /// \param attribute_enum The attribute
+    /// \return The requested value or std::nullopt
+    template <typename T>
+    std::optional<T> get_optional_value(const Component& component_id, const Variable& variable_id,
+                                        const AttributeEnum& attribute_enum = AttributeEnum::Actual) const {
+        std::string value;
+        const auto status = request_value_internal(component_id, variable_id, attribute_enum, value, true);
+
+        if (status != GetVariableStatusEnum::Accepted) {
+            return std::nullopt;
+        }
+
+        try {
+            return to_specific_type<T>(value);
+        } catch (const std::exception&) {
+            return std::nullopt;
+        }
+    }
+
+    /// \brief Retrieves an optional variable attribute value
+    /// \tparam T The target type (must be: std::string, int, double, size_t, DateTime, bool, or uint64_t)
+    /// \param component_variable The component and variable
+    /// \param attribute_enum The attribute
+    /// \return The requested value or std::nullopt
+    template <typename T>
+    std::optional<T> get_optional_value(const ComponentVariable& component_variable,
+                                        const AttributeEnum& attribute_enum = AttributeEnum::Actual) const {
+        if (!component_variable.variable.has_value()) {
+            return std::nullopt;
+        }
+        return get_optional_value<T>(component_variable.component, component_variable.variable.value(), attribute_enum);
+    }
+
+    /// \brief Requests a value of a VariableAttribute specified by combination of \p component_id and \p variable_id
+    /// from the device model
+    /// \tparam T datatype of the value that is requested
+    /// \param component_id
+    /// \param variable_id
+    /// \param attribute_enum
+    /// \return Response to request that contains status of the request and the requested value as std::optional<T> .
+    /// The value is present if the status is GetVariableStatusEnum::Accepted
+    template <typename T>
+    RequestDeviceModelResponse<T> request_value(const Component& component_id, const Variable& variable_id,
+                                                const AttributeEnum& attribute_enum) const {
+        std::string value;
+        const auto status = request_value_internal(component_id, variable_id, attribute_enum, value, false);
+
+        if (status != GetVariableStatusEnum::Accepted) {
+            return {status, std::nullopt};
+        }
+
+        try {
+            return {status, to_specific_type<T>(value)};
+        } catch (const std::exception&) {
+            return {GetVariableStatusEnum::Rejected, std::nullopt};
+        }
+    }
+
+private:
+    virtual GetVariableStatusEnum request_value_internal(const Component& component_id, const Variable& variable_id,
+                                                         const AttributeEnum& attribute_enum, std::string& value,
+                                                         bool allow_write_only = false) const = 0;
+};
+
+} // namespace v2
+} // namespace ocpp

--- a/lib/everest/ocpp/include/ocpp/v2/device_model_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model_interface.hpp
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#ifndef DEVICE_MODEL_INTERFACE_HPP
+#define DEVICE_MODEL_INTERFACE_HPP
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <ocpp/v2/enums.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+namespace ocpp {
+namespace v2 {
+
+/// \brief Helper struct that holds values that don't have spec coverage
+struct VariableMonitoringMeta {
+    VariableMonitoring monitor;
+    VariableMonitorType type;
+    std::optional<std::string> reference_value;
+};
+
+/// \brief Helper struct that contains all monitors related to a variable that are of a periodic type
+struct VariableMonitoringPeriodic {
+    Component component;
+    Variable variable;
+    std::vector<VariableMonitoringMeta> monitors;
+};
+
+/// \brief Helper struct that combines VariableCharacteristics and VariableMonitoring
+struct VariableMetaData {
+    VariableCharacteristics characteristics;
+    std::unordered_map<std::int64_t, VariableMonitoringMeta> monitors;
+    std::optional<std::string> source;
+};
+
+using VariableMap = std::map<Variable, VariableMetaData>;
+using DeviceModelMap = std::map<Component, VariableMap>;
+
+class DeviceModelError : public std::exception {
+public:
+    [[nodiscard]] const char* what() const noexcept override {
+        return this->reason.c_str();
+    }
+    explicit DeviceModelError(std::string msg) : reason(std::move(msg)) {
+    }
+    explicit DeviceModelError(const char* msg) : reason(std::string(msg)) {
+    }
+
+private:
+    std::string reason;
+};
+
+/// \brief Pure abstract interface for device model access.
+class DeviceModelInterface {
+public:
+    virtual ~DeviceModelInterface() = default;
+
+    // ============================================================================
+    // Value getters
+    // ============================================================================
+
+    /// \brief Gets a variable attribute value
+    /// \param component_id The component
+    /// \param variable_id The variable
+    /// \param attribute_enum The attribute
+    /// \param value The value to get (as string)
+    /// \param allow_write_only If true, write-only variables can be accessed
+    /// \return Result of the requested operation
+    virtual GetVariableStatusEnum get_variable(const Component& component_id, const Variable& variable_id,
+                                               const AttributeEnum& attribute_enum, std::string& value,
+                                               bool allow_write_only = false) const = 0;
+
+    // ============================================================================
+    // Value setters
+    // ============================================================================
+
+    /// \brief Sets a variable attribute value
+    /// \param component_id The component
+    /// \param variable_id The variable
+    /// \param attribute_enum The attribute
+    /// \param value The value to set (as string)
+    /// \param source The source of the value (e.g., 'csms', 'default', 'internal')
+    /// \param allow_read_only If true, read-only variables can be changed
+    /// \return Result of the requested operation
+    virtual SetVariableStatusEnum set_value(const Component& component_id, const Variable& variable_id,
+                                            const AttributeEnum& attribute_enum, const std::string& value,
+                                            const std::string& source, bool allow_read_only = false) = 0;
+
+    /// \brief Sets a read-only variable attribute value (only works on certain allowed components)
+    /// \param component_id The component
+    /// \param variable_id The variable
+    /// \param attribute_enum The attribute
+    /// \param value The value to set (as string)
+    /// \param source The source of the value (e.g., 'csms', 'default', 'internal')
+    /// \return Result of the requested operation
+    virtual SetVariableStatusEnum set_read_only_value(const Component& component_id, const Variable& variable_id,
+                                                      const AttributeEnum& attribute_enum, const std::string& value,
+                                                      const std::string& source) = 0;
+
+    // ============================================================================
+    // Metadata and monitoring
+    // ============================================================================
+
+    /// \brief Get the mutability for the given component, variable and attribute
+    /// \param component_id The component
+    /// \param variable_id The variable
+    /// \param attribute_enum The attribute
+    /// \return The mutability of the given component variable, or std::nullopt
+    virtual std::optional<MutabilityEnum> get_mutability(const Component& component_id, const Variable& variable_id,
+                                                         const AttributeEnum& attribute_enum) = 0;
+
+    /// \brief Gets the VariableMetaData for the given component and variable
+    /// \param component_id The component
+    /// \param variable_id The variable
+    /// \return VariableMetaData or std::nullopt if not present
+    virtual std::optional<VariableMetaData> get_variable_meta_data(const Component& component_id,
+                                                                   const Variable& variable_id) = 0;
+
+    /// \brief Gets the ReportData for the specified report base
+    /// \param report_base The report base filter
+    /// \return Vector of ReportData
+    virtual std::vector<ReportData> get_base_report_data(const ReportBaseEnum& report_base) = 0;
+
+    /// \brief Gets the ReportData for the specified filters
+    /// \param component_variables Optional component variables filter
+    /// \param component_criteria Optional component criteria filter
+    /// \return Vector of ReportData
+    virtual std::vector<ReportData> get_custom_report_data(
+        const std::optional<std::vector<ComponentVariable>>& component_variables = std::nullopt,
+        const std::optional<std::vector<ComponentCriterionEnum>>& component_criteria = std::nullopt) = 0;
+
+    // ============================================================================
+    // Monitoring operations
+    // ============================================================================
+
+    /// \brief Sets the given monitor requests in the device model
+    /// \param requests The monitoring requests
+    /// \param type The type of monitors (HardWiredMonitor, PreconfiguredMonitor, CustomMonitor)
+    /// \return List of results of the requested operation
+    virtual std::vector<SetMonitoringResult>
+    set_monitors(const std::vector<SetMonitoringData>& requests,
+                 const VariableMonitorType type = VariableMonitorType::CustomMonitor) = 0;
+
+    /// \brief Updates the reference value for a monitor
+    /// \param monitor_id The monitor ID
+    /// \param reference_value The new reference value
+    /// \return true if successful, false otherwise
+    virtual bool update_monitor_reference(std::int32_t monitor_id, const std::string& reference_value) = 0;
+
+    /// \brief Gets all periodic monitors
+    /// \return Vector of periodic monitors
+    virtual std::vector<VariableMonitoringPeriodic> get_periodic_monitors() = 0;
+
+    /// \brief Gets the monitoring data for the requested criteria and component variables
+    /// \param criteria The monitoring criteria
+    /// \param component_variables The component variables to get monitors for
+    /// \return List of monitoring data
+    virtual std::vector<MonitoringData> get_monitors(const std::vector<MonitoringCriterionEnum>& criteria,
+                                                     const std::vector<ComponentVariable>& component_variables) = 0;
+
+    /// \brief Clears the given monitor IDs from the registered monitors
+    /// \param request_ids The monitor IDs to clear
+    /// \param allow_protected If true, non-custom monitors can be deleted
+    /// \return List of results of the requested operation
+    virtual std::vector<ClearMonitoringResult> clear_monitors(const std::vector<int>& request_ids,
+                                                              bool allow_protected = false) = 0;
+
+    /// \brief Clears all custom monitors (set by the CSMS)
+    /// \return Count of monitors deleted
+    virtual std::int32_t clear_custom_monitors() = 0;
+
+    /// \brief Registers a listener for variable changes
+    /// \param listener The listener function to register
+    virtual void register_variable_listener(
+        std::function<void(const std::unordered_map<std::int64_t, VariableMonitoringMeta>& monitors,
+                           const Component& component, const Variable& variable,
+                           const VariableCharacteristics& characteristics, const VariableAttribute& attribute,
+                           const std::string& value_previous, const std::string& value_current)>&& listener) = 0;
+
+    /// \brief Registers a listener for monitor updates
+    /// \param listener The listener function to register
+    virtual void register_monitor_listener(
+        std::function<void(const VariableMonitoringMeta& updated_monitor, const Component& component,
+                           const Variable& variable, const VariableCharacteristics& characteristics,
+                           const VariableAttribute& attribute, const std::string& current_value)>&& listener) = 0;
+
+    // ============================================================================
+    // Integrity check
+    // ============================================================================
+
+    /// \brief Check data integrity of the device model
+    /// \param evse_connector_structure The EVSE connector structure
+    virtual void check_integrity(const std::map<std::int32_t, std::int32_t>& evse_connector_structure) = 0;
+};
+
+} // namespace v2
+} // namespace ocpp
+
+#endif // DEVICE_MODEL_INTERFACE_HPP

--- a/lib/everest/ocpp/include/ocpp/v2/device_model_storage_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model_storage_interface.hpp
@@ -6,52 +6,14 @@
 #include <map>
 #include <memory>
 #include <ocpp/common/support_older_cpp_versions.hpp>
-#include <ocpp/v2/comparators.hpp>
 #include <optional>
 
+#include <ocpp/v2/device_model_abstract.hpp>
 #include <ocpp/v2/enums.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 
 namespace ocpp {
 namespace v2 {
-
-/// \brief Helper struct that holds database only values that don't have spec coverage
-struct VariableMonitoringMeta {
-    VariableMonitoring monitor;
-    VariableMonitorType type;
-    std::optional<std::string> reference_value;
-};
-
-/// \brief Helper struct that contains all monitors related to a variable that are of a periodic type
-struct VariableMonitoringPeriodic {
-    Component component;
-    Variable variable;
-    std::vector<VariableMonitoringMeta> monitors;
-};
-
-/// \brief Helper struct that combines VariableCharacteristics and VariableMonitoring
-struct VariableMetaData {
-    VariableCharacteristics characteristics;
-    std::unordered_map<std::int64_t, VariableMonitoringMeta> monitors;
-    std::optional<std::string> source;
-};
-
-using VariableMap = std::map<Variable, VariableMetaData>;
-using DeviceModelMap = std::map<Component, VariableMap>;
-
-class DeviceModelError : public std::exception {
-public:
-    [[nodiscard]] const char* what() const noexcept override {
-        return this->reason.c_str();
-    }
-    explicit DeviceModelError(std::string msg) : reason(std::move(msg)) {
-    }
-    explicit DeviceModelError(const char* msg) : reason(std::string(msg)) {
-    }
-
-private:
-    std::string reason;
-};
 
 /// \brief Abstract base class for device model interface. This class provides an interface for accessing and modifying
 /// device model data. Implementations of this class should provide concrete implementations for the virtual methods

--- a/lib/everest/ocpp/include/ocpp/v2/evse.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/evse.hpp
@@ -11,7 +11,7 @@
 #include <ocpp/v2/component_state_manager.hpp>
 #include <ocpp/v2/connector.hpp>
 #include <ocpp/v2/database_handler.hpp>
-#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/device_model_abstract.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 #include <ocpp/v2/transaction.hpp>
 
@@ -171,7 +171,7 @@ class Evse : public EvseInterface {
 
 private:
     std::int32_t evse_id;
-    DeviceModel& device_model;
+    DeviceModelAbstract& device_model;
     std::map<std::int32_t, std::unique_ptr<Connector>> id_connector_map;
     std::function<void(const MeterValue& meter_value, EnhancedTransaction& transaction)> transaction_meter_value_req;
     std::function<void(std::int32_t evse_id)> pause_charging_callback;
@@ -240,7 +240,7 @@ public:
     /// \param transaction_meter_value_req that is called to transmit a meter value request related to a transaction
     /// \param pause_charging_callback that is called when the charging should be paused due to max energy on
     /// invalid id being exceeded
-    Evse(const std::int32_t evse_id, const std::int32_t number_of_connectors, DeviceModel& device_model,
+    Evse(const std::int32_t evse_id, const std::int32_t number_of_connectors, DeviceModelAbstract& device_model,
          std::shared_ptr<DatabaseHandler> database_handler,
          std::shared_ptr<ComponentStateManagerInterface> component_state_manager,
          const std::function<void(const MeterValue& meter_value, EnhancedTransaction& transaction)>&

--- a/lib/everest/ocpp/include/ocpp/v2/evse_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/evse_manager.hpp
@@ -81,7 +81,7 @@ private:
     std::vector<std::unique_ptr<EvseInterface>> evses;
 
 public:
-    EvseManager(const std::map<std::int32_t, std::int32_t>& evse_connector_structure, DeviceModel& device_model,
+    EvseManager(const std::map<std::int32_t, std::int32_t>& evse_connector_structure, DeviceModelAbstract& device_model,
                 std::shared_ptr<DatabaseHandler> database_handler,
                 std::shared_ptr<ComponentStateManagerInterface> component_state_manager,
                 const std::function<void(const MeterValue& meter_value, EnhancedTransaction& transaction)>&

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/functional_block_context.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/functional_block_context.hpp
@@ -10,7 +10,7 @@ namespace ocpp {
 class EvseSecurity;
 
 namespace v2 {
-class DeviceModel;
+class DeviceModelAbstract;
 class ConnectivityManagerInterface;
 class EvseManagerInterface;
 class DatabaseHandlerInterface;
@@ -22,7 +22,7 @@ class ComponentStateManagerInterface;
 /// functional blocks.
 struct FunctionalBlockContext {
     MessageDispatcherInterface<MessageType>& message_dispatcher;
-    DeviceModel& device_model;
+    DeviceModelAbstract& device_model;
     ConnectivityManagerInterface& connectivity_manager;
     EvseManagerInterface& evse_manager;
     DatabaseHandlerInterface& database_handler;
@@ -30,10 +30,10 @@ struct FunctionalBlockContext {
     ComponentStateManagerInterface& component_state_manager;
     std::atomic<OcppProtocolVersion>& ocpp_version;
 
-    FunctionalBlockContext(MessageDispatcherInterface<MessageType>& message_dispatcher, DeviceModel& device_model,
-                           ConnectivityManagerInterface& connectivity_manager, EvseManagerInterface& evse_manager,
-                           DatabaseHandlerInterface& database_handler, EvseSecurity& evse_security,
-                           ComponentStateManagerInterface& component_state_manager,
+    FunctionalBlockContext(MessageDispatcherInterface<MessageType>& message_dispatcher,
+                           DeviceModelAbstract& device_model, ConnectivityManagerInterface& connectivity_manager,
+                           EvseManagerInterface& evse_manager, DatabaseHandlerInterface& database_handler,
+                           EvseSecurity& evse_security, ComponentStateManagerInterface& component_state_manager,
                            std::atomic<OcppProtocolVersion>& ocpp_version) :
         message_dispatcher(message_dispatcher),
         device_model(device_model),

--- a/lib/everest/ocpp/include/ocpp/v2/message_dispatcher.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/message_dispatcher.hpp
@@ -5,7 +5,7 @@
 
 #include <ocpp/common/message_dispatcher.hpp>
 #include <ocpp/v2/connectivity_manager.hpp>
-#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/device_model_abstract.hpp>
 
 namespace ocpp {
 namespace v2 {
@@ -13,7 +13,7 @@ namespace v2 {
 class MessageDispatcher : public MessageDispatcherInterface<MessageType> {
 
 public:
-    MessageDispatcher(ocpp::MessageQueue<MessageType>& message_queue, DeviceModel& device_model,
+    MessageDispatcher(ocpp::MessageQueue<MessageType>& message_queue, DeviceModelAbstract& device_model,
                       std::atomic<RegistrationStatusEnum>& registration_status) :
         message_queue(message_queue), device_model(device_model), registration_status(registration_status){};
     void dispatch_call(const json& call, bool triggered = false) override;
@@ -23,7 +23,7 @@ public:
 
 private:
     ocpp::MessageQueue<MessageType>& message_queue;
-    DeviceModel& device_model;
+    DeviceModelAbstract& device_model;
     std::atomic<RegistrationStatusEnum>& registration_status;
 };
 

--- a/lib/everest/ocpp/include/ocpp/v2/monitoring_updater.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/monitoring_updater.hpp
@@ -11,11 +11,9 @@
 #include <ocpp/v2/ocpp_enums.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 
-#include <ocpp/v2/device_model_storage_interface.hpp>
+#include <ocpp/v2/device_model_abstract.hpp>
 
 namespace ocpp::v2 {
-
-class DeviceModel;
 
 enum class UpdateMonitorMetaType {
     TRIGGER,
@@ -106,7 +104,8 @@ public:
     /// \param notify_csms_events Function that can be invoked with a number of alert events
     /// \param is_chargepoint_offline Function that can be invoked in order to retrieve the
     /// status of the charging station connection to the CSMS
-    MonitoringUpdater(DeviceModel& device_model, notify_events notify_csms_events, is_offline is_chargepoint_offline);
+    MonitoringUpdater(DeviceModelAbstract& device_model, notify_events notify_csms_events,
+                      is_offline is_chargepoint_offline);
     ~MonitoringUpdater();
 
     /// \brief Starts monitoring the variables, kicking the timer
@@ -167,7 +166,7 @@ private:
 
     bool is_monitoring_enabled();
 
-    DeviceModel& device_model;
+    DeviceModelAbstract& device_model;
     Everest::SteadyTimer monitors_timer;
 
     // Charger to CSMS message unique ID for EventData

--- a/lib/everest/ocpp/include/ocpp/v2/utils.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/utils.hpp
@@ -3,6 +3,7 @@
 #ifndef V2_UTILS_HPP
 #define V2_UTILS_HPP
 
+#include <ocpp/v2/device_model_abstract.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 #include <ocpp/v2/types.hpp>
 namespace ocpp {
@@ -79,6 +80,19 @@ std::vector<ChargingProfilePurposeEnum> get_purposes_to_ignore(const std::string
 
 /// \brief Converts the given \p csl of OcppProtocolVersion strings into a std::vector<OcppProtocolVersion>
 std::vector<OcppProtocolVersion> get_ocpp_protocol_versions(const std::string& csl);
+
+/// \brief Filters a single monitor based on the given criteria
+/// \param criteria applied criteria
+/// \param monitor  monitor to filter
+/// \return true if the monitor matches any of the criteria, false otherwise
+bool filter_criteria_monitor(const std::vector<MonitoringCriterionEnum>& criteria,
+                             const VariableMonitoringMeta& monitor);
+
+/// \brief Filters the given monitors based on the given criteria
+/// \param criteria applied criteria
+/// \param monitors monitors to filter, will be modified in place
+void filter_criteria_monitors(const std::vector<MonitoringCriterionEnum>& criteria,
+                              std::vector<VariableMonitoringMeta>& monitors);
 
 } // namespace utils
 } // namespace v2

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -48,7 +48,8 @@ namespace v2 {
 const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 1000;
 
 ChargePoint::ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connector_structure,
-                         std::shared_ptr<DeviceModel> device_model, std::shared_ptr<DatabaseHandler> database_handler,
+                         std::shared_ptr<DeviceModelAbstract> device_model,
+                         std::shared_ptr<DatabaseHandler> database_handler,
                          std::shared_ptr<MessageQueue<v2::MessageType>> message_queue,
                          const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
                          const Callbacks& callbacks) :

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point_callbacks.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point_callbacks.cpp
@@ -4,7 +4,7 @@
 
 namespace ocpp::v2 {
 
-bool Callbacks::all_callbacks_valid(std::shared_ptr<DeviceModel> device_model,
+bool Callbacks::all_callbacks_valid(std::shared_ptr<DeviceModelAbstract> device_model,
                                     const std::map<std::int32_t, std::int32_t>& evse_connector_structure) const {
     bool valid =
         this->is_reset_allowed_callback != nullptr and this->reset_callback != nullptr and

--- a/lib/everest/ocpp/lib/ocpp/v2/connectivity_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/connectivity_manager.cpp
@@ -19,7 +19,7 @@ constexpr std::int32_t default_network_config_timeout_seconds = 60;
 namespace ocpp {
 namespace v2 {
 
-ConnectivityManager::ConnectivityManager(DeviceModel& device_model, std::shared_ptr<EvseSecurity> evse_security,
+ConnectivityManager::ConnectivityManager(DeviceModelAbstract& device_model, std::shared_ptr<EvseSecurity> evse_security,
                                          std::shared_ptr<MessageLogging> logging,
                                          const std::function<void(const std::string& message)>& message_callback) :
     device_model{device_model},

--- a/lib/everest/ocpp/lib/ocpp/v2/device_model_storage_sqlite.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/device_model_storage_sqlite.cpp
@@ -4,9 +4,9 @@
 #include <everest/database/sqlite/statement.hpp>
 #include <everest/logging.hpp>
 #include <limits>
-#include <ocpp/v2/charge_point.hpp>
 #include <ocpp/v2/device_model_storage_sqlite.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>
+#include <ocpp/v2/utils.hpp>
 
 using namespace everest::db;
 using namespace everest::db::sqlite;
@@ -405,7 +405,7 @@ DeviceModelStorageSqlite::get_monitoring_data(const std::vector<MonitoringCriter
         monitors.push_back(monitor_meta);
 
         // Filter only required monitors
-        filter_criteria_monitors(criteria, monitors);
+        ocpp::v2::utils::filter_criteria_monitors(criteria, monitors);
     }
 
     return monitors;

--- a/lib/everest/ocpp/lib/ocpp/v2/evse.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/evse.cpp
@@ -45,7 +45,7 @@ float get_normalized_energy_value(SampledValue sampled_value) {
 }
 } // namespace
 
-Evse::Evse(const std::int32_t evse_id, const std::int32_t number_of_connectors, DeviceModel& device_model,
+Evse::Evse(const std::int32_t evse_id, const std::int32_t number_of_connectors, DeviceModelAbstract& device_model,
            std::shared_ptr<DatabaseHandler> database_handler,
            std::shared_ptr<ComponentStateManagerInterface> component_state_manager,
            const std::function<void(const MeterValue& meter_value, EnhancedTransaction& transaction)>&

--- a/lib/everest/ocpp/lib/ocpp/v2/evse_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/evse_manager.cpp
@@ -9,7 +9,7 @@ namespace v2 {
 using EvseIteratorImpl = VectorOfUniquePtrIterator<EvseInterface>;
 
 EvseManager::EvseManager(const std::map<std::int32_t, std::int32_t>& evse_connector_structure,
-                         DeviceModel& device_model, std::shared_ptr<DatabaseHandler> database_handler,
+                         DeviceModelAbstract& device_model, std::shared_ptr<DatabaseHandler> database_handler,
                          std::shared_ptr<ComponentStateManagerInterface> component_state_manager,
                          const std::function<void(const MeterValue& meter_value, EnhancedTransaction& transaction)>&
                              transaction_meter_value_req,

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -491,7 +491,7 @@ struct CompositeScheduleConfig {
     std::int32_t default_number_phases{};
     float supply_voltage{};
 
-    CompositeScheduleConfig(DeviceModel& device_model, bool is_offline) :
+    CompositeScheduleConfig(DeviceModelAbstract& device_model, bool is_offline) :
         purposes_to_ignore{utils::get_purposes_to_ignore(
             device_model.get_optional_value<std::string>(ControllerComponentVariables::IgnoredProfilePurposesOffline)
                 .value_or(""),

--- a/lib/everest/ocpp/lib/ocpp/v2/monitoring_updater.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/monitoring_updater.cpp
@@ -4,9 +4,9 @@
 #include <ocpp/v2/monitoring_updater.hpp>
 
 #include <chrono>
+#include <everest/logging.hpp>
 
 #include <ocpp/v2/ctrlr_component_variables.hpp>
-#include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/utils.hpp>
 
 namespace ocpp::v2 {
@@ -134,7 +134,7 @@ EventData create_notify_event(std::int32_t unique_id, const std::string& reporte
 }
 } // namespace
 
-MonitoringUpdater::MonitoringUpdater(DeviceModel& device_model, notify_events notify_csms_events,
+MonitoringUpdater::MonitoringUpdater(DeviceModelAbstract& device_model, notify_events notify_csms_events,
                                      is_offline is_chargepoint_offline) :
     device_model(device_model),
     monitors_timer([this]() { this->process_monitors_internal(true, true); }),

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 
+#include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>
 
 const static std::string MIGRATION_FILES_PATH = "./resources/v2/device_model_migration_files";
@@ -28,7 +29,6 @@ class Connection;
 }
 
 namespace v2 {
-class DeviceModel;
 
 class DeviceModelTestHelper {
 public:

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_reservation.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_reservation.cpp
@@ -15,6 +15,7 @@
 #include <ocpp/v2/functional_blocks/reservation.hpp>
 
 #include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/device_model_storage_sqlite.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 
+#include <ocpp/v2/device_model.hpp>
 #include <smart_charging_test_utils.hpp>
 
 #include "ocpp/v2/ctrlr_component_variables.hpp"


### PR DESCRIPTION

## Describe your changes
Extract DeviceModel into an abstract interface to enable dependency inversion and improve testability. Components now depend on DeviceModelInterface rather than the concrete implementation.

Changes:
- Create DeviceModelInterface with pure virtual methods
- Move template helpers and common types to interface header
- Make DeviceModel inherit from DeviceModelInterface
- Update all consumers (ChargePoint, ConnectivityManager, Evse, EvseManager, MonitoringUpdater, functional blocks) to use interface
- Move filter_criteria_monitor functions to utils.cpp
- Add explicit device_model.hpp includes in tests needing concrete impl

This maintains backward compatibility while enabling easier mocking and alternative implementations.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

