### PR TITLE
EvseSlac: implement startup delay config

### DIFF
--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -3,11 +3,13 @@
 
 #include "slacImpl.hpp"
 
+#include <chrono>
 #include <future>
 
 #include <everest/slac/io.hpp>
 #include <fmt/core.h>
 #include <slac/channel.hpp>
+#include <thread>
 
 #include "fsm_controller.hpp"
 
@@ -38,6 +40,12 @@ void slacImpl::ready() {
 void slacImpl::run() {
     // wait until ready
     module_ready.get_future().get();
+
+    if (config.startup_delay_ms > 0) {
+        EVLOG_info << "Delaying SLAC startup by " << config.startup_delay_ms << "ms";
+        std::this_thread::sleep_for(std::chrono::milliseconds(config.startup_delay_ms));
+        EVLOG_info << "Continuing with SLAC initialization";
+    }
 
     // initialize slac i/o
     SlacIO slac_io;

--- a/modules/EVSE/EvseSlac/main/slacImpl.hpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.hpp
@@ -35,6 +35,7 @@ struct Conf {
     int link_status_timeout_ms;
     bool debug_simulate_failed_matching;
     bool reset_instead_of_fail;
+    int startup_delay_ms;
 };
 
 class slacImpl : public slacImplBase {

--- a/modules/EVSE/EvseSlac/manifest.yaml
+++ b/modules/EVSE/EvseSlac/manifest.yaml
@@ -76,6 +76,12 @@ provides:
           To react to this message and restart the SLAC process, the EVSE go to the reset state here.
         type: boolean
         default: true
+      startup_delay_ms:
+        description: >-
+          Delay initialization of SLAC I/O by the given amount.
+          On some hardware platforms with multiple EvseSlac modules loaded this can be necessary to ensure that the initial query of the device information does not happen at the same time.
+        type: integer
+        default: 0
 metadata:
   base_license: https://directory.fsf.org/wiki/License:BSD-3-Clause-Clear
   license: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
## Describe your changes

The new startup_delay_ms configuration option allows the initialization of SLAC I/O to be delayed by the given amount.
On some hardware platforms, with multiple EvseSlac modules loaded, this can be necessary to ensure that the initial query of the device information does not happen at the same time.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

