### PR TITLE
libiso15118: Add response msg interval control

### DIFF
--- a/lib/everest/iso15118/include/iso15118/d20/context.hpp
+++ b/lib/everest/iso15118/include/iso15118/d20/context.hpp
@@ -54,6 +54,12 @@ public:
     }
 
     std::tuple<bool, size_t, io::v2gtp::PayloadType, message_20::Type> check_and_clear_response();
+    bool has_response() const {
+        return response_available;
+    }
+    std::tuple<io::v2gtp::PayloadType, message_20::Type> peek_response_meta() const {
+        return {payload_type, response_type};
+    }
 
 private:
     // input

--- a/lib/everest/iso15118/include/iso15118/d20/context.hpp
+++ b/lib/everest/iso15118/include/iso15118/d20/context.hpp
@@ -54,6 +54,9 @@ public:
     }
 
     std::tuple<bool, size_t, io::v2gtp::PayloadType, message_20::Type> check_and_clear_response();
+    bool has_response() const {
+        return response_available;
+    }
 
 private:
     // input

--- a/lib/everest/iso15118/include/iso15118/io/time.hpp
+++ b/lib/everest/iso15118/include/iso15118/io/time.hpp
@@ -21,11 +21,12 @@ inline int32_t get_timeout_ms_until(const TimePoint& until, int32_t max_timeout_
         std::chrono::duration_cast<std::chrono::duration<int32_t, std::milli>>(until - get_current_time_point());
     const auto timeout_ms = duration.count();
 
-    if (timeout_ms < max_timeout_ms) {
-        return timeout_ms;
-    } else {
-        return max_timeout_ms;
+    // if the timeout is already reached, return 0 to trigger an immediate timeout event
+    if (timeout_ms <= 0) {
+        return 0;
     }
+
+    return timeout_ms < max_timeout_ms ? timeout_ms : max_timeout_ms;
 }
 
 class Timeout {

--- a/lib/everest/iso15118/include/iso15118/session/iso.hpp
+++ b/lib/everest/iso15118/include/iso15118/session/iso.hpp
@@ -72,7 +72,11 @@ private:
 
     d20::Timeouts timeouts;
 
+    std::optional<TimePoint> last_response_tx_time; // timestamp of the last response message sent
+    std::optional<TimePoint> response_send_after;
+
     void handle_connection_event(io::ConnectionEvent event);
+    void send_response(io::v2gtp::PayloadType payload_type, message_20::Type response_type);
 };
 
 } // namespace iso15118

--- a/lib/everest/iso15118/include/iso15118/session/iso.hpp
+++ b/lib/everest/iso15118/include/iso15118/session/iso.hpp
@@ -41,7 +41,7 @@ public:
     void push_control_event(const d20::ControlEvent&);
 
     bool is_finished() const {
-        return (ctx.session_stopped or ctx.session_paused);
+        return (ctx.session_stopped or ctx.session_paused) and not message_exchange.has_response();
     }
 
     void close();
@@ -73,6 +73,9 @@ private:
     d20::Timeouts timeouts;
 
     void handle_connection_event(io::ConnectionEvent event);
+    void send_response();
+    std::optional<TimePoint> last_response_tx_time; // timestamp of the last response message sent
+    std::optional<TimePoint> response_send_after;   // time point when the next response message can be sent
 };
 
 } // namespace iso15118

