### PR TITLE
added wildcard handling for handle_external_mqtt_message

### DIFF
--- a/lib/everest/framework/include/utils/message_handler.hpp
+++ b/lib/everest/framework/include/utils/message_handler.hpp
@@ -62,6 +62,10 @@ private:
     void execute_handlers_from_vector(HandlerMap& handlers, const std::string& topic, ExecuteFn execute_fn);
 
     template <typename HandlerMap, typename ExecuteFn>
+    void execute_handlers_from_vector_with_wildcards(HandlerMap& handlers, const std::string& topic,
+                                                     ExecuteFn execute_fn);
+
+    template <typename HandlerMap, typename ExecuteFn>
     void execute_single_handler(HandlerMap& handlers, const std::string& topic, ExecuteFn execute_fn);
 
     // Threads
@@ -94,7 +98,8 @@ private:
     std::map<MqttTopic, std::vector<std::shared_ptr<TypedHandler>>> var_handlers; // var handlers of module
     std::map<MqttTopic, std::shared_ptr<TypedHandler>> cmd_handlers;              // cmd handlers of module
     std::map<CmdId, std::shared_ptr<TypedHandler>> cmd_result_handlers;           // cmd result handlers of module
-    std::map<MqttTopic, std::shared_ptr<TypedHandler>> error_handlers;            // error handlers of module
+    std::map<MqttTopic, std::vector<std::shared_ptr<TypedHandler>>>
+        error_handlers; // error handlers with wildcard support
     std::map<MqttTopic, std::shared_ptr<TypedHandler>>
         get_module_config_handlers;                        // get module config handler of manager
     std::shared_ptr<TypedHandler> config_response_handler; // get module config response handler of module


### PR DESCRIPTION
## Describe your changes
This PR fixes the issue reported in https://github.com/EVerest/everest-core/issues/1712 where the MQTT message handler was not working with topics containing wildcards.
I used the already existing function 'check_topic_matches'
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

