### PR TITLE
Fix: Add missing slac_API heartbeat counter

### DIFF
--- a/docs/source/reference/EVerest_API/slac_API.yaml
+++ b/docs/source/reference/EVerest_API/slac_API.yaml
@@ -296,11 +296,18 @@ components:
             "sub_type": "string"
             "message": "string"
 
+
     receive_heartbeat:
       name: receive_heartbeat
       title: 'Receive heartbeat'
       summary: Heartbeat produced by EVerest as configured via cfg_heartbeat_interval_ms in the EVerest configuration
       contentType: application/json
+      payload:
+        $ref: '#/components/schemas/HeartBeatId'
+      examples:
+        - summary: "Heartbeat"
+          payload: 42
+
     send_communication_check:
       name: send_communication_check
       title: 'Send communication check'
@@ -313,6 +320,7 @@ components:
           payload:
             true
   
+
   schemas:
     Enabled:
       type: boolean
@@ -364,3 +372,7 @@ components:
     CommunicationCheck:
       type: boolean
       description: "Send 'true' at least every 'cfg_communication_check_to_s' seconds to signal module is alive. Send 'false' to stop communication check'"
+
+    HeartBeatId:
+      type: integer
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached" 

--- a/modules/API/slac_API/slac_API.cpp
+++ b/modules/API/slac_API/slac_API.cpp
@@ -148,7 +148,7 @@ std::string slac_API::make_error_string(API_generic::Error const& error) {
 void slac_API::setup_heartbeat_generator() {
     auto topic = topics.everest_to_extern("heartbeat");
     auto action = [this, topic]() {
-        mqtt.publish(topic, "{}");
+        mqtt.publish(topic, API_generic::serialize(hb_id++));
         return true;
     };
     comm_check.heartbeat(config.cfg_heartbeat_interval_ms, action);

--- a/modules/API/slac_API/slac_API.hpp
+++ b/modules/API/slac_API/slac_API.hpp
@@ -87,6 +87,7 @@ private:
     void setup_heartbeat_generator();
 
     ev_API::Topics topics;
+    size_t hb_id{0};
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 


### PR DESCRIPTION
## Describe your changes
During rework of the documentation, it was noticed that, unlike all other API modules, the slac_API module did not have a heartbeat counter.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

