### PR TITLE
refactor(OCPP): Move ConnectivityManager to common namespace

### DIFF
--- a/lib/everest/ocpp/config/common/component_config/standardized/OCPPCommCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/OCPPCommCtrlr.json
@@ -165,7 +165,8 @@
       "characteristics": {
         "unit": "s",
         "supportsMonitoring": true,
-        "dataType": "integer"
+        "dataType": "integer",
+        "minLimit": 0
       },
       "attributes": [
         {

--- a/lib/everest/ocpp/doc/networkconnectivity/README.md
+++ b/lib/everest/ocpp/doc/networkconnectivity/README.md
@@ -14,8 +14,8 @@ be activated before it is possible to connect to this interface. To do this, you
 
 In the implementation of this callback, you have to create a promise and return the future to the promise:
 ```cpp
-std::promise<ocpp::v2::ConfigNetworkResult> promise();
-std::future<ocpp::v2::ConfigNetworkResult> future = promise.get_future();
+std::promise<ocpp::ConfigNetworkResult> promise();
+std::future<ocpp::ConfigNetworkResult> future = promise.get_future();
 return future;
 ```
 

--- a/lib/everest/ocpp/doc/networkconnectivity/README.md
+++ b/lib/everest/ocpp/doc/networkconnectivity/README.md
@@ -46,11 +46,166 @@ libocpp will inform the caller by the return value if it tries to switch to this
 libocpp provides two callbacks for when the websocket is connected and disconnected. It will provide the network slot
 in these callbacks, so you can keep the network connection in use (e.g. not disable the modem), or disable the network connection (example again: disable the modem).
 
+## External ConnectivityManager (optional)
+
+The `ConnectivityManager` lives in the `ocpp` namespace and is not tied to a specific OCPP version. This
+design allows the websocket connection to be established **before** a protocol version is determined. During the
+websocket handshake the CSMS selects the OCPP protocol version (e.g. OCPP 1.6, OCPP2.0.1 or OCPP2.1). An integrating
+application can use this information to instantiate the appropriate version-specific `ChargePoint` and inject the
+already-connected `ConnectivityManager` into it.
+
+By default, when no external `ConnectivityManager` is provided, libocpp creates and manages one internally.
+However, you can provide your own instance of `ConnectivityManagerInterface` (or the concrete
+`ConnectivityManager`) to take full control over websocket connectivity.
+
+> **Note:** External `ConnectivityManager` injection is currently only supported for `ocpp::v2::ChargePoint`.
+> Support for `ocpp::v16::ChargePoint` is not yet implemented and will follow in a future release.
+
+### Typical flow with an external ConnectivityManager
+
+1. Create a `ConnectivityManager`.
+2. Create **all** version-specific `ChargePoint` instances (e.g. both `ocpp::v16::ChargePoint` and
+   `ocpp::v2::ChargePoint`), passing the shared `ConnectivityManager` to each.
+3. Register a `websocket_connected_callback` on the `ConnectivityManager` that inspects the negotiated
+   `OcppProtocolVersion` and calls `start()` on the matching `ChargePoint`. `start()` automatically sets
+   the message callback in the `ConnectivityManager`, so messages are routed to the correct version.
+4. On subsequent reconnects (where `start()` was already called for that version), forward the event via
+   `on_websocket_connected()` instead.
+5. Because the CSMS may select a **different** protocol version on every websocket handshake, the integrating
+   application must be prepared to switch between `ChargePoint` instances at any reconnect. When a version
+   switch occurs, `stop()` should be called on the previously active `ChargePoint` and `start()` on the
+   newly selected one.
+
+### Creating and injecting a ConnectivityManager
+
+```cpp
+// 1. Create a version-independent ConnectivityManager
+auto connectivity_manager = std::make_shared<ocpp::ConnectivityManager>(device_model, evse_security);
+
+// 2. Create all ChargePoint instances, each receiving the shared ConnectivityManager
+auto charge_point_v16 = std::make_unique<ocpp::v16::ChargePoint>(
+    /* ... */, connectivity_manager, /* ... */);
+
+auto charge_point_v2 = std::make_unique<ocpp::v2::ChargePoint>(
+    evse_connector_structure, device_model, database_handler, evse_security,
+    connectivity_manager, message_log_path, callbacks);
+```
+
+### Wiring up websocket event callbacks
+
+The websocket connected callback must handle both the initial `start()` call and subsequent reconnects.
+It also needs to handle potential version switches:
+
+```cpp
+// Track which ChargePoint is currently active and started
+ocpp::OcppProtocolVersion active_version = ocpp::OcppProtocolVersion::Unknown;
+
+connectivity_manager->set_websocket_connected_callback(
+    [&](int configuration_slot,
+        const ocpp::v2::NetworkConnectionProfile& profile,
+        const ocpp::OcppProtocolVersion version) {
+
+        if (version != active_version) {
+            // Version changed — stop the previously active ChargePoint (if any)
+            if (active_version == ocpp::OcppProtocolVersion::v16) {
+                charge_point_v16->stop();
+            } else if (active_version != ocpp::OcppProtocolVersion::Unknown) {
+                charge_point_v2->stop();
+            }
+
+            // Start the ChargePoint for the newly negotiated version.
+            // start() sets the message callback in the ConnectivityManager
+            // so that incoming messages are routed to the correct ChargePoint.
+            if (version == ocpp::OcppProtocolVersion::v16) {
+                charge_point_v16->start();
+            } else {
+                charge_point_v2->start();
+            }
+            active_version = version;
+        } else {
+            // Same version as before — just notify the active ChargePoint
+            if (version == ocpp::OcppProtocolVersion::v16) {
+                charge_point_v16->on_websocket_connected(configuration_slot, profile, version);
+            } else {
+                charge_point_v2->on_websocket_connected(configuration_slot, profile, version);
+            }
+        }
+    });
+
+connectivity_manager->set_websocket_disconnected_callback(
+    [&](int configuration_slot,
+        const ocpp::v2::NetworkConnectionProfile& profile,
+        auto /*version*/) {
+        if (active_version == ocpp::OcppProtocolVersion::v16) {
+            charge_point_v16->on_websocket_disconnected(configuration_slot, profile);
+        } else {
+            charge_point_v2->on_websocket_disconnected(configuration_slot, profile);
+        }
+    });
+
+connectivity_manager->set_websocket_connection_failed_callback(
+    [&](ocpp::ConnectionFailedReason reason) {
+        if (active_version == ocpp::OcppProtocolVersion::v16) {
+            charge_point_v16->on_websocket_connection_failed(reason);
+        } else {
+            charge_point_v2->on_websocket_connection_failed(reason);
+        }
+    });
+```
+
+Optionally, if your system requires interface setup (e.g. modem activation), set the network configuration
+callback:
+
+```cpp
+connectivity_manager->set_configure_network_connection_profile_callback(
+    [](const int32_t configuration_slot,
+       const ocpp::v2::NetworkConnectionProfile& profile) {
+        std::promise<ocpp::ConfigNetworkResult> promise;
+        // ... set up the network interface ...
+        ocpp::ConfigNetworkResult result;
+        result.success = true;
+        result.interface_address = "eth0"; // optional: bind to specific interface or IP
+        promise.set_value(result);
+        return promise.get_future();
+    });
+```
+
+**Note:** `start()` automatically calls `set_message_callback` on the `ConnectivityManager`, ensuring that
+incoming OCPP messages are routed to the correct `ChargePoint` instance. The `set_logging` method is called
+automatically by `ChargePoint::initialize()`. You do not need to call either of these yourself.
+
+### When to use an external ConnectivityManager
+
+- When a single application needs to support multiple OCPP versions and switch between them at runtime
+  based on the CSMS's protocol selection
+- When the OCPP protocol version is not known ahead of time and should be determined by the websocket
+  handshake before starting a version-specific `ChargePoint`
+- When you want to implement a custom connectivity strategy (e.g. custom reconnection logic by implementing
+  `ConnectivityManagerInterface`)
+
+### Version switching responsibility
+
+When multi-version support is implemented (see note above), the **application** will be responsible for
+implementing the version-switching logic (i.e. deciding which `ChargePoint` to `start()`/`stop()` based on
+the negotiated protocol version). libocpp does not currently provide a built-in orchestrator for this, because
+the v16 and v2 `ChargePoint` implementations do not share a common interface and applications may need to manage
+additional version-specific state during a switch (e.g. active transactions, UI state). Such an orchestrator
+may be provided in the future.
+
+### Default (internal) behavior
+
+If you do **not** provide a `ConnectivityManager`, libocpp creates one internally and automatically registers the
+websocket event callbacks. In this case, the `on_websocket_connected`, `on_websocket_disconnected`, and
+`on_websocket_connection_failed` methods on `ChargePoint` are called automatically and you do not need to call them.
+This is sufficient when the OCPP protocol version is known at compile time or configuration time.
+
 ## Sequence diagram
 
 'core' can be read as any application that implements libocpp
 
 For step 9, ping is one way to check if a CSMS is up, but you of course can implement a way to check this yourself.
+
+### Internal ConnectivityManager (default)
 
 ```mermaid
 sequenceDiagram
@@ -100,4 +255,59 @@ note over csms,libocpp:  Network is disconnected (websocket timeout)
 libocpp ->> libocpp: disconnect csms
 libocpp ->> core: websocket_disconnected_callback(configuration_slot, NetworkConnectionProfile)
 libocpp -->> core: std::future<ConfigNetworkResult>(configure_network_connection_profile_callback(<br>configuration_slot, NetworkConnectionProfile)) (see 1)
+```
+
+### External ConnectivityManager
+
+```mermaid
+sequenceDiagram
+participant csms
+participant core
+participant connectivity_manager as ConnectivityManager<br>(external)
+participant cp_v16 as ChargePoint v16
+participant cp_v2 as ChargePoint v2
+autonumber
+
+note over core: 1. Initialization — create all components upfront
+core ->> connectivity_manager: create ConnectivityManager(device_model, evse_security)
+core ->> cp_v16: create ChargePoint(..., connectivity_manager, ...)
+core ->> cp_v2: create ChargePoint(..., connectivity_manager, ...)
+core ->> connectivity_manager: set_websocket_connected_callback(version_dispatch)
+core ->> connectivity_manager: set_websocket_disconnected_callback(version_dispatch)
+core ->> connectivity_manager: set_websocket_connection_failed_callback(version_dispatch)
+
+note over core: 2. First connection — version unknown
+core ->> connectivity_manager: connect()
+connectivity_manager ->> csms: websocket handshake (offering supported OCPP versions)
+csms ->> connectivity_manager: ACK (selected OCPP version, e.g. v2)
+
+note over core: 3. Connected callback triggers start() for negotiated version
+connectivity_manager ->> core: websocket_connected_callback(slot, profile, v2)
+core ->> core: active_version = Unknown → v2 (first time or version changed)
+core ->> cp_v2: start()
+note over cp_v2: start() sets message_callback<br>in ConnectivityManager
+
+note over core: 4. Reconnect with same version
+connectivity_manager ->> csms: websocket handshake
+csms ->> connectivity_manager: ACK (v2 again)
+connectivity_manager ->> core: websocket_connected_callback(slot, profile, v2)
+core ->> core: active_version == v2, no change
+core ->> cp_v2: on_websocket_connected(slot, profile, v2)
+
+note over core: 5. Reconnect with different version (CSMS switches to v16)
+connectivity_manager ->> csms: websocket handshake
+csms ->> connectivity_manager: ACK (v16)
+connectivity_manager ->> core: websocket_connected_callback(slot, profile, v16)
+core ->> core: active_version v2 → v16 (version changed)
+core ->> cp_v2: stop()
+core ->> cp_v16: start()
+note over cp_v16: start() sets message_callback<br>in ConnectivityManager
+
+note over core: 6. Disconnection — forwarded to active ChargePoint
+connectivity_manager ->> core: websocket_disconnected_callback(slot, profile)
+core ->> cp_v16: on_websocket_disconnected(slot, profile)
+
+note over core: 7. Network disconnected externally
+core ->> cp_v16: on_network_disconnected(ocpp_interface)
+cp_v16 ->> connectivity_manager: on_network_disconnected(ocpp_interface)
 ```

--- a/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
@@ -82,7 +82,8 @@ public:
     /// \param configuration_slot   The configuration slot to get the priority from.
     /// \return The priority if the configuration slot exists.
     ///
-    virtual std::optional<std::int32_t> get_priority_from_configuration_slot(const int configuration_slot) const = 0;
+    virtual std::optional<std::int32_t>
+    get_priority_from_configuration_slot(const std::int32_t configuration_slot) const = 0;
 
     /// @brief Get the network connection slots sorted by priority.
     /// Each item in the vector contains the configured configuration slots, where the slot with index 0 has the highest
@@ -169,7 +170,8 @@ private:
     OcppProtocolVersion connected_ocpp_version;
 
 public:
-    ConnectivityManager(ocpp::v2::DeviceModelAbstract& device_model, std::shared_ptr<EvseSecurity> evse_security);
+    ConnectivityManager(ocpp::v2::DeviceModelAbstract& device_model, std::shared_ptr<EvseSecurity> evse_security,
+                        const fs::path& share_path = {});
 
     void set_message_callback(const std::function<void(const std::string& message)>& callback) override;
     void set_logging(std::shared_ptr<MessageLogging> logging) override;

--- a/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
@@ -15,8 +15,8 @@
 
 namespace ocpp {
 namespace v2 {
-
 class DeviceModelAbstract;
+}
 
 /// \brief The result of a configuration of a network profile.
 struct ConfigNetworkResult {
@@ -25,15 +25,24 @@ struct ConfigNetworkResult {
 };
 
 using WebsocketConnectionCallback =
-    std::function<void(int configuration_slot, const NetworkConnectionProfile& network_connection_profile,
+    std::function<void(int configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile,
                        const OcppProtocolVersion version)>;
 using WebsocketConnectionFailedCallback = std::function<void(ConnectionFailedReason reason)>;
 using ConfigureNetworkConnectionProfileCallback = std::function<std::future<ConfigNetworkResult>(
-    const std::int32_t configuration_slot, const NetworkConnectionProfile& network_connection_profile)>;
+    const std::int32_t configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile)>;
 
 class ConnectivityManagerInterface {
 public:
     virtual ~ConnectivityManagerInterface() = default;
+
+    /// \brief Set the \p callback that is called when a message is received from the websocket
+    ///
+    virtual void set_message_callback(const std::function<void(const std::string& message)>& callback) = 0;
+
+    /// \brief Set the logger \p logging
+    ///
+    virtual void set_logging(std::shared_ptr<MessageLogging> logging) = 0;
+
     /// \brief Set the websocket \p authorization_key
     ///
     virtual void set_websocket_authorization_key(const std::string& authorization_key) = 0;
@@ -66,7 +75,7 @@ public:
     /// \brief Gets the cached NetworkConnectionProfile based on the given \p configuration_slot.
     /// This returns the value from the cached network connection profiles.
     /// \return Returns a profile if the slot is found
-    virtual std::optional<NetworkConnectionProfile>
+    virtual std::optional<ocpp::v2::NetworkConnectionProfile>
     get_network_connection_profile(const std::int32_t configuration_slot) const = 0;
 
     /// \brief Get the priority of the given configuration slot.
@@ -115,7 +124,7 @@ public:
     ///
     /// \param ocpp_interface The interface that is disconnected.
     ///
-    virtual void on_network_disconnected(OCPPInterfaceEnum ocpp_interface) = 0;
+    virtual void on_network_disconnected(ocpp::v2::OCPPInterfaceEnum ocpp_interface) = 0;
 
     /// \brief Called when the charging station certificate is changed
     ///
@@ -128,7 +137,7 @@ public:
 class ConnectivityManager : public ConnectivityManagerInterface {
 private:
     /// \brief Reference to the device model
-    DeviceModelAbstract& device_model;
+    ocpp::v2::DeviceModelAbstract& device_model;
     /// \brief Pointer to the evse security class
     std::shared_ptr<EvseSecurity> evse_security;
     /// \brief Pointer to the logger
@@ -154,16 +163,16 @@ private:
     std::int32_t active_network_configuration_priority;
     int last_known_security_level;
     /// @brief Local cached network connection profiles
-    std::vector<SetNetworkProfileRequest> cached_network_connection_profiles;
+    std::vector<ocpp::v2::SetNetworkProfileRequest> cached_network_connection_profiles;
     /// @brief local cached network connection priorities
     std::vector<std::int32_t> network_connection_slots;
     OcppProtocolVersion connected_ocpp_version;
 
 public:
-    ConnectivityManager(DeviceModelAbstract& device_model, std::shared_ptr<EvseSecurity> evse_security,
-                        std::shared_ptr<MessageLogging> logging, const fs::path& share_path,
-                        const std::function<void(const std::string& message)>& message_callback);
+    ConnectivityManager(ocpp::v2::DeviceModelAbstract& device_model, std::shared_ptr<EvseSecurity> evse_security);
 
+    void set_message_callback(const std::function<void(const std::string& message)>& callback) override;
+    void set_logging(std::shared_ptr<MessageLogging> logging) override;
     void set_websocket_authorization_key(const std::string& authorization_key) override;
     void set_websocket_connection_options(const WebsocketConnectionOptions& connection_options) override;
     void set_websocket_connection_options_without_reconnect() override;
@@ -171,16 +180,17 @@ public:
     void set_websocket_disconnected_callback(WebsocketConnectionCallback callback) override;
     void set_websocket_connection_failed_callback(WebsocketConnectionFailedCallback callback) override;
     void set_configure_network_connection_profile_callback(ConfigureNetworkConnectionProfileCallback callback) override;
-    std::optional<NetworkConnectionProfile>
+    std::optional<ocpp::v2::NetworkConnectionProfile>
     get_network_connection_profile(const std::int32_t configuration_slot) const override;
-    std::optional<std::int32_t> get_priority_from_configuration_slot(const int configuration_slot) const override;
+    std::optional<std::int32_t>
+    get_priority_from_configuration_slot(const std::int32_t configuration_slot) const override;
     const std::vector<int>& get_network_connection_slots() const override;
     bool is_websocket_connected() override;
     std::chrono::time_point<std::chrono::steady_clock> get_time_disconnected() const override;
     void connect(std::optional<std::int32_t> network_profile_slot = std::nullopt) override;
     void disconnect() override;
     bool send_to_websocket(const std::string& message) override;
-    void on_network_disconnected(OCPPInterfaceEnum ocpp_interface) override;
+    void on_network_disconnected(ocpp::v2::OCPPInterfaceEnum ocpp_interface) override;
     void on_charging_station_certificate_changed() override;
     void confirm_successful_connection() override;
 
@@ -203,7 +213,7 @@ private:
     /// \return The network configuration containing the network interface to use, nullptr if the request failed or the
     /// callback is not configured
     std::optional<ConfigNetworkResult>
-    handle_configure_network_connection_profile_callback(int slot, const NetworkConnectionProfile& profile);
+    handle_configure_network_connection_profile_callback(int slot, const ocpp::v2::NetworkConnectionProfile& profile);
 
     /// \brief Function invoked when the web socket connected with the \p security_profile
     ///
@@ -250,5 +260,4 @@ private:
     void remove_network_connection_profiles_below_actual_security_profile();
 };
 
-} // namespace v2
 } // namespace ocpp

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
@@ -90,6 +90,28 @@ public:
     /// @{
 
     ///
+    /// \brief Shall be called when a websocket connection has been established in case the connectivity_handler is
+    /// provided exernally.
+    /// \param configuration_slot The network profile slot used for the connection.
+    /// \param network_connection_profile The network connection profile used for the connection.
+    virtual void on_websocket_connected(const int configuration_slot,
+                                        const NetworkConnectionProfile& network_connection_profile,
+                                        const OcppProtocolVersion ocpp_version) = 0;
+
+    ///
+    /// \brief Shall be called when a websocket connection has been disconnected in case the connectivity_handler is
+    /// provided externally.
+    /// \param configuration_slot The network profile slot used for the connection.
+    /// \param network_connection_profile The network connection profile used for the connection.
+    virtual void on_websocket_disconnected(const int configuration_slot,
+                                           const NetworkConnectionProfile& network_connection_profile) = 0;
+
+    /// \brief Shall be called when a websocket connection attempt has failed in case the connectivity_handler is
+    /// provided externally.
+    /// \param reason The reason why the connection failed.
+    virtual void on_websocket_connection_failed(ConnectionFailedReason reason) = 0;
+
+    ///
     /// \brief Can be called when a network is disconnected, for example when an ethernet cable is removed.
     ///
     /// This is introduced because the websocket can take several minutes to timeout when a network interface becomes
@@ -345,7 +367,7 @@ class ChargePoint : public ChargePointInterface, private ocpp::ChargingStationBa
 private:
     std::shared_ptr<DeviceModelAbstract> device_model;
     std::unique_ptr<EvseManager> evse_manager;
-    std::unique_ptr<ConnectivityManager> connectivity_manager;
+    std::shared_ptr<ConnectivityManagerInterface> connectivity_manager;
 
     std::unique_ptr<MessageDispatcherInterface<MessageType>> message_dispatcher;
 
@@ -373,13 +395,13 @@ private:
     fs::path share_path;
 
     // states
-    std::atomic<RegistrationStatusEnum> registration_status;
-    std::atomic<OcppProtocolVersion> ocpp_version =
-        OcppProtocolVersion::Unknown; // version that is currently in use, selected by CSMS in websocket handshake
-    std::atomic<UploadLogStatusEnum> upload_log_status;
+    std::atomic<RegistrationStatusEnum> registration_status{RegistrationStatusEnum::Rejected};
+    std::atomic<OcppProtocolVersion> ocpp_version{
+        OcppProtocolVersion::Unknown}; // version that is currently in use, selected by CSMS in websocket handshake
+    std::atomic<UploadLogStatusEnum> upload_log_status{UploadLogStatusEnum::Idle};
     std::atomic<std::int32_t> upload_log_status_id;
-    BootReasonEnum bootreason;
-    bool skip_invalid_csms_certificate_notifications;
+    BootReasonEnum bootreason{BootReasonEnum::PowerUp};
+    bool skip_invalid_csms_certificate_notifications{false};
 
     /// \brief Component responsible for maintaining and persisting the operational status of CS, EVSEs, and connectors.
     std::shared_ptr<ComponentStateManagerInterface> component_state_manager;
@@ -411,12 +433,7 @@ private:
     // internal helper functions
     void initialize(const std::map<std::int32_t, std::int32_t>& evse_connector_structure,
                     const std::string& message_log_path);
-    void websocket_connected_callback(const int configuration_slot,
-                                      const NetworkConnectionProfile& network_connection_profile,
-                                      const OcppProtocolVersion ocpp_version);
-    void websocket_disconnected_callback(const int configuration_slot,
-                                         const NetworkConnectionProfile& network_connection_profile);
-    void websocket_connection_failed(ConnectionFailedReason reason);
+    OcspUpdater make_ocsp_updater();
     void update_dm_availability_state(const std::int32_t evse_id, const std::int32_t connector_id,
                                       const ConnectorStatusEnum status);
 
@@ -461,6 +478,23 @@ public:
 
     /// @name Constructors for 2.0.1
     /// @{
+
+    /// \brief Construct a new ChargePoint object
+    /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The
+    /// key represents the id of the EVSE and the value represents the number of connectors for this EVSE. The ids of
+    /// the EVSEs have to increment starting with 1.
+    /// \param device_model device model instance
+    /// \param database_handler database handler instance
+    /// \param evse_security Pointer to evse_security that manages security related operations
+    /// \param connectivity_manager connectivity manager instance
+    /// \param message_log_path Path to where logfiles are written to
+    /// \param callbacks Callbacks that will be registered for ChargePoint
+    ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
+                const std::shared_ptr<DeviceModelAbstract> device_model,
+                const std::shared_ptr<DatabaseHandler> database_handler,
+                const std::shared_ptr<EvseSecurity> evse_security,
+                const std::shared_ptr<ConnectivityManagerInterface> connectivity_manager,
+                const std::string& message_log_path, const Callbacks& callbacks);
 
     /// \brief Construct a new ChargePoint object
     /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The
@@ -526,6 +560,12 @@ public:
     void connect_websocket(std::optional<std::int32_t> network_profile_slot = std::nullopt) override;
     void disconnect_websocket() override;
 
+    void on_websocket_connected(const int configuration_slot,
+                                const NetworkConnectionProfile& network_connection_profile,
+                                const OcppProtocolVersion ocpp_version) override;
+    void on_websocket_disconnected(const int configuration_slot,
+                                   const NetworkConnectionProfile& network_connection_profile) override;
+    void on_websocket_connection_failed(ConnectionFailedReason reason) override;
     void on_network_disconnected(OCPPInterfaceEnum ocpp_interface) override;
 
     void on_firmware_update_status_notification(std::int32_t request_id,

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
@@ -506,10 +506,12 @@ public:
     /// \param message_log_path Path to where logfiles are written to
     /// \param evse_security Pointer to evse_security that manages security related operations
     /// \param callbacks Callbacks that will be registered for ChargePoint
+    /// \param share_path Path where utility files for OCPP are read and written to
     ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connector_structure,
                 std::shared_ptr<DeviceModelAbstract> device_model, std::shared_ptr<DatabaseHandler> database_handler,
                 std::shared_ptr<MessageQueue<v2::MessageType>> message_queue, const std::string& message_log_path,
-                const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks);
+                const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks,
+                const fs::path& share_path = {});
 
     /// \brief Construct a new ChargePoint object
     /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point_callbacks.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point_callbacks.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <memory>
 
-#include <ocpp/v2/connectivity_manager.hpp>
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/v2/device_model.hpp>
 
 #include <ocpp/v2/messages/BootNotification.hpp>

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/functional_block_context.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/functional_block_context.hpp
@@ -8,10 +8,10 @@
 
 namespace ocpp {
 class EvseSecurity;
+class ConnectivityManagerInterface;
 
 namespace v2 {
 class DeviceModelAbstract;
-class ConnectivityManagerInterface;
 class EvseManagerInterface;
 class DatabaseHandlerInterface;
 class ComponentStateManagerInterface;

--- a/lib/everest/ocpp/include/ocpp/v2/message_dispatcher.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/message_dispatcher.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/common/message_dispatcher.hpp>
-#include <ocpp/v2/connectivity_manager.hpp>
 #include <ocpp/v2/device_model_abstract.hpp>
 
 namespace ocpp {

--- a/lib/everest/ocpp/lib/CMakeLists.txt
+++ b/lib/everest/ocpp/lib/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(ocpp
     PRIVATE
         ocpp/common/call_types.cpp
         ocpp/common/charging_station_base.cpp
+        ocpp/common/connectivity_manager.cpp
         ocpp/common/ocpp_logging.cpp
         ocpp/common/schemas.cpp
         ocpp/common/types.cpp
@@ -92,7 +93,6 @@ if(LIBOCPP_ENABLE_V2)
             ocpp/v2/types.cpp
             ocpp/v2/utils.cpp
             ocpp/v2/component_state_manager.cpp
-            ocpp/v2/connectivity_manager.cpp
             ocpp/v2/message_dispatcher.cpp
             ocpp/v2/functional_blocks/authorization.cpp
             ocpp/v2/functional_blocks/availability.cpp

--- a/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
@@ -28,11 +28,10 @@ using SetNetworkProfileRequest = ocpp::v2::SetNetworkProfileRequest;
 namespace ControllerComponentVariables = ocpp::v2::ControllerComponentVariables;
 
 ConnectivityManager::ConnectivityManager(ocpp::v2::DeviceModelAbstract& device_model,
-                                         std::shared_ptr<EvseSecurity> evse_security,
-                                        std::shared_ptr<MessageLogging> logging, const fs::path& share_path,
-                                         const std::function<void(const std::string& message)>& message_callback) :
+                                         std::shared_ptr<EvseSecurity> evse_security, const fs::path& share_path) :
     device_model{device_model},
     evse_security{evse_security},
+    share_path{share_path},
     message_callback([](const std::string& message) {
         EVLOG_warning << "No message callback set in ConnectivityManager. Dropping message: " << message;
     }),
@@ -431,7 +430,7 @@ void ConnectivityManager::on_websocket_connected(OcppProtocolVersion protocol) {
 void ConnectivityManager::on_websocket_disconnected() {
     std::optional<NetworkConnectionProfile> network_connection_profile =
         this->get_network_connection_profile(this->get_active_network_configuration_slot());
-    if (this->time_disconnected.load().time_since_epoch() == 0s) {
+    if (this->time_disconnected.load().time_since_epoch() == std::chrono::seconds(0)) {
         this->time_disconnected = std::chrono::steady_clock::now();
     }
 

--- a/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
 
-#include <ocpp/v2/connectivity_manager.hpp>
+#include <ocpp/common/connectivity_manager.hpp>
 
 #include <fstream>
 
@@ -19,24 +19,37 @@ constexpr std::int32_t default_network_config_timeout_seconds = 60;
 } // namespace
 
 namespace ocpp {
-namespace v2 {
 
-using namespace std::chrono_literals;
+using NetworkConnectionProfile = ocpp::v2::NetworkConnectionProfile;
+using AttributeEnum = ocpp::v2::AttributeEnum;
+using DeviceModel = ocpp::v2::DeviceModel;
+using OCPPInterfaceEnum = ocpp::v2::OCPPInterfaceEnum;
+using SetNetworkProfileRequest = ocpp::v2::SetNetworkProfileRequest;
+namespace ControllerComponentVariables = ocpp::v2::ControllerComponentVariables;
 
-ConnectivityManager::ConnectivityManager(DeviceModelAbstract& device_model, std::shared_ptr<EvseSecurity> evse_security,
-                                         std::shared_ptr<MessageLogging> logging, const fs::path& share_path,
+ConnectivityManager::ConnectivityManager(ocpp::v2::DeviceModelAbstract& device_model,
+                                         std::shared_ptr<EvseSecurity> evse_security,
+                                        std::shared_ptr<MessageLogging> logging, const fs::path& share_path,
                                          const std::function<void(const std::string& message)>& message_callback) :
     device_model{device_model},
     evse_security{evse_security},
-    logging{logging},
-    share_path{share_path},
+    message_callback([](const std::string& message) {
+        EVLOG_warning << "No message callback set in ConnectivityManager. Dropping message: " << message;
+    }),
     websocket{nullptr},
-    message_callback{message_callback},
     wants_to_be_connected{false},
     active_network_configuration_priority{0},
     last_known_security_level{0},
     connected_ocpp_version{OcppProtocolVersion::Unknown} {
     cache_network_connection_profiles();
+}
+
+void ConnectivityManager::set_message_callback(const std::function<void(const std::string& message)>& callback) {
+    this->message_callback = callback;
+}
+
+void ConnectivityManager::set_logging(std::shared_ptr<MessageLogging> logging) {
+    this->logging = logging;
 }
 
 void ConnectivityManager::set_websocket_authorization_key(const std::string& authorization_key) {
@@ -347,7 +360,7 @@ ConnectivityManager::get_ws_connection_options(const std::int32_t configuration_
             this->device_model.get_value<std::string>(ControllerComponentVariables::SecurityCtrlrIdentity),
             network_connection_profile.securityProfile);
 
-        const auto ocpp_versions = utils::get_ocpp_protocol_versions(
+        const auto ocpp_versions = ocpp::v2::utils::get_ocpp_protocol_versions(
             this->device_model.get_value<std::string>(ControllerComponentVariables::SupportedOcppVersions));
 
         WebsocketConnectionOptions connection_options{
@@ -552,5 +565,4 @@ void ConnectivityManager::remove_network_connection_profiles_below_actual_securi
                                  AttributeEnum::Actual, new_network_priority, VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
 }
 
-} // namespace v2
 } // namespace ocpp

--- a/lib/everest/ocpp/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/websocket/websocket.cpp
@@ -16,6 +16,11 @@ namespace ocpp {
 Websocket::Websocket(const WebsocketConnectionOptions& connection_options, std::shared_ptr<EvseSecurity> evse_security,
                      std::shared_ptr<MessageLogging> logging) :
     logging(logging) {
+
+    if (logging == nullptr) {
+        throw std::runtime_error("Websocket requires a valid MessageLogging instance");
+    }
+
     this->websocket = std::make_unique<WebsocketLibwebsockets>(connection_options, evse_security);
 }
 

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -127,7 +127,7 @@ void ChargePoint::start(BootReasonEnum bootreason, bool start_connecting) {
     // call clear_invalid_charging_profiles when system boots
     this->clear_invalid_charging_profiles();
 
-    if (start_connecting) {
+    if (start_connecting && !this->connectivity_manager->is_websocket_connected()) {
         this->connectivity_manager->connect();
     }
 
@@ -171,90 +171,6 @@ void ChargePoint::stop() {
 
 void ChargePoint::disconnect_websocket() {
     this->connectivity_manager->disconnect();
-}
-
-void ChargePoint::on_websocket_connected(const int configuration_slot,
-                                         const NetworkConnectionProfile& network_connection_profile,
-                                         const OcppProtocolVersion ocpp_version) {
-    this->message_queue->resume(this->message_queue_resume_delay);
-    this->ocpp_version = ocpp_version;
-    if (this->registration_status == RegistrationStatusEnum::Accepted) {
-        this->connectivity_manager->confirm_successful_connection();
-
-        if (this->time_disconnected.time_since_epoch() != 0s) {
-            // handle offline threshold
-            //  Get the current time point using steady_clock
-            auto offline_duration = std::chrono::steady_clock::now() - this->time_disconnected;
-
-            // B04.FR.01
-            // If offline period exceeds offline threshold then send the status notification for all connectors
-            if (offline_duration > std::chrono::seconds(this->device_model->get_value<int>(
-                                       ControllerComponentVariables::OfflineThreshold))) {
-                EVLOG_debug << "offline for more than offline threshold ";
-                this->component_state_manager->send_status_notification_all_connectors();
-            } else {
-                // B04.FR.02
-                // If offline period doesn't exceed offline threshold then send the status notification for all
-                // connectors that changed state
-                EVLOG_debug << "offline for less than offline threshold ";
-                this->component_state_manager->send_status_notification_changed_connectors();
-            }
-            this->security->init_certificate_expiration_check_timers(); // re-init as timers are stopped on disconnect
-        }
-    }
-    // set time_disconnected to zero
-    this->time_disconnected = std::chrono::time_point<std::chrono::steady_clock>();
-
-    // We have a connection again so next time it fails we should send the notification again
-    this->skip_invalid_csms_certificate_notifications = false;
-
-    if (this->callbacks.connection_state_changed_callback.has_value()) {
-        this->callbacks.connection_state_changed_callback.value()(true, configuration_slot, network_connection_profile,
-                                                                  ocpp_version);
-    }
-}
-
-void ChargePoint::on_websocket_disconnected(const int configuration_slot,
-                                            const NetworkConnectionProfile& network_connection_profile) {
-    this->message_queue->pause();
-
-    // check if offline threshold has been defined
-    if (this->device_model->get_value<int>(ControllerComponentVariables::OfflineThreshold) != 0) {
-        // Get the current time point using steady_clock
-        this->time_disconnected = std::chrono::steady_clock::now();
-    }
-
-    this->security->stop_certificate_expiration_check_timers();
-    if (this->callbacks.connection_state_changed_callback.has_value()) {
-        this->callbacks.connection_state_changed_callback.value()(false, configuration_slot, network_connection_profile,
-                                                                  this->ocpp_version);
-    }
-}
-
-void ChargePoint::on_websocket_connection_failed(ConnectionFailedReason reason) {
-    switch (reason) {
-    case ConnectionFailedReason::InvalidCSMSCertificate:
-        if (!this->skip_invalid_csms_certificate_notifications) {
-            this->security->security_event_notification_req(CiString<50>(ocpp::security_events::INVALIDCSMSCERTIFICATE),
-                                                            std::nullopt, true, true);
-            this->skip_invalid_csms_certificate_notifications = true;
-        } else {
-            EVLOG_debug << "Skipping InvalidCsmsCertificate SecurityEvent since it has been sent already";
-        }
-        break;
-    case ConnectionFailedReason::FailedToAuthenticateAtCsms: {
-        const auto& security_event = ocpp::security_events::FAILEDTOAUTHENTICATEATCSMS;
-        this->security->security_event_notification_req(CiString<50>(security_event), std::nullopt, true,
-                                                        utils::is_critical(security_event));
-        break;
-    }
-    default: {
-        const auto& security_event = "WebsocketConnectionFailedWithUnknownReason";
-        EVLOG_error << "Websocket connection failed with unknown reason";
-        this->security->security_event_notification_req(CiString<50>(security_event), std::nullopt, true, false);
-        break;
-    }
-    }
 }
 
 void ChargePoint::on_network_disconnected(OCPPInterfaceEnum ocpp_interface) {
@@ -583,7 +499,8 @@ void ChargePoint::initialize(const std::map<std::int32_t, std::int32_t>& evse_co
 
     if (this->connectivity_manager == nullptr) {
         // connectivity manager was not provided in constructor. Create a new one and set the message callbacks
-        this->connectivity_manager = std::make_shared<ConnectivityManager>(*this->device_model, this->evse_security);
+        this->connectivity_manager =
+            std::make_shared<ConnectivityManager>(*this->device_model, this->evse_security, this->share_path);
         this->connectivity_manager->set_websocket_connected_callback(
             [this](int configuration_slot, const NetworkConnectionProfile& network_connection_profile,
                    const OcppProtocolVersion ocpp_version) {
@@ -1197,9 +1114,9 @@ std::optional<DataTransferResponse> ChargePoint::data_transfer_req(const DataTra
     return this->data_transfer->data_transfer_req(request);
 }
 
-void ChargePoint::websocket_connected_callback(const int configuration_slot,
-                                               const NetworkConnectionProfile& network_connection_profile,
-                                               const OcppProtocolVersion ocpp_version) {
+void ChargePoint::on_websocket_connected(const int configuration_slot,
+                                         const NetworkConnectionProfile& network_connection_profile,
+                                         const OcppProtocolVersion ocpp_version) {
     this->message_queue->update_message_timeout(network_connection_profile.messageTimeout);
     this->message_queue->resume(this->message_queue_resume_delay);
     this->ocpp_version = ocpp_version;
@@ -1243,8 +1160,8 @@ void ChargePoint::websocket_connected_callback(const int configuration_slot,
     }
 }
 
-void ChargePoint::websocket_disconnected_callback(const int configuration_slot,
-                                                  const NetworkConnectionProfile& network_connection_profile) {
+void ChargePoint::on_websocket_disconnected(const int configuration_slot,
+                                            const NetworkConnectionProfile& network_connection_profile) {
     this->message_queue->pause();
 
     this->security->stop_certificate_expiration_check_timers();
@@ -1257,7 +1174,7 @@ void ChargePoint::websocket_disconnected_callback(const int configuration_slot,
     }
 }
 
-void ChargePoint::websocket_connection_failed(ConnectionFailedReason reason) {
+void ChargePoint::on_websocket_connection_failed(ConnectionFailedReason reason) {
     switch (reason) {
     case ConnectionFailedReason::InvalidCSMSCertificate:
         if (!this->skip_invalid_csms_certificate_notifications) {
@@ -1268,13 +1185,21 @@ void ChargePoint::websocket_connection_failed(ConnectionFailedReason reason) {
             EVLOG_debug << "Skipping InvalidCsmsCertificate SecurityEvent since it has been sent already";
         }
         break;
-    case ConnectionFailedReason::FailedToAuthenticateAtCsms:
+    case ConnectionFailedReason::FailedToAuthenticateAtCsms: {
         const auto& security_event = ocpp::security_events::FAILEDTOAUTHENTICATEATCSMS;
         this->security->security_event_notification_req(CiString<50>(security_event), std::nullopt, true,
                                                         utils::is_critical(security_event));
         break;
     }
+    default: {
+        const auto& security_event = "WebsocketConnectionFailedWithUnknownReason";
+        EVLOG_error << "Websocket connection failed with unknown reason";
+        this->security->security_event_notification_req(CiString<50>(security_event), std::nullopt, true, false);
+        break;
+    }
+    }
 }
+
 void ChargePoint::update_dm_availability_state(const std::int32_t evse_id, const std::int32_t connector_id,
                                                const ConnectorStatusEnum status) {
     RequiredComponentVariable charging_station = ControllerComponentVariables::ChargingStationAvailabilityState;

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -48,6 +48,21 @@ namespace v2 {
 const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 1000;
 
 ChargePoint::ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connector_structure,
+                         const std::shared_ptr<DeviceModelAbstract> device_model,
+                         const std::shared_ptr<DatabaseHandler> database_handler,
+                         const std::shared_ptr<EvseSecurity> evse_security,
+                         const std::shared_ptr<ConnectivityManagerInterface> connectivity_manager,
+                         const std::string& message_log_path, const Callbacks& callbacks) :
+    ocpp::ChargingStationBase(evse_security),
+    device_model(device_model),
+    database_handler(database_handler),
+    connectivity_manager(connectivity_manager),
+    ocsp_updater(make_ocsp_updater()),
+    callbacks(callbacks) {
+    initialize(evse_connector_structure, message_log_path);
+}
+
+ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
                          std::shared_ptr<DeviceModelAbstract> device_model,
                          std::shared_ptr<DatabaseHandler> database_handler,
                          std::shared_ptr<MessageQueue<v2::MessageType>> message_queue,
@@ -57,37 +72,8 @@ ChargePoint::ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connec
     message_queue(message_queue),
     device_model(device_model),
     database_handler(database_handler),
-    registration_status(RegistrationStatusEnum::Rejected),
-    skip_invalid_csms_certificate_notifications(false),
-    upload_log_status(UploadLogStatusEnum::Idle),
-    bootreason(BootReasonEnum::PowerUp),
-    ocsp_updater(this->evse_security,
-                 [this](GetCertificateStatusRequest req) -> GetCertificateStatusResponse {
-                     try {
-                         return this->send_callback<GetCertificateStatusRequest, GetCertificateStatusResponse>(
-                             MessageType::GetCertificateStatusResponse)(req);
-                     } catch (const UnexpectedMessageTypeFromCSMS& e) {
-                         EVLOG_warning << e.what();
-                     }
-                     GetCertificateStatusResponse response;
-                     response.status = GetCertificateStatusEnum::Failed;
-                     return response;
-                 }),
+    ocsp_updater(make_ocsp_updater()),
     callbacks(callbacks) {
-
-    if (!this->device_model) {
-        EVLOG_AND_THROW(std::invalid_argument("Device model should not be null"));
-    }
-
-    // Make sure the received callback struct is completely filled early before we actually start running
-    if (!this->callbacks.all_callbacks_valid(this->device_model, evse_connector_structure)) {
-        EVLOG_AND_THROW(std::invalid_argument("All non-optional callbacks must be supplied"));
-    }
-
-    if (!this->database_handler) {
-        EVLOG_AND_THROW(std::invalid_argument("Database handler should not be null"));
-    }
-
     initialize(evse_connector_structure, message_log_path);
 }
 
@@ -122,6 +108,8 @@ ChargePoint::ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connec
 ChargePoint::~ChargePoint() = default;
 
 void ChargePoint::start(BootReasonEnum bootreason, bool start_connecting) {
+    this->connectivity_manager->set_message_callback(
+        std::bind(&ChargePoint::message_callback, this, std::placeholders::_1));
     this->message_queue->start();
 
     // Publish the initial default price before connecting (offline state at startup).
@@ -183,6 +171,90 @@ void ChargePoint::stop() {
 
 void ChargePoint::disconnect_websocket() {
     this->connectivity_manager->disconnect();
+}
+
+void ChargePoint::on_websocket_connected(const int configuration_slot,
+                                         const NetworkConnectionProfile& network_connection_profile,
+                                         const OcppProtocolVersion ocpp_version) {
+    this->message_queue->resume(this->message_queue_resume_delay);
+    this->ocpp_version = ocpp_version;
+    if (this->registration_status == RegistrationStatusEnum::Accepted) {
+        this->connectivity_manager->confirm_successful_connection();
+
+        if (this->time_disconnected.time_since_epoch() != 0s) {
+            // handle offline threshold
+            //  Get the current time point using steady_clock
+            auto offline_duration = std::chrono::steady_clock::now() - this->time_disconnected;
+
+            // B04.FR.01
+            // If offline period exceeds offline threshold then send the status notification for all connectors
+            if (offline_duration > std::chrono::seconds(this->device_model->get_value<int>(
+                                       ControllerComponentVariables::OfflineThreshold))) {
+                EVLOG_debug << "offline for more than offline threshold ";
+                this->component_state_manager->send_status_notification_all_connectors();
+            } else {
+                // B04.FR.02
+                // If offline period doesn't exceed offline threshold then send the status notification for all
+                // connectors that changed state
+                EVLOG_debug << "offline for less than offline threshold ";
+                this->component_state_manager->send_status_notification_changed_connectors();
+            }
+            this->security->init_certificate_expiration_check_timers(); // re-init as timers are stopped on disconnect
+        }
+    }
+    // set time_disconnected to zero
+    this->time_disconnected = std::chrono::time_point<std::chrono::steady_clock>();
+
+    // We have a connection again so next time it fails we should send the notification again
+    this->skip_invalid_csms_certificate_notifications = false;
+
+    if (this->callbacks.connection_state_changed_callback.has_value()) {
+        this->callbacks.connection_state_changed_callback.value()(true, configuration_slot, network_connection_profile,
+                                                                  ocpp_version);
+    }
+}
+
+void ChargePoint::on_websocket_disconnected(const int configuration_slot,
+                                            const NetworkConnectionProfile& network_connection_profile) {
+    this->message_queue->pause();
+
+    // check if offline threshold has been defined
+    if (this->device_model->get_value<int>(ControllerComponentVariables::OfflineThreshold) != 0) {
+        // Get the current time point using steady_clock
+        this->time_disconnected = std::chrono::steady_clock::now();
+    }
+
+    this->security->stop_certificate_expiration_check_timers();
+    if (this->callbacks.connection_state_changed_callback.has_value()) {
+        this->callbacks.connection_state_changed_callback.value()(false, configuration_slot, network_connection_profile,
+                                                                  this->ocpp_version);
+    }
+}
+
+void ChargePoint::on_websocket_connection_failed(ConnectionFailedReason reason) {
+    switch (reason) {
+    case ConnectionFailedReason::InvalidCSMSCertificate:
+        if (!this->skip_invalid_csms_certificate_notifications) {
+            this->security->security_event_notification_req(CiString<50>(ocpp::security_events::INVALIDCSMSCERTIFICATE),
+                                                            std::nullopt, true, true);
+            this->skip_invalid_csms_certificate_notifications = true;
+        } else {
+            EVLOG_debug << "Skipping InvalidCsmsCertificate SecurityEvent since it has been sent already";
+        }
+        break;
+    case ConnectionFailedReason::FailedToAuthenticateAtCsms: {
+        const auto& security_event = ocpp::security_events::FAILEDTOAUTHENTICATEATCSMS;
+        this->security->security_event_notification_req(CiString<50>(security_event), std::nullopt, true,
+                                                        utils::is_critical(security_event));
+        break;
+    }
+    default: {
+        const auto& security_event = "WebsocketConnectionFailedWithUnknownReason";
+        EVLOG_error << "Websocket connection failed with unknown reason";
+        this->security->security_event_notification_req(CiString<50>(security_event), std::nullopt, true, false);
+        break;
+    }
+    }
 }
 
 void ChargePoint::on_network_disconnected(OCPPInterfaceEnum ocpp_interface) {
@@ -438,6 +510,19 @@ void ChargePoint::on_ev_charging_needs(const NotifyEVChargingNeedsRequest& reque
 
 void ChargePoint::initialize(const std::map<std::int32_t, std::int32_t>& evse_connector_structure,
                              const std::string& message_log_path) {
+    if (this->device_model == nullptr) {
+        EVLOG_AND_THROW(std::invalid_argument("Device model should not be null"));
+    }
+
+    // Make sure the received callback struct is completely filled early before we actually start running
+    if (!this->callbacks.all_callbacks_valid(this->device_model, evse_connector_structure)) {
+        EVLOG_AND_THROW(std::invalid_argument("All non-optional callbacks must be supplied"));
+    }
+
+    if (this->database_handler == nullptr) {
+        EVLOG_AND_THROW(std::invalid_argument("Database handler should not be null"));
+    }
+
     this->device_model->check_integrity(evse_connector_structure);
     this->database_handler->open_connection();
     this->component_state_manager = std::make_shared<ComponentStateManager>(
@@ -493,23 +578,25 @@ void ChargePoint::initialize(const std::map<std::int32_t, std::int32_t>& evse_co
     this->evse_manager = std::make_unique<EvseManager>(
         evse_connector_structure, *this->device_model, this->database_handler, component_state_manager,
         transaction_meter_value_callback, this->callbacks.pause_charging_callback);
+
     this->configure_message_logging_format(message_log_path);
 
-    this->connectivity_manager =
-        std::make_unique<ConnectivityManager>(*this->device_model, this->evse_security, this->logging, this->share_path,
-                                              [this](const std::string& message) { this->message_callback(message); });
-
-    this->connectivity_manager->set_websocket_connected_callback(
-        [this](int configuration_slot, const NetworkConnectionProfile& network_connection_profile,
-               const OcppProtocolVersion ocpp_version) {
-            this->websocket_connected_callback(configuration_slot, network_connection_profile, ocpp_version);
-        });
-    this->connectivity_manager->set_websocket_disconnected_callback(
-        [this](int configuration_slot, const NetworkConnectionProfile& network_connection_profile, auto) {
-            this->websocket_disconnected_callback(configuration_slot, network_connection_profile);
-        });
-    this->connectivity_manager->set_websocket_connection_failed_callback(
-        [this](ConnectionFailedReason reason) { this->websocket_connection_failed(reason); });
+    if (this->connectivity_manager == nullptr) {
+        // connectivity manager was not provided in constructor. Create a new one and set the message callbacks
+        this->connectivity_manager = std::make_shared<ConnectivityManager>(*this->device_model, this->evse_security);
+        this->connectivity_manager->set_websocket_connected_callback(
+            [this](int configuration_slot, const NetworkConnectionProfile& network_connection_profile,
+                   const OcppProtocolVersion ocpp_version) {
+                this->on_websocket_connected(configuration_slot, network_connection_profile, ocpp_version);
+            });
+        this->connectivity_manager->set_websocket_disconnected_callback(
+            [this](int configuration_slot, const NetworkConnectionProfile& network_connection_profile, auto) {
+                this->on_websocket_disconnected(configuration_slot, network_connection_profile);
+            });
+        this->connectivity_manager->set_websocket_connection_failed_callback(
+            std::bind(&ChargePoint::on_websocket_connection_failed, this, std::placeholders::_1));
+    }
+    this->connectivity_manager->set_logging(this->logging);
 
     if (this->message_queue == nullptr) {
         std::set<v2::MessageType> message_types_discard_for_queueing;
@@ -658,6 +745,20 @@ void ChargePoint::initialize(const std::map<std::int32_t, std::int32_t>& evse_co
     this->device_model->set_value(ControllerComponents::OCPPCommCtrlr, field_length, AttributeEnum::Actual,
                                   std::to_string(ISO15118_GET_EV_CERTIFICATE_EXI_RESPONSE_SIZE),
                                   VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL, true);
+}
+
+OcspUpdater ChargePoint::make_ocsp_updater() {
+    return OcspUpdater(this->evse_security, [this](GetCertificateStatusRequest req) -> GetCertificateStatusResponse {
+        try {
+            return this->send_callback<GetCertificateStatusRequest, GetCertificateStatusResponse>(
+                MessageType::GetCertificateStatusResponse)(req);
+        } catch (const UnexpectedMessageTypeFromCSMS& e) {
+            EVLOG_warning << e.what();
+        }
+        GetCertificateStatusResponse response;
+        response.status = GetCertificateStatusEnum::Failed;
+        return response;
+    });
 }
 
 void ChargePoint::handle_message(const EnhancedMessage<v2::MessageType>& message) {

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -67,11 +67,12 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
                          std::shared_ptr<DatabaseHandler> database_handler,
                          std::shared_ptr<MessageQueue<v2::MessageType>> message_queue,
                          const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
-                         const Callbacks& callbacks) :
+                         const Callbacks& callbacks, const fs::path& share_path) :
     ocpp::ChargingStationBase(evse_security),
     message_queue(message_queue),
     device_model(device_model),
     database_handler(database_handler),
+    share_path(share_path),
     ocsp_updater(make_ocsp_updater()),
     callbacks(callbacks) {
     initialize(evse_connector_structure, message_log_path);
@@ -86,9 +87,8 @@ ChargePoint::ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connec
         evse_connector_structure, std::make_shared<DeviceModel>(std::move(device_model_storage_interface)),
         std::make_shared<DatabaseHandler>(
             std::make_unique<everest::db::sqlite::Connection>(fs::path(core_database_path) / "cp.db"), sql_init_path),
-        nullptr /* message_queue initialized in this constructor */, message_log_path, evse_security, callbacks) {
-
-    this->share_path = ocpp_main_path;
+        nullptr /* message_queue initialized in this constructor */, message_log_path, evse_security, callbacks,
+        ocpp_main_path) {
 }
 
 ChargePoint::ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connector_structure,
@@ -101,8 +101,6 @@ ChargePoint::ChargePoint(const std::map<std::int32_t, std::int32_t>& evse_connec
                 std::make_unique<DeviceModelStorageSqlite>(device_model_storage_address, device_model_migration_path,
                                                            device_model_config_path),
                 ocpp_main_path, core_database_path, sql_init_path, message_log_path, evse_security, callbacks) {
-
-    this->share_path = ocpp_main_path;
 }
 
 ChargePoint::~ChargePoint() = default;

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/authorization.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/authorization.cpp
@@ -3,9 +3,9 @@
 
 #include <ocpp/v2/functional_blocks/authorization.hpp>
 
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/common/constants.hpp>
 #include <ocpp/common/evse_security.hpp>
-#include <ocpp/v2/connectivity_manager.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/database_handler.hpp>
 #include <ocpp/v2/device_model.hpp>

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/diagnostics.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/diagnostics.cpp
@@ -3,8 +3,8 @@
 
 #include <ocpp/v2/functional_blocks/diagnostics.hpp>
 
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/common/constants.hpp>
-#include <ocpp/v2/connectivity_manager.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/database_handler.hpp>
 #include <ocpp/v2/device_model.hpp>

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/provisioning.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/provisioning.cpp
@@ -3,10 +3,10 @@
 
 #include <ocpp/v2/functional_blocks/provisioning.hpp>
 
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/common/constants.hpp>
 #include <ocpp/common/evse_security.hpp>
 #include <ocpp/v2/component_state_manager.hpp>
-#include <ocpp/v2/connectivity_manager.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/evse_manager.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/remote_transaction_control.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/remote_transaction_control.cpp
@@ -3,7 +3,7 @@
 
 #include <ocpp/v2/functional_blocks/remote_transaction_control.hpp>
 
-#include <ocpp/v2/connectivity_manager.hpp>
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/evse_manager.hpp>

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/security.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/security.cpp
@@ -3,9 +3,9 @@
 
 #include <ocpp/v2/functional_blocks/security.hpp>
 
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/common/constants.hpp>
 #include <ocpp/common/ocpp_logging.hpp>
-#include <ocpp/v2/connectivity_manager.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -8,7 +8,7 @@
 
 #include <ocpp/common/constants.hpp>
 
-#include <ocpp/v2/connectivity_manager.hpp>
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/evse_manager.hpp>

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
@@ -3,7 +3,7 @@
 
 #include <ocpp/v2/functional_blocks/transaction.hpp>
 
-#include <ocpp/v2/connectivity_manager.hpp>
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/evse_manager.hpp>

--- a/lib/everest/ocpp/lib/ocpp/v21/functional_blocks/bidirectional.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v21/functional_blocks/bidirectional.cpp
@@ -5,9 +5,9 @@
 
 #include <ocpp/v21/functional_blocks/bidirectional.hpp>
 
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/common/constants.hpp>
 #include <ocpp/common/evse_security.hpp>
-#include <ocpp/v2/connectivity_manager.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/database_handler.hpp>
 #include <ocpp/v2/device_model.hpp>

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/mocks/connectivity_manager_mock.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/mocks/connectivity_manager_mock.hpp
@@ -5,11 +5,13 @@
 
 #include "gmock/gmock.h"
 
-#include <ocpp/v2/connectivity_manager.hpp>
+#include <ocpp/common/connectivity_manager.hpp>
 
 namespace ocpp::v2 {
-class ConnectivityManagerMock : public ConnectivityManagerInterface {
+class ConnectivityManagerMock : public ocpp::ConnectivityManagerInterface {
 public:
+    MOCK_METHOD(void, set_message_callback, (const std::function<void(const std::string& message)>& callback));
+    MOCK_METHOD(void, set_logging, (std::shared_ptr<MessageLogging> logging));
     MOCK_METHOD(void, set_websocket_authorization_key, (const std::string& authorization_key));
     MOCK_METHOD(void, set_websocket_connection_options, (const WebsocketConnectionOptions& connection_options));
     MOCK_METHOD(void, set_websocket_connection_options_without_reconnect, ());

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -718,9 +718,9 @@ void OCPP201::ready() {
 
     callbacks.configure_network_connection_profile_callback =
         [this](const int32_t configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile) {
-            std::promise<ocpp::v2::ConfigNetworkResult> promise;
-            std::future<ocpp::v2::ConfigNetworkResult> future = promise.get_future();
-            ocpp::v2::ConfigNetworkResult result;
+            std::promise<ocpp::ConfigNetworkResult> promise;
+            std::future<ocpp::ConfigNetworkResult> future = promise.get_future();
+            ocpp::ConfigNetworkResult result;
             result.success = true;
             promise.set_value(result);
             return future;


### PR DESCRIPTION
## Describe your changes
Move ConnectivityManager from v2 to common namespace:
* Move ConnectivityManager to common namespace for reuse across OCPP versions
* Refactor constructor to accept logging and message callbacks via setters instead of constructor parameters
* Add ChargePoint constructor accepting shared ConnectivityManagerInterface for external injection
* Add validation that MessageLogging instance is provided to websocket at construction

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

