### PR TITLE
fix: Add missing errors to EVSE Board Support API

### DIFF
--- a/docs/source/reference/EVerest_API/evse_board_support_API.yaml
+++ b/docs/source/reference/EVerest_API/evse_board_support_API.yaml
@@ -787,6 +787,9 @@ components:
         - Selftest: 'The Selftest failed, device permanently broken'
         - DC: 'RCD was triggered by a DC fault'
         - AC: 'RCD was triggered by an AC fault'
+        - TiltDetected: 'The EVSE has been tilted beyond acceptable limits.'
+        - WaterIngressDetected: 'A substantial amount of water has been detected inside the EVSE.'
+        - EnclosureOpen: 'The EVSE enclosure is open, e.g. a door or panel is not properly closed.'
         - VendorError: 'Vendor specific error code. Will stop charging session.'
         - VendorWarning: 'Vendor specific error code. Charging may continue.'
 
@@ -823,6 +826,9 @@ components:
         - Selftest
         - DC
         - AC
+        - TiltDetected
+        - WaterIngressDetected
+        - EnclosureOpen
         - VendorError
         - VendorWarning
     Error:

--- a/lib/everest/everest_api_types/include/everest_api_types/evse_board_support/API.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/evse_board_support/API.hpp
@@ -59,6 +59,9 @@ enum class ErrorEnum {
     Selftest,
     DC,
     AC,
+    TiltDetected,
+    WaterIngressDetected,
+    EnclosureOpen,
     VendorError,
     VendorWarning,
     CommunicationFault

--- a/lib/everest/everest_api_types/src/everest_api_types/evse_board_support/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/evse_board_support/json_codec.cpp
@@ -205,6 +205,15 @@ void to_json(json& j, ErrorEnum const& k) noexcept {
     case ErrorEnum::AC:
         j = "AC";
         return;
+    case ErrorEnum::TiltDetected:
+        j = "TiltDetected";
+        return;
+    case ErrorEnum::WaterIngressDetected:
+        j = "WaterIngressDetected";
+        return;
+    case ErrorEnum::EnclosureOpen:
+        j = "EnclosureOpen";
+        return;
     case ErrorEnum::VendorError:
         j = "VendorError";
         return;
@@ -343,6 +352,18 @@ void from_json(json const& j, ErrorEnum& k) {
     }
     if (s == "AC") {
         k = ErrorEnum::AC;
+        return;
+    }
+    if (s == "TiltDetected") {
+        k = ErrorEnum::TiltDetected;
+        return;
+    }
+    if (s == "WaterIngressDetected") {
+        k = ErrorEnum::WaterIngressDetected;
+        return;
+    }
+    if (s == "EnclosureOpen") {
+        k = ErrorEnum::EnclosureOpen;
         return;
     }
     if (s == "VendorError") {

--- a/modules/API/evse_board_support_API/evse_board_support_API.cpp
+++ b/modules/API/evse_board_support_API/evse_board_support_API.cpp
@@ -210,6 +210,9 @@ evse_board_support_API::ErrorHandler evse_board_support_API::make_error_handler(
     case ErrorEnum::MREC24ConnectorVoltageHigh:
     case ErrorEnum::MREC25BrokenLatch:
     case ErrorEnum::MREC26CutCable:
+    case ErrorEnum::TiltDetected:
+    case ErrorEnum::WaterIngressDetected:
+    case ErrorEnum::EnclosureOpen:
     case ErrorEnum::VendorError:
     case ErrorEnum::VendorWarning:
     case ErrorEnum::CommunicationFault:


### PR DESCRIPTION
## Describe your changes

Added TiltDetected, WaterIngressDetection and EnclosureOpen errors to EVSE Board Support API.

These errors had been introduced with https://github.com/EVerest/everest-core/commit/97cffb5daf37f286ec78052fb0f418a3a4f6bf07#diff-93e8c3297e839bf71fd4ee4b2cfb95821df9c34c3f4769dd34420fe86e9434bc . 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

