### PR TITLE
OCPP201: Fix access to r_evse_manager vector

### DIFF
--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -922,8 +922,13 @@ void OCPP201::ready() {
         [this](const std::vector<ocpp::v2::EnergyTransferModeEnum>& allowed_energy_transfer_modes,
                const ocpp::CiString<36>& transaction_id) -> bool {
         const int evse_id = transaction_handler->get_evse_id(transaction_id);
-        if (evse_id != -1 and this->r_evse_manager[evse_id] != nullptr) {
-            return this->r_evse_manager[evse_id]->call_update_allowed_energy_transfer_modes(
+        if (evse_id == -1 || evse_id > this->r_evse_manager.size()) {
+            return false;
+        }
+        auto& evse = this->r_evse_manager.at(evse_id - 1); // evse_id starts at 1 if valid
+
+        if (evse != nullptr) {
+            return evse->call_update_allowed_energy_transfer_modes(
                        conversions::to_everest_allowed_energy_transfer_modes(allowed_energy_transfer_modes)) ==
                    types::evse_manager::UpdateAllowedEnergyTransferModesResult::Accepted;
         }


### PR DESCRIPTION
## Describe your changes

transaction_handler->get_evse_id() returns a 1-based evse_id, while the r_evse_manager vector is 0-indexed

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

