### PR TITLE
lib: framework/yaml_loader: add missing error handling inside save_yaml function

### DIFF
--- a/lib/everest/framework/lib/yaml_loader.cpp
+++ b/lib/everest/framework/lib/yaml_loader.cpp
@@ -3,8 +3,10 @@
 #include <utils/yaml_loader.hpp>
 
 #include <cstddef>
+#include <cstring>
 #include <fstream>
 #include <limits>
+#include <stdexcept>
 
 #include <fmt/core.h>
 #include <ryml.hpp>
@@ -128,10 +130,20 @@ nlohmann::ordered_json load_yaml(const std::filesystem::path& path) {
 }
 
 void save_yaml(const nlohmann::ordered_json& data, const std::filesystem::path& path) {
+    if (!std::filesystem::exists(path.parent_path())) {
+        std::filesystem::create_directory(path.parent_path());
+    }
+
     // FIXME: saving yaml seems to be quite complicated, but we should be able to just emit json here...
-    std::ofstream ofs(path.c_str());
+    std::ofstream ofs(path);
     ofs << data << std::endl;
     ofs.close();
+
+    if (!ofs) {
+        const int ec = errno;
+        throw std::runtime_error(
+            fmt::format("Writing user-config to '{}' failed with ec: {}", path.string(), std::strerror(ec)));
+    }
 }
 
 } // namespace Everest


### PR DESCRIPTION
Adds missing error handling for the save_yaml function used to update user config files.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

