### PR TITLE
fix: adding missing OCPP1.6 Configuration Keys (#1796)

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
@@ -124,14 +124,19 @@ public:
     void setVerifyCsmsAllowWildcards(bool verify_csms_allow_wildcards) override;
     KeyValue getVerifyCsmsAllowWildcardsKeyValue() override;
     bool getUseTPM() override;
+    KeyValue getUseTPMKeyValue() override;
     bool getUseTPMSeccLeafCertificate() override;
+    KeyValue getUseTPMSeccLeafCertificateKeyValue() override;
+
     std::string getSupportedMeasurands() override;
     KeyValue getSupportedMeasurandsKeyValue() override;
     int getMaxMessageSize() override;
     KeyValue getMaxMessageSizeKeyValue() override;
 
     bool getEnableTLSKeylog() override;
+    KeyValue getEnableTLSKeylogKeyValue() override;
     std::string getTLSKeylogFile() override;
+    KeyValue getTLSKeylogFileKeyValue() override;
 
     bool getStopTransactionIfUnlockNotSupported() override;
     void setStopTransactionIfUnlockNotSupported(bool stop_transaction_if_unlock_not_supported) override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
@@ -192,6 +192,7 @@ public:
     KeyValue getChargePointIdKeyValue() override;
     KeyValue getChargePointModelKeyValue() override;
     KeyValue getChargePointVendorKeyValue() override;
+    KeyValue getEnableTLSKeylogKeyValue() override;
     KeyValue getLogMessagesFormatKeyValue() override;
     KeyValue getLogMessagesKeyValue() override;
     KeyValue getLogMessagesRawKeyValue() override;
@@ -210,7 +211,10 @@ public:
     KeyValue getSupportedCiphers12KeyValue() override;
     KeyValue getSupportedCiphers13KeyValue() override;
     KeyValue getSupportedMeasurandsKeyValue() override;
+    KeyValue getTLSKeylogFileKeyValue() override;
     KeyValue getUseSslDefaultVerifyPathsKeyValue() override;
+    KeyValue getUseTPMKeyValue() override;
+    KeyValue getUseTPMSeccLeafCertificateKeyValue() override;
     KeyValue getVerifyCsmsAllowWildcardsKeyValue() override;
     KeyValue getVerifyCsmsCommonNameKeyValue() override;
     KeyValue getWaitForStopTransactionsOnResetTimeoutKeyValue() override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
@@ -114,6 +114,7 @@ public:
     virtual KeyValue getChargePointIdKeyValue() = 0;
     virtual KeyValue getChargePointModelKeyValue() = 0;
     virtual KeyValue getChargePointVendorKeyValue() = 0;
+    virtual KeyValue getEnableTLSKeylogKeyValue() = 0;
     virtual KeyValue getLogMessagesFormatKeyValue() = 0;
     virtual KeyValue getLogMessagesKeyValue() = 0;
     virtual KeyValue getLogMessagesRawKeyValue() = 0;
@@ -132,7 +133,10 @@ public:
     virtual KeyValue getSupportedCiphers12KeyValue() = 0;
     virtual KeyValue getSupportedCiphers13KeyValue() = 0;
     virtual KeyValue getSupportedMeasurandsKeyValue() = 0;
+    virtual KeyValue getTLSKeylogFileKeyValue() = 0;
     virtual KeyValue getUseSslDefaultVerifyPathsKeyValue() = 0;
+    virtual KeyValue getUseTPMKeyValue() = 0;
+    virtual KeyValue getUseTPMSeccLeafCertificateKeyValue() = 0;
     virtual KeyValue getVerifyCsmsAllowWildcardsKeyValue() = 0;
     virtual KeyValue getVerifyCsmsCommonNameKeyValue() = 0;
     virtual KeyValue getWaitForStopTransactionsOnResetTimeoutKeyValue() = 0;

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -478,8 +478,24 @@ bool ChargePointConfiguration::getUseTPM() {
     return this->config["Internal"]["UseTPM"];
 }
 
+KeyValue ChargePointConfiguration::getUseTPMKeyValue() {
+    KeyValue kv;
+    kv.key = "UseTPM";
+    kv.readonly = true;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getUseTPM()));
+    return kv;
+}
+
 bool ChargePointConfiguration::getUseTPMSeccLeafCertificate() {
     return this->config["Internal"]["UseTPMSeccLeafCertificate"];
+}
+
+KeyValue ChargePointConfiguration::getUseTPMSeccLeafCertificateKeyValue() {
+    KeyValue kv;
+    kv.key = "UseTPMSeccLeafCertificate";
+    kv.readonly = true;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getUseTPMSeccLeafCertificate()));
+    return kv;
 }
 
 bool ChargePointConfiguration::getVerifyCsmsAllowWildcards() {
@@ -780,8 +796,24 @@ bool ChargePointConfiguration::getEnableTLSKeylog() {
     return this->config["Internal"]["EnableTLSKeylog"];
 }
 
+KeyValue ChargePointConfiguration::getEnableTLSKeylogKeyValue() {
+    KeyValue kv;
+    kv.key = "EnableTLSKeylog";
+    kv.readonly = true;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getEnableTLSKeylog()));
+    return kv;
+}
+
 std::string ChargePointConfiguration::getTLSKeylogFile() {
     return this->config["Internal"]["TLSKeylogFile"];
+}
+
+KeyValue ChargePointConfiguration::getTLSKeylogFileKeyValue() {
+    KeyValue kv;
+    kv.key = "TLSKeylogFile";
+    kv.readonly = true;
+    kv.value.emplace(this->getTLSKeylogFile());
+    return kv;
 }
 
 bool ChargePointConfiguration::getStopTransactionIfUnlockNotSupported() {
@@ -3110,6 +3142,18 @@ std::optional<KeyValue> ChargePointConfiguration::get(const CiString<50>& key) {
     if (key == "LogMessagesFormat") {
         return this->getLogMessagesFormatKeyValue();
     }
+    if (key == "LogRotation") {
+        return this->getLogRotationKeyValue();
+    }
+    if (key == "LogRotationDateSuffix") {
+        return this->getLogRotationDateSuffixKeyValue();
+    }
+    if (key == "LogRotationMaximumFileCount") {
+        return this->getLogRotationMaximumFileCountKeyValue();
+    }
+    if (key == "LogRotationMaximumFileSize") {
+        return this->getLogRotationMaximumFileSizeKeyValue();
+    }
     if (key == "SupportedChargingProfilePurposeTypes") {
         return this->getSupportedChargingProfilePurposeTypesKeyValue();
     }
@@ -3188,7 +3232,18 @@ std::optional<KeyValue> ChargePointConfiguration::get(const CiString<50>& key) {
     if (key == "StopTransactionIfUnlockNotSupported") {
         return this->getStopTransactionIfUnlockNotSupportedKeyValue();
     }
-
+    if (key == "TLSKeylogFile") {
+        return this->getTLSKeylogFileKeyValue();
+    }
+    if (key == "EnableTLSKeylog") {
+        return this->getEnableTLSKeylogKeyValue();
+    }
+    if (key == "UseTPM") {
+        return this->getUseTPMKeyValue();
+    }
+    if (key == "UseTPMSeccLeafCertificate") {
+        return this->getUseTPMSeccLeafCertificateKeyValue();
+    }
     // Core Profile
     if (key == "AllowOfflineTxForUnknownId") {
         return this->getAllowOfflineTxForUnknownIdKeyValue();

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -1321,6 +1321,10 @@ KeyValue ChargePointConfigurationDeviceModel::getChargePointVendorKeyValue() {
     return get_key_value(*storage, keys::valid_keys::ChargePointVendor);
 }
 
+KeyValue ChargePointConfigurationDeviceModel::getEnableTLSKeylogKeyValue() {
+    return get_key_value(*storage, keys::valid_keys::EnableTLSKeylog);
+}
+
 KeyValue ChargePointConfigurationDeviceModel::getLogMessagesFormatKeyValue() {
     return get_key_value(*storage, keys::valid_keys::LogMessagesFormat);
 }
@@ -1393,8 +1397,20 @@ KeyValue ChargePointConfigurationDeviceModel::getSupportedMeasurandsKeyValue() {
     return get_key_value(*storage, keys::valid_keys::SupportedMeasurands);
 }
 
+KeyValue ChargePointConfigurationDeviceModel::getTLSKeylogFileKeyValue() {
+    return get_key_value(*storage, keys::valid_keys::TLSKeylogFile);
+}
+
 KeyValue ChargePointConfigurationDeviceModel::getUseSslDefaultVerifyPathsKeyValue() {
     return get_key_value(*storage, keys::valid_keys::UseSslDefaultVerifyPaths);
+}
+
+KeyValue ChargePointConfigurationDeviceModel::getUseTPMKeyValue() {
+    return get_key_value(*storage, keys::valid_keys::UseTPM);
+}
+
+KeyValue ChargePointConfigurationDeviceModel::getUseTPMSeccLeafCertificateKeyValue() {
+    return get_key_value(*storage, keys::valid_keys::UseTPMSeccLeafCertificate);
 }
 
 KeyValue ChargePointConfigurationDeviceModel::getVerifyCsmsAllowWildcardsKeyValue() {

--- a/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/known_keys.cpp
@@ -28,8 +28,8 @@ using ocpp::v16::keys::valid_keys;
     key(LogMessagesFormat) \
     key(LogRotation) \
     key(LogRotationDateSuffix) \
-    key(LogRotationMaximumFileSize) \
     key(LogRotationMaximumFileCount) \
+    key(LogRotationMaximumFileSize) \
     key(SupportedChargingProfilePurposeTypes) \
     key(MaxCompositeScheduleDuration) \
     key(SupportedCiphers12) \
@@ -72,23 +72,17 @@ using ocpp::v16::keys::valid_keys;
     key(NumberOfDecimalsForCostValues) \
     key(CustomMultiLanguageMessages) \
     key(SupportedLanguages) \
-    key(Language)
-
-// Hidden keys are ones that are not made available over OCPP
-//  AuthorizationKey because it contains the connection secret
-//  <others> because they are not in ChargePointConfiguration::get()
-//  (which could be a bug)
-
-#define FOR_ALL_HIDDEN(key) \
-    key(AuthorizationKey) \
+    key(Language) \
     key(EnableTLSKeylog) \
-    key(LogRotation) \
-    key(LogRotationDateSuffix) \
-    key(LogRotationMaximumFileCount) \
-    key(LogRotationMaximumFileSize) \
     key(TLSKeylogFile) \
     key(UseTPM) \
     key(UseTPMSeccLeafCertificate)
+
+// Hidden keys are ones that are not made available over OCPP
+//  AuthorizationKey because it contains the connection secret
+
+#define FOR_ALL_HIDDEN(key) \
+    key(AuthorizationKey)
 
 // clang-format on
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_custom.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_custom.cpp
@@ -81,6 +81,14 @@ const std::map<std::string, std::string> expected_key_value = {
     {"ContractValidationOffline", "true"},
     {"ISO15118CertificateManagementEnabled", "true"},
     {"ISO15118PnCEnabled", "true"},
+    {"UseTPM", "false"},
+    {"UseTPMSeccLeafCertificate", "false"},
+    {"LogRotationMaximumFileCount", "0"},
+    {"LogRotationMaximumFileSize", "0"},
+    {"TLSKeylogFile", "/tmp/ocpp_tls_keylog.txt"},
+    {"LogRotation", "false"},
+    {"LogRotationDateSuffix", "false"},
+    {"EnableTLSKeylog", "false"},
 };
 
 TEST_P(Configuration, CustomKey) {
@@ -120,14 +128,15 @@ TEST_P(Configuration, Get) {
     EXPECT_EQ(kv.value().value, "900");
     EXPECT_FALSE(kv.value().readonly);
 
-    // hidden key
-
     // check key exists and has a value
     EXPECT_EQ(get()->getTLSKeylogFile(), "/tmp/ocpp_tls_keylog.txt");
 
-    // check it is not available via this call
+    // check it is available via this call (read-only)
     kv = get()->get("TLSKeylogFile");
-    ASSERT_FALSE(kv);
+    ASSERT_TRUE(kv);
+    EXPECT_EQ(kv.value().key, "TLSKeylogFile");
+    EXPECT_EQ(kv.value().value, "/tmp/ocpp_tls_keylog.txt");
+    EXPECT_TRUE(kv.value().readonly);
 
     // custom key (none defined)
 }
@@ -177,10 +186,13 @@ TEST_P(Configuration, Set) {
     EXPECT_EQ(kv.value().value, "1201");
     EXPECT_FALSE(kv.value().readonly);
 
-    // hidden key - these are read-only
-
-    // check key exists and has a value
+    // check if read-only key exists and has a value
     EXPECT_EQ(get()->getTLSKeylogFile(), "/tmp/ocpp_tls_keylog.txt");
+    kv = get()->get("TLSKeylogFile");
+    ASSERT_TRUE(kv);
+    EXPECT_EQ(kv.value().key, "TLSKeylogFile");
+    EXPECT_EQ(kv.value().value, "/tmp/ocpp_tls_keylog.txt");
+    EXPECT_TRUE(kv.value().readonly);
     EXPECT_EQ(get()->set("TLSKeylogFile", "1201"), std::nullopt);
     EXPECT_EQ(get()->getTLSKeylogFile(), "/tmp/ocpp_tls_keylog.txt");
 
@@ -296,13 +308,6 @@ TEST_F(Configuration, SetV2) {
     EXPECT_EQ(kv.value().key, "ClockAlignedDataInterval");
     EXPECT_EQ(kv.value().value, "1201");
     EXPECT_FALSE(kv.value().readonly);
-
-    // hidden key - these are read-only
-
-    // check key exists and has a value
-    EXPECT_EQ(v2_config->getTLSKeylogFile(), "/tmp/ocpp_tls_keylog.txt");
-    EXPECT_EQ(v2_config->set("TLSKeylogFile", "1201"), std::nullopt);
-    EXPECT_EQ(v2_config->getTLSKeylogFile(), "/tmp/ocpp_tls_keylog.txt");
 
     // custom key (read only)
     kv = v2_config->get("ACustomKey");


### PR DESCRIPTION
OCPP 1.6: add missing configuration keys to ChargePointConfiguration::get()

Fixes #1796.

Expose configuration keys that were configurable locally but not retrievable via OCPP 1.6 GetConfiguration due to missing cases in ChargePointConfiguration::get().

## Describe your changes

## Issue ticket number and link
https://github.com/EVerest/everest-core/issues/1796

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

