### PR TITLE
[OCPP] Configuration key mapping from 1.6 to 2.x

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
@@ -8,7 +8,6 @@
 #include <ocpp/v16/charge_point_configuration_interface.hpp>
 #include <ocpp/v16/types.hpp>
 
-#include <map>
 #include <set>
 #include <vector>
 
@@ -93,6 +92,9 @@ protected:
     SetResult setInternalNextTimeOffsetTransitionDateTime(const std::string& value);
     SetResult setInternalTimeOffsetNextTransition(const std::string& value);
     SetResult setInternalWaitForSetUserPriceTimeout(const std::string& value);
+
+    std::optional<std::string> calculateEvseIds();
+    std::string calculateSupportedMeasurands();
 
 public:
     explicit ChargePointConfigurationDeviceModel(const std::string_view& ocpp_main_path,

--- a/lib/everest/ocpp/include/ocpp/v16/known_keys.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/known_keys.hpp
@@ -4,140 +4,346 @@
 #ifndef OCPP_V16_KNOWN_KEYS_HPP
 #define OCPP_V16_KNOWN_KEYS_HPP
 
+#include "ocpp/v16/types.hpp"
+#include "ocpp/v2/ocpp_enums.hpp"
+#include "ocpp/v2/ocpp_types.hpp"
+
 #include <cstdint>
 #include <optional>
 #include <string_view>
+#include <tuple>
 
 namespace ocpp::v16::keys {
 
 // clang-format off
-#define FOR_ALL_KEYS(key) \
-key(Core, AllowOfflineTxForUnknownId) \
-key(Core, AuthorizationCacheEnabled) \
-key(Core, AuthorizeRemoteTxRequests) \
-key(Core, BlinkRepeat) \
-key(Core, ClockAlignedDataInterval) \
-key(Core, ConnectionTimeOut) \
-key(Core, ConnectorPhaseRotation) \
-key(Core, ConnectorPhaseRotationMaxLength) \
-key(Core, GetConfigurationMaxKeys) \
-key(Core, HeartbeatInterval) \
-key(Core, LightIntensity) \
-key(Core, LocalAuthorizeOffline) \
-key(Core, LocalPreAuthorize) \
-key(Core, MaxEnergyOnInvalidId) \
-key(Core, MeterValuesAlignedData) \
-key(Core, MeterValuesAlignedDataMaxLength) \
-key(Core, MeterValueSampleInterval) \
-key(Core, MeterValuesSampledData) \
-key(Core, MeterValuesSampledDataMaxLength) \
-key(Core, MinimumStatusDuration) \
-key(Core, NumberOfConnectors) \
-key(Core, ResetRetries) \
-key(Core, StopTransactionOnEVSideDisconnect) \
-key(Core, StopTransactionOnInvalidId) \
-key(Core, StopTxnAlignedData) \
-key(Core, StopTxnAlignedDataMaxLength) \
-key(Core, StopTxnSampledData) \
-key(Core, StopTxnSampledDataMaxLength) \
-key(Core, SupportedFeatureProfiles) \
-key(Core, SupportedFeatureProfilesMaxLength) \
-key(Core, TransactionMessageAttempts) \
-key(Core, TransactionMessageRetryInterval) \
-key(Core, UnlockConnectorOnEVSideDisconnect) \
-key(Core, WebSocketPingInterval) \
-key(CostAndPrice, CustomDisplayCostAndPrice) \
-key(CostAndPrice, CustomIdleFeeAfterStop) \
-key(CostAndPrice, CustomMultiLanguageMessages) \
-key(CostAndPrice, DefaultPrice) \
-key(CostAndPrice, DefaultPriceText) \
-key(CostAndPrice, Language) \
-key(CostAndPrice, NextTimeOffsetTransitionDateTime) \
-key(CostAndPrice, NumberOfDecimalsForCostValues) \
-key(CostAndPrice, SupportedLanguages) \
-key(CostAndPrice, TimeOffset) \
-key(CostAndPrice, TimeOffsetNextTransition) \
-key(CostAndPrice, WaitForSetUserPriceTimeout) \
-key(FirmwareManagement, SupportedFileTransferProtocols) \
-key(Internal, AllowChargingProfileWithoutStartSchedule) \
-key(Internal, AuthorizeConnectorZeroOnConnectorOne) \
-key(Internal, CentralSystemURI) \
-key(Internal, ChargeBoxSerialNumber) \
-key(Internal, ChargePointId) \
-key(Internal, ChargePointModel) \
-key(Internal, ChargePointSerialNumber) \
-key(Internal, ChargePointVendor) \
-key(Internal, CompositeScheduleDefaultLimitAmps) \
-key(Internal, CompositeScheduleDefaultLimitWatts) \
-key(Internal, CompositeScheduleDefaultNumberPhases) \
-key(Internal, ConnectorEvseIds) \
-key(Internal, EnableTLSKeylog) \
-key(Internal, FirmwareVersion) \
-key(Internal, HostName) \
-key(Internal, ICCID) \
-key(Internal, IFace) \
-key(Internal, IgnoredProfilePurposesOffline) \
-key(Internal, IMSI) \
-key(Internal, LogMessages) \
-key(Internal, LogMessagesFormat) \
-key(Internal, LogMessagesRaw) \
-key(Internal, LogRotation) \
-key(Internal, LogRotationDateSuffix) \
-key(Internal, LogRotationMaximumFileCount) \
-key(Internal, LogRotationMaximumFileSize) \
-key(Internal, MaxCompositeScheduleDuration) \
-key(Internal, MaxMessageSize) \
-key(Internal, MessageQueueSizeThreshold) \
-key(Internal, MessageTypesDiscardForQueueing) \
-key(Internal, MeterPublicKeys) \
-key(Internal, MeterSerialNumber) \
-key(Internal, MeterType) \
-key(Internal, OcspRequestInterval) \
-key(Internal, QueueAllMessages) \
-key(Internal, RetryBackoffRandomRange) \
-key(Internal, RetryBackoffRepeatTimes) \
-key(Internal, RetryBackoffWaitMinimum) \
-key(Internal, SeccLeafSubjectCommonName) \
-key(Internal, SeccLeafSubjectCountry) \
-key(Internal, SeccLeafSubjectOrganization) \
-key(Internal, StopTransactionIfUnlockNotSupported) \
-key(Internal, SupplyVoltage) \
-key(Internal, SupportedChargingProfilePurposeTypes) \
-key(Internal, SupportedCiphers12) \
-key(Internal, SupportedCiphers13) \
-key(Internal, SupportedMeasurands) \
-key(Internal, TLSKeylogFile) \
-key(Internal, UseSslDefaultVerifyPaths) \
-key(Internal, UseTPM) \
-key(Internal, UseTPMSeccLeafCertificate) \
-key(Internal, VerifyCsmsAllowWildcards) \
-key(Internal, VerifyCsmsCommonName) \
-key(Internal, WaitForStopTransactionsOnResetTimeout) \
-key(Internal, WebsocketPingPayload) \
-key(Internal, WebsocketPongTimeout) \
-key(LocalAuthListManagement, LocalAuthListEnabled) \
-key(LocalAuthListManagement, LocalAuthListMaxLength) \
-key(LocalAuthListManagement, SendLocalListMaxLength) \
-key(PnC, CentralContractValidationAllowed) \
-key(PnC, CertSigningRepeatTimes) \
-key(PnC, CertSigningWaitMinimum) \
-key(PnC, ContractValidationOffline) \
-key(PnC, ISO15118CertificateManagementEnabled) \
-key(PnC, ISO15118PnCEnabled) \
-key(Reservation, ReserveConnectorZeroSupported) \
-key(Security, AdditionalRootCertificateCheck) \
-key(Security, AuthorizationKey) \
-key(Security, CertificateSignedMaxChainSize) \
-key(Security, CertificateStoreMaxLength) \
-key(Security, CpoName) \
-key(Security, DisableSecurityEventNotifications) \
-key(Security, SecurityProfile) \
-key(SmartCharging, ChargeProfileMaxStackLevel) \
-key(SmartCharging, ChargingScheduleAllowedChargingRateUnit) \
-key(SmartCharging, ChargingScheduleMaxPeriods) \
-key(SmartCharging, ConnectorSwitch3to1PhaseSupported) \
-key(SmartCharging, MaxChargingProfilesInstalled)
+// ============================================================================
+// Standard OCPP 1.6 keys
+// ============================================================================
 
+// SupportedMeasurands is collected from the following valuesList elements
+// - AlignedDataMeasurands
+// - AlignedDataTxEndedMeasurands
+// - SampledDataTxEndedMeasurands
+// - SampledDataTxStartedMeasurands
+// - SampledDataTxUpdatedMeasurands
+
+#define MAPPING_STANDARD(mapping) \
+    mapping(AllowOfflineTxForUnknownId, OfflineTxForUnknownIdEnabled, Actual) \
+    mapping(AuthorizationCacheEnabled, AuthCacheCtrlrEnabled, Actual) \
+    mapping(AuthorizeRemoteTxRequests, AuthorizeRemoteStart, Actual) \
+    mapping(ClockAlignedDataInterval, AlignedDataInterval, Actual) \
+    mapping(ConnectionTimeOut, EVConnectionTimeOut, Actual) \
+    mapping(HeartbeatInterval, HeartbeatInterval, Actual) \
+    mapping(LocalAuthorizeOffline, LocalAuthorizeOffline, Actual) \
+    mapping(LocalPreAuthorize, LocalPreAuthorize, Actual) \
+    mapping(MaxEnergyOnInvalidId, MaxEnergyOnInvalidId, Actual) \
+    mapping(MeterValuesAlignedData, AlignedDataMeasurands, Actual) \
+    mapping(MeterValuesAlignedDataMaxLength, AlignedDataMeasurands, MaxSet) \
+    mapping(MeterValuesSampledData, SampledDataTxUpdatedMeasurands, Actual) \
+    mapping(MeterValuesSampledDataMaxLength, SampledDataTxUpdatedMeasurands, MaxSet) \
+    mapping(MeterValueSampleInterval, SampledDataTxUpdatedInterval, Actual) \
+    mapping(ResetRetries, ResetRetries, Actual) \
+    mapping(StopTransactionOnInvalidId, StopTxOnInvalidId, Actual) \
+    mapping(StopTxnAlignedData, AlignedDataTxEndedMeasurands, Actual) \
+    mapping(StopTxnAlignedDataMaxLength, AlignedDataTxEndedMeasurands, MaxSet) \
+    mapping(StopTxnSampledData, SampledDataTxEndedMeasurands, Actual) \
+    mapping(StopTxnSampledDataMaxLength, SampledDataTxEndedMeasurands, MaxSet) \
+    mapping(TransactionMessageAttempts, MessageAttempts, Actual) \
+    mapping(TransactionMessageRetryInterval, MessageAttemptInterval, Actual) \
+    mapping(WebSocketPingInterval, WebSocketPingInterval, Actual) \
+    mapping(LocalAuthListEnabled, LocalAuthListCtrlrEnabled, Actual) \
+    mapping(ChargeProfileMaxStackLevel, ChargingProfileMaxStackLevel, Actual) \
+    mapping(ChargingScheduleAllowedChargingRateUnit, ChargingScheduleChargingRateUnit, Actual) \
+    mapping(ChargingScheduleMaxPeriods, PeriodsPerSchedule, Actual) \
+    mapping(ConnectorSwitch3to1PhaseSupported, Phases3to1, Actual) \
+    mapping(SupportedFileTransferProtocols, FileTransferProtocols, Actual)
+
+// ============================================================================
+// Internal configuration keys
+// ============================================================================
+
+#define MAPPING_INTERNAL(mapping) \
+    mapping(ChargePointId, ChargePointId, Actual) \
+    mapping(ChargeBoxSerialNumber, ChargeBoxSerialNumber, Actual) \
+    mapping(ChargePointModel, ChargePointModel, Actual) \
+    mapping(ChargePointSerialNumber, ChargePointSerialNumber, Actual) \
+    mapping(ChargePointVendor, ChargePointVendor, Actual) \
+    mapping(FirmwareVersion, FirmwareVersion, Actual) \
+    mapping(ICCID, ICCID, Actual) \
+    mapping(IFace, IFace, Actual) \
+    mapping(IMSI, IMSI, Actual) \
+    mapping(MeterSerialNumber, MeterSerialNumber, Actual) \
+    mapping(MeterType, MeterType, Actual) \
+    mapping(SupportedCiphers12, SupportedCiphers12, Actual) \
+    mapping(SupportedCiphers13, SupportedCiphers13, Actual) \
+    mapping(UseTPM, UseTPM, Actual) \
+    mapping(UseTPMSeccLeafCertificate, UseTPMSeccLeafCertificate, Actual) \
+    mapping(RetryBackoffRandomRange, RetryBackOffRandomRange, Actual) \
+    mapping(RetryBackoffRepeatTimes, RetryBackOffRepeatTimes, Actual) \
+    mapping(AuthorizeConnectorZeroOnConnectorOne,AuthorizeConnectorZeroOnConnectorOne, Actual) \
+    mapping(LogMessages, LogMessages, Actual) \
+    mapping(LogMessagesRaw, LogMessagesRaw, Actual) \
+    mapping(LogMessagesFormat, LogMessagesFormat, Actual) \
+    mapping(LogRotation, LogRotation, Actual) \
+    mapping(LogRotationDateSuffix, LogRotationDateSuffix, Actual) \
+    mapping(LogRotationMaximumFileSize, LogRotationMaximumFileSize, Actual) \
+    mapping(LogRotationMaximumFileCount, LogRotationMaximumFileCount, Actual) \
+    mapping(SupportedChargingProfilePurposeTypes,SupportedChargingProfilePurposeTypes, Actual) \
+    mapping(IgnoredProfilePurposesOffline, IgnoredProfilePurposesOffline, Actual) \
+    mapping(MaxCompositeScheduleDuration, MaxCompositeScheduleDuration, Actual) \
+    mapping(CompositeScheduleDefaultLimitAmps, CompositeScheduleDefaultLimitAmps, Actual) \
+    mapping(CompositeScheduleDefaultLimitWatts, CompositeScheduleDefaultLimitWatts, Actual) \
+    mapping(CompositeScheduleDefaultNumberPhases, CompositeScheduleDefaultNumberPhases, Actual) \
+    mapping(SupplyVoltage, SupplyVoltage, Actual) \
+    mapping(WebsocketPingPayload, WebsocketPingPayload, Actual) \
+    mapping(WebsocketPongTimeout, WebsocketPongTimeout, Actual) \
+    mapping(UseSslDefaultVerifyPaths, UseSslDefaultVerifyPaths, Actual) \
+    mapping(VerifyCsmsCommonName, VerifyCsmsCommonName, Actual) \
+    mapping(VerifyCsmsAllowWildcards, VerifyCsmsAllowWildcards, Actual) \
+    mapping(OcspRequestInterval, OcspRequestInterval, Actual) \
+    mapping(SeccLeafSubjectCommonName, ISO15118CtrlrSeccId, Actual) \
+    mapping(SeccLeafSubjectCountry, ISO15118CtrlrCountryName, Actual) \
+    mapping(SeccLeafSubjectOrganization, ISO15118CtrlrOrganizationName, Actual) \
+    mapping(QueueAllMessages, QueueAllMessages, Actual) \
+    mapping(MessageTypesDiscardForQueueing, MessageTypesDiscardForQueueing, Actual) \
+    mapping(MessageQueueSizeThreshold, MessageQueueSizeThreshold, Actual) \
+    mapping(MaxMessageSize, MaxMessageSize, Actual) \
+    mapping(TLSKeylogFile, TLSKeylogFile, Actual) \
+    mapping(EnableTLSKeylog, EnableTLSKeylog, Actual) \
+    mapping(NumberOfConnectors, NumberOfConnectors, Actual) \
+    mapping(RetryBackoffWaitMinimum, RetryBackOffWaitMinimum, Actual)
+
+// ============================================================================
+// LocalAuthList Section
+// ============================================================================
+
+#define MAPPING_LOCAL_AUTH_LIST(mapping) \
+    mapping(LocalAuthListMaxLength, LocalAuthListCtrlrEntries, Actual) \
+    mapping(SendLocalListMaxLength, ItemsPerMessageSendLocalList, Actual)
+
+// ============================================================================
+// Smart Charging Section
+// ============================================================================
+
+#define MAPPING_SMART_CHARGING(mapping) \
+    mapping(MaxChargingProfilesInstalled, EntriesChargingProfiles, Actual)
+
+// ============================================================================
+// Security Section
+// ============================================================================
+
+#define MAPPING_SECURITY(mapping) \
+    mapping(AdditionalRootCertificateCheck, AdditionalRootCertificateCheck, Actual) \
+    mapping(CertificateSignedMaxChainSize, MaxCertificateChainSize, Actual) \
+    mapping(CpoName, OrganizationName, Actual) \
+    mapping(CertSigningWaitMinimum, CertSigningWaitMinimum, Actual) \
+    mapping(CertSigningRepeatTimes, CertSigningRepeatTimes, Actual) \
+    mapping(CertificateStoreMaxLength, CertificateEntries, Actual)
+
+// ============================================================================
+// PnC Section
+// ============================================================================
+
+#define MAPPING_PNC(mapping) \
+    mapping(ISO15118PnCEnabled, PnCEnabled, Actual) \
+    mapping(CentralContractValidationAllowed, CentralContractValidationAllowed, Actual) \
+    mapping(ContractValidationOffline, ContractValidationOffline, Actual)
+
+// ============================================================================
+// CostAndPrice Section
+// ============================================================================
+
+#define MAPPING_COST(mapping) \
+    mapping(NumberOfDecimalsForCostValues, NumberOfDecimalsForCostValues, Actual) \
+    mapping(TimeOffset, TimeOffset, Actual) \
+    mapping(NextTimeOffsetTransitionDateTime, NextTimeOffsetTransitionDateTime, Actual) \
+    mapping(TimeOffsetNextTransition, TimeOffsetNextTransition, Actual)
+
+// ============================================================================
+// Mavericks Section - OCPP 1.6 keys without direct OCPP 2.x equivalents
+// ============================================================================
+
+#define MAPPING_MISC(mapping) \
+    mapping(BlinkRepeat, BlinkRepeat, Actual) \
+    mapping(ConnectorPhaseRotation, ConnectorPhaseRotation, Actual) \
+    mapping(ConnectorPhaseRotationMaxLength, ConnectorPhaseRotationMaxLength, Actual) \
+    mapping(GetConfigurationMaxKeys, GetConfigurationMaxKeys, Actual) \
+    mapping(LightIntensity, LightIntensity, Actual) \
+    mapping(MinimumStatusDuration, MinimumStatusDuration, Actual) \
+    mapping(StopTransactionOnEVSideDisconnect, StopTransactionOnEVSideDisconnect, Actual) \
+    mapping(SupportedFeatureProfiles, SupportedFeatureProfiles, Actual) \
+    mapping(SupportedFeatureProfilesMaxLength, SupportedFeatureProfilesMaxLength, Actual) \
+    mapping(UnlockConnectorOnEVSideDisconnect, UnlockConnectorOnEVSideDisconnect, Actual) \
+    mapping(ReserveConnectorZeroSupported, ReserveConnectorZeroSupported, Actual) \
+    mapping(HostName, HostName, Actual) \
+    mapping(AllowChargingProfileWithoutStartSchedule, AllowChargingProfileWithoutStartSchedule, Actual) \
+    mapping(WaitForStopTransactionsOnResetTimeout, WaitForStopTransactionsOnResetTimeout, Actual) \
+    mapping(StopTransactionIfUnlockNotSupported, StopTransactionIfUnlockNotSupported, Actual) \
+    mapping(MeterPublicKeys, MeterPublicKeys, Actual) \
+    mapping(DisableSecurityEventNotifications, DisableSecurityEventNotifications, Actual) \
+    mapping(ISO15118CertificateManagementEnabled, ISO15118CertificateManagementEnabled, Actual) \
+    mapping(CustomDisplayCostAndPrice, CustomDisplayCostAndPrice, Actual) \
+    mapping(DefaultPrice, DefaultPrice, Actual) \
+    mapping(DefaultPriceText, DefaultPriceText, Actual) \
+    mapping(CustomIdleFeeAfterStop, CustomIdleFeeAfterStop, Actual) \
+    mapping(SupportedLanguages, SupportedLanguages, Actual) \
+    mapping(CustomMultiLanguageMessages, CustomMultiLanguageMessages, Actual) \
+    mapping(Language, Language, Actual) \
+    mapping(WaitForSetUserPriceTimeout, WaitForSetUserPriceTimeout, Actual)
+
+// ============================================================================
+// Mavericks Section - OCPP 1.6 keys where OCPP 2.x mapping is problematic
+// ============================================================================
+
+#define MAPPING_MISC_ADDITIONAL(mapping) \
+    mapping(AuthorizationKey, AuthorizationKey16, Actual) \
+    mapping(CentralSystemURI, CentralSystemURI16, Actual) \
+    mapping(SecurityProfile, SecurityProfile16, Actual)
+
+#define MAPPING_ALL(mapping) \
+    MAPPING_MISC_ADDITIONAL(mapping) \
+    MAPPING_MISC(mapping) \
+    MAPPING_STANDARD(mapping) \
+    MAPPING_INTERNAL(mapping) \
+    MAPPING_LOCAL_AUTH_LIST(mapping) \
+    MAPPING_SMART_CHARGING(mapping) \
+    MAPPING_SECURITY(mapping) \
+    MAPPING_PNC(mapping) \
+    MAPPING_COST(mapping)
+
+#define FOR_ALL_MAPPED_KEYS(key) \
+    key(Core, AllowOfflineTxForUnknownId) \
+    key(Core, AuthorizationCacheEnabled) \
+    key(Core, AuthorizeRemoteTxRequests) \
+    key(Core, BlinkRepeat) \
+    key(Core, ClockAlignedDataInterval) \
+    key(Core, ConnectionTimeOut) \
+    key(Core, ConnectorPhaseRotation) \
+    key(Core, ConnectorPhaseRotationMaxLength) \
+    key(Core, GetConfigurationMaxKeys) \
+    key(Core, HeartbeatInterval) \
+    key(Core, LightIntensity) \
+    key(Core, LocalAuthorizeOffline) \
+    key(Core, LocalPreAuthorize) \
+    key(Core, MaxEnergyOnInvalidId) \
+    key(Core, MeterValuesAlignedData) \
+    key(Core, MeterValuesAlignedDataMaxLength) \
+    key(Core, MeterValueSampleInterval) \
+    key(Core, MeterValuesSampledData) \
+    key(Core, MeterValuesSampledDataMaxLength) \
+    key(Core, MinimumStatusDuration) \
+    key(Core, NumberOfConnectors) \
+    key(Core, ResetRetries) \
+    key(Core, StopTransactionOnEVSideDisconnect) \
+    key(Core, StopTransactionOnInvalidId) \
+    key(Core, StopTxnAlignedData) \
+    key(Core, StopTxnAlignedDataMaxLength) \
+    key(Core, StopTxnSampledData) \
+    key(Core, StopTxnSampledDataMaxLength) \
+    key(Core, SupportedFeatureProfiles) \
+    key(Core, SupportedFeatureProfilesMaxLength) \
+    key(Core, TransactionMessageAttempts) \
+    key(Core, TransactionMessageRetryInterval) \
+    key(Core, UnlockConnectorOnEVSideDisconnect) \
+    key(Core, WebSocketPingInterval) \
+    key(CostAndPrice, CustomDisplayCostAndPrice) \
+    key(CostAndPrice, CustomIdleFeeAfterStop) \
+    key(CostAndPrice, CustomMultiLanguageMessages) \
+    key(CostAndPrice, DefaultPrice) \
+    key(CostAndPrice, DefaultPriceText) \
+    key(CostAndPrice, Language) \
+    key(CostAndPrice, NextTimeOffsetTransitionDateTime) \
+    key(CostAndPrice, NumberOfDecimalsForCostValues) \
+    key(CostAndPrice, SupportedLanguages) \
+    key(CostAndPrice, TimeOffset) \
+    key(CostAndPrice, TimeOffsetNextTransition) \
+    key(CostAndPrice, WaitForSetUserPriceTimeout) \
+    key(FirmwareManagement, SupportedFileTransferProtocols) \
+    key(Internal, AllowChargingProfileWithoutStartSchedule) \
+    key(Internal, AuthorizeConnectorZeroOnConnectorOne) \
+    key(Internal, CentralSystemURI) \
+    key(Internal, ChargeBoxSerialNumber) \
+    key(Internal, ChargePointId) \
+    key(Internal, ChargePointModel) \
+    key(Internal, ChargePointSerialNumber) \
+    key(Internal, ChargePointVendor) \
+    key(Internal, CompositeScheduleDefaultLimitAmps) \
+    key(Internal, CompositeScheduleDefaultLimitWatts) \
+    key(Internal, CompositeScheduleDefaultNumberPhases) \
+    key(Internal, EnableTLSKeylog) \
+    key(Internal, FirmwareVersion) \
+    key(Internal, HostName) \
+    key(Internal, ICCID) \
+    key(Internal, IFace) \
+    key(Internal, IgnoredProfilePurposesOffline) \
+    key(Internal, IMSI) \
+    key(Internal, LogMessages) \
+    key(Internal, LogMessagesFormat) \
+    key(Internal, LogMessagesRaw) \
+    key(Internal, LogRotation) \
+    key(Internal, LogRotationDateSuffix) \
+    key(Internal, LogRotationMaximumFileCount) \
+    key(Internal, LogRotationMaximumFileSize) \
+    key(Internal, MaxCompositeScheduleDuration) \
+    key(Internal, MaxMessageSize) \
+    key(Internal, MessageQueueSizeThreshold) \
+    key(Internal, MessageTypesDiscardForQueueing) \
+    key(Internal, MeterPublicKeys) \
+    key(Internal, MeterSerialNumber) \
+    key(Internal, MeterType) \
+    key(Internal, OcspRequestInterval) \
+    key(Internal, QueueAllMessages) \
+    key(Internal, RetryBackoffRandomRange) \
+    key(Internal, RetryBackoffRepeatTimes) \
+    key(Internal, RetryBackoffWaitMinimum) \
+    key(Internal, SeccLeafSubjectCommonName) \
+    key(Internal, SeccLeafSubjectCountry) \
+    key(Internal, SeccLeafSubjectOrganization) \
+    key(Internal, StopTransactionIfUnlockNotSupported) \
+    key(Internal, SupplyVoltage) \
+    key(Internal, SupportedChargingProfilePurposeTypes) \
+    key(Internal, SupportedCiphers12) \
+    key(Internal, SupportedCiphers13) \
+    key(Internal, TLSKeylogFile) \
+    key(Internal, UseSslDefaultVerifyPaths) \
+    key(Internal, UseTPM) \
+    key(Internal, UseTPMSeccLeafCertificate) \
+    key(Internal, VerifyCsmsAllowWildcards) \
+    key(Internal, VerifyCsmsCommonName) \
+    key(Internal, WaitForStopTransactionsOnResetTimeout) \
+    key(Internal, WebsocketPingPayload) \
+    key(Internal, WebsocketPongTimeout) \
+    key(LocalAuthListManagement, LocalAuthListEnabled) \
+    key(LocalAuthListManagement, LocalAuthListMaxLength) \
+    key(LocalAuthListManagement, SendLocalListMaxLength) \
+    key(PnC, CentralContractValidationAllowed) \
+    key(PnC, CertSigningRepeatTimes) \
+    key(PnC, CertSigningWaitMinimum) \
+    key(PnC, ContractValidationOffline) \
+    key(PnC, ISO15118CertificateManagementEnabled) \
+    key(PnC, ISO15118PnCEnabled) \
+    key(Reservation, ReserveConnectorZeroSupported) \
+    key(Security, AdditionalRootCertificateCheck) \
+    key(Security, AuthorizationKey) \
+    key(Security, CertificateSignedMaxChainSize) \
+    key(Security, CertificateStoreMaxLength) \
+    key(Security, CpoName) \
+    key(Security, DisableSecurityEventNotifications) \
+    key(Security, SecurityProfile) \
+    key(SmartCharging, ChargeProfileMaxStackLevel) \
+    key(SmartCharging, ChargingScheduleAllowedChargingRateUnit) \
+    key(SmartCharging, ChargingScheduleMaxPeriods) \
+    key(SmartCharging, ConnectorSwitch3to1PhaseSupported) \
+    key(SmartCharging, MaxChargingProfilesInstalled)
+
+// these have special handling
+#define FOR_ALL_UNMAPPED_KEYS(key) \
+    key(Internal, ConnectorEvseIds) \
+    key(Internal, SupportedMeasurands)
+
+#define FOR_ALL_KEYS(key) \
+    FOR_ALL_MAPPED_KEYS(key) \
+    FOR_ALL_UNMAPPED_KEYS(key)
 // clang-format on
 
 #define VALUE(a, b) b,
@@ -170,6 +376,13 @@ inline bool is_in_section(sections section, valid_keys key) {
     return to_section(key) == section;
 }
 bool is_hidden(valid_keys key);
+std::optional<ocpp::v16::SupportedFeatureProfiles> get_profile(valid_keys key);
+
+using DeviceModel_CV = std::optional<std::tuple<ocpp::v2::Component, ocpp::v2::Variable, ocpp::v2::AttributeEnum>>;
+DeviceModel_CV convert_v2(const std::string_view& str);
+DeviceModel_CV convert_v2(valid_keys key);
+std::optional<std::string> convert_v2(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
+                                      ocpp::v2::AttributeEnum attribute);
 
 } // namespace ocpp::v16::keys
 

--- a/lib/everest/ocpp/include/ocpp/v16/types.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/types.hpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <string_view>
 
 #include <nlohmann/json_fwd.hpp>
 
@@ -137,7 +138,7 @@ std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e);
 
 /// \brief Converts the given std::string \p s to SupportedFeatureProfiles
 /// \returns a SupportedFeatureProfiles from a string representation
-SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string& s);
+SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string_view& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given \p supported_feature_profiles to the given output stream \p os

--- a/lib/everest/ocpp/include/ocpp/v16/utils.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/utils.hpp
@@ -8,6 +8,8 @@
 #include <ocpp/v16/ocpp_types.hpp>
 #include <ocpp/v16/types.hpp>
 
+#include <cstddef>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -31,6 +33,49 @@ std::string to_csl(const std::vector<std::string>& vec);
 /// \brief convert a comma separated list in a string to a vector of strings
 /// \note will not contain empty strings when a comma is repeated
 std::vector<std::string> from_csl(const std::string& csl);
+
+/// \brief List that maintains insertion order and prevents duplicates
+class OrderedUniqueStringList {
+private:
+    using Store = std::map<std::string, std::size_t>;
+    std::size_t count{0};
+    Store list{};
+
+    void do_insert(std::string&& s);
+
+public:
+    /// \brief Add to list assuming not a duplicate
+    /// \param s - the string to add
+    void insert(const std::string& s) {
+        do_insert(std::string{s});
+    }
+    /// \brief Add to list assuming not a duplicate
+    /// \param s - the string to add
+    void insert(std::string&& s) {
+        do_insert(std::move(s));
+    }
+
+    /// \brief Clear the list
+    void clear() {
+        count = 0;
+        list.clear();
+    }
+
+    /// \brief obtain an ordered vector of the unique strings
+    std::vector<std::string> get() const;
+
+    /// \brief is the list empty
+    /// \returns true when empty
+    bool empty() const {
+        return list.empty();
+    }
+
+    /// \brief how many strings are in the list
+    /// \returns the size of the list
+    auto size() const {
+        return list.size();
+    }
+};
 
 } // namespace ocpp::v16::utils
 

--- a/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
@@ -88,6 +88,9 @@ extern const Component SecurityCtrlr;
 extern const Component SmartChargingCtrlr;
 extern const Component TariffCostCtrlr;
 extern const Component TxCtrlr;
