### PR TITLE
EvseManager: remove config options for current limits

### DIFF
--- a/config/config-CB-EVAL-DC.yaml
+++ b/config/config-CB-EVAL-DC.yaml
@@ -40,8 +40,6 @@ active_modules:
       ev_receipt_required: false
       evse_id: DE*PNX*E12345*1
       has_ventilation: true
-      max_current_import_A: 16
-      max_current_export_A: 16
       payment_enable_contract: false
       payment_enable_eim: true
       session_logging: true

--- a/config/config-CB-SAT-AC-powermeter-iso20.yaml
+++ b/config/config-CB-SAT-AC-powermeter-iso20.yaml
@@ -44,8 +44,6 @@ active_modules:
       ev_receipt_required: false
       evse_id: DE*PNX*E12345*1
       has_ventilation: true
-      max_current_import_A: 16
-      max_current_export_A: 16
       payment_enable_contract: false
       payment_enable_eim: true
       session_logging: true

--- a/config/config-CB-SAT-AC-powermeter.yaml
+++ b/config/config-CB-SAT-AC-powermeter.yaml
@@ -44,8 +44,6 @@ active_modules:
       ev_receipt_required: false
       evse_id: DE*PNX*E12345*1
       has_ventilation: true
-      max_current_import_A: 16
-      max_current_export_A: 16
       payment_enable_contract: false
       payment_enable_eim: true
       session_logging: true

--- a/config/config-CB-SAT-AC.yaml
+++ b/config/config-CB-SAT-AC.yaml
@@ -44,8 +44,6 @@ active_modules:
       ev_receipt_required: false
       evse_id: DE*PNX*E12345*1
       has_ventilation: true
-      max_current_import_A: 16
-      max_current_export_A: 16
       payment_enable_contract: false
       payment_enable_eim: true
       session_logging: true

--- a/config/config-sil-ac-d20.yaml
+++ b/config/config-sil-ac-d20.yaml
@@ -31,8 +31,6 @@ active_modules:
       ev_receipt_required: false
       evse_id: DE*PNX*E12345*1
       has_ventilation: true
-      max_current_import_A: 32
-      max_current_export_A: 32
       payment_enable_contract: false
       payment_enable_eim: true
       session_logging: true

--- a/config/config-sil.yaml
+++ b/config/config-sil.yaml
@@ -81,8 +81,6 @@ active_modules:
       ev_receipt_required: false
       evse_id: DE*PNX*E12345*1
       has_ventilation: true
-      max_current_import_A: 32
-      max_current_export_A: 32
       payment_enable_contract: true
       payment_enable_eim: true
       session_logging: true

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -147,13 +147,6 @@ void EvseManager::init() {
         {
             std::scoped_lock lock(hw_caps_mutex);
             hw_capabilities = c;
-            // Maybe override with user setting for this EVSE
-            if (config.max_current_import_A < hw_capabilities.max_current_A_import) {
-                hw_capabilities.max_current_A_import = config.max_current_import_A;
-            }
-            if (config.max_current_export_A < hw_capabilities.max_current_A_export) {
-                hw_capabilities.max_current_A_export = config.max_current_export_A;
-            }
         }
 
         if (ac_nr_phases_active == 0) {

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -66,8 +66,6 @@ struct Conf {
     std::string session_logging_path;
     bool session_logging_xml;
     bool has_ventilation;
-    double max_current_import_A;
-    double max_current_export_A;
     std::string charge_mode;
     bool supported_iso_ac_bpt;
     bool ac_hlc_enabled;

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -50,14 +50,6 @@ config:
     description: Allow ventilated charging or not
     type: boolean
     default: true
-  max_current_import_A:
-    description: User configurable current limit for this EVSE in Ampere
-    type: number
-    default: 32
-  max_current_export_A:
-    description: User configurable current limit for this EVSE in Ampere
-    type: number
-    default: 32
   charge_mode:
     description: Select charging mode
     type: string


### PR DESCRIPTION
## Describe your changes

It seems that all open-source BSP modules allow to manually set hardware capabilities via config options. So having additional limits in EvseManager can be useful, but is also hard to maintain in real deployments. Especially, when hardware caps are reported kind of dynamically by the BSP (for example when using DIP switches and rotary encoder switches).

As discussed, this PR was updated to remove these parameters.

## Issue ticket number and link

none

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

