### PR TITLE
fix(EvSlac): Use correct MAC address on EV side

### DIFF
--- a/lib/everest/slac/fsm/ev/include/everest/slac/fsm/ev/context.hpp
+++ b/lib/everest/slac/fsm/ev/include/everest/slac/fsm/ev/context.hpp
@@ -63,6 +63,9 @@ struct Context {
     // MAC address of our PLC modem (EV side)
     uint8_t plc_mac[ETH_ALEN] = {0x00, 0xB0, 0x52, 0x00, 0x00, 0x01};
 
+    // MAC address to use for SET KEY req
+    uint8_t plc_mac_chip_commands[ETH_ALEN] = {0x00, 0xB0, 0x52, 0x00, 0x00, 0x01};
+
     // event specific payloads
     // FIXME (aw): due to the synchroneous nature of the fsm, this could be even a ptr/ref
     slac::messages::HomeplugMessage slac_message;

--- a/lib/everest/slac/fsm/ev/src/states/others.cpp
+++ b/lib/everest/slac/fsm/ev/src/states/others.cpp
@@ -250,7 +250,7 @@ void JoinNetworkState::enter() {
     msg.new_eks = slac::defs::CM_SET_KEY_REQ_PEKS_NMK_KNOWN_TO_STA;
     memcpy(msg.new_key, nmk, sizeof(msg.new_key));
 
-    ctx.send_slac_message(ctx.plc_mac, msg);
+    ctx.send_slac_message(ctx.plc_mac_chip_commands, msg);
 
     timeout = std::chrono::steady_clock::now() + std::chrono::milliseconds(SET_KEY_TIMEOUT_MS);
 }

--- a/modules/EV/EvSlac/main/ev_slacImpl.cpp
+++ b/modules/EV/EvSlac/main/ev_slacImpl.cpp
@@ -59,6 +59,10 @@ void ev_slacImpl::run() {
     callbacks.log_error = [](const std::string& text) { EVLOG_error << "EvSlac: " << text; };
 
     auto fsm_ctx = slac::fsm::ev::Context(callbacks);
+
+    // Copy correct MAC address
+    memcpy(fsm_ctx.plc_mac, slac_io.get_mac_addr(), sizeof(fsm_ctx.plc_mac));
+
     // fsm_ctx.slac_config.set_key_timeout_ms = config.set_key_timeout_ms;
     // fsm_ctx.slac_config.ac_mode_five_percent = config.ac_mode_five_percent;
     // fsm_ctx.slac_config.sounding_atten_adjustment = config.sounding_attenuation_adjustment;


### PR DESCRIPTION
## Describe your changes

EVSE SLAC implementation became more strict with patches to fulfill -5 test cases. This PR adapts the EV implementation to work again with the stricter EVSE slac implementation.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

