### PR TITLE
EvseV2G: avoid missing payment option

### DIFF
--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -194,10 +194,16 @@ void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::Pay
                 v2g_ctx->evse_v2g_data.payment_option_list[v2g_ctx->evse_v2g_data.payment_option_list_len] =
                     iso2_paymentOptionType_ExternalPayment;
                 v2g_ctx->evse_v2g_data.payment_option_list_len++;
-            } else if (v2g_ctx->evse_v2g_data.payment_option_list_len == 0) {
-                dlog(DLOG_LEVEL_WARNING, "Unable to configure PaymentOptions %s",
+            } else {
+                dlog(DLOG_LEVEL_WARNING, "Unable to configure PaymentOption %s",
                      types::iso15118::payment_option_to_string(option).c_str());
             }
+        }
+
+        if (v2g_ctx->evse_v2g_data.payment_option_list_len == 0) {
+            dlog(DLOG_LEVEL_ERROR, "No valid PaymentOptions configured, falling back to ExternalPayment");
+            v2g_ctx->evse_v2g_data.payment_option_list[0] = iso2_paymentOptionType_ExternalPayment;
+            v2g_ctx->evse_v2g_data.payment_option_list_len = 1;
         }
     }
 


### PR DESCRIPTION
This fixes confused logic which could lead to a segmentation fault, notably if no payment options were configured in the EvseManager.

This has been worked around in EvseManager in commit https://github.com/EVerest/everest-core/commit/46aab34c3515a045a192d516342c1dc910477052 (PR https://github.com/EVerest/everest-core/pull/597), but the logic in EvseV2G was incorrect and should not allow accessing uninitialized memory in the first place.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

