### PR TITLE
Sending voltage/current to powersupply even the voltage is greater than 0

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -2587,6 +2587,19 @@ void EvseManager::process_dc_ev_target_voltage_current(const types::iso15118::Dc
         car_breaks_limit = true;
     }
 
+    // ISO15118-20 [V2G20-2183] allows EVs to only provide voltage or current,
+    // i.e. some EV implementations send target voltage as zero later.
+    // While this requirement is going to be dropped from the standard, we
+    // have to support older implementations by using a "cached" latest non-zero
+    // voltage the EV told us.
+    // EVs sending a current of zero has not yet been seen, so we don't care
+    // about this particular case here at the moment.
+    bool car_sent_zero_voltage{false};
+    if (almost_eq(clamped_voltage, 0.0) and ev_info.target_voltage.value_or(0.f) > 0.f) {
+        clamped_voltage = ev_info.target_voltage.value();
+        car_sent_zero_voltage = true;
+    }
+
     const auto actual_voltage =
         ev_info_snapshot.present_voltage.has_value() ? ev_info_snapshot.present_voltage.value() : clamped_voltage;
 
@@ -2611,6 +2624,9 @@ void EvseManager::process_dc_ev_target_voltage_current(const types::iso15118::Dc
         }
         if (car_breaks_limit) {
             EVLOG_warning << "EV ignores new EVSE max limits. Setting target current to new EVSE max limits";
+        }
+        if (car_sent_zero_voltage) {
+            EVLOG_warning << "EV did not provide a recent voltage. Re-using the previously communicated value again.";
         }
 
         {


### PR DESCRIPTION
The standard ISO15518-20 [V2G20-2183] describes the provided EV target voltage and current in ChargeLoopReq from EV.

The voltage and current shall never send in the same message. In the current implementation, the voltage and current is only sent to powersupplyDC when voltage is greater than 0. But The voltage is only sent at the beginning of the chargeloop (and in other states). After that, only the current is sent peridically. This leads to the problem, that the current is never sent again during chargeloop. We can't found any limitation regarding voltage >= 0 in iso-2.  We assume that this change does not influence the existing implementation of DC.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

