### PR TITLE
Fix CMake project-config when using out-of-tree modules in yocto

### DIFF
--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -2,6 +2,12 @@ set(@LIBRARY_PACKAGE_NAME@_VERSION @PROJECT_VERSION@)
 
 @PACKAGE_INIT@
 
+set(EVEREST_SCHEMA_DIR "@PACKAGE_EVEREST_DATADIR@/schemas")
+find_package(everest-log REQUIRED)
+find_package(everest-sqlite REQUIRED)
+find_package(everest-timer REQUIRED)
+find_package(everest-evse_security REQUIRED)
+find_package(everest-ocpp REQUIRED)
 find_package(everest-framework REQUIRED)
 
 include(${CMAKE_CURRENT_LIST_DIR}/ev-project-bootstrap.cmake)

--- a/lib/everest/sqlite/CMakeLists.txt
+++ b/lib/everest/sqlite/CMakeLists.txt
@@ -62,6 +62,12 @@ if (EVEREST_SQLITE_INSTALL)
         TYPE INCLUDE
     )
 
+    install(
+        FILES cmake/CollectMigrationFiles.cmake
+        DESTINATION
+            ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/cmake
+    )
+
     evc_setup_package(
         NAME everest-sqlite
         NAMESPACE everest


### PR DESCRIPTION
Add missing find_package calls to libraries integrated into everest-core

Add missing install for sqlite CollectMigrationFiles.cmake file

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

