### PR TITLE
Fix(EvseV2G): PnC enabled check did not work correctly in ServiceDiscovery state

### DIFF
--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -5,6 +5,7 @@
 #include "log.hpp"
 #include "tools.hpp"
 #include "v2g_ctx.hpp"
+#include <algorithm>
 #include <string.h>
 #include <string_view>
 
@@ -181,34 +182,34 @@ void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::Setup
 void ISO15118_chargerImpl::handle_session_setup(std::vector<types::iso15118::PaymentOption>& payment_options,
                                                 bool& supported_certificate_service,
                                                 bool& central_contract_validation_allowed) {
-    if (v2g_ctx->hlc_pause_active != true) {
-        v2g_ctx->evse_v2g_data.payment_option_list_len = 0;
-
-        for (auto option : payment_options) {
-
-            if (option == types::iso15118::PaymentOption::Contract) {
-                v2g_ctx->evse_v2g_data.payment_option_list[v2g_ctx->evse_v2g_data.payment_option_list_len] =
-                    iso2_paymentOptionType_Contract;
-                v2g_ctx->evse_v2g_data.payment_option_list_len++;
-            } else if (option == types::iso15118::PaymentOption::ExternalPayment) {
-                v2g_ctx->evse_v2g_data.payment_option_list[v2g_ctx->evse_v2g_data.payment_option_list_len] =
-                    iso2_paymentOptionType_ExternalPayment;
-                v2g_ctx->evse_v2g_data.payment_option_list_len++;
-            } else {
-                dlog(DLOG_LEVEL_WARNING, "Unable to configure PaymentOption %s",
-                     types::iso15118::payment_option_to_string(option).c_str());
+    if (not v2g_ctx->hlc_pause_active) {
+        v2g_ctx->evse_v2g_data.payment_option_list.clear();
+        if (not payment_options.empty()) {
+            const auto max_payment_options =
+                std::min(static_cast<size_t>(iso2_paymentOptionType_2_ARRAY_SIZE), payment_options.size());
+            for (size_t i = 0; i < max_payment_options; i++) {
+                const auto& payment_option = payment_options.at(i);
+                if (payment_option == types::iso15118::PaymentOption::ExternalPayment) {
+                    v2g_ctx->evse_v2g_data.payment_option_list.push_back(iso2_paymentOptionType_ExternalPayment);
+                } else if (payment_option == types::iso15118::PaymentOption::Contract) {
+                    v2g_ctx->evse_v2g_data.payment_option_list.push_back(iso2_paymentOptionType_Contract);
+                } else {
+                    dlog(DLOG_LEVEL_WARNING, "Unable to configure PaymentOption %s",
+                         types::iso15118::payment_option_to_string(payment_option).c_str());
+                }
             }
         }
 
-        if (v2g_ctx->evse_v2g_data.payment_option_list_len == 0) {
+        if (payment_options.empty() or v2g_ctx->evse_v2g_data.payment_option_list.empty()) {
             dlog(DLOG_LEVEL_ERROR, "No valid PaymentOptions configured, falling back to ExternalPayment");
-            v2g_ctx->evse_v2g_data.payment_option_list[0] = iso2_paymentOptionType_ExternalPayment;
-            v2g_ctx->evse_v2g_data.payment_option_list_len = 1;
+            v2g_ctx->evse_v2g_data.payment_option_list.clear();
+            v2g_ctx->evse_v2g_data.payment_option_list.push_back(iso2_paymentOptionType_ExternalPayment);
         }
     }
 
-    const auto pnc_enabled = ((v2g_ctx->evse_v2g_data.payment_option_list[0] == iso2_paymentOptionType_Contract) or
-                              (v2g_ctx->evse_v2g_data.payment_option_list[1] == iso2_paymentOptionType_Contract));
+    const auto pnc_enabled =
+        std::find(v2g_ctx->evse_v2g_data.payment_option_list.begin(), v2g_ctx->evse_v2g_data.payment_option_list.end(),
+                  iso2_paymentOptionType_Contract) != v2g_ctx->evse_v2g_data.payment_option_list.end();
 
     using state_t = tls::Server::state_t;
     const auto tls_server_state = v2g_ctx->tls_server->state();

--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -277,8 +277,7 @@ struct v2g_context {
         struct iso2_SAScheduleListType evse_sa_schedule_list;
         bool evse_sa_schedule_list_is_used;
 
-        iso2_paymentOptionType payment_option_list[iso2_paymentOptionType_2_ARRAY_SIZE];
-        uint8_t payment_option_list_len;
+        std::vector<iso2_paymentOptionType> payment_option_list;
         bool central_contract_validation_allowed;
 
         bool cert_install_status;

--- a/modules/EVSE/EvseV2G/v2g_ctx.cpp
+++ b/modules/EVSE/EvseV2G/v2g_ctx.cpp
@@ -193,8 +193,9 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
         ctx->evse_v2g_data.rcd = (int)0; // 0 if RCD has not detected an error
         ctx->contactor_is_closed = false;
 
-        ctx->evse_v2g_data.payment_option_list[0] = iso2_paymentOptionType_ExternalPayment;
-        ctx->evse_v2g_data.payment_option_list_len = (uint8_t)1; // One option must be set
+        ctx->evse_v2g_data.payment_option_list.clear();
+        ctx->evse_v2g_data.payment_option_list.reserve(iso2_paymentOptionType_2_ARRAY_SIZE);
+        ctx->evse_v2g_data.payment_option_list.push_back(iso2_paymentOptionType_ExternalPayment);
 
         ctx->evse_v2g_data.evse_service_list.clear();
         ctx->evse_v2g_data.evse_service_list.reserve(iso2_ServiceType_8_ARRAY_SIZE);
@@ -261,8 +262,8 @@ void v2g_ctx_init_charging_values(struct v2g_context* const ctx) {
     if (ctx->hlc_pause_active != true) {
         ctx->session.iso_selected_payment_option = iso2_paymentOptionType_ExternalPayment;
     } else {
-        ctx->evse_v2g_data.payment_option_list[0] = ctx->session.iso_selected_payment_option;
-        ctx->evse_v2g_data.payment_option_list_len = (uint8_t)1; // One option must be set
+        ctx->evse_v2g_data.payment_option_list.clear();
+        ctx->evse_v2g_data.payment_option_list.push_back(ctx->session.iso_selected_payment_option);
     }
     memset(ctx->session.gen_challenge, 0, sizeof(ctx->session.gen_challenge));
 


### PR DESCRIPTION
## Describe your changes
Replacing the c array `payment_option_list` with std::vector. With a std::vector it is easier to check if certain payment options are supported or not.

## Issue ticket number and link
In the ServiceDiscovery state this warning log message was falsly printed:
```PnC is not allowed without TLS-communication. Correcting value to '1' (ExternalPayment)```
This fix changes that.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

