### PR TITLE
fix: resolve data races in OCPP and OCPP201 modules

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -36,3 +36,8 @@ alias(
     actual = "//lib/everest/external_energy_limits:external_energy_limits",
     visibility = ["//visibility:public"],
 )
+alias(
+    name = "util",
+    actual = "//lib/everest/util:util",
+    visibility = ["//visibility:public"],
+)

--- a/modules/EVSE/OCPP/CMakeLists.txt
+++ b/modules/EVSE/OCPP/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(${MODULE_NAME}
     PRIVATE
         OpenSSL::SSL
         OpenSSL::Crypto
+        everest::util
         everest::ocpp
         everest::ocpp_evse_security
         everest::ocpp_conversions

--- a/modules/EVSE/OCPP/OCPP.hpp
+++ b/modules/EVSE/OCPP/OCPP.hpp
@@ -36,6 +36,7 @@
 #include <date/date.h>
 #include <date/tz.h>
 #include <everest/timer.hpp>
+#include <everest/util/async/monitor.hpp>
 #include <filesystem>
 #include <memory>
 #include <mutex>
@@ -178,12 +179,9 @@ private:
                                                          // EVerests evse and connector id
     std::map<int32_t, int32_t> connector_evse_index_map; // provides access to r_evse_manager index by
                                                          // using OCPP connector id
-    std::map<int32_t, bool> evse_ready_map;
-    std::map<int32_t, std::optional<float>> evse_soc_map;
+    everest::lib::util::monitor<std::map<int32_t, bool>> evse_ready_map;
+    everest::lib::util::monitor<std::map<int32_t, std::optional<float>>> evse_soc_map;
     std::set<std::string> resuming_session_ids;
-    std::mutex evse_ready_mutex;
-    std::condition_variable evse_ready_cv;
-    bool all_evse_ready();
 
     std::mutex event_mutex;
     bool started{false};

--- a/modules/EVSE/OCPP201/BUILD.bazel
+++ b/modules/EVSE/OCPP201/BUILD.bazel
@@ -113,6 +113,7 @@ cc_everest_module(
         "@openssl//:ssl",
         "@openssl//:crypto",
         "@libcap//:libcap",
+        "@everest-core//lib:util",
         "@everest-core//lib:ocpp",
         "@everest-core//lib:ocpp_evse_security",
         "@everest-core//lib:ocpp_conversions",

--- a/modules/EVSE/OCPP201/CMakeLists.txt
+++ b/modules/EVSE/OCPP201/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(${MODULE_NAME}
     PRIVATE
         OpenSSL::SSL
         OpenSSL::Crypto
+        everest::util
         everest::ocpp
         everest::ocpp_evse_security
         everest::ocpp_conversions

--- a/modules/EVSE/OCPP201/OCPP201.hpp
+++ b/modules/EVSE/OCPP201/OCPP201.hpp
@@ -35,6 +35,7 @@
 #include <variant>
 
 #include <device_model/everest_device_model_storage.hpp>
+#include <everest/util/async/monitor.hpp>
 #include <generated/types/evse_board_support.hpp>
 #include <ocpp/v2/charge_point.hpp>
 #include <transaction_handler.hpp>
@@ -139,23 +140,20 @@ private:
     std::string source_ext_limit;
 
     // key represents evse_id, value indicates if ready
-    std::map<int32_t, bool> evse_ready_map;
-    std::map<int32_t, std::optional<float>> evse_soc_map;
+    everest::lib::util::monitor<std::map<int32_t, bool>> evse_ready_map;
+    everest::lib::util::monitor<std::map<int32_t, std::optional<float>>> evse_soc_map;
     std::map<int32_t, types::evse_board_support::HardwareCapabilities> evse_hardware_capabilities_map;
     std::map<int32_t, std::vector<types::iso15118::EnergyTransferMode>> evse_supported_energy_transfer_modes;
     std::map<int32_t, bool> evse_service_renegotiation_supported;
-    std::map<int32_t, std::string> evse_evcc_id;
+    everest::lib::util::monitor<std::map<int32_t, std::string>> evse_evcc_id;
     std::atomic<ocpp::OcppProtocolVersion> ocpp_protocol_version{ocpp::OcppProtocolVersion::Unknown};
     int32_t event_id_counter{0};
-    std::mutex evse_ready_mutex;
     std::mutex session_event_mutex;
-    std::condition_variable evse_ready_cv;
     std::atomic_bool started{false};
     EventQueue event_queue;
     void init_evse_maps();
     void init_evse_subscriptions();
     void init_module_configuration();
-    bool all_evse_ready();
     std::map<int32_t, int32_t> get_connector_structure();
     void process_session_event(const int32_t evse_id, const types::evse_manager::SessionEvent& session_event);
     void process_tx_event_effect(const int32_t evse_id, const TxEventEffect tx_event_effect,


### PR DESCRIPTION
## Describe your changes

Replace unprotected ``std::map`` members with ``everest::lib::util::monitor`` for thread-safe access:
* evse_soc_map (both modules): concurrent reads from powermeter callbacks and writes from ev_info/session_finished callbacks
* evse_evcc_id (OCPP201): concurrent reads/writes across session event processing and ev_info callbacks
* evse_ready_map (both modules): migrated from manual mutex/condition_variable to monitor, removing
* evse_ready_mutex, evse_ready_cv, and all_evse_ready()

Additionally:
* event_queue (OCPP201): add missing session_event_mutex lock in firmware/log status callbacks
* event_queue (OCPP): add missing event_mutex lock in subscribe_powermeter_public_key_ocmf callback

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

