### PR TITLE
EvseManager: set three phases correctly

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -235,7 +235,22 @@ void EvseManager::init() {
 
         signalNrOfPhasesAvailable(ac_nr_phases_active);
 
-        bsp->set_three_phases(c.max_phase_count_import);
+        const auto get_max_phases = [](int max_phase_count) -> AcPhases {
+            switch (max_phase_count) {
+            case 1:
+                return AcPhases::SinglePhase;
+            case 2:
+                return AcPhases::TwoPhases;
+            case 3:
+                return AcPhases::ThreePhases;
+
+            default:
+                EVLOG_warning << "Invalid max_phase_count of " << max_phase_count << ". Falling back to single phase";
+            }
+            return AcPhases::SinglePhase;
+        };
+
+        bsp->set_max_phases(get_max_phases(c.max_phase_count_import));
         charger->set_connector_type(c.connector_type);
         p_evse->publish_hw_capabilities(c);
         if (config.charge_mode == "AC" and hlc_enabled) {

--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -433,10 +433,10 @@ void IECStateMachine::set_pp_ampacity(types::board_support_common::ProximityPilo
         pp_ampacity = 32.;
         break;
     case types::board_support_common::Ampacity::A_63_3ph_70_1ph:
-        if (three_phases) {
-            pp_ampacity = 63.;
-        } else {
+        if (max_phases == AcPhases::SinglePhase) {
             pp_ampacity = 70.;
+        } else {
+            pp_ampacity = 63.;
         }
         break;
     default:

--- a/modules/EVSE/EvseManager/IECStateMachine.hpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.hpp
@@ -65,6 +65,13 @@ enum class RawCPState {
     F
 };
 
+// Number of active phases for AC charging
+enum class AcPhases {
+    SinglePhase,
+    TwoPhases,
+    ThreePhases
+};
+
 class IECStateMachine {
 public:
     // We need the r_bsp reference to be able to talk to the bsp driver module
@@ -86,8 +93,8 @@ public:
     void set_pwm_off();
     void set_pwm_F();
 
-    void set_three_phases(bool t) {
-        three_phases = t;
+    void set_max_phases(AcPhases phases) {
+        max_phases = phases;
     }
 
     void enable(bool en);
@@ -122,7 +129,7 @@ private:
     bool last_power_on_allowed{false};
     std::atomic<double> pp_ampacity{0.0};
     std::atomic<double> last_amps{-1};
-    std::atomic_bool three_phases{true};
+    std::atomic<AcPhases> max_phases{AcPhases::ThreePhases};
 
     bool car_plugged_in{false};
 


### PR DESCRIPTION
Currently the three phases boolean is always set to true, even for BSPs that only support one phase. This leads to an incorrect pp_amp. The changes here try to fix that.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

