### PR TITLE
feat(voltage_plausibility_monitor): Voltage plausibility check during DC charging to detect configuration of hardware inconsistencies

### DIFF
--- a/errors/evse_manager.yaml
+++ b/errors/evse_manager.yaml
@@ -21,3 +21,5 @@ errors:
     description: An Isolation Monitoring Device tripped due to low resistance to the chassis during active charging.
   - name: MREC11CableCheckFault
     description: Cable check failed. Isolation monitor self test failed before charging.
+  - name: VoltagePlausibilityFault
+    description: Voltage plausibility check failed. Standard deviation between voltage measurements from different sources exceeded threshold for configured duration.

--- a/modules/EVSE/EvseManager/BUILD.bazel
+++ b/modules/EVSE/EvseManager/BUILD.bazel
@@ -6,7 +6,8 @@ IMPLS = [
     "token_provider",
     "random_delay",
     "dc_external_derate",
-    "over_voltage"
+    "over_voltage",
+    "voltage_plausibility"
 ]
 
 cc_everest_module(

--- a/modules/EVSE/EvseManager/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(${MODULE_NAME}
         backtrace.cpp
         PersistentStore.cpp
         over_voltage/OverVoltageMonitor.cpp
+        voltage_plausibility/VoltagePlausibilityMonitor.cpp
 )
 
 target_link_libraries(${MODULE_NAME}

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -2173,6 +2173,7 @@ void Charger::clear_errors_on_unplug() {
     error_handling->clear_isolation_resistance_fault("Resistance");
     error_handling->clear_isolation_resistance_fault("VoltageToEarth");
     error_handling->clear_cable_check_fault();
+    error_handling->clear_voltage_plausibility_fault();
 }
 
 types::evse_manager::EnableDisableSource Charger::get_last_enable_disable_source() {

--- a/modules/EVSE/EvseManager/ErrorHandling.cpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.cpp
@@ -345,4 +345,21 @@ void ErrorHandling::clear_cable_check_fault() {
     }
 }
 
+void ErrorHandling::raise_voltage_plausibility_fault(const std::string& description) {
+    // raise externally
+    // High severity as this indicates a serious measurement inconsistency
+    Everest::error::Error error_object = p_evse->error_factory->create_error(
+        "evse_manager/VoltagePlausibilityFault", "", description, Everest::error::Severity::High);
+    p_evse->raise_error(error_object);
+    process_error();
+}
+
+void ErrorHandling::clear_voltage_plausibility_fault() {
+    // clear externally
+    if (p_evse->error_state_monitor->is_error_active("evse_manager/VoltagePlausibilityFault", "")) {
+        p_evse->clear_error("evse_manager/VoltagePlausibilityFault");
+        process_error();
+    }
+}
+
 } // namespace module

--- a/modules/EVSE/EvseManager/ErrorHandling.hpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.hpp
@@ -96,6 +96,9 @@ public:
     void raise_cable_check_fault(const std::string& description);
     void clear_cable_check_fault();
 
+    void raise_voltage_plausibility_fault(const std::string& description);
+    void clear_voltage_plausibility_fault();
+
 protected:
     void raise_inoperative_error(const Everest::error::Error& caused_by);
 

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -49,6 +49,7 @@
 #include "VarContainer.hpp"
 #include "over_voltage/OverVoltageMonitor.hpp"
 #include "scoped_lock_timeout.hpp"
+#include "voltage_plausibility/VoltagePlausibilityMonitor.hpp"
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {
@@ -118,6 +119,8 @@ struct Conf {
     std::string bpt_channel;
     std::string bpt_generator_mode;
     std::string bpt_grid_code_island_method;
+    double voltage_plausibility_max_spread_threshold_V;
+    int voltage_plausibility_fault_duration_ms;
 };
 
 class EvseManager : public Everest::ModuleBase {
@@ -346,6 +349,9 @@ private:
     bool reserved;
     int32_t reservation_id;
     Everest::timed_mutex_traceable reservation_mutex;
+
+    // Voltage plausibility monitor
+    std::unique_ptr<VoltagePlausibilityMonitor> voltage_plausibility_monitor;
 
     void setup_AC_mode();
     void setup_fake_DC_mode();

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -346,6 +346,21 @@ config:
       When raising evse_manager/Inoperative use the vendor ID from the original cause
     type: boolean
     default: false
+  voltage_plausibility_max_spread_threshold_V:
+    description: >-
+      Maximum allowed spread (max-min) in volts between voltage measurements from different
+      sources (power supply, powermeter, isolation monitor, over voltage monitor) before a
+      voltage plausibility fault is triggered. During DC charging, if the spread
+      exceeds this threshold for the configured duration, a fault is raised.
+    type: number
+    default: 50.0
+  voltage_plausibility_fault_duration_ms:
+    description: >-
+      Duration in milliseconds for which the spread must exceed the threshold
+      before a voltage plausibility fault is raised. A duration of 0 ms means that a fault
+      will be raised immediately when the threshold is exceeded.
+    type: integer
+    default: 30000
   session_id_type:
     description: >-
       Type to use for generation of session ids.

--- a/modules/EVSE/EvseManager/tests/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/tests/CMakeLists.txt
@@ -19,10 +19,12 @@ target_sources(${TEST_TARGET_NAME} PRIVATE
     ErrorHandlingTest.cpp
     IECStateMachineTest.cpp
     OverVoltageMonitorTest.cpp
+    VoltagePlausibilityMonitorTest.cpp
     ../ErrorHandling.cpp
     ../IECStateMachine.cpp
     ../backtrace.cpp
     ../over_voltage/OverVoltageMonitor.cpp
+    ../voltage_plausibility/VoltagePlausibilityMonitor.cpp
 )
 
 target_compile_definitions(${TEST_TARGET_NAME} PRIVATE

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -782,6 +782,8 @@ void ErrorHandling::raise_cable_check_fault(const std::string& description) {
 }
 void ErrorHandling::clear_cable_check_fault() {
 }
+void ErrorHandling::clear_voltage_plausibility_fault() {
+}
 
 // ----------------------------------------------------------------------------
 // SessionLog stub

--- a/modules/EVSE/EvseManager/tests/VoltagePlausibilityMonitorTest.cpp
+++ b/modules/EVSE/EvseManager/tests/VoltagePlausibilityMonitorTest.cpp
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include "voltage_plausibility/VoltagePlausibilityMonitor.hpp"
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+
+using namespace module;
+using namespace std::chrono_literals;
+
+class VoltagePlausibilityMonitorTest : public ::testing::Test {
+protected:
+    struct CallbackState {
+        std::mutex mtx;
+        std::condition_variable cv;
+        bool called{false};
+        std::string reason;
+    };
+
+    static VoltagePlausibilityMonitor make_monitor(CallbackState& state, double max_spread_threshold_V,
+                                                   std::chrono::milliseconds fault_duration) {
+        return VoltagePlausibilityMonitor(
+            [&state](const std::string& reason) {
+                std::lock_guard<std::mutex> lock(state.mtx);
+                state.called = true;
+                state.reason = reason;
+                state.cv.notify_all();
+            },
+            max_spread_threshold_V, fault_duration);
+    }
+
+    static bool wait_for_callback(CallbackState& state, std::chrono::milliseconds timeout = 500ms) {
+        std::unique_lock<std::mutex> lock(state.mtx);
+        return state.cv.wait_for(lock, timeout, [&state] { return state.called; });
+    }
+
+    static void clear_callback_state(CallbackState& state) {
+        std::lock_guard<std::mutex> lock(state.mtx);
+        state.called = false;
+        state.reason.clear();
+    }
+
+    static void set_two_sources(VoltagePlausibilityMonitor& monitor, double power_supply_V, double powermeter_V) {
+        monitor.update_power_supply_voltage(power_supply_V);
+        monitor.update_powermeter_voltage(powermeter_V);
+    }
+};
+
+TEST_F(VoltagePlausibilityMonitorTest, no_fault_below_threshold) {
+    CallbackState state;
+    auto monitor = make_monitor(state, /*max_spread_threshold_V=*/10.0, /*fault_duration=*/50ms);
+
+    monitor.start_monitor();
+
+    set_two_sources(monitor, 400.0, 405.0); // spread 5 V <= 10 V
+
+    EXPECT_FALSE(wait_for_callback(state, 200ms));
+
+    monitor.stop_monitor();
+}
+
+TEST_F(VoltagePlausibilityMonitorTest, requires_at_least_two_sources) {
+    CallbackState state;
+    auto monitor = make_monitor(state, /*max_spread_threshold_V=*/1.0, /*fault_duration=*/50ms);
+
+    monitor.start_monitor();
+
+    monitor.update_power_supply_voltage(400.0); // only one source available
+
+    EXPECT_FALSE(wait_for_callback(state, 200ms));
+
+    monitor.stop_monitor();
+}
+
+TEST_F(VoltagePlausibilityMonitorTest, zero_duration_triggers_immediately) {
+    CallbackState state;
+    auto monitor = make_monitor(state, /*max_spread_threshold_V=*/5.0, /*fault_duration=*/0ms);
+
+    monitor.start_monitor();
+
+    set_two_sources(monitor, 400.0, 420.0); // spread 20 V > 5 V
+
+    ASSERT_TRUE(wait_for_callback(state, 200ms));
+    EXPECT_NE(state.reason.find("fault immediately"), std::string::npos);
+}
+
+TEST_F(VoltagePlausibilityMonitorTest, spread_above_threshold_triggers_after_duration) {
+    CallbackState state;
+    auto monitor = make_monitor(state, /*max_spread_threshold_V=*/5.0, /*fault_duration=*/50ms);
+
+    monitor.start_monitor();
+
+    set_two_sources(monitor, 400.0, 420.0); // arms timer
+
+    ASSERT_TRUE(wait_for_callback(state, 300ms));
+    EXPECT_NE(state.reason.find("for at least"), std::string::npos);
+    EXPECT_NE(state.reason.find("exceeded threshold"), std::string::npos);
+}
+
+TEST_F(VoltagePlausibilityMonitorTest, returning_within_threshold_cancels_timer) {
+    CallbackState state;
+    auto monitor = make_monitor(state, /*max_spread_threshold_V=*/5.0, /*fault_duration=*/120ms);
+
+    monitor.start_monitor();
+
+    set_two_sources(monitor, 400.0, 420.0); // spread 20 V -> arm timer
+
+    std::this_thread::sleep_for(40ms);
+
+    // Bring spread back within the threshold before the timer expires
+    monitor.update_powermeter_voltage(402.0); // spread now 2 V -> cancel timer
+
+    EXPECT_FALSE(wait_for_callback(state, 250ms));
+}
+
+TEST_F(VoltagePlausibilityMonitorTest, fault_is_latched_and_not_retriggered) {
+    CallbackState state;
+    auto monitor = make_monitor(state, /*max_spread_threshold_V=*/1.0, /*fault_duration=*/0ms);
+
+    monitor.start_monitor();
+
+    set_two_sources(monitor, 400.0, 405.0); // immediate fault
+
+    ASSERT_TRUE(wait_for_callback(state, 200ms));
+
+    clear_callback_state(state);
+
+    // After a fault the monitor stops and latches the fault; further updates must not retrigger.
+    set_two_sources(monitor, 410.0, 430.0);
+    EXPECT_FALSE(wait_for_callback(state, 150ms));
+}
+
+TEST_F(VoltagePlausibilityMonitorTest, stop_monitor_suppresses_fault) {
+    CallbackState state;
+    auto monitor = make_monitor(state, /*max_spread_threshold_V=*/5.0, /*fault_duration=*/80ms);
+
+    monitor.start_monitor();
+
+    set_two_sources(monitor, 400.0, 420.0); // arm timer
+    monitor.stop_monitor();                 // cancels timer
+
+    EXPECT_FALSE(wait_for_callback(state, 250ms));
+}
+
+TEST_F(VoltagePlausibilityMonitorTest, reset_clears_samples_so_old_values_are_not_used) {
+    CallbackState state;
+    auto monitor = make_monitor(state, /*max_spread_threshold_V=*/5.0, /*fault_duration=*/80ms);
+
+    monitor.start_monitor();
+
+    // Prime both sources with a large spread, then stop and reset.
+    set_two_sources(monitor, 400.0, 420.0);
+    monitor.stop_monitor();
+    monitor.reset();
+
+    // Restart monitoring. Provide only a single new source sample.
+    // If reset() didn't clear the old powermeter sample timestamp, we'd still have 2 sources and might arm/fault.
+    monitor.start_monitor();
+    monitor.update_power_supply_voltage(400.0);
+
+    EXPECT_FALSE(wait_for_callback(state, 250ms));
+}

--- a/modules/EVSE/EvseManager/voltage_plausibility/VoltagePlausibilityMonitor.cpp
+++ b/modules/EVSE/EvseManager/voltage_plausibility/VoltagePlausibilityMonitor.cpp
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "voltage_plausibility/VoltagePlausibilityMonitor.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <everest/logging.hpp>
+#include <fmt/core.h>
+#include <thread>
+
+namespace module {
+
+VoltagePlausibilityMonitor::VoltagePlausibilityMonitor(ErrorCallback callback, double max_spread_threshold_V,
+                                                       std::chrono::milliseconds fault_duration) :
+    error_callback_(std::move(callback)),
+    max_spread_threshold_V_(max_spread_threshold_V),
+    fault_duration_(fault_duration) {
+    timer_thread_ = std::thread(&VoltagePlausibilityMonitor::timer_thread_func, this);
+}
+
+VoltagePlausibilityMonitor::~VoltagePlausibilityMonitor() {
+    {
+        std::lock_guard<std::mutex> lock(timer_mutex_);
+        timer_thread_exit_ = true;
+        timer_armed_ = false;
+    }
+    timer_cv_.notify_one();
+    if (timer_thread_.joinable()) {
+        timer_thread_.join();
+    }
+}
+
+void VoltagePlausibilityMonitor::start_monitor() {
+    EVLOG_info << "VoltagePlausibilityMonitor, start monitoring";
+    fault_latched_.store(false);
+    cancel_fault_timer();
+    running_.store(true);
+}
+
+void VoltagePlausibilityMonitor::stop_monitor() {
+    EVLOG_info << "VoltagePlausibilityMonitor, stop monitoring";
+    running_.store(false);
+    cancel_fault_timer();
+}
+
+void VoltagePlausibilityMonitor::reset() {
+    fault_latched_.store(false);
+    {
+        // Reset all voltage samples to zero time - protected by data_mutex_
+        std::lock_guard<std::mutex> lock(data_mutex_);
+        power_supply_sample_.timestamp = std::chrono::steady_clock::time_point{};
+        powermeter_sample_.timestamp = std::chrono::steady_clock::time_point{};
+        isolation_monitor_sample_.timestamp = std::chrono::steady_clock::time_point{};
+        over_voltage_monitor_sample_.timestamp = std::chrono::steady_clock::time_point{};
+    }
+    cancel_fault_timer();
+}
+
+void VoltagePlausibilityMonitor::update_power_supply_voltage(double voltage_V) {
+    std::vector<double> valid_voltages;
+    if (running_.load() && !fault_latched_.load()) {
+        {
+            std::lock_guard<std::mutex> lock(data_mutex_);
+            power_supply_sample_.voltage_V = voltage_V;
+            power_supply_sample_.timestamp = std::chrono::steady_clock::now();
+            valid_voltages = get_valid_voltages();
+        }
+        evaluate_voltages(valid_voltages);
+    }
+}
+
+void VoltagePlausibilityMonitor::update_powermeter_voltage(double voltage_V) {
+    std::vector<double> valid_voltages;
+    if (running_.load() && !fault_latched_.load()) {
+        {
+            std::lock_guard<std::mutex> lock(data_mutex_);
+            powermeter_sample_.voltage_V = voltage_V;
+            powermeter_sample_.timestamp = std::chrono::steady_clock::now();
+            valid_voltages = get_valid_voltages();
+        }
+        evaluate_voltages(valid_voltages);
+    }
+}
+
+void VoltagePlausibilityMonitor::update_isolation_monitor_voltage(double voltage_V) {
+    std::vector<double> valid_voltages;
+    if (running_.load() && !fault_latched_.load()) {
+        {
+            std::lock_guard<std::mutex> lock(data_mutex_);
+            isolation_monitor_sample_.voltage_V = voltage_V;
+            isolation_monitor_sample_.timestamp = std::chrono::steady_clock::now();
+            valid_voltages = get_valid_voltages();
+        }
+        evaluate_voltages(valid_voltages);
+    }
+}
+
+void VoltagePlausibilityMonitor::update_over_voltage_monitor_voltage(double voltage_V) {
+    std::vector<double> valid_voltages;
+    if (running_.load() && !fault_latched_.load()) {
+        {
+            std::lock_guard<std::mutex> lock(data_mutex_);
+            over_voltage_monitor_sample_.voltage_V = voltage_V;
+            over_voltage_monitor_sample_.timestamp = std::chrono::steady_clock::now();
+            valid_voltages = get_valid_voltages();
+        }
+        evaluate_voltages(valid_voltages);
+    }
+}
+
+std::vector<double> VoltagePlausibilityMonitor::get_valid_voltages() const {
+    std::vector<double> valid_voltages;
+    const auto zero_time = std::chrono::steady_clock::time_point{};
+
+    // Collect voltage samples that were updated since the last reset/start.
+    // A timestamp of zero (default-initialized) means we've never received a value (or it was cleared on reset()).
+    if (power_supply_sample_.timestamp != zero_time) {
+        valid_voltages.push_back(power_supply_sample_.voltage_V);
+    }
+
+    if (powermeter_sample_.timestamp != zero_time) {
+        valid_voltages.push_back(powermeter_sample_.voltage_V);
+    }
+
+    if (isolation_monitor_sample_.timestamp != zero_time) {
+        valid_voltages.push_back(isolation_monitor_sample_.voltage_V);
+    }
+
+    if (over_voltage_monitor_sample_.timestamp != zero_time) {
+        valid_voltages.push_back(over_voltage_monitor_sample_.voltage_V);
+    }
+    return valid_voltages;
+}
+
+void VoltagePlausibilityMonitor::evaluate_voltages(const std::vector<double>& valid_voltages) {
+    // Need at least 2 valid sources to compute spread
+    if (valid_voltages.size() < 2) {
+        const bool cancelled = cancel_fault_timer();
+        if (cancelled) {
+            EVLOG_info << "VoltagePlausibilityMonitor, using less than 2 valid voltage sources -> cancelling timer";
+        }
+        return;
+    }
+
+    // Order values and compute spread (max-min)
+    const double spread_V = calculate_spread(valid_voltages);
+    // Check against threshold
+    if (spread_V > max_spread_threshold_V_) {
+        const bool armed = arm_fault_timer(spread_V);
+        if (armed) {
+            EVLOG_info << "VoltagePlausibilityMonitor, spread: " << spread_V
+                       << " V > threshold: " << max_spread_threshold_V_ << " V -> arming timer";
+        }
+    } else {
+        const bool cancelled = cancel_fault_timer();
+        if (cancelled) {
+            EVLOG_info << "VoltagePlausibilityMonitor, spread: " << spread_V
+                       << " V <= threshold: " << max_spread_threshold_V_ << " V -> cancelling timer";
+        }
+    }
+}
+
+double VoltagePlausibilityMonitor::calculate_spread(std::vector<double> valid_voltages) {
+    if (valid_voltages.size() < 2) {
+        return 0.0;
+    }
+    std::sort(valid_voltages.begin(), valid_voltages.end());
+    return valid_voltages.back() - valid_voltages.front();
+}
+
+void VoltagePlausibilityMonitor::trigger_fault(const std::string& reason) {
+    fault_latched_.store(true);
+    running_.store(false);
+    cancel_fault_timer();
+    if (error_callback_) {
+        error_callback_(reason);
+    }
+}
+
+bool VoltagePlausibilityMonitor::arm_fault_timer(double spread_V) {
+    if (fault_duration_.count() == 0) {
+        trigger_fault(fmt::format(
+            "Voltage spread {:.2f} V exceeded threshold {:.2f} V and fault duration is 0 ms -> fault immediately",
+            spread_V, max_spread_threshold_V_));
+        return false;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(timer_mutex_);
+        if (timer_armed_) {
+            return false;
+        }
+        timer_armed_ = true;
+        timer_deadline_ = std::chrono::steady_clock::now() + fault_duration_;
+    }
+    timer_cv_.notify_one();
+    return true;
+}
+
+bool VoltagePlausibilityMonitor::cancel_fault_timer() {
+    bool cancelled_now = false;
+    {
+        std::lock_guard<std::mutex> lock(timer_mutex_);
+        if (!timer_armed_) {
+            return false;
+        }
+        timer_armed_ = false;
+        cancelled_now = true;
+    }
+    timer_cv_.notify_one();
+    return cancelled_now;
+}
+
+void VoltagePlausibilityMonitor::timer_thread_func() {
+    std::unique_lock<std::mutex> lock(timer_mutex_);
+
+    while (!timer_thread_exit_) {
+        // Wait until a timer is armed or exit is requested
+        timer_cv_.wait(lock, [this] { return timer_thread_exit_ || timer_armed_; });
+        if (timer_thread_exit_) {
+            break;
+        }
+
+        // Capture the current deadline and wait until it expires or is cancelled/updated
+        auto deadline = timer_deadline_;
+        while (!timer_thread_exit_ && timer_armed_) {
+            if (timer_cv_.wait_until(lock, deadline) == std::cv_status::timeout) {
+                break;
+            }
+            // Woken up: check for exit, cancellation or re-arming with a new deadline
+            if (timer_thread_exit_ || !timer_armed_ || timer_deadline_ != deadline) {
+                break;
+            }
+        }
+
+        if (timer_thread_exit_) {
+            break;
+        }
+        if (!timer_armed_ || timer_deadline_ != deadline) {
+            // Timer was cancelled or re-armed; go back to waiting
+            continue;
+        }
+
+        // Timer expired with this deadline and is still armed.
+        // Re-check the fault condition using the *current* set of valid voltages. This avoids triggering a fault if
+        // updates stopped and we no longer have enough sources (or monitoring stopped) while the timer was armed.
+        timer_armed_ = false;
+
+        // Release the lock while invoking the callback path
+        lock.unlock();
+        bool should_trigger = false;
+        double current_spread_V = 0.0;
+        if (running_.load() && !fault_latched_.load()) {
+            std::vector<double> valid_voltages;
+            {
+                std::lock_guard<std::mutex> data_lock(data_mutex_);
+                valid_voltages = get_valid_voltages();
+            }
+            if (valid_voltages.size() >= 2) {
+                current_spread_V = calculate_spread(std::move(valid_voltages));
+                should_trigger = current_spread_V > max_spread_threshold_V_;
+            }
+        }
+
+        if (should_trigger) {
+            trigger_fault(fmt::format("Voltage spread {:.2f} V exceeded threshold {:.2f} V for at least {} ms.",
+                                      current_spread_V, max_spread_threshold_V_, fault_duration_.count()));
+        } else {
+            EVLOG_info << "VoltagePlausibilityMonitor, timer expired but fault condition no longer true -> no fault";
+        }
+        lock.lock();
+    }
+}
+
+} // namespace module

--- a/modules/EVSE/EvseManager/voltage_plausibility/VoltagePlausibilityMonitor.hpp
+++ b/modules/EVSE/EvseManager/voltage_plausibility/VoltagePlausibilityMonitor.hpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace module {
+
+/// \brief Voltage plausibility monitor used by EvseManager during DC charging.
+///
+/// The monitor compares voltage measurements from multiple sources (power supply, powermeter,
+/// isolation monitor, over voltage monitor) and checks that they report similar values. If the
+/// spread (max-min) between available sources exceeds a configured threshold for a given
+/// duration, a fault is raised.
+///
+/// Thread-safety:
+/// - Public APIs are intended to be called from EvseManager threads and from callbacks of the
+///   external voltage source interfaces.
+/// - Internally, a dedicated background thread waits on a fault timer condition and synchronizes
+///   access to timer-related state via an internal mutex and condition variable.
+class VoltagePlausibilityMonitor {
+public:
+    /// \brief Callback type used to report detected faults.
+    ///
+    /// The callback is invoked from an internal monitoring context when a fault is detected.
+    /// It receives a human-readable description of the fault.
+    using ErrorCallback = std::function<void(const std::string&)>;
+
+    /// \brief Construct a new VoltagePlausibilityMonitor.
+    ///
+    /// \param callback  Function that will be called whenever a fault is detected.
+    /// \param max_spread_threshold_V  Maximum allowed spread (max-min) in volts between
+    ///                                   voltage sources before a fault is triggered.
+    /// \param fault_duration  Duration for which the max-min spread must exceed the threshold
+    ///                        before a fault is raised. A duration of 0 ms means that a fault will
+    ///                        be raised immediately when the threshold is exceeded.
+    VoltagePlausibilityMonitor(ErrorCallback callback, double max_spread_threshold_V,
+                               std::chrono::milliseconds fault_duration);
+
+    /// \brief Destructor joins the internal timer thread before destroying the object.
+    ~VoltagePlausibilityMonitor();
+
+    VoltagePlausibilityMonitor(const VoltagePlausibilityMonitor&) = delete;
+    VoltagePlausibilityMonitor& operator=(const VoltagePlausibilityMonitor&) = delete;
+    VoltagePlausibilityMonitor(VoltagePlausibilityMonitor&&) = delete;
+    VoltagePlausibilityMonitor& operator=(VoltagePlausibilityMonitor&&) = delete;
+
+    /// \brief Start monitoring of incoming voltage samples.
+    ///
+    /// Clears any latched fault state and cancels a pending fault timer, then enables
+    /// evaluation of voltage samples.
+    void start_monitor();
+
+    /// \brief Stop monitoring of incoming voltage samples.
+    ///
+    /// Monitoring is disabled and any pending fault timer is cancelled. Existing latched
+    /// faults remain active until \ref reset() is called.
+    void stop_monitor();
+
+    /// \brief Feed a new voltage sample from the power supply.
+    ///
+    /// \param voltage_V  Measured DC voltage in volts.
+    void update_power_supply_voltage(double voltage_V);
+
+    /// \brief Feed a new voltage sample from the powermeter.
+    ///
+    /// \param voltage_V  Measured DC voltage in volts.
+    void update_powermeter_voltage(double voltage_V);
+
+    /// \brief Feed a new voltage sample from the isolation monitor.
+    ///
+    /// \param voltage_V  Measured DC voltage in volts.
+    void update_isolation_monitor_voltage(double voltage_V);
+
+    /// \brief Feed a new voltage sample from the over voltage monitor.
+    ///
+    /// \param voltage_V  Measured DC voltage in volts.
+    void update_over_voltage_monitor_voltage(double voltage_V);
+
+    /// \brief Reset the internal fault latch and cancel timers.
+    ///
+    /// This clears any previously raised fault and stops the internal fault timer. Monitoring
+    /// remains disabled until \ref start_monitor() is called again.
+    void reset();
+
+private:
+    struct VoltageSample {
+        std::chrono::steady_clock::time_point timestamp{};
+        double voltage_V{0.0};
+    };
+
+    void timer_thread_func();
+    void trigger_fault(const std::string& reason);
+    bool arm_fault_timer(double spread_V);
+    bool cancel_fault_timer();
+    std::vector<double> get_valid_voltages() const;
+    void evaluate_voltages(const std::vector<double>& valid_voltages);
+    static double calculate_spread(std::vector<double> valid_voltages);
+
+    ErrorCallback error_callback_;
+    double max_spread_threshold_V_;
+    std::chrono::milliseconds fault_duration_;
+    std::atomic_bool running_{false};
+    std::atomic_bool fault_latched_{false};
+
+    std::mutex data_mutex_;
+    VoltageSample power_supply_sample_;
+    VoltageSample powermeter_sample_;
+    VoltageSample isolation_monitor_sample_;
+    VoltageSample over_voltage_monitor_sample_;
+
+    std::mutex timer_mutex_;
+    std::chrono::steady_clock::time_point timer_deadline_;
+    bool timer_armed_{false};
+    bool timer_thread_exit_{false};
+    std::condition_variable timer_cv_;
+    std::thread timer_thread_;
+};
+
+} // namespace module


### PR DESCRIPTION
## Describe your changes
Adds a voltage plausibility check during DC charging to detect inconsistencies between voltage measurements from multiple sources.

Monitors voltage from 4 sources:
- Power Supply (always available)
- Powermeter (optional)
- Isolation Monitor (optional)
- Over Voltage Monitor (optional)
Calculates standard deviation between available sources and compares it to a configurable threshold.
Raises a fault if the standard deviation value exceeds the threshold for a configurable duration, trying to prevent false positives from brief spikes.

Handles missing or stale data:
- Requires at least 2 valid sources to compute standard deviation
- Excludes measurements older than a configurable max age

Configuration:
voltage_plausibility_std_deviation_threshold_V: Maximum allowed standard deviation (default: 50.0 V)
voltage_plausibility_fault_duration_ms: Duration SD must exceed threshold before fault (default: 10000 ms)
voltage_plausibility_measurement_max_age_ms: Maximum age of measurements before considered stale (default: 3000 ms)

Implementation
New VoltagePlausibilityMonitor class following the same pattern as OverVoltageMonitor
New error type: evse_manager/VoltagePlausibilityFault (High severity)
This helps detect configuration or hardware issues by comparing voltage readings from independent sources.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

