### PR TITLE
fix(module-dependencies): PhyVersoBSP depends on sigslot

### DIFF
--- a/module-dependencies.cmake
+++ b/module-dependencies.cmake
@@ -4,7 +4,7 @@
 
 ev_define_dependency(
     DEPENDENCY_NAME sigslot
-    DEPENDENT_MODULES_LIST EnergyNode EvseManager MicroMegaWattBSP YetiDriver)
+    DEPENDENT_MODULES_LIST EnergyNode EvseManager MicroMegaWattBSP YetiDriver PhyVersoBSP)
 
 ev_define_dependency(
     DEPENDENCY_NAME pugixml


### PR DESCRIPTION
## Describe your changes

CMake configure stage will fail when trying to build a subset of modules with PhyVersoBSP included but none of "EnergyNode EvseManager MicroMegaWattBSP YetiDriver" included, because the sigslot dependency will not have been included.

Therefore: add PhyVersoBSP to sigslot DEPENDENT_MODULES_LIST

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

