### PR TITLE
Fix(API): Remove 'receive_' prefix from isolation_monitor_API topics

### DIFF
--- a/docs/source/reference/EVerest_API/isolation_monitor_API.yaml
+++ b/docs/source/reference/EVerest_API/isolation_monitor_API.yaml
@@ -27,17 +27,17 @@ defaultContentType: application/json
 
 channels:
   receive_start:
-    address: 'e2m/receive_start'
+    address: 'e2m/start'
     messages:
       receive_start:
         $ref: '#/components/messages/receive_start'
   receive_stop:
-    address: 'e2m/receive_stop'
+    address: 'e2m/stop'
     messages:
       receive_stop:
         $ref: '#/components/messages/receive_stop'
   receive_start_self_test:
-    address: 'e2m/receive_start_self_test'
+    address: 'e2m/start_self_test'
     messages:
       receive_start_self_test:
         $ref: '#/components/messages/receive_start_self_test'

--- a/modules/API/isolation_monitor_API/main/isolation_monitorImpl.cpp
+++ b/modules/API/isolation_monitor_API/main/isolation_monitorImpl.cpp
@@ -18,16 +18,16 @@ void isolation_monitorImpl::ready() {
 }
 
 void isolation_monitorImpl::handle_start() {
-    mod->mqtt.publish(mod->get_topics().everest_to_extern("receive_start"), "{}");
+    mod->mqtt.publish(mod->get_topics().everest_to_extern("start"), "{}");
 }
 
 void isolation_monitorImpl::handle_stop() {
-    mod->mqtt.publish(mod->get_topics().everest_to_extern("receive_stop"), "{}");
+    mod->mqtt.publish(mod->get_topics().everest_to_extern("stop"), "{}");
 }
 
 void isolation_monitorImpl::handle_start_self_test(double& test_voltage_V) {
     auto value = API_generic::serialize(test_voltage_V);
-    mod->mqtt.publish(mod->get_topics().everest_to_extern("receive_start_self_test"), value);
+    mod->mqtt.publish(mod->get_topics().everest_to_extern("start_self_test"), value);
 }
 
 } // namespace main


### PR DESCRIPTION
## Describe your changes

isolation_monitor_API topics had an undesired prefix. This is now fixed.
Change has been tested with run-tmux-bringup-api-isolation-monitor.sh .

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

