### PR TITLE
EvseV2G: handle DC charging renegotiation correctly

### DIFF
--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -1560,6 +1560,12 @@ static enum v2g_event handle_iso_power_delivery(struct v2g_connection* conn) {
 
     case iso2_chargeProgressType_Renegotiate:
         conn->ctx->session.renegotiation_required = true;
+        // For DC charging, CurrentDemand is stopped. In AC mode, charging is still possible, so we should
+        // remain in charging state and not communicate any changes externally.
+        if (conn->ctx->is_dc_charger == true) {
+            conn->ctx->p_charger->publish_current_demand_finished(nullptr);
+            conn->ctx->p_charger->publish_dc_open_contactor(nullptr);
+        }
         break;
 
     default:


### PR DESCRIPTION
## Describe your changes

I noticed that when the renegotiation process is started by the EV, no notification is sent to the EvseManager  that the DC CurrentDemand loop has been stopped. Currently, the EvseManager remains in the “Charging” state (at least as long as no CP state transition to B has occurred). In AC, charging is still permitted during the renegotiation process, so it is not necessary to send a notification. It's only a draft because I haven't been able to test my changes yet, and this case is not currently covered in the SIL.

## Issue ticket number and link
--

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements