### PR TITLE
Enumerate evse managers correctly in API module

### DIFF
--- a/modules/API/API/API.hpp
+++ b/modules/API/API/API.hpp
@@ -99,7 +99,7 @@ private:
         FinishedEV
     } state;
 
-    bool is_state_charging(const SessionInfo::State current_state);
+    static bool is_state_charging(SessionInfo::State current_state);
 
     std::string state_to_string(State s);
 


### PR DESCRIPTION
## Describe your changes
Fix: `evse_id` should not be defined based on the order the evse managers are listed among the API connections.
Moved all the code requiring the `evse_id` parameter from the `init` function to the `ready` function where it's safe to call `call_get_evse` on the evse managers. 

Refactor: performed a couple of suggested changes from clang tidy

## Issue ticket number and link
Fix #1710 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

