### PR TITLE
Throw exception in slac setup_payload if message length is too large

### DIFF
--- a/lib/everest/slac/fsm/ev/include/everest/slac/fsm/ev/context.hpp
+++ b/lib/everest/slac/fsm/ev/include/everest/slac/fsm/ev/context.hpp
@@ -4,6 +4,7 @@
 #define EV_SLAC_CONTEXT_HPP
 
 #include <functional>
+#include <stdexcept>
 #include <string>
 
 #include <slac/slac.hpp>
@@ -71,8 +72,13 @@ struct Context {
     void send_slac_message(const uint8_t* dest_mac, SlacMessageType const& message) {
         slac::messages::HomeplugMessage hp_message;
         hp_message.setup_ethernet_header(dest_mac);
-        hp_message.setup_payload(&message, sizeof(message), _context_detail::MMTYPE<SlacMessageType>::value,
-                                 _context_detail::MMV<SlacMessageType>::value);
+        try {
+            hp_message.setup_payload(&message, sizeof(message), _context_detail::MMTYPE<SlacMessageType>::value,
+                                     _context_detail::MMV<SlacMessageType>::value);
+        } catch (const std::runtime_error& e) {
+            const auto error_message = std::string("Could not setup SLAC payload: ") + std::string(e.what());
+            log_error(error_message);
+        }
         callbacks.send_raw_slac(hp_message);
     }
 

--- a/lib/everest/slac/src/slac.cpp
+++ b/lib/everest/slac/src/slac.cpp
@@ -10,6 +10,7 @@
 #include <endian.h>
 
 #include <everest/tls/openssl_util.hpp>
+#include <stdexcept>
 
 namespace slac {
 namespace utils {
@@ -68,8 +69,9 @@ static constexpr auto effective_payload_length(const defs::MMV mmv) {
 }
 
 void HomeplugMessage::setup_payload(void const* payload, int len, uint16_t mmtype, const defs::MMV mmv) {
-    // FIXME (aw): shouldn't this assert test for "<="? Furthermore it will just crash the client code ...
-    assert(("Homeplug Payload length too long", len < effective_payload_length(mmv)));
+    if (len > effective_payload_length(mmv)) {
+        throw std::runtime_error("Homeplug Payload length too long");
+    }
     raw_msg.homeplug_header.mmv = static_cast<std::underlying_type_t<defs::MMV>>(mmv);
     raw_msg.homeplug_header.mmtype = htole16(mmtype);
 

--- a/lib/everest/slac/tests/libslac_unit_test.cpp
+++ b/lib/everest/slac/tests/libslac_unit_test.cpp
@@ -4,6 +4,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <slac/slac.hpp>
+#include <stdexcept>
 
 namespace libslac {
 class LibSLACUnitTest : public ::testing::Test {
@@ -42,4 +43,12 @@ TEST_F(LibSLACUnitTest, test_generate_nid_from_nmk_check_security_bits) {
     ASSERT_TRUE((nid[6] >> 4) == 0x00);
 }
 
+TEST_F(LibSLACUnitTest, test_setup_payload) {
+    slac::messages::cm_set_key_cnf set_key_cnf;
+    slac::messages::HomeplugMessage message;
+    ASSERT_THROW(message.setup_payload(&set_key_cnf, 2000, // this is way too large
+                                       (slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_CNF),
+                                       slac::defs::MMV::AV_1_1),
+                 std::runtime_error);
+}
 } // namespace libslac


### PR DESCRIPTION
The assert used previously could be compiled out depending on compiler flags

Catch this exception when setup_payload is used and print an error

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

