### PR TITLE
fix: Thread safe ErrorManagerImpl operations

### DIFF
--- a/lib/everest/framework/include/utils/error/error_manager_impl.hpp
+++ b/lib/everest/framework/include/utils/error/error_manager_impl.hpp
@@ -6,6 +6,7 @@
 
 #include <list>
 #include <memory>
+#include <mutex>
 
 #include <utils/error.hpp>
 
@@ -67,6 +68,8 @@ private:
     std::shared_ptr<ErrorTypeMap> error_type_map;
     std::shared_ptr<ErrorDatabase> database;
     std::list<ErrorType> allowed_error_types;
+
+    std::mutex mutex;
 
     PublishErrorFunc publish_raised_error;
     PublishErrorFunc publish_cleared_error;

--- a/lib/everest/framework/lib/error/error_manager_impl.cpp
+++ b/lib/everest/framework/lib/error/error_manager_impl.cpp
@@ -49,6 +49,7 @@ void ErrorManagerImpl::raise_error(const Error& error) {
             return;
         }
     }
+    const std::lock_guard<std::mutex> lock(mutex);
     if (!can_be_raised(error.type, error.sub_type)) {
         std::stringstream ss;
         ss << "Error can't be raised, because type " << error.type << ", sub_type " << error.sub_type
@@ -69,6 +70,7 @@ std::list<ErrorPtr> ErrorManagerImpl::clear_error(const ErrorType& type) {
 }
 
 std::list<ErrorPtr> ErrorManagerImpl::clear_error(const ErrorType& type, const ErrorSubType& sub_type) {
+    const std::lock_guard<std::mutex> lock(mutex);
     if (!can_be_cleared(type, sub_type)) {
         EVLOG_debug << "Error can't be cleared, because type " << type << ", sub_type " << sub_type
                     << " is not active.";
@@ -93,6 +95,7 @@ std::list<ErrorPtr> ErrorManagerImpl::clear_error(const ErrorType& type, const E
 }
 
 std::list<ErrorPtr> ErrorManagerImpl::clear_all_errors() {
+    const std::lock_guard<std::mutex> lock(mutex);
     const std::list<ErrorFilter> filters = {};
     std::list<ErrorPtr> res = database->remove_errors(filters);
     if (res.empty()) {
@@ -111,6 +114,7 @@ std::list<ErrorPtr> ErrorManagerImpl::clear_all_errors() {
 }
 
 std::list<ErrorPtr> ErrorManagerImpl::clear_all_errors(const ErrorType& error_type) {
+    const std::lock_guard<std::mutex> lock(mutex);
     if (!can_be_cleared(error_type)) {
         EVLOG_debug << "Errors can't be cleared, because type " << error_type << " is not active.";
         return {};


### PR DESCRIPTION
## Describe your changes
Add thread safety to ErrorManagerImpl operations. Avoid check then act pattern of database operations

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

