### PR TITLE
Disable Bender on stop measurement

### DIFF
--- a/modules/HardwareDrivers/IsolationMonitors/Bender_isoCHA425HV/main/isolation_monitorImpl.hpp
+++ b/modules/HardwareDrivers/IsolationMonitors/Bender_isoCHA425HV/main/isolation_monitorImpl.hpp
@@ -42,6 +42,7 @@ struct Conf {
     bool voltage_to_earth_monitoring_alarm_enable;
     int relay_k1_alarm_assignment;
     int relay_k2_alarm_assignment;
+    bool disable_device_on_stop;
 };
 
 class isolation_monitorImpl : public isolation_monitorImplBase {

--- a/modules/HardwareDrivers/IsolationMonitors/Bender_isoCHA425HV/manifest.yaml
+++ b/modules/HardwareDrivers/IsolationMonitors/Bender_isoCHA425HV/manifest.yaml
@@ -122,6 +122,11 @@ provides:
           3000 Enable over voltage to earth monitoring alarm
         type: boolean
         default: false
+      disable_device_on_stop:
+        description: >-
+          Disable the device upon stop measurement
+        type: boolean
+        default: false
 requires:
   serial_comm_hub:
     interface: serial_communication_hub


### PR DESCRIPTION
## Describe your changes
Adds optional device lifecycle management for the Bender isoCHA425HV isolation monitor, allowing the device to be disabled when not in use and enabled only during active measurement periods.
Reducing other mesurement errors when the isolation monitor is not actively measuring.

### New Configuration Option 
- Added disable_device_on_stop configuration option (default: false)
- When enabled, the device is only powered on during active measurement periods
- Device is disabled when measurements are stopped

### Device Lifecycle Management
When disable_device_on_stop is enabled:
- Configuration phase: Device is not automatically started during configure_device()
- Start measurements (handle_start()): Device is enabled before measurements begin
- Stop measurements (handle_stop()): Device is disabled after measurements stop
- Self-test (handle_start_self_test()): Device is enabled before self-test and disabled after completion

### Incompatibility Handling
- Detects incompatible configuration when both disable_device_on_stop and selftest_enable_at_start are enabled
- Logs a warning and automatically disables selftest_enable_at_start (since the device won't be started during configuration)

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