--- a/lib/everest/iso15118/src/iso15118/session/iso.cpp
+++ b/lib/everest/iso15118/src/iso15118/session/iso.cpp
@@ -16,6 +16,7 @@
 namespace iso15118 {
 
 static constexpr auto SESSION_IDLE_TIMEOUT_MS = 5000;
+static constexpr auto MIN_RESPONSE_INTERVAL_MS = 100; // minimum time between two response messages
 
 static void log_sdp_packet(const iso15118::io::SdpPacket& sdp) {
     static constexpr auto ESCAPED_BYTE_CHAR_COUNT = 4;
@@ -140,10 +141,11 @@ void Session::push_control_event(const d20::ControlEvent& event) {
 
 TimePoint const& Session::poll() {
     const auto now = get_current_time_point();
+    // This is the default next session event, which is used when nothing else happens.
+    next_session_event = offset_time_point_by_ms(now, SESSION_IDLE_TIMEOUT_MS);
 
     if (not state.connected) {
         // nothing happened so far, just return
-        next_session_event = offset_time_point_by_ms(now, SESSION_IDLE_TIMEOUT_MS);
         return next_session_event;
     }
 
@@ -223,22 +225,37 @@ TimePoint const& Session::poll() {
         // FIXME(sl): check result!
     }
 
-    const auto [got_response, payload_size, payload_type, response_type] = message_exchange.check_and_clear_response();
+    if (message_exchange.has_response()) {
+        // Before we send back the response message, we check the time between two response messages
+        // sent out. If this is less than MIN_RESPONSE_INTERVAL_MS, we delay the response message to
+        // avoid potential performance issues.
+        if (not response_send_after.has_value()) {
+            response_send_after = now;
+            if (last_response_tx_time.has_value()) {
+                const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    get_current_time_point() - last_response_tx_time.value());
+                if (elapsed < std::chrono::milliseconds(MIN_RESPONSE_INTERVAL_MS)) {
+                    response_send_after =
+                        offset_time_point_by_ms(last_response_tx_time.value(), MIN_RESPONSE_INTERVAL_MS);
+                }
+            }
+        }
 
-    if (got_response) {
-        const auto response_size = setup_response_header(response_buffer, payload_type, payload_size);
-        connection->write(response_buffer, response_size);
-
-        timeouts.start_timeout(d20::TimeoutType::SEQUENCE, d20::TIMEOUT_SEQUENCE);
-
-        // FIXME (aw): this is hacky ...
-        log.exi(static_cast<uint16_t>(payload_type), response_buffer + io::SdpPacket::V2GTP_HEADER_SIZE, payload_size,
-                session::logging::ExiMessageDirection::TO_EV);
-
-        ctx.feedback.v2g_message(response_type);
+        // Send the response as soon as the response interval is reached
+        if (response_send_after.has_value() && now < response_send_after.value()) {
+            next_session_event = response_send_after.value();
+        } else {
+            response_send_after.reset();
+            // FIXME(fh): Currently, the response is still generated when the request is received.
+            // This may have changed after the delay. Ideally, the processing of the request message
+            // and the generated of the response message should be decoupled from each other.
+            send_response();
+        }
+    } else {
+        response_send_after.reset();
     }
 
-    if (ctx.session_stopped or ctx.session_paused) {
+    if (is_finished()) {
         // TODO(SL): Does this also apply when a timeout is triggered? Or should the TCP/TLS connection be terminated
         // directly?
         // Wait for 5 seconds [V2G20-1643]
@@ -250,9 +267,26 @@ TimePoint const& Session::poll() {
         ctx.feedback.signal(signal);
     }
 
-    // FIXME (aw): proper timeout handling!
-    next_session_event = offset_time_point_by_ms(now, SESSION_IDLE_TIMEOUT_MS);
     return next_session_event;
+}
+
+void Session::send_response() {
+    const auto [got_response, payload_size, stored_payload_type, stored_response_type] =
+        message_exchange.check_and_clear_response();
+    if (not got_response) {
+        return;
+    }
+    const auto response_size = setup_response_header(response_buffer, stored_payload_type, payload_size);
+    connection->write(response_buffer, response_size);
+    last_response_tx_time = get_current_time_point();
+
+    timeouts.start_timeout(d20::TimeoutType::SEQUENCE, d20::TIMEOUT_SEQUENCE);
+
+    // FIXME (aw): this is hacky ...
+    log.exi(static_cast<uint16_t>(stored_payload_type), response_buffer + io::SdpPacket::V2GTP_HEADER_SIZE,
+            payload_size, session::logging::ExiMessageDirection::TO_EV);
+
+    ctx.feedback.v2g_message(stored_response_type);
 }
 
 void Session::handle_connection_event(io::ConnectionEvent event) {


### PR DESCRIPTION
## Describe your changes

There are EV implementations that can configure request messages within a few milliseconds, which can currently trigger a flood of internal communication. To avoid performance issues, we should therefore wait a certain amount of time after receiving a request message before sending the next response message. The delay of maximum 100 ms should not cause any problems, as the most critical time of the ISO 15118-20 (V2G_SECC_Msg_Performance_Time of the charging loop) is 250 ms.

Already successfully tested in the SIL environment (with a higher delay, because the josev lib based implementation needs ~500ms to configure a request message).

Changes:
- introduce MIN_RESPONSE_INTERVAL_MS to manage time between responses
- add last_response_tx_time to track last response timestamp
- implement delay to ensure minimum interval between response messages

## Issue ticket number and link

## Checklist before requesting a review
- [X ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

