### PR TITLE
YetiSimulator: fix typo in parsing of nodered error simulation commands

### DIFF
--- a/modules/Simulation/YetiSimulator/util/errors.cpp
+++ b/modules/Simulation/YetiSimulator/util/errors.cpp
@@ -98,7 +98,7 @@ std::tuple<bool, std::optional<ErrorDefinition>> parse_error_type(const std::str
     if (error_type == "ac_rcd_Selftest") {
         return {raise, error_definitions::ac_rcd_Selftest};
     }
-    if (error_type == "ac_rc_AC") {
+    if (error_type == "ac_rcd_AC") {
         return {raise, error_definitions::ac_rcd_AC};
     }
     if (error_type == "ac_rcd_DC") {


### PR DESCRIPTION
## Describe your changes
Fixed a small typo.

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] No functional changes
- [ ] Documentation / text only