### PR TITLE
fix(EvManager): Check ev requirement of EvManager

### DIFF
--- a/modules/EV/EvManager/main/car_simulation.cpp
+++ b/modules/EV/EvManager/main/car_simulation.cpp
@@ -148,7 +148,10 @@ void CarSimulation::simulate_soc() {
 
     if (latest_soc != soc) {
         latest_soc = soc;
-        r_ev[0]->call_update_soc(soc);
+
+        if (!r_ev.empty()) {
+            r_ev[0]->call_update_soc(soc);
+        }
     }
 
     ev_info.soc = soc;


### PR DESCRIPTION

## Describe your changes
Fixes a bug introduced by https://github.com/EVerest/everest-core/pull/1742 where the EvManager attempts to call a command of an optional requirement before checking if the requirement is set.

This PR adds a check if ev requirement of EvManager is fullfiled before calling update_soc. 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

