### PR TITLE
cmake support for setting pybind11 include files location

### DIFF
--- a/lib/everest/framework/everestpy/src/everest/CMakeLists.txt
+++ b/lib/everest/framework/everestpy/src/everest/CMakeLists.txt
@@ -9,6 +9,18 @@ if (DISABLE_EDM)
     find_package(pybind11_json REQUIRED)
 endif()
 
+# support overriding where the include files are to be found.
+# Used for Yocto where the pybind11 libraries may have come from a cache and the
+# full path is no longer the same
+if (PYBIND11_INTERFACE_INCLUDE_DIRECTORIES)
+    set_target_properties(pybind11::pybind11 PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES ${PYBIND11_INTERFACE_INCLUDE_DIRECTORIES}
+    )
+    set_target_properties(pybind11_json PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES ${PYBIND11_INTERFACE_INCLUDE_DIRECTORIES}
+    )
+endif()
+
 pybind11_add_module(everestpy misc.cpp module.cpp everestpy.cpp)
 
 target_compile_options(everestpy PRIVATE ${COMPILER_WARNING_OPTIONS})


### PR DESCRIPTION

## Describe your changes
support optional setting of the pybind11 include files location
Useful for Yocto and other build systems that use a cache and the full path to the include files is no longer valid

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

