### PR TITLE
fix(OCPP): improve message queue retry/timeout handling and connection resilience

### DIFF
--- a/lib/everest/ocpp/include/ocpp/common/websocket/websocket_base.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/websocket/websocket_base.hpp
@@ -20,6 +20,7 @@ struct WebsocketConnectionOptions {
     Uri csms_uri;                                   // the URI of the CSMS
     int security_profile;                           // FIXME: change type to `SecurityProfile`
     std::optional<std::string> authorization_key;
+    std::chrono::milliseconds message_timeout;
     int retry_backoff_random_range_s;
     int retry_backoff_repeat_times;
     int retry_backoff_wait_minimum_s;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
@@ -92,6 +92,7 @@ private:
     BootReasonEnum bootreason{BootReasonEnum::PowerUp};
     bool initialized{false};
     bool InvalidCSMSCertificate_logged{false};
+    bool wants_to_be_connected{false};
     ChargePointConnectionState connection_state{ChargePointConnectionState::Disconnected};
     std::atomic<RegistrationStatus> registration_status{RegistrationStatus::Pending};
     DiagnosticsStatus diagnostics_status{DiagnosticsStatus::Idle};

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -1086,6 +1086,7 @@ std::optional<DataTransferResponse> ChargePoint::data_transfer_req(const DataTra
 void ChargePoint::websocket_connected_callback(const int configuration_slot,
                                                const NetworkConnectionProfile& network_connection_profile,
                                                const OcppProtocolVersion ocpp_version) {
+    this->message_queue->update_message_timeout(network_connection_profile.messageTimeout);
     this->message_queue->resume(this->message_queue_resume_delay);
     this->ocpp_version = ocpp_version;
     if (this->registration_status == RegistrationStatusEnum::Accepted) {

--- a/lib/everest/ocpp/lib/ocpp/v2/connectivity_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/connectivity_manager.cpp
@@ -345,10 +345,10 @@ ConnectivityManager::get_ws_connection_options(const std::int32_t configuration_
             this->device_model.get_value<std::string>(ControllerComponentVariables::SupportedOcppVersions));
 
         WebsocketConnectionOptions connection_options{
-            ocpp_versions,
-            uri,
-            network_connection_profile.securityProfile,
+            ocpp_versions, uri, network_connection_profile.securityProfile,
             this->device_model.get_optional_value<std::string>(ControllerComponentVariables::BasicAuthPassword),
+            // Always use a minimum of 1 second otherwise each message would timeout immediately
+            std::chrono::seconds(std::max(network_connection_profile.messageTimeout, 1)),
             this->device_model.get_value<int>(ControllerComponentVariables::RetryBackOffRandomRange),
             this->device_model.get_value<int>(ControllerComponentVariables::RetryBackOffRepeatTimes),
             this->device_model.get_value<int>(ControllerComponentVariables::RetryBackOffWaitMinimum),

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/provisioning.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/provisioning.cpp
@@ -599,13 +599,6 @@ void Provisioning::handle_variable_changed(const SetVariableData& set_variable_d
         }
     }
 
-    if (component_variable == ControllerComponentVariables::MessageTimeout) {
-        if (component_variable.variable.has_value()) {
-            this->message_queue.update_message_timeout(
-                this->context.device_model.get_value<int>(ControllerComponentVariables::MessageTimeout));
-        }
-    }
-
     // TODO(piet): other special handling of changed variables can be added here...
 }
 


### PR DESCRIPTION
## Describe your changes

**Configurable websocket send timeout:**
The websocket layer had a hardcoded 1-second send timeout. When a transmission exceeded this, the message queue would pause and never resume until a new websocket connection was established. The timeout is now derived from the messageTimeout in the network connection profile (OCPP 2.x) or defaults to 10 seconds (OCPP 1.6), with a 1-second minimum enforced.

**Unified failed-send handling:**
Previously, a failed send_callback had its own inline retry/drop logic separate from the timeout/call-error path, leading to inconsistent behavior. Now the message is removed from the queue before sending, and failures are routed through handle_timeout_or_callerror uniformly. The queue is no longer paused on send failure — connection loss is detected via websocket ping/pong instead.

**OCPP 1.6 auto-reconnect:**
Added a `wants_to_be_connected` flag so the charge point automatically attempts to reconnect if the websocket stops connecting unexpectedly.

Minor fixes: Suppressed a spurious pong timeout warning when ping_interval_s is 0.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