+// following controllers contains OCPP1.6 configuration keys without a clear mapping to OCPP2.x.
+extern const Component OCPP16LegacyCtrlr;
+extern const Component CustomLegacyController;
 } // namespace ControllerComponents
 
 namespace StandardizedVariables {
@@ -310,6 +313,39 @@ extern const ComponentVariable TxBeforeAcceptedEnabled;
 extern const RequiredComponentVariable TxStartPoint;
 extern const RequiredComponentVariable TxStopPoint;
 extern const ComponentVariable ISO15118CtrlrAvailable;
+
+// OCPP1.6 mavericks: The following ComponentVariable definitions are required because some OCPP1.6 configuration keys
+// do not map to any existing component variable combination in OCPP2.x. The following definitions only control the
+// OCPP1.6 implementation
+extern const ComponentVariable BlinkRepeat;
+extern const ComponentVariable ConnectorPhaseRotation;
+extern const ComponentVariable ConnectorPhaseRotationMaxLength;
+extern const RequiredComponentVariable GetConfigurationMaxKeys;
+extern const ComponentVariable LightIntensity;
+extern const ComponentVariable MinimumStatusDuration;
+extern const ComponentVariable StopTransactionOnEVSideDisconnect;
+extern const RequiredComponentVariable SupportedFeatureProfiles;
+extern const ComponentVariable SupportedFeatureProfilesMaxLength;
+extern const RequiredComponentVariable UnlockConnectorOnEVSideDisconnect;
+extern const ComponentVariable ReserveConnectorZeroSupported;
+extern const ComponentVariable HostName;
+extern const ComponentVariable AllowChargingProfileWithoutStartSchedule;
+extern const ComponentVariable WaitForStopTransactionsOnResetTimeout;
+extern const ComponentVariable StopTransactionIfUnlockNotSupported;
+extern const ComponentVariable MeterPublicKeys;
+extern const ComponentVariable DisableSecurityEventNotifications;
+extern const ComponentVariable ISO15118CertificateManagementEnabled;
+extern const ComponentVariable CustomDisplayCostAndPrice; // Required only if CaliforniaPricing enabled
+extern const ComponentVariable DefaultPrice;
+extern const ComponentVariable DefaultPriceText;
+extern const ComponentVariable CustomIdleFeeAfterStop;
+extern const ComponentVariable SupportedLanguages;
+extern const ComponentVariable CustomMultiLanguageMessages;
+extern const ComponentVariable Language;
+extern const ComponentVariable WaitForSetUserPriceTimeout;
+extern const ComponentVariable AuthorizationKey16;
+extern const RequiredComponentVariable CentralSystemURI16;
+extern const RequiredComponentVariable SecurityProfile16;
 } // namespace ControllerComponentVariables
 
 namespace EvseComponentVariables {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -1,17 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
-#include "ocpp/v2/ocpp_enums.hpp"
+#include <everest/logging.hpp>
+#include <ocpp/common/cistring.hpp>
 #include <ocpp/common/utils.hpp>
 #include <ocpp/v16/charge_point_configuration_devicemodel.hpp>
 #include <ocpp/v16/known_keys.hpp>
+#include <ocpp/v16/ocpp_types.hpp>
 #include <ocpp/v16/types.hpp>
 #include <ocpp/v16/utils.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/device_model_interface.hpp>
+#include <ocpp/v2/ocpp_enums.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <exception>
 #include <functional>
 #include <optional>
@@ -20,12 +25,30 @@
 #include <type_traits>
 #include <utility>
 
+namespace ocpp {
+// CiString has issues - no support for string_view and creates many temporary
+// strings. e.g. lhs.get() returns a copy of the string ...
+template <size_t L> bool operator==(const CiString<L>& lhs, const std::string_view& rhs) {
+    return iequals(lhs.get(), std::string{rhs});
+}
+} // namespace ocpp
+
 namespace {
 using namespace ocpp;
 using SetResult = v16::ChargePointConfigurationDeviceModel::SetResult;
 using DeviceModelInterface = v2::DeviceModelInterface;
+using SupportedFeatureProfiles = v16::SupportedFeatureProfiles;
 
-constexpr const char* custom_component = "Custom";
+constexpr const std::string_view cost_and_price_component{"OCPP16LegacyCtrlr"};
+constexpr const std::string_view cost_and_price_feature{"CostAndPrice"};
+constexpr const std::string_view custom_component{"Custom16LegacyCtrlr"};
+constexpr const std::string_view custom_feature{"Custom"};
+constexpr const std::string_view pnc_component{"ISO15118Ctrlr"};
+constexpr const std::string_view pnc_feature{"PnC"};
+
+constexpr bool starts_with(const std::string_view& str, const std::string_view& looking_for) {
+    return str.rfind(looking_for, 0) == 0;
+}
 
 constexpr v16::ConfigurationStatus convert(SetResult res) {
     switch (res) {
@@ -106,26 +129,39 @@ void raise_not_found(const std::string_view& section, const std::string_view& na
 // Component/Variable support ...
 
 std::optional<bool> isReadOnly(DeviceModelInterface& storage, const std::string_view& component,
-                               const std::string_view& variable) {
+                               const std::string_view& variable, v2::AttributeEnum attribute) {
     // known keys are checked via is_readonly() in known_keys.hpp
     // for other keys get_mutability() is used
     const v2::Component component_v{std::string{component}};
     const v2::Variable variable_v{std::string{variable}};
     std::optional<bool> result;
-    const auto res = storage.get_mutability(component_v, variable_v, v2::AttributeEnum::Actual);
+    const auto res = storage.get_mutability(component_v, variable_v, attribute);
     if (res) {
         result = res.value() == v2::MutabilityEnum::ReadOnly;
     }
     return result;
 }
 
+inline std::optional<bool> isReadOnly(DeviceModelInterface& storage, const v2::RequiredComponentVariable& var,
+                                      v2::AttributeEnum attribute) {
+    const std::string component = var.component.name;
+    std::string variable;
+    if (var.variable) {
+        variable = var.variable.value().name;
+    }
+    return isReadOnly(storage, component, variable, attribute);
+}
+
+inline bool is_same(const ocpp::v2::RequiredComponentVariable& var, const ocpp::v2::Component& component,
+                    const ocpp::v2::Variable& variable) {
+    return ((var.component == component) && (var.variable == variable));
+}
+
 template <typename T>
-std::optional<T> get_optional(DeviceModelInterface& storage, const std::string_view& component,
-                              const std::string_view& variable) {
-    const v2::Component component_v{std::string{component}};
-    const v2::Variable variable_v{std::string{variable}};
+std::optional<T> get_optional(DeviceModelInterface& storage, const v2::Component& component,
+                              const v2::Variable& variable, v2::AttributeEnum attribute, bool writeOnly = false) {
     std::string value;
-    const auto get_result = storage.get_variable(component_v, variable_v, v2::AttributeEnum::Actual, value);
+    const auto get_result = storage.get_variable(component, variable, attribute, value, writeOnly);
     if (get_result == v2::GetVariableStatusEnum::Accepted) {
         try {
             if constexpr (std::is_same_v<bool, T>) {
@@ -136,23 +172,61 @@ std::optional<T> get_optional(DeviceModelInterface& storage, const std::string_v
                 return v2::to_specific_type<T>(value);
             }
         } catch (const std::exception& ex) {
-            EVLOG_warning << component_v.name << '[' << variable_v.name << "] '" << value
+            EVLOG_warning << component.name << '[' << variable.name << "] '" << value
                           << "' to_specific_type exception: " << ex.what();
         }
     }
     return std::nullopt;
 }
 
-template <typename T> std::optional<T> get_optional(DeviceModelInterface& storage, v16::keys::valid_keys key) {
-    const auto component = v16::keys::to_section_string_view(key);
-    const auto variable = v16::keys::convert(key);
-    return get_optional<T>(storage, component, variable);
+template <typename T, typename C>
+std::optional<T> get_optional(DeviceModelInterface& storage, const C& var, v2::AttributeEnum attribute,
+                              bool writeOnly = false) {
+    if (var.variable) {
+        return get_optional<T>(storage, var.component, var.variable.value(), attribute, writeOnly);
+    }
+    return std::nullopt;
+}
+
+template <typename T>
+std::optional<T> get_optional(DeviceModelInterface& storage, const std::string_view& component,
+                              const std::string_view& variable, v2::AttributeEnum attribute, bool writeOnly = false) {
+    const v2::Component component_v{std::string{component}};
+    const v2::Variable variable_v{std::string{variable}};
+    return get_optional<T>(storage, component_v, variable_v, attribute, writeOnly);
+}
+
+template <typename T>
+std::optional<T> get_optional(DeviceModelInterface& storage, v16::keys::valid_keys key, bool writeOnly = false) {
+    std::optional<T> result;
+    const auto cv = v16::keys::convert_v2(key);
+    if (cv) {
+        const auto& component = std::get<v2::Component>(*cv);
+        const auto& variable = std::get<v2::Variable>(*cv);
+        const auto& attribute = std::get<v2::AttributeEnum>(*cv);
+        result = get_optional<T>(storage, component, variable, attribute, writeOnly);
+    }
+    return result;
 }
 
 template <typename T> T inline get_value(DeviceModelInterface& storage, v16::keys::valid_keys key) {
     const auto result = get_optional<T>(storage, key);
     if (!result) {
         raise_not_found(v16::keys::to_section_string_view(key), v16::keys::convert(key));
+    }
+    return result.value();
+}
+
+template <typename T, typename C>
+T get_value(DeviceModelInterface& storage, const C& var, v2::AttributeEnum attribute) {
+    const auto result = get_optional<T>(storage, var, attribute);
+    if (!result) {
+        const std::string component = var.component.name;
+        std::string variable;
+        if (var.variable) {
+            variable = var.variable.value().name;
+        }
+        raise_not_found(component, variable);
     }
     return result.value();
 }
@@ -166,17 +240,26 @@ template <typename T> inline void get_value(T& value, DeviceModelInterface& stor
     value = get_value<T>(storage, key);
 }
 
-bool key_exists(DeviceModelInterface& storage, const std::string_view& component, const std::string_view& variable) {
-    const v2::Component component_v{std::string{component}};
-    const v2::Variable variable_v{std::string{variable}};
-    const auto result = storage.get_variable_meta_data(component_v, variable_v);
+bool key_exists(DeviceModelInterface& storage, const v2::Component& component, const v2::Variable& variable) {
+    const auto result = storage.get_variable_meta_data(component, variable);
     return result.has_value();
 }
 
+bool key_exists(DeviceModelInterface& storage, const std::string_view& component, const std::string_view& variable) {
+    const v2::Component component_v{std::string{component}};
+    const v2::Variable variable_v{std::string{variable}};
+    return key_exists(storage, component_v, variable_v);
+}
+
 bool key_exists(DeviceModelInterface& storage, v16::keys::valid_keys key) {
-    const auto component = v16::keys::to_section_string_view(key);
-    const auto variable = v16::keys::convert(key);
-    return key_exists(storage, component, variable);
+    bool result{false};
+    const auto cv = v16::keys::convert_v2(key);
+    if (cv) {
+        const auto& component = std::get<v2::Component>(*cv);
+        const auto& variable = std::get<v2::Variable>(*cv);
+        result = key_exists(storage, component, variable);
+    }
+    return result;
 }
 
 std::optional<v16::KeyValue> get_key_value_optional(DeviceModelInterface& storage, v16::keys::valid_keys key) {
@@ -205,17 +288,35 @@ inline v16::KeyValue get_key_value(DeviceModelInterface& storage, v16::keys::val
 }
 
 /// set known key to specified value
+SetResult set_value(DeviceModelInterface& storage, const v2::Component& component, const v2::Variable& variable,
+                    const std::string& value) {
+    return storage.set_value(component, variable, v2::AttributeEnum::Actual, value, "OCPP 1.6");
+}
+
+SetResult set_value(DeviceModelInterface& storage, const v2::RequiredComponentVariable& var, const std::string& value) {
+    auto result = SetResult::UnknownVariable;
+    if (var.variable) {
+        result = set_value(storage, var.component, var.variable.value(), value);
+    }
+    return result;
+}
+
 SetResult set_value(DeviceModelInterface& storage, const std::string_view& component, const std::string_view& variable,
                     const std::string& value) {
     const v2::Component component_v{std::string{component}};
     const v2::Variable variable_v{std::string{variable}};
-    return storage.set_value(component_v, variable_v, v2::AttributeEnum::Actual, value, "OCPP 1.6");
+    return set_value(storage, component_v, variable_v, value);
 }
 
 SetResult set_value(DeviceModelInterface& storage, v16::keys::valid_keys key, const std::string& value) {
-    const v2::Component component{std::string{v16::keys::to_section_string_view(key)}};
-    const v2::Variable variable{std::string{v16::keys::convert(key)}};
-    return storage.set_value(component, variable, v2::AttributeEnum::Actual, value, "OCPP 1.6");
+    auto result = SetResult::UnknownVariable;
+    const auto cv = v16::keys::convert_v2(key);
+    if (cv) {
+        const auto& component = std::get<v2::Component>(*cv);
+        const auto& variable = std::get<v2::Variable>(*cv);
+        result = set_value(storage, component, variable, value);
+    }
+    return result;
 }
 
 /// set known key to optional specified value
@@ -278,7 +379,7 @@ inline SetResult set_value_check(check_fn fn, DeviceModelInterface& storage, v16
 // Custom key support ...
 
 template <typename T> std::optional<T> get_optional(DeviceModelInterface& storage, const std::string_view& name) {
-    return get_optional<T>(storage, custom_component, name);
+    return get_optional<T>(storage, custom_component, name, v2::AttributeEnum::Actual);
 }
 
 template <typename T> inline T get_value(DeviceModelInterface& storage, const std::string_view& name) {
@@ -304,7 +405,7 @@ std::optional<v16::KeyValue> get_key_value_optional(DeviceModelInterface& storag
     if (get_result) {
         v16::KeyValue kv;
         kv.key = std::move(std::string{name});
-        kv.readonly = isReadOnly(storage, custom_component, name).value_or(true);
+        kv.readonly = isReadOnly(storage, custom_component, name, v2::AttributeEnum::Actual).value_or(true);
         kv.value = get_result.value();
         result = kv;
     }
@@ -326,9 +427,10 @@ bool key_exists(DeviceModelInterface& storage, const std::string_view& name) {
 
 /// \brief set custom value
 SetResult set_value(DeviceModelInterface& storage, const std::string_view& name, const std::string& value) {
-    const v2::Component component{custom_component};
+    // CiString is missing many construct options - so creating a temporary string
+    const v2::Component component{std::string{custom_component}};
     const v2::Variable variable{std::string{name}};
-    return storage.set_value(component, variable, v2::AttributeEnum::Actual, value, "OCPP 1.6");
+    return set_value(storage, component, variable, value);
 }
 
 /// \brief set custom value
@@ -353,6 +455,22 @@ inline SetResult set_value_check(DeviceModelInterface& storage, const std::strin
     return result;
 }
 
+void add_to_list(v16::utils::OrderedUniqueStringList& list, const ocpp::v2::ReportData& entry) {
+    // VariableCharacteristics of valuesList are added to the set of they exist
+    if (entry.variableCharacteristics) {
+        std::optional<std::string> csl = entry.variableCharacteristics.value().valuesList;
+        if (csl) {
+            auto vec = v16::utils::from_csl(csl.value());
+            for (auto& i : vec) {
+                list.insert(std::move(i));
+            }
+        }
+    } else {
+        EVLOG_info << "ReportData with no variableCharacteristics: " << entry.component.name << '['
+                   << entry.variable.name << ']';
+    }
+}
+
 } // namespace
 
 // ----------------------------------------------------------------------------
@@ -370,9 +488,9 @@ ChargePointConfigurationDeviceModel::setInternalAllowChargingProfileWithoutStart
 
 ChargePointConfigurationDeviceModel::SetResult
 ChargePointConfigurationDeviceModel::setInternalCentralSystemURI(const std::string& value) {
-    EVLOG_warning << "CentralSystemURI changed to: " << value;
     auto result = set_value(*storage, keys::valid_keys::CentralSystemURI, value);
     if (result == SetResult::Accepted) {
+        EVLOG_warning << "CentralSystemURI changed to: " << value;
         result = SetResult::RebootRequired;
     }
     return result;
@@ -408,7 +526,32 @@ ChargePointConfigurationDeviceModel::setInternalCompositeScheduleDefaultNumberPh
 
 ChargePointConfigurationDeviceModel::SetResult
 ChargePointConfigurationDeviceModel::setInternalConnectorEvseIds(const std::string& value) {
-    return set_value_check(areValidEvseIds, *storage, keys::valid_keys::ConnectorEvseIds, value);
+    auto result = SetResult::Rejected;
+    const auto existing = calculateEvseIds();
+    if (existing) {
+        // an existing value for ConnectorEvseIds needs to exist
+        if (areValidEvseIds(value)) {
+            bool valid{true};
+            const auto evse_ids = v16::utils::split_string(',', value);
+            std::size_t index{1};
+            v2::Component component{"EVSE"};
+            v2::Variable variable{"ISO15118EvseId"};
+            for (const auto evse_id : evse_ids) {
+                v2::EVSE evse;
+                evse.id = static_cast<decltype(evse.id)>(index++);
+                component.evse = std::move(evse);
+                if (set_value(*storage, component, variable, evse_id) != SetResult::Accepted) {
+                    valid = false;
+                }
+            }
+            if (valid) {
+                result = SetResult::Accepted;
+            }
+        } else {
+            EVLOG_warning << "Invalid ConnectorEvseIds: " << value;
+        }
+    }
+    return result;
 }
 
 ChargePointConfigurationDeviceModel::SetResult
@@ -756,8 +899,7 @@ ChargePointConfigurationDeviceModel::SetResult
 ChargePointConfigurationDeviceModel::setInternalDefaultPrice(const std::string& value) {
     SetResult result{SetResult::Rejected};
     try {
-        json default_price = json::object();
-        default_price = json::parse(value);
+        auto default_price = json::parse(value);
 
         // perform schema validation on value
         json test_value;
@@ -923,6 +1065,63 @@ ChargePointConfigurationDeviceModel::setInternalWaitForSetUserPriceTimeout(const
     return set_value_check(check, *storage, keys::valid_keys::WaitForSetUserPriceTimeout, value);
 }
 
+std::optional<std::string> ChargePointConfigurationDeviceModel::calculateEvseIds() {
+    // the 15118 EVSE ID is available from the EVSE component
+    // iterate through the valid EVSEs to obtain the IDs
+    // variable name is ISO15118EvseId
+    std::optional<std::string> result;
+    bool found{false};
+    const auto max = getNumberOfConnectors();
+    v2::Component component{"EVSE"};
+    v2::Variable variable{"ISO15118EvseId"};
+    std::vector<std::string> evse_ids;
+    if (max > 0) {
+        for (std::size_t i = 1; i <= max; i++) {
+            v2::EVSE evse;
+            evse.id = static_cast<decltype(evse.id)>(i);
+            component.evse = std::move(evse);
+            auto value = get_optional<std::string>(*storage, component, variable, v2::AttributeEnum::Actual);
+            if (value) {
+                found = true; // at least one instance exists
+                evse_ids.push_back(std::move(value.value()));
+            } else {
+                // support EVSEs with no ISO15118EvseId
+                evse_ids.emplace_back();
+            }
+        }
+    }
+    if (found) {
+        result = std::move(v16::utils::to_csl(evse_ids));
+    }
+    return result;
+}
+
+std::string ChargePointConfigurationDeviceModel::calculateSupportedMeasurands() {
+    // these are not in a single place in the V2 device model
+    // - AlignedDataCtrlr->Measurands
+    // - AlignedDataCtrlr->TxEndedMeasurands
+    // - SampledDataCtrlr->TxEndedMeasurands
+    // - SampledDataCtrlr->TxStartedMeasurands
+    // - SampledDataCtrlr->TxUpdatedMeasurands
+
+    using namespace ocpp::v2::ControllerComponentVariables;
+
+    const std::vector<v2::ComponentVariable> component_variables = {
+        {AlignedDataMeasurands.component, AlignedDataMeasurands.variable},
+        {AlignedDataTxEndedMeasurands.component, AlignedDataTxEndedMeasurands.variable},
+        {SampledDataTxEndedMeasurands.component, SampledDataTxEndedMeasurands.variable},
+        {SampledDataTxStartedMeasurands.component, SampledDataTxStartedMeasurands.variable},
+        {SampledDataTxUpdatedMeasurands.component, SampledDataTxUpdatedMeasurands.variable},
+    };
+
+    const auto report = storage->get_custom_report_data(component_variables);
+    v16::utils::OrderedUniqueStringList valid_measurands;
+    for (const auto& i : report) {
+        add_to_list(valid_measurands, i);
+    }
+    return v16::utils::to_csl(valid_measurands.get());
+}
+
 // ----------------------------------------------------------------------------
 // Public methods
 
@@ -930,35 +1129,43 @@ ChargePointConfigurationDeviceModel::ChargePointConfigurationDeviceModel(
     const std::string_view& ocpp_main_path, std::unique_ptr<v2::DeviceModelInterface> device_model_interface) :
     ChargePointConfigurationBase(ocpp_main_path), storage(std::move(device_model_interface)) {
     const auto profiles = get_optional<std::string>(*storage, keys::valid_keys::SupportedFeatureProfiles);
-    const auto measurands = get_optional<std::string>(*storage, keys::valid_keys::SupportedMeasurands);
+    const auto measurands = calculateSupportedMeasurands();
     ProfilesSet initial;
 
-    // TODO(james-ctc): check how to determine this for v2
-    // get from the device model e.g. perhaps:
-    // CustomizationCtrlr, ISO15118Ctrlr, TariffCostCtrlr
+    bool PnC_found{false};
+    bool CostAndPrice_found{false};
+    bool Custom_found{false};
 
-#if 0
-    // If supported add to initial set
+    // check the device model to identify other supported feature profiles
+    const auto report = storage->get_base_report_data(v2::ReportBaseEnum::ConfigurationInventory);
+    for (const auto& entry : report) {
+        const std::string component = entry.component.name;
+        const std::string variable = entry.variable.name;
+        EVLOG_debug << "Component: " << component << " Variable: " << variable;
+        if (component == custom_component && variable == "CustomImplementationEnabled") {
+            Custom_found = true;
+        } else if (component == pnc_component && variable == "PnCEnabled") {
+            PnC_found = true;
+        } else if (component == cost_and_price_component &&
+                   (variable == "CustomDisplayCostAndPrice" || starts_with(variable, "DefaultPrice"))) {
+            CostAndPrice_found = true;
+        }
+    }
 
-    if (config.contains("PnC")) {
+    if (PnC_found) {
         // add PnC behind the scenes as supported feature profile
-        initial.insert(conversions::string_to_supported_feature_profiles("PnC"));
+        initial.insert(conversions::string_to_supported_feature_profiles(pnc_feature));
     }
 
-    if (config.contains("CostAndPrice")) {
+    if (CostAndPrice_found) {
         // Add California Pricing Requirements behind the scenes as supported feature profile
-        initial.insert(conversions::string_to_supported_feature_profiles("CostAndPrice"));
+        initial.insert(conversions::string_to_supported_feature_profiles(cost_and_price_feature));
     }
 
-    if (config.contains(custom_component)) {
+    if (Custom_found) {
         // add Custom behind the scenes as supported feature profile
-        initial.insert(conversions::string_to_supported_feature_profiles(custom_component));
+        initial.insert(conversions::string_to_supported_feature_profiles(custom_feature));
     }
-#else
-    // TODO(james-ctc): remove these - just added for unit tests
-    initial.insert(conversions::string_to_supported_feature_profiles("PnC"));
-    initial.insert(conversions::string_to_supported_feature_profiles("CostAndPrice"));
-#endif
 
     initialise(initial, profiles, measurands);
 }
@@ -1065,7 +1272,7 @@ std::string ChargePointConfigurationDeviceModel::getSupportedCiphers13() {
 }
 
 std::string ChargePointConfigurationDeviceModel::getSupportedMeasurands() {
-    return get_value<std::string>(*storage, keys::valid_keys::SupportedMeasurands);
+    return calculateSupportedMeasurands();
 }
 
 std::string ChargePointConfigurationDeviceModel::getTLSKeylogFile() {
@@ -1219,7 +1426,12 @@ std::vector<ChargingProfilePurposeType> ChargePointConfigurationDeviceModel::get
 }
 
 std::optional<std::string> ChargePointConfigurationDeviceModel::getConnectorEvseIds() {
-    return get_optional<std::string>(*storage, keys::valid_keys::ConnectorEvseIds);
+    std::optional<std::string> result;
+    auto evse_ids = calculateEvseIds();
+    if (evse_ids) {
+        result = std::move(evse_ids.value());
+    }
+    return result;
 }
 
 std::optional<std::string> ChargePointConfigurationDeviceModel::getHostName() {
@@ -1286,7 +1498,7 @@ std::optional<KeyValue> ChargePointConfigurationDeviceModel::getPublicKeyKeyValu
                       << ", because the connector id does not exist.";
     } else {
         auto key = meterPublicKeyString(connector_id);
-        auto value = get_optional<std::string>(*storage, "Internal", key);
+        auto value = get_optional<std::string>(*storage, "Internal", key, v2::AttributeEnum::Actual);
         if (value) {
             KeyValue kv;
             kv.key = std::move(key);
@@ -1304,8 +1516,9 @@ KeyValue ChargePointConfigurationDeviceModel::getAuthorizeConnectorZeroOnConnect
 
 KeyValue ChargePointConfigurationDeviceModel::getCentralSystemURIKeyValue() {
     auto kv = get_key_value(*storage, keys::valid_keys::CentralSystemURI);
-    // this may be changeable so check the device model rather than known_keys
-    kv.readonly = isReadOnly(*storage, "Internal", "CentralSystemURI").value_or(true);
+    kv.readonly =
+        isReadOnly(*storage, ocpp::v2::ControllerComponentVariables::CentralSystemURI16, v2::AttributeEnum::Actual)
+            .value_or(true);
     return kv;
 }
 
@@ -1394,7 +1607,15 @@ KeyValue ChargePointConfigurationDeviceModel::getSupportedCiphers13KeyValue() {
 }
 
 KeyValue ChargePointConfigurationDeviceModel::getSupportedMeasurandsKeyValue() {
-    return get_key_value(*storage, keys::valid_keys::SupportedMeasurands);
+    auto result = calculateSupportedMeasurands();
+    const auto key = keys::valid_keys::SupportedMeasurands;
+    v16::KeyValue kv;
+    kv.key = std::move(std::string{v16::keys::convert(key)});
+    kv.readonly = v16::keys::is_readonly(key);
+    if (!result.empty()) {
+        kv.value = std::move(result);
+    }
+    return kv;
 }
 
 KeyValue ChargePointConfigurationDeviceModel::getTLSKeylogFileKeyValue() {
@@ -1454,7 +1675,17 @@ std::optional<KeyValue> ChargePointConfigurationDeviceModel::getCompositeSchedul
 }
 
 std::optional<KeyValue> ChargePointConfigurationDeviceModel::getConnectorEvseIdsKeyValue() {
-    return get_key_value_optional(*storage, keys::valid_keys::ConnectorEvseIds);
+    auto evse_ids = calculateEvseIds();
+    std::optional<KeyValue> result;
+    if (evse_ids) {
+        const auto key = keys::valid_keys::ConnectorEvseIds;
+        v16::KeyValue kv;
+        kv.key = std::move(std::string{v16::keys::convert(key)});
+        kv.readonly = v16::keys::is_readonly(key);
+        kv.value = std::move(evse_ids.value());
+        result = std::move(kv);
+    }
+    return result;
 }
 
 std::optional<KeyValue> ChargePointConfigurationDeviceModel::getHostNameKeyValue() {
@@ -2084,7 +2315,7 @@ std::int32_t ChargePointConfigurationDeviceModel::getSecurityProfile() {
 }
 
 std::optional<std::string> ChargePointConfigurationDeviceModel::getAuthorizationKey() {
-    return get_optional<std::string>(*storage, keys::valid_keys::AuthorizationKey);
+    return get_optional<std::string>(*storage, keys::valid_keys::AuthorizationKey, true);
 }
 
 std::optional<std::string> ChargePointConfigurationDeviceModel::getCpoName() {
@@ -2413,9 +2644,9 @@ KeyValue ChargePointConfigurationDeviceModel::getDefaultPriceTextKeyValue(const 
         result.value = get_result.value();
     } else {
         // It's a bit odd to return an empty string here, but it must be possible to set a default price text for a
-        // new language. But since the 'set' function for configurations first performs a 'get' and does not continue
-        // if it receives a nullopt, we can better just return an empty string so the 'set' function can continue.
-        // Resolving it differently required more complexer code, this was the easiest way to do it.
+        // new language. But since the 'set' function for configurations first performs a 'get' and does not
+        // continue if it receives a nullopt, we can better just return an empty string so the 'set' function can
+        // continue. Resolving it differently required more complexer code, this was the easiest way to do it.
         result.value = "";
     }
     return result;
@@ -2546,7 +2777,7 @@ ConfigurationStatus ChargePointConfigurationDeviceModel::setCustomKey(const CiSt
     const std::string sv_key{key};
     auto result = ConfigurationStatus::Rejected;
 
-    const auto exists_ro = isReadOnly(*storage, custom_component, sv_key);
+    const auto exists_ro = isReadOnly(*storage, custom_component, sv_key, v2::AttributeEnum::Actual);
     if (exists_ro) {
         // the key exists (not allowed to create keys)
         const auto ro = exists_ro.value();
@@ -2593,8 +2824,6 @@ std::optional<KeyValue> ChargePointConfigurationDeviceModel::get(const CiString<
             get_value = false;
         }
 
-        // TODO(james-ctc): check for SupportedFeatureProfiles::Custom from device model
-
         if (keys::is_hidden(sv_key)) {
             // we should not return an AuthorizationKey because it's write only
             get_value = false;
@@ -2628,6 +2857,7 @@ std::optional<KeyValue> ChargePointConfigurationDeviceModel::get(const CiString<
             // known key
             result = get_key_value_optional(*storage, sv_key_opt.value());
         } else {
+            // TODO(james-ctc): check for SupportedFeatureProfiles::Custom from device model
             // custom key
             result = get_key_value_optional(*storage, key_str);
         }
@@ -2637,23 +2867,95 @@ std::optional<KeyValue> ChargePointConfigurationDeviceModel::get(const CiString<
 }
 
 std::vector<KeyValue> ChargePointConfigurationDeviceModel::get_all_key_value() {
+    using namespace v2::ControllerComponentVariables;
+
     std::vector<KeyValue> all;
+    v16::utils::OrderedUniqueStringList valid_measurands;
     const auto report = storage->get_base_report_data(v2::ReportBaseEnum::ConfigurationInventory);
     for (const auto& entry : report) {
         const auto& component = entry.component;
         const auto& variable = entry.variable;
+        const auto& value_attribute = entry.variableAttribute;
+        auto attribute = v2::AttributeEnum::Actual;
+        auto mutability = v2::MutabilityEnum::ReadOnly;
+        std::string value;
+        if (!value_attribute.empty()) {
+            attribute = value_attribute.front().type.value_or(v2::AttributeEnum::Actual);
+            mutability = value_attribute.front().mutability.value_or(v2::MutabilityEnum::ReadOnly);
+            value = value_attribute.front().value.value_or("");
+        }
         try {
-            const auto feature = conversions::string_to_supported_feature_profiles(component.name);
-            if (const auto it = supported_feature_profiles.find(feature); it != supported_feature_profiles.end()) {
-                auto kv = get(variable.name);
-                if (kv) {
-                    all.push_back(std::move(kv.value()));
+            // convert to OCPP 1.6 key
+            const auto v16_key_opt = keys::convert_v2(component, variable, attribute);
+            if (v16_key_opt) {
+                // convert string to enum
+                const auto key = keys::convert(*v16_key_opt);
+                if (key) {
+                    const auto feature = keys::get_profile(*key);
+                    if (feature) {
+                        // check key is valid against the supported profiles
+                        if (const auto it = supported_feature_profiles.find(*feature);
+                            it != supported_feature_profiles.end()) {
+                            KeyValue kv;
+                            kv.key = *v16_key_opt;
+                            if (!value.empty()) {
+                                kv.value = std::move(value);
+                            }
+                            kv.readonly = mutability == v2::MutabilityEnum::ReadOnly;
+                            all.push_back(std::move(kv));
+                        }
+                    } else {
+                        EVLOG_warning << "OCPP 1.6 key not associated with a profile: " << *v16_key_opt;
+                    }
+
+                    if (key == keys::valid_keys::MeterValuesAlignedData) {
+                        add_to_list(valid_measurands, entry);
+                    } else if (key == keys::valid_keys::StopTxnAlignedData) {
+                        add_to_list(valid_measurands, entry);
+                    } else if (key == keys::valid_keys::StopTxnSampledData) {
+                        add_to_list(valid_measurands, entry);
+                    } else if (key == keys::valid_keys::MeterValuesSampledData) {
+                        add_to_list(valid_measurands, entry);
+                    }
+                } else {
+                    EVLOG_warning << "OCPP 1.6 key not recognised: " << *v16_key_opt;
+                }
+            } else {
+                if (is_same(SampledDataTxStartedMeasurands, component, variable)) {
+                    add_to_list(valid_measurands, entry);
+                } else {
+                    // check for OCPP 1.6 custom variables
+                    // don't include all 2.x keys
+                    if (component.name == custom_component) {
+                        KeyValue kv;
+                        kv.key = variable.name;
+                        if (!value.empty()) {
+                            kv.value = std::move(value);
+                        }
+                        kv.readonly = mutability == v2::MutabilityEnum::ReadOnly;
+                        all.push_back(std::move(kv));
+                    }
                 }
             }
         } catch (std::exception& ex) {
             EVLOG_error << "Device model '" << component.name << "' not supported: " << ex.what();
         }
     }
+
+    // add SupportedMeasurands
+    std::string supported_measurands;
+    if (!valid_measurands.empty()) {
+        supported_measurands = v16::utils::to_csl(valid_measurands.get());
+    }
+    KeyValue kv;
+    const auto key = keys::valid_keys::SupportedMeasurands;
+    kv.key = std::move(std::string{v16::keys::convert(key)});
+    if (!supported_measurands.empty()) {
+        kv.value = supported_measurands;
+    }
+    kv.readonly = v16::keys::is_readonly(key);
+    all.push_back(std::move(kv));
+
     return all;
 }
 
@@ -2945,7 +3247,7 @@ std::optional<ConfigurationStatus> ChargePointConfigurationDeviceModel::set(cons
             // not setable
         } else {
             // custom key
-            const auto exists_ro = isReadOnly(*storage, custom_component, key_str);
+            const auto exists_ro = isReadOnly(*storage, custom_component, key_str, v2::AttributeEnum::Actual);
             if (!exists_ro.value_or(true)) {
                 // key exists and is not read-only
                 const auto res = set_value(*storage, key_str, value_str);

--- a/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
@@ -1,10 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
+#include "ocpp/v2/ocpp_enums.hpp"
+#include <everest/logging.hpp>
 #include <ocpp/v16/known_keys.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
 
 #include <algorithm>
 #include <iterator>
+#include <map>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
 
 namespace {
 using ocpp::v16::keys::valid_keys;
@@ -92,6 +100,126 @@ constexpr valid_keys read_only[] = {FOR_ALL_READONLY(VALUE)};
 constexpr valid_keys hidden[] = {FOR_ALL_HIDDEN(VALUE)};
 
 #undef VALUE
+
+constexpr char convert(ocpp::v2::AttributeEnum attribute) {
+    char result{'.'};
+    switch (attribute) {
+    case ocpp::v2::AttributeEnum::Actual:
+        result = 'A';
+        break;
+    case ocpp::v2::AttributeEnum::MaxSet:
+        result = '+';
+        break;
+    case ocpp::v2::AttributeEnum::MinSet:
+        result = '-';
+        break;
+    case ocpp::v2::AttributeEnum::Target:
+        result = '=';
+        break;
+    default:
+        break;
+    }
+    return result;
+}
+
+inline std::string mapping_name(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
+                                ocpp::v2::AttributeEnum attribute) {
+    return std::string{component.name} + std::string{variable.name} + std::string{variable.instance.value_or("")} +
+           convert(attribute);
+}
+
+class V2ConfigMap {
+private:
+    bool configured{false};
+    using v2details = std::pair<const ocpp::v2::ComponentVariable*, ocpp::v2::AttributeEnum>;
+
+    std::map<std::string_view, v2details> map;
+    std::map<std::string, std::string_view> reverse_map;
+
+    void configure(const std::string_view& v16, const ocpp::v2::ComponentVariable& cv,
+                   ocpp::v2::AttributeEnum attribute);
+    void configure();
+    void warn_no_mapping(const std::string_view& v16);
+    void check();
+
+public:
+    ocpp::v16::keys::DeviceModel_CV convert_v2(const std::string_view& v16_key);
+    std::optional<std::string> convert_v2(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
+                                          ocpp::v2::AttributeEnum attribute);
+};
+
+void V2ConfigMap::configure(const std::string_view& v16, const ocpp::v2::ComponentVariable& cv,
+                            ocpp::v2::AttributeEnum attribute) {
+    if (cv.variable) {
+        if (const auto it = map.find(v16); it != map.end()) {
+            const auto& tmp_cv = std::get<const ocpp::v2::ComponentVariable*>(it->second);
+            if (tmp_cv->variable) {
+                EVLOG_warning << "V16 " << v16 << ": '" << tmp_cv->variable->name << "' replaced with '"
+                              << cv.variable->name << '\'';
+            }
+        }
+        map.insert_or_assign(v16, v2details{&cv, attribute});
+        std::string name = mapping_name(cv.component, cv.variable.value(), attribute);
+        if (const auto it = reverse_map.find(name); it != reverse_map.end()) {
+            EVLOG_error << "V2 " << name << ": '" << it->second << "' replaced with '" << v16 << '\'';
+        }
+        reverse_map.insert_or_assign(std::move(name), v16);
+    }
+}
+
+#define VALUE(a, b, c) configure(#a, ocpp::v2::ControllerComponentVariables::b, ocpp::v2::AttributeEnum::c);
+void V2ConfigMap::configure() {
+    if (!configured) {
+        configured = true;
+        MAPPING_ALL(VALUE)
+        check();
+    }
+}
+#undef VALUE
+
+void V2ConfigMap::warn_no_mapping(const std::string_view& v16) {
+    const auto it = map.find(v16);
+    if (it == map.end()) {
+        EVLOG_error << "No V2 mapping for " << v16;
+    }
+}
+
+#define VALUE(a, b) warn_no_mapping(#b);
+void V2ConfigMap::check() {
+    if (configured) {
+        FOR_ALL_MAPPED_KEYS(VALUE);
+    }
+}
+#undef VALUE
+
+ocpp::v16::keys::DeviceModel_CV V2ConfigMap::convert_v2(const std::string_view& v16_key) {
+    configure();
+    ocpp::v16::keys::DeviceModel_CV result;
+    std::string name{v16_key};
+    if (const auto it = map.find(name); it != map.end()) {
+        const auto& cv = std::get<const ocpp::v2::ComponentVariable*>(it->second);
+        const auto attribute = std::get<ocpp::v2::AttributeEnum>(it->second);
+        if (cv->variable) {
+            result = std::make_tuple(cv->component, cv->variable.value(), attribute);
+        }
+    }
+    return result;
+}
+
+std::optional<std::string> V2ConfigMap::convert_v2(const ocpp::v2::Component& component,
+                                                   const ocpp::v2::Variable& variable,
+                                                   ocpp::v2::AttributeEnum attribute) {
+    configure();
+    std::optional<std::string> result;
+    std::string name = mapping_name(component, variable, attribute);
+    if (const auto it = reverse_map.find(name); it != reverse_map.end()) {
+        result = it->second;
+    }
+    return result;
+}
+
+V2ConfigMap v2_map;
+
 } // namespace
 
 namespace ocpp::v16::keys {
@@ -156,6 +284,35 @@ bool is_readonly(valid_keys key) {
 
 bool is_hidden(valid_keys key) {
     return std::find(std::cbegin(hidden), std::cend(hidden), key) != std::cend(hidden);
+}
+
+#undef VALUE
+#define VALUE(a, b)                                                                                                    \
+    case valid_keys::b:                                                                                                \
+        return ocpp::v16::SupportedFeatureProfiles::a;
+
+std::optional<ocpp::v16::SupportedFeatureProfiles> get_profile(valid_keys key) {
+    switch (key) {
+        FOR_ALL_KEYS(VALUE)
+    default:
+        break;
+    }
+    return std::nullopt;
+}
+
+#undef VALUE
+
+DeviceModel_CV convert_v2(const std::string_view& str) {
+    return v2_map.convert_v2(str);
+}
+
+DeviceModel_CV convert_v2(valid_keys key) {
+    return convert_v2(convert(key));
+}
+
+std::optional<std::string> convert_v2(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
+                                      ocpp::v2::AttributeEnum attribute) {
+    return v2_map.convert_v2(component, variable, attribute);
 }
 
 } // namespace ocpp::v16::keys

--- a/lib/everest/ocpp/lib/ocpp/v16/types.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/types.cpp
@@ -459,7 +459,7 @@ std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
 
 /// \brief Converts the given std::string \p s to SupportedFeatureProfiles
 /// \returns a SupportedFeatureProfiles from a string representation
-SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string& s) {
+SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string_view& s) {
     if (s == "Internal") {
         return SupportedFeatureProfiles::Internal;
     }

--- a/lib/everest/ocpp/lib/ocpp/v16/utils.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/utils.cpp
@@ -94,4 +94,17 @@ std::vector<std::string> split_string(char separator, const std::string& csl) {
     return vec;
 }
 
+void OrderedUniqueStringList::do_insert(std::string&& s) {
+    if (const auto it = list.find(s); it == list.end()) {
+        list.insert({std::move(s), count++});
+    }
+}
+std::vector<std::string> OrderedUniqueStringList::get() const {
+    std::vector<std::string> result(list.size());
+    for (const auto& i : list) {
+        result[i.second] = i.first;
+    }
+    return result;
+}
+
 } // namespace ocpp::v16::utils

--- a/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -27,6 +27,8 @@ const Component SecurityCtrlr = {"SecurityCtrlr"};
 const Component SmartChargingCtrlr = {"SmartChargingCtrlr"};
 const Component TariffCostCtrlr = {"TariffCostCtrlr"};
 const Component TxCtrlr = {"TxCtrlr"};
+const Component OCPP16LegacyCtrlr = {"OCPP16LegacyCtrlr"};
+const Component CustomLegacyController = {"CustomLegacyController"};
 } // namespace ControllerComponents
 
 namespace StandardizedVariables {
@@ -1215,6 +1217,181 @@ const ComponentVariable ISO15118CtrlrAvailable = {
     }),
 };
 
+// OCPP1.6 Mavericks - Configuration keys without direct OCPP 2.x equivalents
+const ComponentVariable BlinkRepeat = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "BlinkRepeat",
+    }),
+};
+const ComponentVariable ConnectorPhaseRotation = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "ConnectorPhaseRotation",
+    }),
+};
+const ComponentVariable ConnectorPhaseRotationMaxLength = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "ConnectorPhaseRotationMaxLength",
+    }),
+};
+const RequiredComponentVariable GetConfigurationMaxKeys = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "GetConfigurationMaxKeys",
+    }),
+};
+const ComponentVariable LightIntensity = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "LightIntensity",
+    }),
+};
+const ComponentVariable MinimumStatusDuration = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "MinimumStatusDuration",
+    }),
+};
+const ComponentVariable StopTransactionOnEVSideDisconnect = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "StopTransactionOnEVSideDisconnect",
+    }),
+};
+const RequiredComponentVariable SupportedFeatureProfiles = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "SupportedFeatureProfiles",
+    }),
+};
+const ComponentVariable SupportedFeatureProfilesMaxLength = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "SupportedFeatureProfilesMaxLength",
+    }),
+};
+const RequiredComponentVariable UnlockConnectorOnEVSideDisconnect = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "UnlockConnectorOnEVSideDisconnect",
+    }),
+};
+const ComponentVariable ReserveConnectorZeroSupported = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "ReserveConnectorZeroSupported",
+    }),
+};
+const ComponentVariable HostName = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "HostName",
+    }),
+};
+const ComponentVariable AllowChargingProfileWithoutStartSchedule = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "AllowChargingProfileWithoutStartSchedule",
+    }),
+};
+const ComponentVariable WaitForStopTransactionsOnResetTimeout = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "WaitForStopTransactionsOnResetTimeout",
+    }),
+};
+const ComponentVariable StopTransactionIfUnlockNotSupported = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "StopTransactionIfUnlockNotSupported",
+    }),
+};
+const ComponentVariable MeterPublicKeys = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "MeterPublicKeys",
+    }),
+};
+const ComponentVariable DisableSecurityEventNotifications = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "DisableSecurityEventNotifications",
+    }),
+};
+const ComponentVariable ISO15118CertificateManagementEnabled = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "ISO15118CertificateManagementEnabled",
+    }),
+};
+const ComponentVariable CustomDisplayCostAndPrice = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "CustomDisplayCostAndPrice",
+    }),
+};
+const ComponentVariable DefaultPrice = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "DefaultPrice",
+    }),
+};
+const ComponentVariable DefaultPriceText = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "DefaultPriceText",
+    }),
+};
+const ComponentVariable CustomIdleFeeAfterStop = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "CustomIdleFeeAfterStop",
+    }),
+};
+const ComponentVariable SupportedLanguages = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "SupportedLanguages",
+    }),
+};
+const ComponentVariable CustomMultiLanguageMessages = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "CustomMultiLanguageMessages",
+    }),
+};
+const ComponentVariable Language = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "Language",
+    }),
+};
+const ComponentVariable WaitForSetUserPriceTimeout = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "WaitForSetUserPriceTimeout",
+    }),
+};
+const ComponentVariable AuthorizationKey16 = {
+    ControllerComponents::CustomLegacyController,
+    std::optional<Variable>({
+        "AuthorizationKey",
+    }),
+};
+const RequiredComponentVariable CentralSystemURI16 = {
+    ControllerComponents::CustomLegacyController,
+    std::optional<Variable>({
+        "CentralSystemURI",
+    }),
+};
+const RequiredComponentVariable SecurityProfile16 = {
+    ControllerComponents::CustomLegacyController,
+    std::optional<Variable>({
+        "SecurityProfile",
+    }),
+};
 } // namespace ControllerComponentVariables
 
 namespace EvseComponentVariables {

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_utils.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_utils.cpp
@@ -26,6 +26,42 @@ TEST(CSL, ToCSL) {
     EXPECT_FALSE(res.empty());
     EXPECT_EQ(res, "One,Two");
 
+    res = to_csl({"", "Two"});
+    EXPECT_FALSE(res.empty());
+    EXPECT_EQ(res, ",Two");
+
+    res = to_csl({"One", ""});
+    EXPECT_FALSE(res.empty());
+    EXPECT_EQ(res, "One,");
+
+    res = to_csl({"One", "Two", "Three"});
+    EXPECT_FALSE(res.empty());
+    EXPECT_EQ(res, "One,Two,Three");
+
+    res = to_csl({"", "", ""});
+    EXPECT_FALSE(res.empty());
+    EXPECT_EQ(res, ",,");
+
+    res = to_csl({"One", "", "Three"});
+    EXPECT_FALSE(res.empty());
+    EXPECT_EQ(res, "One,,Three");
+
+    res = to_csl({"", "Two", "Three"});
+    EXPECT_FALSE(res.empty());
+    EXPECT_EQ(res, ",Two,Three");
+
+    res = to_csl({"One", "Two", ""});
+    EXPECT_FALSE(res.empty());
+    EXPECT_EQ(res, "One,Two,");
+
+    res = to_csl({"", "", "Three"});
+    EXPECT_FALSE(res.empty());
+    EXPECT_EQ(res, ",,Three");
+
+    res = to_csl({"One", "", ""});
+    EXPECT_FALSE(res.empty());
+    EXPECT_EQ(res, "One,,");
+
     // TODO(james-ctc): should this be detected?
     res = to_csl({"One", "Two", "Three,Four"});
     EXPECT_FALSE(res.empty());

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
@@ -3,11 +3,14 @@
 
 #include "memory_storage.hpp"
 
-#include <iterator>
-#include <ocpp/v16/known_keys.hpp>
+#include <exception>
+#include <ocpp/v16/charge_point_configuration_devicemodel.hpp>
+#include <ocpp/v16/utils.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/ocpp_enums.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 
+#include <map>
 #include <optional>
 #include <string>
 
@@ -141,48 +144,113 @@ const std::map<std::string, std::string> full_vars_california_pricing = {
     {"Language", "en"},
 };
 
-std::map<std::string, std::string> vars_internal;
-std::map<std::string, std::string> vars_core;
-std::map<std::string, std::string> vars_firmware_management;
-std::map<std::string, std::string> vars_smart_charging;
-std::map<std::string, std::string> vars_security;
-std::map<std::string, std::string> vars_local_auth_list;
-std::map<std::string, std::string> vars_pnc;
-std::map<std::string, std::string> vars_california_pricing;
-std::map<std::string, std::string> vars_custom;
+using MemoryStorage = ocpp::v16::stubs::MemoryStorage;
+MemoryStorage::Storage vars_internal;
+MemoryStorage::Storage vars_core;
+MemoryStorage::Storage vars_firmware_management;
+MemoryStorage::Storage vars_smart_charging;
+MemoryStorage::Storage vars_security;
+MemoryStorage::Storage vars_local_auth_list;
+MemoryStorage::Storage vars_pnc;
+MemoryStorage::Storage vars_california_pricing;
+MemoryStorage::Storage vars_custom;
+MemoryStorage::Storage vars_additional;
+
+const std::vector<MemoryStorage::Storage*> vars_list = {
+    &vars_internal,        &vars_core, &vars_firmware_management, &vars_smart_charging, &vars_security,
+    &vars_local_auth_list, &vars_pnc,  &vars_california_pricing,  &vars_custom,         &vars_additional,
+};
 
 const ocpp::v2::VariableCharacteristics characteristics = {ocpp::v2::DataEnum::string, false, {}, {}, {}, {}, {}, {}};
 const ocpp::v2::VariableMetaData meta_data = {characteristics, {}, {}};
 
-void add_to_report(std::vector<ocpp::v2::ReportData>& report, const std::string_view& name,
-                   const std::map<std::string, std::string>& vars) {
-    ocpp::v2::Component component{std::string{name}, {}, {}, {}};
-
-    for (const auto& i : vars) {
-        ocpp::v2::Variable variable{i.first, {}, {}};
-        ocpp::v2::ReportData data;
-        data.component = component;
-        data.variable = variable;
-        report.push_back(std::move(data));
-    }
+bool operator==(const ocpp::v2::Component& lhs, const ocpp::v2::Component& rhs) {
+    return lhs.name == rhs.name;
 }
 
-void generate_report(std::vector<ocpp::v2::ReportData>& report) {
-    report.clear();
-    add_to_report(report, "Internal", vars_internal);
-    add_to_report(report, "Core", vars_core);
-    add_to_report(report, "FirmwareManagement", vars_firmware_management);
-    add_to_report(report, "SmartCharging", vars_smart_charging);
-    add_to_report(report, "Security", vars_security);
-    add_to_report(report, "LocalAuthListManagement", vars_local_auth_list);
-    add_to_report(report, "PnC", vars_pnc);
-    add_to_report(report, "CostAndPrice", vars_california_pricing);
-    add_to_report(report, "Custom", vars_custom);
+bool operator==(const std::optional<ocpp::v2::Variable>& lhs, const ocpp::v2::Variable& rhs) {
+    if (lhs) {
+        return lhs.value().name == rhs.name;
+    }
+    return false;
+}
+
+bool is_same(const ocpp::v2::RequiredComponentVariable& var, const ocpp::v2::Component& component,
+             const ocpp::v2::Variable& variable) {
+    return ((var.component == component) && (var.variable == variable));
+}
+
+std::string enhanced_convert(const ocpp::v2::Component& component, const ocpp::v2::Variable& variable,
+                             ocpp::v2::AttributeEnum attribute) {
+    using namespace ocpp::v2::ControllerComponentVariables;
+    auto result = ocpp::v16::keys::convert_v2(component, variable, attribute);
+    if (!result.has_value()) {
+        if (component.name == "EVSE" && variable.name == "ISO15118EvseId") {
+            result = std::string{ocpp::v16::keys::convert(ocpp::v16::keys::valid_keys::ConnectorEvseIds)};
+        }
+    }
+    return result.value_or(variable.name);
+}
+
+std::string central_system_uri_to_json(const std::string& value) {
+    // convert to JSON
+    auto profile = json::parse(R"([{"ocppCsmsUrl":""}])");
+    profile[0]["ocppCsmsUrl"] = value;
+    return profile.dump(-1);
+}
+
+void add_to_report(std::vector<ocpp::v2::ReportData>& report, const ocpp::v2::RequiredComponentVariable& rcv,
+                   ocpp::v2::MutabilityEnum mutability, const std::string& value) {
+    if (rcv.variable) {
+        ocpp::v2::ReportData data;
+        data.component = rcv.component;
+        data.variable = rcv.variable.value();
+        ocpp::v2::VariableAttribute va;
+        va.type = ocpp::v2::AttributeEnum::Actual;
+        va.mutability = mutability;
+        if (!value.empty()) {
+            va.value = value;
+        }
+        data.variableAttribute.push_back(std::move(va));
+        report.push_back(std::move(data));
+    }
 }
 
 } // namespace
 
 namespace ocpp::v16::stubs {
+// ----------------------------------------------------------------------------
+// Static methods
+
+std::optional<std::string> MemoryStorage::set_connector_id(std::int32_t id, const std::string& current,
+                                                           const std::string& value) {
+    std::optional<std::string> result;
+    if (id > 0) {
+        const std::size_t index = id - 1;
+        auto vec = ocpp::v16::utils::split_string(',', current);
+        if (index >= vec.size()) {
+            // add empty elements
+            vec.insert(vec.end(), (index + 1) - vec.size(), {});
+        }
+        vec[index] = value;
+        result = ocpp::v16::utils::to_csl(vec);
+    }
+    return result;
+}
+
+std::optional<std::string> MemoryStorage::get_connector_id(std::int32_t id, const std::string& current) {
+    std::optional<std::string> result;
+    if (id > 0 && !current.empty()) {
+        const std::size_t index = id - 1;
+        auto vec = ocpp::v16::utils::split_string(',', current);
+        if (index < vec.size()) {
+            result = vec[index];
+        } else {
+            result = std::move(std::string{});
+        }
+    }
+    return result;
+}
 
 MemoryStorage::MemoryStorage() {
     vars_internal = required_vars_internal;
@@ -195,6 +263,7 @@ MemoryStorage::MemoryStorage() {
     vars_california_pricing = required_vars_california_pricing;
     vars_custom = required_vars_custom;
 
+    vars_additional.clear();
     read_only.clear();
 }
 
@@ -202,18 +271,214 @@ void MemoryStorage::apply_full_config() {
     vars_california_pricing.insert(full_vars_california_pricing.begin(), full_vars_california_pricing.end());
 }
 
+std::optional<MemoryStorage::Storage::iterator> MemoryStorage::locate_v16(const std::string& name) const {
+    // since V16 items are unique, just search through the storage items
+    // to locate it
+    for (auto& i : vars_list) {
+        if (auto it = i->find(name); it != i->end()) {
+            return it;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> MemoryStorage::get_v16(const std::string& name) const {
+    // since V16 items are unique, just search through the storage items
+    // to locate it
+    auto it = locate_v16(name);
+    if (it) {
+        return it.value()->second;
+    } else {
+        std::cout << "get_v16: unable to locate '" << name << "'\n";
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> MemoryStorage::get_v16(ocpp::v16::keys::valid_keys key) const {
+    return get_v16(std::string{ocpp::v16::keys::convert(key)});
+}
+
+MemoryStorage::SetVariableStatusEnum MemoryStorage::set_v16(const std::string& name, const std::string& value) {
+    // since V16 items are unique, just search through the storage items
+    // to locate it
+    SetVariableStatusEnum result{SetVariableStatusEnum::UnknownVariable};
+
+    auto it = locate_v16(name);
+    if (it) {
+        it.value()->second = value;
+        result = SetVariableStatusEnum::Accepted;
+    } else {
+        auto found = keys::convert(name);
+        bool create = found.has_value();
+
+        if (name.rfind("MeterPublicKey") == 0) {
+            create = true;
+        }
+
+        if (create) {
+            std::cout << "set_v16: unable to locate '" << name << "' creating\n";
+            vars_additional.insert({name, value});
+            result = SetVariableStatusEnum::Accepted;
+
+        } else {
+            std::cout << "set_v16: unable to locate '" << name << "' ignoring\n";
+        }
+    }
+
+    return result;
+}
+
+MemoryStorage::SetVariableStatusEnum MemoryStorage::set_v16_custom(const std::string& name, const std::string& value) {
+    // since V16 items are unique, just search through the storage items
+    // to locate it
+
+    auto it = locate_v16(name);
+    if (it) {
+        it.value()->second = value;
+    } else {
+        vars_additional.insert({name, value});
+    }
+
+    return SetVariableStatusEnum::Accepted;
+}
+
 void MemoryStorage::set_readonly(const std::string& key) {
     read_only.insert(key);
 }
 
+std::optional<MemoryStorage::MutabilityEnum> MemoryStorage::get_mutability(const std::string& key_str) {
+    std::optional<MutabilityEnum> result;
+
+    const auto sv_key_opt = keys::convert(key_str);
+    if (sv_key_opt) {
+        const auto sv_key = sv_key_opt.value();
+        if (sv_key == keys::valid_keys::AuthorizationKey) {
+            result = MemoryStorage::MutabilityEnum::WriteOnly;
+        } else {
+            result = (keys::is_readonly(sv_key)) ? MemoryStorage::MutabilityEnum::ReadOnly
+                                                 : MemoryStorage::MutabilityEnum::ReadWrite;
+        }
+    } else {
+        if (const auto it = read_only.find(key_str); it == read_only.end()) {
+            // check if key exists (not in the read only list)
+            auto found = locate_v16(key_str);
+            if (found) {
+                result = MemoryStorage::MutabilityEnum::ReadWrite;
+            }
+        } else {
+            result = MemoryStorage::MutabilityEnum::ReadOnly;
+        }
+    }
+
+    return result;
+}
+
+void MemoryStorage::add_supported_measureands_values_list(ocpp::v2::ReportData& data) {
+    const auto supported = get_v16(ocpp::v16::keys::valid_keys::SupportedMeasurands);
+    if (supported) {
+        ocpp::v2::VariableCharacteristics vc;
+        vc.valuesList = supported.value();
+        data.variableCharacteristics = std::move(vc);
+    }
+}
+
+void MemoryStorage::add_to_report(std::vector<ocpp::v2::ReportData>& report, const std::string_view& name,
+                                  const std::string_view& value) {
+    using namespace ocpp::v2::ControllerComponentVariables;
+    const auto cv = ocpp::v16::keys::convert_v2(name);
+    const std::string name_str{name};
+    std::string value_str{value};
+    if (cv) {
+        auto component = std::get<ocpp::v2::Component>(*cv);
+        auto variable = std::get<ocpp::v2::Variable>(*cv);
+        auto attribute = std::get<ocpp::v2::AttributeEnum>(*cv);
+        ocpp::v2::ReportData data;
+        data.component = std::move(component);
+        data.variable = std::move(variable);
+        ocpp::v2::VariableAttribute va;
+        va.type = attribute;
+        va.mutability = get_mutability(name_str);
+        if (!value_str.empty()) {
+            va.value = std::move(value_str);
+        }
+
+        const auto key = keys::convert(name);
+        if (key == keys::valid_keys::MeterValuesAlignedData) {
+            add_supported_measureands_values_list(data);
+        } else if (key == keys::valid_keys::StopTxnAlignedData) {
+            add_supported_measureands_values_list(data);
+        } else if (key == keys::valid_keys::StopTxnSampledData) {
+            add_supported_measureands_values_list(data);
+        } else if (key == keys::valid_keys::MeterValuesSampledData) {
+            add_supported_measureands_values_list(data);
+        }
+
+        data.variableAttribute.push_back(std::move(va));
+        report.push_back(std::move(data));
+    } else {
+        if (name_str == "SupportedMeasurands") {
+            // ignore
+        } else {
+            std::cerr << "add_to_report: missing '" << name_str << "'\n";
+        }
+    }
+}
+
+void MemoryStorage::add_to_report(std::vector<ocpp::v2::ReportData>& report, const std::string_view& name,
+                                  const std::map<std::string, std::string>& vars) {
+    using namespace ocpp::v2::ControllerComponentVariables;
+    for (const auto& i : vars) {
+        add_to_report(report, i.first, i.second);
+    }
+}
+
+void MemoryStorage::generate_report(std::vector<ocpp::v2::ReportData>& report) {
+    report.clear();
+    add_to_report(report, "Internal", vars_internal);
+    add_to_report(report, "Core", vars_core);
+    add_to_report(report, "FirmwareManagement", vars_firmware_management);
+    add_to_report(report, "SmartCharging", vars_smart_charging);
+    add_to_report(report, "Security", vars_security);
+    add_to_report(report, "LocalAuthListManagement", vars_local_auth_list);
+    add_to_report(report, "PnC", vars_pnc);
+    add_to_report(report, "CostAndPrice", vars_california_pricing);
+    add_to_report(report, "Custom", vars_custom);
+}
+
 void MemoryStorage::set(const std::string_view& component, const std::string_view& variable,
                         const std::string_view& value) {
-    Component component_id;
-    Variable variable_id;
-
-    component_id.name = std::string{component};
-    variable_id.name = std::string{variable};
-    (void)set_value(component_id, variable_id, AttributeEnum::Actual, std::string{value}, "TestCase");
+    const std::string variable_v{variable};
+    std::cout << "set " << component << '[' << variable << "] = '" << value << "'\n";
+    if (component == "Internal") {
+        // std::cout << "Internal[" << variable_id.name << "]=" << value << '\n';
+        vars_internal[variable_v] = value;
+    } else if (component == "Core") {
+        // std::cout << "Core[" << variable << "]=" << value << '\n';
+        vars_core[variable_v] = value;
+    } else if (component == "FirmwareManagement") {
+        // std::cout << "FirmwareManagement[" << variable << "]=" << value << '\n';
+        vars_firmware_management[variable_v] = value;
+    } else if (component == "SmartCharging") {
+        // std::cout << "SmartCharging[" << variable << "]=" << value << '\n';
+        vars_smart_charging[variable_v] = value;
+    } else if (component == "Security") {
+        // std::cout << "Security[" << variable << "]=" << value << '\n';
+        vars_security[variable_v] = value;
+    } else if (component == "LocalAuthListManagement") {
+        // std::cout << "LocalAuthListManagement[" << variable << "]=" << value << '\n';
+        vars_local_auth_list[variable_v] = value;
+    } else if (component == "PnC") {
+        // std::cout << "PnC[" << variable << "]=" << value << '\n';
+        vars_pnc[variable_v] = value;
+    } else if (component == "CostAndPrice") {
+        // std::cout << "CostAndPrice[" << variable << "]=" << value << '\n';
+        vars_california_pricing[variable_v] = value;
+    } else if (component == "Custom") {
+        // std::cout << "Custom[" << variable << "]=" << value << '\n';
+        vars_custom[variable_v] = value;
+    } else {
+        std::cerr << "set not implemented for: " << component << '\n';
+    }
 }
 
 std::string MemoryStorage::get(const std::string_view& component, const std::string_view& variable) {
@@ -258,75 +523,46 @@ MemoryStorage::GetVariableStatusEnum MemoryStorage::get_variable(const Component
                                                                  const AttributeEnum& attribute_enum,
                                                                  std::string& value, bool allow_write_only) const {
     auto result = GetVariableStatusEnum::UnknownVariable;
-    if (component_id.name == "Internal") {
-        if (const auto it = vars_internal.find(variable_id.name); it != vars_internal.end()) {
-            MemoryStorage::VariableAttribute va;
-            // std::cout << "Internal[" << it->first << "]==" << it->second << '\n';
-            value = it->second;
-            result = GetVariableStatusEnum::Accepted;
-        }
-    } else if (component_id.name == "Core") {
-        if (const auto it = vars_core.find(variable_id.name); it != vars_core.end()) {
-            MemoryStorage::VariableAttribute va;
-            // std::cout << "Core[" << it->first << "]==" << it->second << '\n';
-            value = it->second;
-            result = GetVariableStatusEnum::Accepted;
-        }
-    } else if (component_id.name == "FirmwareManagement") {
-        if (const auto it = vars_firmware_management.find(variable_id.name); it != vars_firmware_management.end()) {
-            MemoryStorage::VariableAttribute va;
-            // std::cout << "FirmwareManagement[" << it->first << "]==" << it->second << '\n';
-            value = it->second;
-            result = GetVariableStatusEnum::Accepted;
-        }
-    } else if (component_id.name == "SmartCharging") {
-        if (const auto it = vars_smart_charging.find(variable_id.name); it != vars_smart_charging.end()) {
-            MemoryStorage::VariableAttribute va;
-            // std::cout << "SmartCharging[" << it->first << "]==" << it->second << '\n';
-            value = it->second;
-            result = GetVariableStatusEnum::Accepted;
-        }
-    } else if (component_id.name == "Security") {
-        if (const auto it = vars_security.find(variable_id.name); it != vars_security.end()) {
-            MemoryStorage::VariableAttribute va;
-            // std::cout << "Security[" << it->first << "]==" << it->second << '\n';
-            value = it->second;
-            result = GetVariableStatusEnum::Accepted;
-        }
-    } else if (component_id.name == "LocalAuthListManagement") {
-        if (const auto it = vars_local_auth_list.find(variable_id.name); it != vars_local_auth_list.end()) {
-            MemoryStorage::VariableAttribute va;
-            // std::cout << "LocalAuthListManagement[" << it->first << "]==" << it->second << '\n';
-            value = it->second;
-            result = GetVariableStatusEnum::Accepted;
-        }
-    } else if (component_id.name == "PnC") {
-        if (const auto it = vars_pnc.find(variable_id.name); it != vars_pnc.end()) {
-            MemoryStorage::VariableAttribute va;
-            // std::cout << "PnC[" << it->first << "]==" << it->second << '\n';
-            value = it->second;
-            result = GetVariableStatusEnum::Accepted;
-        }
-    } else if (component_id.name == "CostAndPrice") {
-        if (const auto it = vars_california_pricing.find(variable_id.name); it != vars_california_pricing.end()) {
-            MemoryStorage::VariableAttribute va;
-            // std::cout << "CostAndPrice[" << it->first << "]==" << it->second << '\n';
-            value = it->second;
-            result = GetVariableStatusEnum::Accepted;
-        }
-    } else if (component_id.name == "Custom") {
-        if (const auto it = vars_custom.find(variable_id.name); it != vars_custom.end()) {
-            MemoryStorage::VariableAttribute va;
-            // std::cout << "Custom[" << it->first << "]==" << it->second << '\n';
-            value = it->second;
-            result = GetVariableStatusEnum::Accepted;
-        }
+    const auto name = enhanced_convert(component_id, variable_id, attribute_enum);
+    std::optional<std::string> retrieved;
+    // std::cout << "--> " << component_id.name << '[' << variable_id.name << "]\n";
+    if (name.empty()) {
+        retrieved = get_v16(variable_id.name);
     } else {
-        result = GetVariableStatusEnum::Rejected;
-        std::cerr << "get_variable_attribute not implemented for: " << component_id.name << '\n';
+        retrieved = get_v16(name);
+        if (retrieved) {
+            const auto key_opt = v16::keys::convert(name);
+            if (key_opt) {
+                if (key_opt.value() == v16::keys::valid_keys::ConnectorEvseIds) {
+                    if (component_id.evse) {
+                        const auto id = component_id.evse.value().id;
+                        auto fetched = get_connector_id(id, *retrieved);
+                        if (fetched) {
+                            retrieved = *fetched;
+                        } else {
+                            retrieved = "";
+                        }
+                        std::cout << component_id.name << '[' << variable_id.name << "]." << id << " has value: '"
+                                  << *retrieved << "' (" << name << ")\n";
+                    } else {
+                        std::cerr << "get_value with missing evse: " << component_id.name << '[' << variable_id.name
+                                  << "]\n";
+                    }
+                }
+            }
+        } else {
+            std::cout << component_id.name << '[' << variable_id.name << "] has no value (" << name << ")\n";
+        }
     }
-
-    // std::cout << component_id.name << '[' << variable_id.name << "] has value: " << result.has_value() << '\n';
+    if (retrieved) {
+        value = *retrieved;
+        result = GetVariableStatusEnum::Accepted;
+        // std::cout << component_id.name << '[' << variable_id.name << "]." << id << " has value: '" << *retrieved
+        //           << "' (" << name << ")\n";
+    } else {
+        std::cerr << "get_variable not implemented for: " << component_id.name << ':' << variable_id.name << " ("
+                  << name << ")\n";
+    }
     return result;
 }
 
@@ -335,48 +571,45 @@ MemoryStorage::SetVariableStatusEnum MemoryStorage::set_value(const Component& c
                                                               const AttributeEnum& attribute_enum,
                                                               const std::string& value, const std::string& source,
                                                               bool allow_read_only) {
-    auto result = SetVariableStatusEnum::Accepted;
-    if (component_id.name == "Internal") {
-        // std::cout << "Internal[" << variable_id.name << "]=" << value << '\n';
-        vars_internal[variable_id.name] = value;
-        result = SetVariableStatusEnum::Accepted;
-    } else if (component_id.name == "Core") {
-        // std::cout << "Core[" << variable_id.name << "]=" << value << '\n';
-        vars_core[variable_id.name] = value;
-        result = SetVariableStatusEnum::Accepted;
-    } else if (component_id.name == "FirmwareManagement") {
-        // std::cout << "FirmwareManagement[" << variable_id.name << "]=" << value << '\n';
-        vars_firmware_management[variable_id.name] = value;
-        result = SetVariableStatusEnum::Accepted;
-    } else if (component_id.name == "SmartCharging") {
-        // std::cout << "SmartCharging[" << variable_id.name << "]=" << value << '\n';
-        vars_smart_charging[variable_id.name] = value;
-        result = SetVariableStatusEnum::Accepted;
-    } else if (component_id.name == "Security") {
-        // std::cout << "Security[" << variable_id.name << "]=" << value << '\n';
-        vars_security[variable_id.name] = value;
-        result = SetVariableStatusEnum::Accepted;
-    } else if (component_id.name == "LocalAuthListManagement") {
-        // std::cout << "LocalAuthListManagement[" << variable_id.name << "]=" << value << '\n';
-        vars_local_auth_list[variable_id.name] = value;
-        result = SetVariableStatusEnum::Accepted;
-    } else if (component_id.name == "PnC") {
-        // std::cout << "PnC[" << variable_id.name << "]=" << value << '\n';
-        vars_pnc[variable_id.name] = value;
-        result = SetVariableStatusEnum::Accepted;
-    } else if (component_id.name == "CostAndPrice") {
-        // std::cout << "CostAndPrice[" << variable_id.name << "]=" << value << '\n';
-        vars_california_pricing[variable_id.name] = value;
-        result = SetVariableStatusEnum::Accepted;
-    } else if (component_id.name == "Custom") {
-        // std::cout << "Custom[" << variable_id.name << "]=" << value << '\n';
-        vars_custom[variable_id.name] = value;
-        result = SetVariableStatusEnum::Accepted;
+    const auto key_str = enhanced_convert(component_id, variable_id, attribute_enum);
+    MemoryStorage::SetVariableStatusEnum result;
+    if (!key_str.empty()) {
+        const auto key_opt = v16::keys::convert(key_str);
+        std::string store_value = value;
+        result = MemoryStorage::SetVariableStatusEnum::Accepted;
+        if (key_opt) {
+            if (key_opt.value() == v16::keys::valid_keys::ConnectorEvseIds) {
+                result = MemoryStorage::SetVariableStatusEnum::Rejected;
+                auto retrieved = get_v16(v16::keys::valid_keys::ConnectorEvseIds);
+                store_value.clear();
+                if (retrieved) {
+                    store_value = *retrieved;
+                }
+                if (component_id.evse) {
+                    const auto id = component_id.evse.value().id;
+                    auto updated = set_connector_id(id, store_value, value);
+                    if (updated) {
+                        store_value = *updated;
+                        result = MemoryStorage::SetVariableStatusEnum::Accepted;
+                    } else {
+                        std::cerr << "set_value with invalid evse: " << component_id.name << '[' << variable_id.name
+                                  << "] " << id << '\n';
+                    }
+                } else {
+                    std::cerr << "set_value with missing evse: " << component_id.name << '[' << variable_id.name
+                              << "]\n";
+                }
+            }
+        }
+        if (result == MemoryStorage::SetVariableStatusEnum::Accepted) {
+            result = set_v16(key_str, store_value);
+            std::cout << component_id.name << '[' << variable_id.name << "] = '" << store_value << "' (" << key_str
+                      << ") " << (int)result << '\n';
+        }
     } else {
-        result = SetVariableStatusEnum::Rejected;
-        std::cerr << "set_variable_attribute not implemented for: " << component_id.name << '\n';
+        result = set_v16_custom(variable_id.name, value);
+        std::cout << component_id.name << '[' << variable_id.name << "] = '" << value << "' " << (int)result << '\n';
     }
-
     return result;
 }
 
@@ -391,39 +624,24 @@ MemoryStorage::SetVariableStatusEnum MemoryStorage::set_read_only_value(const Co
 std::optional<MemoryStorage::MutabilityEnum> MemoryStorage::get_mutability(const Component& component_id,
                                                                            const Variable& variable_id,
                                                                            const AttributeEnum& attribute_enum) {
-    std::optional<MemoryStorage::MutabilityEnum> result;
-    const auto key_str = std::string{variable_id.name};
-    std::string value;
-    if (get_variable(component_id, variable_id, attribute_enum, value) == v2::GetVariableStatusEnum::Accepted) {
-        const auto sv_key_opt = keys::convert(key_str);
-        if (sv_key_opt) {
-            const auto sv_key = sv_key_opt.value();
-            if (sv_key == keys::valid_keys::AuthorizationKey) {
-                result = MemoryStorage::MutabilityEnum::WriteOnly;
-            } else {
-                result = (keys::is_readonly(sv_key)) ? MemoryStorage::MutabilityEnum::ReadOnly
-                                                     : MemoryStorage::MutabilityEnum::ReadWrite;
-            }
-        } else {
-            if (const auto it = read_only.find(key_str); it == read_only.end()) {
-                result = MemoryStorage::MutabilityEnum::ReadWrite;
-            } else {
-                result = MemoryStorage::MutabilityEnum::ReadOnly;
-            }
-        }
-    }
-    return result;
+    auto key_str_opt = keys::convert_v2(component_id, variable_id, attribute_enum);
+    auto key_str = key_str_opt.value_or(variable_id.name);
+    return get_mutability(key_str);
 }
 
 std::optional<MemoryStorage::VariableMetaData> MemoryStorage::get_variable_meta_data(const Component& component_id,
                                                                                      const Variable& variable_id) {
     std::optional<MemoryStorage::VariableMetaData> result;
-    std::string value;
-    if (get_variable(component_id, variable_id, AttributeEnum::Actual, value) == GetVariableStatusEnum::Accepted) {
+    const auto key_str = keys::convert_v2(component_id, variable_id, ocpp::v2::AttributeEnum::Actual);
+    const auto retrieved = get_v16(key_str.value_or(""));
+    if (retrieved) {
         MemoryStorage::VariableMetaData md;
         md.characteristics.dataType = v2::DataEnum::string;
         md.characteristics.supportsMonitoring = false;
         result = std::move(md);
+    } else {
+        std::cerr << "get_variable_meta_data not implemented for: " << component_id.name << ':' << variable_id.name
+                  << " (" << key_str.value_or("") << ")\n";
     }
     return result;
 }
@@ -440,7 +658,22 @@ std::vector<MemoryStorage::ReportData> MemoryStorage::get_base_report_data(const
 std::vector<MemoryStorage::ReportData>
 MemoryStorage::get_custom_report_data(const std::optional<std::vector<ComponentVariable>>& component_variables,
                                       const std::optional<std::vector<ComponentCriterionEnum>>& component_criteria) {
-    return {};
+    std::vector<MemoryStorage::ReportData> result;
+    if (component_variables) {
+        for (const auto& component : component_variables.value()) {
+            if (component.variable) {
+                const auto name = ocpp::v16::keys::convert_v2(component.component, component.variable.value(),
+                                                              ocpp::v2::AttributeEnum::Actual);
+                if (name) {
+                    const auto retrieved = get_v16(name.value());
+                    if (retrieved) {
+                        add_to_report(result, name.value(), *retrieved);
+                    }
+                }
+            }
+        }
+    }
+    return result;
 }
 
 std::vector<MemoryStorage::SetMonitoringResult>

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.hpp
@@ -5,10 +5,12 @@
 
 #pragma once
 
+#include <ocpp/v16/known_keys.hpp>
 #include <ocpp/v2/device_model_interface.hpp>
 #include <ocpp/v2/ocpp_enums.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 
+#include <map>
 #include <set>
 #include <string>
 #include <string_view>
@@ -16,10 +18,8 @@
 namespace ocpp::v16::stubs {
 
 class MemoryStorage : public ocpp::v2::DeviceModelInterface {
-private:
-    std::set<std::string> read_only;
-
 public:
+    using Storage = std::map<std::string, std::string>;
     using VariableAttribute = ocpp::v2::VariableAttribute;
     using Component = ocpp::v2::Component;
     using ComponentVariable = ocpp::v2::ComponentVariable;
@@ -43,6 +43,27 @@ public:
     using ReportData = ocpp::v2::ReportData;
     using ReportBaseEnum = ocpp::v2::ReportBaseEnum;
 
+    static std::optional<std::string> set_connector_id(std::int32_t id, const std::string& current,
+                                                       const std::string& value);
+    static std::optional<std::string> get_connector_id(std::int32_t id, const std::string& current);
+
+private:
+    std::set<std::string> read_only;
+
+    std::optional<MemoryStorage::Storage::iterator> locate_v16(const std::string& name) const;
+    std::optional<std::string> get_v16(const std::string& name) const;
+    std::optional<std::string> get_v16(ocpp::v16::keys::valid_keys key) const;
+    SetVariableStatusEnum set_v16(const std::string& name, const std::string& value);
+    SetVariableStatusEnum set_v16_custom(const std::string& name, const std::string& value);
+    std::optional<MutabilityEnum> get_mutability(const std::string& key_str);
+    void add_supported_measureands_values_list(ocpp::v2::ReportData& data);
+    void add_to_report(std::vector<ocpp::v2::ReportData>& report, const std::string_view& name,
+                       const std::string_view& value);
+    void add_to_report(std::vector<ocpp::v2::ReportData>& report, const std::string_view& name,
+                       const std::map<std::string, std::string>& vars);
+    void generate_report(std::vector<ocpp::v2::ReportData>& report);
+
+public:
     MemoryStorage();
 
     void apply_full_config();
@@ -139,65 +160,67 @@ public:
 
     GetVariableStatusEnum get_variable(const Component& component_id, const Variable& variable_id,
                                        const AttributeEnum& attribute_enum, std::string& value,
-                                       bool allow_write_only = false) const {
-        return storage.get_variable(component_id, variable_id, attribute_enum, value);
+                                       bool allow_write_only) const override {
+        return storage.get_variable(component_id, variable_id, attribute_enum, value, allow_write_only);
     }
 
     SetVariableStatusEnum set_value(const Component& component_id, const Variable& variable_id,
                                     const AttributeEnum& attribute_enum, const std::string& value,
-                                    const std::string& source, bool allow_read_only = false) {
-        return storage.set_value(component_id, variable_id, attribute_enum, value, source);
+                                    const std::string& source, bool allow_read_only) override {
+        return storage.set_value(component_id, variable_id, attribute_enum, value, source, allow_read_only);
     }
 
     SetVariableStatusEnum set_read_only_value(const Component& component_id, const Variable& variable_id,
                                               const AttributeEnum& attribute_enum, const std::string& value,
-                                              const std::string& source) {
+                                              const std::string& source) override {
         return storage.set_read_only_value(component_id, variable_id, attribute_enum, value, source);
     }
 
     std::optional<MutabilityEnum> get_mutability(const Component& component_id, const Variable& variable_id,
-                                                 const AttributeEnum& attribute_enum) {
+                                                 const AttributeEnum& attribute_enum) override {
         return storage.get_mutability(component_id, variable_id, attribute_enum);
     }
 
-    std::optional<VariableMetaData> get_variable_meta_data(const Component& component_id, const Variable& variable_id) {
+    std::optional<VariableMetaData> get_variable_meta_data(const Component& component_id,
+                                                           const Variable& variable_id) override {
         return storage.get_variable_meta_data(component_id, variable_id);
     }
 
-    std::vector<ReportData> get_base_report_data(const ReportBaseEnum& report_base) {
+    std::vector<ReportData> get_base_report_data(const ReportBaseEnum& report_base) override {
         return storage.get_base_report_data(report_base);
     }
 
-    std::vector<ReportData> get_custom_report_data(
-        const std::optional<std::vector<ComponentVariable>>& component_variables = std::nullopt,
-        const std::optional<std::vector<ComponentCriterionEnum>>& component_criteria = std::nullopt) {
+    std::vector<ReportData>
+    get_custom_report_data(const std::optional<std::vector<ComponentVariable>>& component_variables,
+                           const std::optional<std::vector<ComponentCriterionEnum>>& component_criteria) override {
         return storage.get_custom_report_data(component_variables, component_criteria);
     }
 
-    std::vector<SetMonitoringResult> set_monitors(const std::vector<SetMonitoringData>& requests,
-                                                  const VariableMonitorType type = VariableMonitorType::CustomMonitor) {
+    std::vector<SetMonitoringResult>
+    set_monitors(const std::vector<SetMonitoringData>& requests,
+                 const VariableMonitorType type = VariableMonitorType::CustomMonitor) override {
         return storage.set_monitors(requests);
     }
 
-    bool update_monitor_reference(std::int32_t monitor_id, const std::string& reference_value) {
+    bool update_monitor_reference(std::int32_t monitor_id, const std::string& reference_value) override {
         return storage.update_monitor_reference(monitor_id, reference_value);
     }
 
-    std::vector<VariableMonitoringPeriodic> get_periodic_monitors() {
+    std::vector<VariableMonitoringPeriodic> get_periodic_monitors() override {
         return storage.get_periodic_monitors();
     }
 
     std::vector<MonitoringData> get_monitors(const std::vector<MonitoringCriterionEnum>& criteria,
-                                             const std::vector<ComponentVariable>& component_variables) {
+                                             const std::vector<ComponentVariable>& component_variables) override {
         return storage.get_monitors(criteria, component_variables);
     }
 
     std::vector<ClearMonitoringResult> clear_monitors(const std::vector<int>& request_ids,
-                                                      bool allow_protected = false) {
-        return storage.clear_monitors(request_ids);
+                                                      bool allow_protected) override {
+        return storage.clear_monitors(request_ids, allow_protected);
     }
 
-    std::int32_t clear_custom_monitors() {
+    std::int32_t clear_custom_monitors() override {
         return storage.clear_custom_monitors();
     }
 
@@ -205,18 +228,18 @@ public:
         std::function<void(const std::unordered_map<std::int64_t, VariableMonitoringMeta>& monitors,
                            const Component& component, const Variable& variable,
                            const VariableCharacteristics& characteristics, const VariableAttribute& attribute,
-                           const std::string& value_previous, const std::string& value_current)>&& listener) {
+                           const std::string& value_previous, const std::string& value_current)>&& listener) override {
         return storage.register_variable_listener(std::move(listener));
     }
 
     void register_monitor_listener(
         std::function<void(const VariableMonitoringMeta& updated_monitor, const Component& component,
                            const Variable& variable, const VariableCharacteristics& characteristics,
-                           const VariableAttribute& attribute, const std::string& current_value)>&& listener) {
+                           const VariableAttribute& attribute, const std::string& current_value)>&& listener) override {
         return storage.register_monitor_listener(std::move(listener));
     }
 
-    void check_integrity(const std::map<std::int32_t, std::int32_t>& evse_connector_structure) {
+    void check_integrity(const std::map<std::int32_t, std::int32_t>& evse_connector_structure) override {
         return storage.check_integrity(evse_connector_structure);
     }
 };

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_config.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_config.cpp
@@ -4,6 +4,9 @@
 #include <gtest/gtest.h>
 
 #include "configuration_stub.hpp"
+#include "ocpp/v16/known_keys.hpp"
+#include "ocpp/v2/ocpp_enums.hpp"
+#include "ocpp/v2/ocpp_types.hpp"
 #include <ocpp/v16/charge_point_configuration_base.hpp>
 #include <optional>
 
@@ -66,6 +69,45 @@ TEST(ConnectorID, PhaseRotation) {
     EXPECT_FALSE(CPCB::isConnectorPhaseRotationValid(5, "11."));
     EXPECT_FALSE(CPCB::isConnectorPhaseRotationValid(5, "111."));
     EXPECT_FALSE(CPCB::isConnectorPhaseRotationValid(5, "1a.RST"));
+}
+
+using namespace ocpp;
+
+TEST(V2Mapping, V16ToV2) {
+    using namespace ocpp::v16::keys;
+    using namespace ocpp::v2;
+
+    auto res = convert_v2(valid_keys::CpoName);
+    ASSERT_TRUE(res);
+    auto component = std::get<Component>(res.value());
+    auto variable = std::get<Variable>(res.value());
+    EXPECT_EQ(component.name, "SecurityCtrlr");
+    EXPECT_EQ(variable.name, "OrganizationName");
+
+    res = convert_v2("CpoName");
+    ASSERT_TRUE(res);
+    component = std::get<Component>(res.value());
+    variable = std::get<Variable>(res.value());
+    EXPECT_EQ(component.name, "SecurityCtrlr");
+    EXPECT_EQ(variable.name, "OrganizationName");
+}
+
+TEST(V2Mapping, V2ToV16) {
+    using namespace ocpp::v16::keys;
+    using namespace ocpp::v2;
+
+    Component comp;
+    comp.name = "SecurityCtrlr";
+    Variable var;
+    var.name = "OrganizationName";
+    auto res = convert_v2(comp, var, ocpp::v2::AttributeEnum::Actual);
+    EXPECT_EQ(res, "CpoName");
+
+    comp.name = "SmartChargingCtrlr";
+    var.name = "Entries";
+    var.instance = "ChargingProfiles";
+    res = convert_v2(comp, var, ocpp::v2::AttributeEnum::Actual);
+    EXPECT_EQ(res, "MaxChargingProfilesInstalled");
 }
 
 } // namespace

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_custom.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_custom.cpp
@@ -209,6 +209,7 @@ TEST_P(Configuration, GetAllKeyValue) {
     std::map<std::string, std::string> missing = expected_key_value;
 
     for (const auto& i : values) {
+        // std::cout << "Looking for: " << i << '\n';
         if (const auto& search = expected_key_value.find(i.key); search == expected_key_value.end()) {
             not_found.insert({i.key, i.value.value_or("")});
         } else {

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
@@ -7,8 +7,9 @@
 #include <string>
 
 #include "configuration_stub.hpp"
-#include "ocpp/v16/ocpp_enums.hpp"
-#include "ocpp/v16/types.hpp"
+#include "v2config/memory_storage.hpp"
+#include <ocpp/v16/ocpp_enums.hpp>
+#include <ocpp/v16/types.hpp>
 
 namespace {
 using namespace ocpp::v16::stubs;
@@ -235,13 +236,36 @@ TEST_P(Configuration, SupportedCiphers13) {
 TEST_P(Configuration, SupportedMeasurands) {
     ASSERT_NE(get(), nullptr);
     // initial values are from the JSON unit test config files
-    EXPECT_EQ(get()->getSupportedMeasurands(),
-              "Energy.Active.Import.Register,Energy.Active.Export.Register,Power.Active.Import,Voltage,Current.Import,"
-              "Frequency,Current.Offered,Power.Offered,SoC,Temperature");
+    // using sets for comparison since order of a cls cannot be guaranteed
+    const std::string expected_str{"Energy.Active.Import.Register,Energy.Active.Export.Register,Power.Active.Import,"
+                                   "Voltage,Current.Import,Frequency,Current.Offered,Power.Offered,SoC,Temperature"};
+    const std::set<std::string> expected{"Energy.Active.Import.Register",
+                                         "Energy.Active.Export.Register",
+                                         "Power.Active.Import",
+                                         "Voltage",
+                                         "Current.Import",
+                                         "Frequency",
+                                         "Current.Offered",
+                                         "Power.Offered",
+                                         "SoC",
+                                         "Temperature"};
+    const auto supported = get()->getSupportedMeasurands();
+    EXPECT_EQ(supported, expected_str);
+    auto list = ocpp::v16::utils::from_csl(supported);
+    std::set<std::string> res_set;
+    std::move(list.begin(), list.end(), std::inserter(res_set, res_set.end()));
+    // ordered set now used so string compare should work
+    EXPECT_EQ(expected, res_set);
+
     auto kv = get()->getSupportedMeasurandsKeyValue();
     EXPECT_EQ(kv.key, "SupportedMeasurands");
-    EXPECT_EQ(kv.value, "Energy.Active.Import.Register,Energy.Active.Export.Register,Power.Active.Import,Voltage,"
-                        "Current.Import,Frequency,Current.Offered,Power.Offered,SoC,Temperature");
+    ASSERT_TRUE(kv.value);
+    // ordered set now used so string compare should work
+    EXPECT_EQ(std::string{kv.value.value()}, expected_str);
+    list = ocpp::v16::utils::from_csl(kv.value.value());
+    res_set.clear();
+    std::move(list.begin(), list.end(), std::inserter(res_set, res_set.end()));
+    EXPECT_EQ(expected, res_set);
     EXPECT_TRUE(kv.readonly);
 }
 
@@ -965,6 +989,119 @@ TEST_F(Configuration, SetSeccLeafSubjectOrganizationV2) {
     EXPECT_FALSE(kv.value().readonly);
 }
 
+TEST(ConnectorEvseIds, Get) {
+    using namespace ocpp::v16::stubs;
+    auto res = MemoryStorage::get_connector_id(0, "");
+    EXPECT_FALSE(res.has_value());
+    res = MemoryStorage::get_connector_id(0, "1,2,3,4");
+    EXPECT_FALSE(res.has_value());
+    res = MemoryStorage::get_connector_id(-1, "");
+    EXPECT_FALSE(res.has_value());
+    res = MemoryStorage::get_connector_id(-1, "1,2,3,4");
+    EXPECT_FALSE(res.has_value());
+
+    res = MemoryStorage::get_connector_id(1, "");
+    EXPECT_FALSE(res.has_value());
+    res = MemoryStorage::get_connector_id(2, "");
+    EXPECT_FALSE(res.has_value());
+
+    res = MemoryStorage::get_connector_id(1, "one");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "one");
+    res = MemoryStorage::get_connector_id(1, "one,two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "one");
+    res = MemoryStorage::get_connector_id(1, ",two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "");
+    res = MemoryStorage::get_connector_id(1, ",");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "");
+
+    res = MemoryStorage::get_connector_id(2, "one");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "");
+    res = MemoryStorage::get_connector_id(2, "one,two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "two");
+    res = MemoryStorage::get_connector_id(2, ",two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "two");
+    res = MemoryStorage::get_connector_id(2, ",");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "");
+
+    res = MemoryStorage::get_connector_id(3, "one");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "");
+    res = MemoryStorage::get_connector_id(3, "one,two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "");
+    res = MemoryStorage::get_connector_id(3, "one,two,three");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "three");
+    res = MemoryStorage::get_connector_id(3, ",two,three");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "three");
+    res = MemoryStorage::get_connector_id(3, "one,,three");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "three");
+    res = MemoryStorage::get_connector_id(3, ",,three");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "three");
+}
+
+TEST(ConnectorEvseIds, Set) {
+    using namespace ocpp::v16::stubs;
+    auto res = MemoryStorage::set_connector_id(0, "", "");
+    EXPECT_FALSE(res.has_value());
+    res = MemoryStorage::set_connector_id(0, "one", "");
+    EXPECT_FALSE(res.has_value());
+    res = MemoryStorage::set_connector_id(0, "one", "two");
+    EXPECT_FALSE(res.has_value());
+    res = MemoryStorage::set_connector_id(-1, "", "");
+    EXPECT_FALSE(res.has_value());
+    res = MemoryStorage::set_connector_id(-1, "one", "");
+    EXPECT_FALSE(res.has_value());
+    res = MemoryStorage::set_connector_id(-1, "one", "two");
+    EXPECT_FALSE(res.has_value());
+
+    res = MemoryStorage::set_connector_id(1, "", "");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "");
+    res = MemoryStorage::set_connector_id(1, "", "one");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "one");
+    res = MemoryStorage::set_connector_id(1, "two", "one");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "one");
+
+    res = MemoryStorage::set_connector_id(2, "", "");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), ",");
+    res = MemoryStorage::set_connector_id(2, "one", "");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "one,");
+    res = MemoryStorage::set_connector_id(2, "", "two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), ",two");
+    res = MemoryStorage::set_connector_id(2, ",", "two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), ",two");
+    res = MemoryStorage::set_connector_id(2, "one", "two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "one,two");
+    res = MemoryStorage::set_connector_id(2, ",,", "two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), ",two,");
+    res = MemoryStorage::set_connector_id(2, ",,three", "two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), ",two,three");
+    res = MemoryStorage::set_connector_id(2, "one,,three", "two");
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value_or("X"), "one,two,three");
+}
+
 TEST_F(Configuration, SetConnectorEvseIdsV2) {
     ASSERT_TRUE(device_model);
     // set an initial value
@@ -985,6 +1122,50 @@ TEST_F(Configuration, SetConnectorEvseIdsV2) {
     ASSERT_TRUE(kv.has_value());
     EXPECT_EQ(kv.value().key, "ConnectorEvseIds");
     EXPECT_EQ(kv.value().value, "01234567");
+    EXPECT_FALSE(kv.value().readonly);
+}
+
+TEST_F(Configuration, SetConnectorEvseIdsV2Multi) {
+    ASSERT_TRUE(device_model);
+
+    EXPECT_FALSE(v2_config->getConnectorEvseIds().has_value());
+
+    device_model->set("Core", "NumberOfConnectors", "3");
+    device_model->set("Internal", "ConnectorEvseIds", "");
+
+    EXPECT_TRUE(v2_config->getConnectorEvseIds().has_value());
+    EXPECT_EQ(v2_config->getConnectorEvseIds(), ",,");
+    auto kv = v2_config->getConnectorEvseIdsKeyValue();
+    ASSERT_TRUE(kv.has_value());
+    EXPECT_EQ(kv.value().key, "ConnectorEvseIds");
+    EXPECT_EQ(kv.value().value, ",,");
+    EXPECT_FALSE(kv.value().readonly);
+
+    v2_config->setConnectorEvseIds(",01234567,76543210");
+    EXPECT_TRUE(v2_config->getConnectorEvseIds().has_value());
+    EXPECT_EQ(v2_config->getConnectorEvseIds(), ",01234567,76543210");
+    kv = v2_config->getConnectorEvseIdsKeyValue();
+    ASSERT_TRUE(kv.has_value());
+    EXPECT_EQ(kv.value().key, "ConnectorEvseIds");
+    EXPECT_EQ(kv.value().value, ",01234567,76543210");
+    EXPECT_FALSE(kv.value().readonly);
+
+    v2_config->setConnectorEvseIds("01234567,,76543210");
+    EXPECT_TRUE(v2_config->getConnectorEvseIds().has_value());
+    EXPECT_EQ(v2_config->getConnectorEvseIds(), "01234567,,76543210");
+    kv = v2_config->getConnectorEvseIdsKeyValue();
+    ASSERT_TRUE(kv.has_value());
+    EXPECT_EQ(kv.value().key, "ConnectorEvseIds");
+    EXPECT_EQ(kv.value().value, "01234567,,76543210");
+    EXPECT_FALSE(kv.value().readonly);
+
+    v2_config->setConnectorEvseIds("01234567,76543210,");
+    EXPECT_TRUE(v2_config->getConnectorEvseIds().has_value());
+    EXPECT_EQ(v2_config->getConnectorEvseIds(), "01234567,76543210,");
+    kv = v2_config->getConnectorEvseIdsKeyValue();
+    ASSERT_TRUE(kv.has_value());
+    EXPECT_EQ(kv.value().key, "ConnectorEvseIds");
+    EXPECT_EQ(kv.value().value, "01234567,76543210,");
     EXPECT_FALSE(kv.value().readonly);
 }
 


### PR DESCRIPTION
## Describe your changes

This builds upon #1714 incorporating the mapping of OCPP 1.6 configuration keys into v2.x device model component and variables.

#1714 should be merged first.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

