### PR TITLE
lib: framework/storage_types: add missing include guard

### DIFF
--- a/lib/everest/framework/include/utils/config/storage_types.hpp
+++ b/lib/everest/framework/include/utils/config/storage_types.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 
+#pragma once
+
 #include <optional>
 #include <string>
 #include <vector>


### PR DESCRIPTION
## Describe your changes
Adds missing include guard inside storage_type header from lib-framework.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

