### PR TITLE
fix: framework: store retain flag of messages published before connected

### DIFF
--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -26,9 +26,10 @@ constexpr auto MQTT_BUF_SIZE = 500 * std::size_t{1024};
 namespace Everest {
 /// \brief Contains a payload and the topic it was received on with additional QOS
 struct MessageWithQOS : Message {
-    QOS qos; ///< The Quality of Service level
+    QOS qos;     ///< The Quality of Service level
+    bool retain; ///< If the retain flag should be set on publishing this message
 
-    MessageWithQOS(const std::string& topic, const std::string& payload, QOS qos);
+    MessageWithQOS(const std::string& topic, const std::string& payload, QOS qos, bool retain);
 };
 
 ///


### PR DESCRIPTION
## Describe your changes

If this flag is not stored the retained flag is accidentally dropped which can lead to issues further down the line

This mostly would be an issue in the framework manager which publishes a few topics on startup such as everest/interfaces which must be retained for modules to receive their payload later. If the flag is not set the module would try to get() this data only to timeout with a "Timeout while waiting for result of get()" error message, terminating the startup of the module

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

