### PR TITLE
feat(framework): Add thread pool to message handler to avoid backed up mqtt queues

### DIFF
--- a/lib/everest/framework/BUILD.bazel
+++ b/lib/everest/framework/BUILD.bazel
@@ -50,6 +50,7 @@ cc_library(
         "@rapidyaml//:rapidyaml",
         "//lib/everest/log:liblog",
         "//lib/everest/sqlite:everest-sqlite",
+        "//lib/everest/util:util",
         "@com_github_fmtlib_fmt//:fmt",
         "@com_github_nlohmann_json//:json",
         "@com_github_pboettch_json-schema-validator//:json-schema-validator",

--- a/lib/everest/framework/include/utils/message_handler.hpp
+++ b/lib/everest/framework/include/utils/message_handler.hpp
@@ -5,15 +5,17 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <queue>
 #include <string>
 #include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
+#include <everest/util/async/thread_pool_scaling.hpp>
 #include <utils/message_queue.hpp>
 #include <utils/types.hpp>
 
@@ -21,6 +23,10 @@ using MqttTopic = std::string;
 using CmdId = std::string;
 
 namespace Everest {
+
+constexpr int THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS = 50;
+constexpr int THREAD_POOL_SCALING_LATENCY_THREAD_IDLE_TIMEOUT_S = 2;
+constexpr int THREAD_POOL_SCALING_MIN_THREAD_COUNT = 1;
 
 /// \brief Handles message dispatching and thread-safe queuing of different message types. This class uses two separate
 /// threads and message queues: one for operation messages (vars, cmds, errors, GetConfig, ModuleReady) and one for
@@ -40,9 +46,13 @@ public:
     void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler);
 
 private:
-    void run_operation_message_worker();
+    void run_operation_dispatcher();
     void run_result_message_worker();
     void run_external_mqtt_worker();
+
+    void dispatch_operation_message(ParsedMessage&& message);
+    void schedule_operation_message(ParsedMessage&& message);
+    void on_operation_message_done(const std::string& topic);
 
     void handle_operation_message(const std::string& topic, const json& payload);
     void handle_result_message(const std::string& topic, const json& payload);
@@ -69,19 +79,29 @@ private:
     void execute_single_handler(HandlerMap& handlers, const std::string& topic, ExecuteFn execute_fn);
 
     // Threads
-    std::thread
-        operation_worker_thread; // processes vars, commands, external MQTT, errors, GetConfig and ModuleReady messages
+    std::thread operation_dispatcher_thread; // processes vars, commands, external MQTT, errors, GetConfig and
+                                             // ModuleReady messages
     std::thread result_worker_thread;        // processes cmd results and GetConfig responses
     std::thread external_mqtt_worker_thread; // processes external MQTT messages
     std::thread ready_thread;                // runs the modules ready function
 
     // Queues and sync primitives
+    std::unique_ptr<everest::lib::util::thread_pool_scaling<
+        everest::lib::util::LatencyScaling<THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS>>>
+        operation_thread_pool{std::make_unique<everest::lib::util::thread_pool_scaling<
+            everest::lib::util::LatencyScaling<THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS>>>(
+            THREAD_POOL_SCALING_MIN_THREAD_COUNT, std::thread::hardware_concurrency(),
+            std::chrono::seconds(THREAD_POOL_SCALING_LATENCY_THREAD_IDLE_TIMEOUT_S))};
     std::queue<ParsedMessage> operation_message_queue;
     std::queue<ParsedMessage> result_message_queue;
     std::queue<ParsedMessage> external_mqtt_message_queue;
 
     std::mutex operation_queue_mutex;
     std::condition_variable operation_cv;
+
+    std::mutex operation_topic_state_mutex;
+    std::unordered_set<std::string> operation_topics_in_flight;
+    std::unordered_map<std::string, std::queue<ParsedMessage>> pending_operation_messages_by_topic;
 
     std::mutex result_queue_mutex;
     std::condition_variable result_cv;

--- a/lib/everest/framework/lib/CMakeLists.txt
+++ b/lib/everest/framework/lib/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(framework
 
         everest::log
         everest::sqlite
+        everest::util
         ${STD_FILESYSTEM_COMPAT_LIB}
     PRIVATE
         ${EVEREST_FRAMEWORK_BOOST_SYSTEM_LINK_LIBRARY}

--- a/lib/everest/framework/lib/message_handler.cpp
+++ b/lib/everest/framework/lib/message_handler.cpp
@@ -6,6 +6,8 @@
 #include <everest/logging.hpp>
 #include <fmt/format.h>
 
+#include <optional>
+
 namespace Everest {
 
 namespace {
@@ -62,7 +64,7 @@ bool check_topic_matches(const std::string& full_topic, const std::string& wildc
 } // namespace
 
 MessageHandler::MessageHandler() {
-    operation_worker_thread = std::thread([this] { run_operation_message_worker(); });
+    operation_dispatcher_thread = std::thread([this] { run_operation_dispatcher(); });
     result_worker_thread = std::thread([this] { run_result_message_worker(); });
     external_mqtt_worker_thread = std::thread([this] { run_external_mqtt_worker(); });
 }
@@ -120,9 +122,13 @@ void MessageHandler::stop() {
     result_cv.notify_all();
     external_mqtt_cv.notify_all();
 
-    if (operation_worker_thread.joinable()) {
-        operation_worker_thread.join();
+    // Join the dispatcher first: it must not be able to call schedule_operation_message()
+    // (which dereferences operation_thread_pool) after the pool is destroyed.
+    if (operation_dispatcher_thread.joinable()) {
+        operation_dispatcher_thread.join();
     }
+    // The thread_pool destructor handles stopping and joining its workers.
+    operation_thread_pool.reset();
     if (result_worker_thread.joinable()) {
         result_worker_thread.join();
     }
@@ -134,7 +140,7 @@ void MessageHandler::stop() {
     }
 }
 
-void MessageHandler::run_operation_message_worker() {
+void MessageHandler::run_operation_dispatcher() {
     while (true) {
         std::unique_lock<std::mutex> lock(operation_queue_mutex);
         operation_cv.wait(lock, [this] { return !operation_message_queue.empty() || !running; });
@@ -145,9 +151,73 @@ void MessageHandler::run_operation_message_worker() {
         operation_message_queue.pop();
         lock.unlock();
 
-        handle_operation_message(message.topic, message.data);
+        dispatch_operation_message(std::move(message));
     }
-    EVLOG_info << "Main worker thread stopped";
+    EVLOG_info << "Operation dispatcher thread stopped";
+}
+
+void MessageHandler::dispatch_operation_message(ParsedMessage&& message) {
+    {
+        std::lock_guard<std::mutex> lock(operation_topic_state_mutex);
+        if (operation_topics_in_flight.find(message.topic) != operation_topics_in_flight.end()) {
+            pending_operation_messages_by_topic[message.topic].push(std::move(message));
+            return;
+        }
+
+        operation_topics_in_flight.insert(message.topic);
+    }
+
+    schedule_operation_message(std::move(message));
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+void MessageHandler::schedule_operation_message(ParsedMessage&& message) {
+    // NOLINTNEXTLINE(misc-no-recursion)
+    auto operation = [this, message = std::move(message)]() {
+        // Wrap in try-catch so that on_operation_message_done is always called: an exception in
+        // the handler must not leave the topic permanently stuck in operation_topics_in_flight,
+        // which would block all subsequent messages for that topic.
+        try {
+            handle_operation_message(message.topic, message.data);
+        } catch (const std::exception& e) {
+            EVLOG_error << "Exception while handling operation message on topic '" << message.topic
+                        << "': " << e.what();
+        } catch (...) {
+            EVLOG_error << "Unknown exception while handling operation message on topic '" << message.topic << "'";
+        }
+        on_operation_message_done(message.topic);
+    };
+
+    if (operation_thread_pool) {
+        operation_thread_pool->run(std::move(operation));
+    }
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+void MessageHandler::on_operation_message_done(const std::string& topic) {
+    std::optional<ParsedMessage> next_message;
+    {
+        std::lock_guard<std::mutex> lock(operation_topic_state_mutex);
+        if (!running) {
+            // Shutting down: stop scheduling and release the in-flight slot.
+            operation_topics_in_flight.erase(topic);
+            return;
+        }
+        auto pending_it = pending_operation_messages_by_topic.find(topic);
+        if (pending_it != pending_operation_messages_by_topic.end() && !pending_it->second.empty()) {
+            next_message = std::move(pending_it->second.front());
+            pending_it->second.pop();
+
+            if (pending_it->second.empty()) {
+                pending_operation_messages_by_topic.erase(pending_it);
+            }
+        } else {
+            operation_topics_in_flight.erase(topic);
+            return;
+        }
+    }
+
+    schedule_operation_message(std::move(*next_message));
 }
 
 void MessageHandler::run_result_message_worker() {

--- a/lib/everest/framework/schemas/config.yaml
+++ b/lib/everest/framework/schemas/config.yaml
@@ -231,5 +231,5 @@ properties:
     default: {}
     # don't allow arbitrary additional properties
     additionalProperties: false
-  
+
   x-module-layout: {}

--- a/lib/everest/framework/tests/CMakeLists.txt
+++ b/lib/everest/framework/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(${TEST_TARGET_NAME} PRIVATE
     test_config_sqlite.cpp
     test_conversions.cpp
     test_filesystem_helpers.cpp
+    test_message_handler.cpp
     helpers.cpp
 )
 

--- a/lib/everest/framework/tests/test_message_handler.cpp
+++ b/lib/everest/framework/tests/test_message_handler.cpp
@@ -1,0 +1,890 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <utils/message_handler.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <map>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <vector>
+
+using namespace Everest;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Helper class to track execution order and timing
+class ExecutionTracker {
+public:
+    struct Event {
+        std::string topic;
+        int sequence;
+        std::chrono::steady_clock::time_point timestamp;
+    };
+
+    void record(const std::string& topic, int sequence) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        events_.push_back({topic, sequence, std::chrono::steady_clock::now()});
+        cv_.notify_all();
+    }
+
+    void wait_for_count(size_t count, std::chrono::milliseconds timeout = 5000ms) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait_for(lock, timeout, [this, count] { return events_.size() >= count; });
+    }
+
+    std::vector<Event> get_events() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return events_;
+    }
+
+    size_t count() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return events_.size();
+    }
+
+    void clear() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        events_.clear();
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::vector<Event> events_;
+};
+
+ParsedMessage create_message(const std::string& topic, const std::string& msg_type, const json& data = json{}) {
+    ParsedMessage msg;
+    msg.topic = topic;
+    msg.data = {{"msg_type", msg_type}, {"data", data}};
+    return msg;
+}
+
+ParsedMessage create_cmd_message(const std::string& topic, int sequence = 0) {
+    json data = {{"sequence", sequence}};
+    return create_message(topic, "Cmd", data);
+}
+
+ParsedMessage create_var_message(const std::string& topic, int sequence = 0) {
+    json data = {{"data", {{"sequence", sequence}}}};
+    ParsedMessage msg;
+    msg.topic = topic;
+    msg.data = {{"msg_type", "Var"}, {"data", data}};
+    return msg;
+}
+
+ParsedMessage create_external_mqtt_message(const std::string& topic, int value = 0) {
+    ParsedMessage msg;
+    msg.topic = topic;
+    msg.data = {{"value", value}}; // ExternalMQTT uses data directly, no msg_type wrapper
+    return msg;
+}
+
+ParsedMessage create_raise_error_message(const std::string& topic, int error_code = 0) {
+    json data = {{"error_code", error_code}};
+    ParsedMessage msg;
+    msg.topic = topic;
+    msg.data = {{"msg_type", "RaiseError"}, {"data", data}};
+    return msg;
+}
+
+ParsedMessage create_clear_error_message(const std::string& topic) {
+    ParsedMessage msg;
+    msg.topic = topic;
+    msg.data = {{"msg_type", "ClearError"}, {"data", json{}}};
+    return msg;
+}
+
+class MessageHandlerFixture {
+public:
+    MessageHandlerFixture() : handler(std::make_unique<MessageHandler>()) {
+    }
+
+    ~MessageHandlerFixture() {
+        if (handler) {
+            handler->stop();
+        }
+    }
+
+    MessageHandler* operator->() {
+        return handler.get();
+    }
+
+    MessageHandler& get() {
+        return *handler;
+    }
+
+private:
+    std::unique_ptr<MessageHandler> handler;
+};
+
+} // namespace
+
+// ============================================================================
+// Test: Basic Message Processing
+// ============================================================================
+
+TEST_CASE("MessageHandler processes single message", "[message_handler][basic]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func = std::make_shared<Handler>(
+        [&tracker](const std::string& topic, const json& data) { tracker.record(topic, data.value("sequence", 0)); });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
+
+    handler->register_handler("test/topic", test_handler);
+
+    ParsedMessage msg = create_cmd_message("test/topic", 1);
+    handler->add(msg);
+
+    tracker.wait_for_count(1);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == 1);
+    CHECK(events[0].topic == "test/topic");
+    CHECK(events[0].sequence == 1);
+}
+
+// ============================================================================
+// Test: Same Topic Ordering (Core Functionality)
+// ============================================================================
+
+TEST_CASE("MessageHandler processes same topic messages in order", "[message_handler][ordering]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+    std::atomic<bool> first_message_processing{false};
+    std::atomic<bool> release_first_message{false};
+
+    auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+        int seq = data.value("sequence", 0);
+
+        if (seq == 1) {
+            first_message_processing = true;
+            // Block first message until we release it
+            while (!release_first_message) {
+                std::this_thread::sleep_for(10ms);
+            }
+        }
+
+        tracker.record(topic, seq);
+    });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
+
+    handler->register_handler("test/topic", test_handler);
+
+    // Send 3 messages to same topic
+    handler->add(create_cmd_message("test/topic", 1));
+    handler->add(create_cmd_message("test/topic", 2));
+    handler->add(create_cmd_message("test/topic", 3));
+
+    // Wait for first message to start processing
+    while (!first_message_processing) {
+        std::this_thread::sleep_for(10ms);
+    }
+
+    // Give some time for second/third messages to potentially be processed (they shouldn't be)
+    std::this_thread::sleep_for(100ms);
+    CHECK(tracker.count() == 0); // First message still blocked
+
+    // Release first message
+    release_first_message = true;
+
+    // Wait for all messages
+    tracker.wait_for_count(3);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == 3);
+
+    // Verify order
+    CHECK(events[0].sequence == 1);
+    CHECK(events[1].sequence == 2);
+    CHECK(events[2].sequence == 3);
+}
+
+// ============================================================================
+// Test: Different Topics Concurrent Processing
+// ============================================================================
+
+TEST_CASE("MessageHandler processes different topics concurrently", "[message_handler][concurrency]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+    std::atomic<int> concurrent_count{0};
+    std::atomic<int> max_concurrent{0};
+    std::mutex concurrent_mutex;
+
+    // Handler duration must exceed the latency threshold so that the first task is still
+    // running when the second task has been queued long enough to trigger scaling.
+    constexpr auto HANDLER_DURATION = std::chrono::milliseconds(THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS * 3);
+
+    auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+        {
+            std::lock_guard<std::mutex> lock(concurrent_mutex);
+            concurrent_count++;
+            if (concurrent_count > max_concurrent) {
+                max_concurrent = concurrent_count.load();
+            }
+        }
+
+        tracker.record(topic, data.value("sequence", 0));
+        std::this_thread::sleep_for(HANDLER_DURATION);
+
+        {
+            std::lock_guard<std::mutex> lock(concurrent_mutex);
+            concurrent_count--;
+        }
+    });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
+
+    handler->register_handler("topic/1", test_handler);
+    handler->register_handler("topic/2", test_handler);
+    handler->register_handler("topic/3", test_handler);
+
+    // The pool starts with a single thread and uses LatencyScaling: it spawns a new thread
+    // only when a queued task has been waiting longer than THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS.
+    //
+    // Sequence to trigger scaling reliably:
+    //  1. topic/1 submitted → single worker picks it up immediately (queue is empty)
+    //  2. topic/2 submitted → queues up (worker is busy with topic/1)
+    //  3. Sleep past the latency threshold → topic/2's wait time exceeds the threshold
+    //  4. topic/3 submitted → queue size becomes 2 and oldest task (topic/2) has waited
+    //     beyond the threshold → scaling fires, worker 2 is spawned → topic/1 and topic/2
+    //     now run concurrently
+    handler->add(create_cmd_message("topic/1", 1));
+    handler->add(create_cmd_message("topic/2", 2));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS + 10));
+
+    handler->add(create_cmd_message("topic/3", 3));
+
+    tracker.wait_for_count(3);
+
+    INFO("max_concurrent was " << max_concurrent.load());
+    CHECK(max_concurrent.load() > 1);
+}
+
+// ============================================================================
+// Test: Multiple Topics with Queuing
+// ============================================================================
+
+TEST_CASE("MessageHandler handles multiple topics with queuing", "[message_handler][queuing]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+    std::atomic<bool> block_topic1{true};
+    std::atomic<bool> block_topic2{true};
+
+    auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+        int seq = data.value("sequence", 0);
+
+        if (topic == "topic/1" && seq == 1) {
+            while (block_topic1) {
+                std::this_thread::sleep_for(10ms);
+            }
+        } else if (topic == "topic/2" && seq == 1) {
+            while (block_topic2) {
+                std::this_thread::sleep_for(10ms);
+            }
+        }
+
+        tracker.record(topic, seq);
+    });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
+
+    handler->register_handler("topic/1", test_handler);
+    handler->register_handler("topic/2", test_handler);
+
+    // Queue multiple messages for each topic
+    handler->add(create_cmd_message("topic/1", 1));
+    handler->add(create_cmd_message("topic/1", 2));
+    handler->add(create_cmd_message("topic/1", 3));
+    handler->add(create_cmd_message("topic/2", 1));
+    handler->add(create_cmd_message("topic/2", 2));
+    handler->add(create_cmd_message("topic/2", 3));
+
+    std::this_thread::sleep_for(100ms);
+
+    // Release topic/1
+    block_topic1 = false;
+    tracker.wait_for_count(3);
+
+    // Topic 1 should be complete, topic 2 still blocked
+    auto events = tracker.get_events();
+    for (const auto& event : events) {
+        CHECK(event.topic == "topic/1");
+    }
+
+    // Release topic/2
+    block_topic2 = false;
+    tracker.wait_for_count(6);
+
+    events = tracker.get_events();
+    REQUIRE(events.size() == 6);
+
+    // Verify ordering per topic
+    std::vector<int> topic1_seqs;
+    std::vector<int> topic2_seqs;
+
+    for (const auto& event : events) {
+        if (event.topic == "topic/1") {
+            topic1_seqs.push_back(event.sequence);
+        } else {
+            // "topic/2"
+            topic2_seqs.push_back(event.sequence);
+        }
+    }
+
+    CHECK(topic1_seqs == std::vector<int>({1, 2, 3}));
+    CHECK(topic2_seqs == std::vector<int>({1, 2, 3}));
+}
+
+// ============================================================================
+// Test: High Load Stress Test
+// ============================================================================
+
+TEST_CASE("MessageHandler handles high load", "[message_handler][stress]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+    constexpr int TOPICS_COUNT = 5;
+    constexpr int MESSAGES_PER_TOPIC = 20;
+
+    auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+        // Simulate variable processing time
+        std::this_thread::sleep_for(std::chrono::milliseconds(1 + (rand() % 5)));
+        tracker.record(topic, data.value("sequence", 0));
+    });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
+
+    // Register handlers for all topics
+    for (int t = 0; t < TOPICS_COUNT; ++t) {
+        std::string topic = "topic/" + std::to_string(t);
+        handler->register_handler(topic, test_handler);
+    }
+
+    // Send messages
+    for (int t = 0; t < TOPICS_COUNT; ++t) {
+        for (int m = 0; m < MESSAGES_PER_TOPIC; ++m) {
+            std::string topic = "topic/" + std::to_string(t);
+            handler->add(create_cmd_message(topic, m));
+        }
+    }
+
+    tracker.wait_for_count(TOPICS_COUNT * MESSAGES_PER_TOPIC, 10s);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == TOPICS_COUNT * MESSAGES_PER_TOPIC);
+
+    // Verify ordering per topic
+    std::map<std::string, std::vector<int>> sequences_by_topic;
+    for (const auto& event : events) {
+        sequences_by_topic[event.topic].push_back(event.sequence);
+    }
+
+    for (const auto& [topic, sequences] : sequences_by_topic) {
+        INFO("Checking topic: " << topic);
+        REQUIRE(sequences.size() == MESSAGES_PER_TOPIC);
+
+        // Verify ascending order
+        for (size_t i = 0; i < sequences.size(); ++i) {
+            INFO("Position: " << i);
+            CHECK(sequences[i] == static_cast<int>(i));
+        }
+    }
+}
+
+// ============================================================================
+// Test: Pending Queue Cleanup
+// ============================================================================
+
+TEST_CASE("MessageHandler cleans up pending queues", "[message_handler][cleanup]") {
+    // This test verifies that empty queues are removed from pending_operation_messages_by_topic
+    // We can't directly access the internal state, but we can verify behavior is consistent
+
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+    std::atomic<bool> block{true};
+
+    auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+        int seq = data.value("sequence", 0);
+        if (seq == 1) {
+            while (block) {
+                std::this_thread::sleep_for(10ms);
+            }
+        }
+        tracker.record(topic, seq);
+    });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
+
+    handler->register_handler("test/topic", test_handler);
+
+    // Queue messages
+    handler->add(create_cmd_message("test/topic", 1));
+    handler->add(create_cmd_message("test/topic", 2));
+
+    std::this_thread::sleep_for(100ms);
+
+    // Release and process all
+    block = false;
+    tracker.wait_for_count(2);
+
+    // Send another message - if cleanup didn't happen, behavior might be different
+    handler->add(create_cmd_message("test/topic", 3));
+    tracker.wait_for_count(3);
+
+    auto events = tracker.get_events();
+    CHECK(events.size() == 3);
+    CHECK(events[2].sequence == 3);
+}
+
+// ============================================================================
+// Test: Result Message Processing (different queue)
+// ============================================================================
+
+TEST_CASE("MessageHandler processes result messages separately", "[message_handler][result]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { tracker.record(topic, data.value("sequence", 0)); });
+    auto result_handler =
+        std::make_shared<TypedHandler>("test-handler", "test-id-123", HandlerType::Result, handler_func);
+
+    handler->register_handler("", result_handler);
+
+    ParsedMessage msg;
+    msg.topic = "test/result";
+    msg.data = {{"msg_type", "CmdResult"}, {"data", {{"data", {{"id", "test-id-123"}, {"sequence", 42}}}}}};
+
+    handler->add(msg);
+
+    tracker.wait_for_count(1);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == 1);
+    CHECK(events[0].sequence == 42);
+}
+
+// ============================================================================
+// Test: Shutdown with Pending Messages
+// ============================================================================
+
+TEST_CASE("MessageHandler shuts down gracefully with pending messages", "[message_handler][shutdown]") {
+    ExecutionTracker tracker;
+    std::atomic<int> processing_count{0};
+
+    {
+        MessageHandlerFixture handler;
+
+        auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+            // Simulate some processing time but don't block indefinitely
+            processing_count++;
+            std::this_thread::sleep_for(20ms);
+            tracker.record(topic, data.value("sequence", 0));
+        });
+        auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
+
+        handler->register_handler("test/topic", test_handler);
+
+        // Queue multiple messages
+        handler->add(create_cmd_message("test/topic", 1));
+        handler->add(create_cmd_message("test/topic", 2));
+        handler->add(create_cmd_message("test/topic", 3));
+        handler->add(create_cmd_message("test/topic", 4));
+        handler->add(create_cmd_message("test/topic", 5));
+
+        // Give time for first message to start processing but not finish
+        std::this_thread::sleep_for(10ms);
+
+        // At this point, message 1 should be processing and 2-5 should be queued
+        // Shutdown should handle this gracefully
+    }
+
+    // If we get here without hanging, the test passed
+    INFO("Processed " << processing_count.load() << " messages before shutdown");
+    SUCCEED("Shutdown completed without crash or hang");
+}
+
+// ============================================================================
+// Test: Thread Safety - Concurrent Adds
+// ============================================================================
+
+TEST_CASE("MessageHandler handles concurrent message addition", "[message_handler][thread_safety]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { tracker.record(topic, data.value("sequence", 0)); });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
+
+    handler->register_handler("topic/1", test_handler);
+    handler->register_handler("topic/2", test_handler);
+
+    constexpr int THREADS = 4;
+    constexpr int MESSAGES_PER_THREAD = 25;
+
+    std::vector<std::thread> threads;
+    for (int t = 0; t < THREADS; ++t) {
+        threads.emplace_back([&handler, t]() {
+            std::string topic = (t % 2 == 0) ? "topic/1" : "topic/2";
+            for (int m = 0; m < MESSAGES_PER_THREAD; ++m) {
+                handler->add(create_cmd_message(topic, t * 1000 + m));
+                std::this_thread::sleep_for(1ms);
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    tracker.wait_for_count(THREADS * MESSAGES_PER_THREAD, 10s);
+
+    auto events = tracker.get_events();
+    CHECK(events.size() == THREADS * MESSAGES_PER_THREAD);
+}
+
+// ============================================================================
+// Test: Var Message Processing
+// ============================================================================
+
+TEST_CASE("MessageHandler processes Var messages", "[message_handler][var]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { tracker.record(topic, data.value("sequence", 0)); });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::SubscribeVar, handler_func);
+
+    handler->register_handler("module/impl/var_name", test_handler);
+
+    // Create Var message
+    ParsedMessage msg;
+    msg.topic = "module/impl/var_name";
+    msg.data = {{"msg_type", "Var"}, {"data", {{"data", {{"sequence", 42}}}}}};
+
+    handler->add(msg);
+
+    tracker.wait_for_count(1);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == 1);
+    CHECK(events[0].topic == "module/impl/var_name");
+    CHECK(events[0].sequence == 42);
+}
+
+TEST_CASE("MessageHandler processes multiple Var messages on same topic in order", "[message_handler][var][ordering]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+    std::atomic<bool> first_var_processing{false};
+    std::atomic<bool> release_first_var{false};
+
+    auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+        int seq = data.value("sequence", 0);
+
+        if (seq == 1) {
+            first_var_processing = true;
+            while (!release_first_var) {
+                std::this_thread::sleep_for(10ms);
+            }
+        }
+
+        tracker.record(topic, seq);
+    });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::SubscribeVar, handler_func);
+
+    handler->register_handler("module/impl/var_name", test_handler);
+
+    // Send 3 var messages to same topic
+    for (int i = 1; i <= 3; ++i) {
+        ParsedMessage msg;
+        msg.topic = "module/impl/var_name";
+        msg.data = {{"msg_type", "Var"}, {"data", {{"data", {{"sequence", i}}}}}};
+        handler->add(msg);
+    }
+
+    // Wait for first message to start processing
+    while (!first_var_processing) {
+        std::this_thread::sleep_for(10ms);
+    }
+
+    // Give time for potential out-of-order processing (shouldn't happen)
+    std::this_thread::sleep_for(100ms);
+    CHECK(tracker.count() == 0); // First message still blocked
+
+    // Release first message
+    release_first_var = true;
+
+    // Wait for all messages
+    tracker.wait_for_count(3);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == 3);
+
+    // Verify order
+    CHECK(events[0].sequence == 1);
+    CHECK(events[1].sequence == 2);
+    CHECK(events[2].sequence == 3);
+}
+
+TEST_CASE("MessageHandler handles multiple Var subscribers to same topic", "[message_handler][var]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker1;
+    ExecutionTracker tracker2;
+
+    auto handler_func1 = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { tracker1.record(topic, data.value("sequence", 0)); });
+    auto test_handler1 = std::make_shared<TypedHandler>(HandlerType::SubscribeVar, handler_func1);
+
+    auto handler_func2 = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { tracker2.record(topic, data.value("sequence", 0)); });
+    auto test_handler2 = std::make_shared<TypedHandler>(HandlerType::SubscribeVar, handler_func2);
+
+    handler->register_handler("module/impl/var_name", test_handler1);
+    handler->register_handler("module/impl/var_name", test_handler2);
+
+    ParsedMessage msg;
+    msg.topic = "module/impl/var_name";
+    msg.data = {{"msg_type", "Var"}, {"data", {{"data", {{"sequence", 99}}}}}};
+
+    handler->add(msg);
+
+    tracker1.wait_for_count(1);
+    tracker2.wait_for_count(1);
+
+    auto events1 = tracker1.get_events();
+    auto events2 = tracker2.get_events();
+
+    REQUIRE(events1.size() == 1);
+    REQUIRE(events2.size() == 1);
+    CHECK(events1[0].sequence == 99);
+    CHECK(events2[0].sequence == 99);
+}
+
+// ============================================================================
+// Test: ExternalMQTT Message Processing
+// ============================================================================
+
+TEST_CASE("MessageHandler processes ExternalMQTT messages", "[message_handler][external_mqtt]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+        // ExternalMQTT passes data directly, not nested
+        tracker.record(topic, data.value("value", 0));
+    });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::ExternalMQTT, handler_func);
+
+    handler->register_handler("external/topic/+", test_handler);
+
+    ParsedMessage msg;
+    msg.topic = "external/topic/sensor1";
+    msg.data = {{"value", 123}}; // ExternalMQTT uses data directly, no msg_type
+
+    handler->add(msg);
+
+    tracker.wait_for_count(1);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == 1);
+    CHECK(events[0].topic == "external/topic/sensor1");
+    CHECK(events[0].sequence == 123);
+}
+
+TEST_CASE("MessageHandler handles ExternalMQTT with wildcard topics", "[message_handler][external_mqtt]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { tracker.record(topic, data.value("value", 0)); });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::ExternalMQTT, handler_func);
+
+    // Register with wildcard
+    handler->register_handler("sensors/#", test_handler);
+
+    // Send messages to different sub-topics
+    for (int i = 1; i <= 3; ++i) {
+        ParsedMessage msg;
+        msg.topic = "sensors/floor" + std::to_string(i) + "/temp";
+        msg.data = {{"value", i * 10}}; // ExternalMQTT uses data directly
+        handler->add(msg);
+    }
+
+    tracker.wait_for_count(3);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == 3);
+
+    // Verify all different topics were received
+    std::set<std::string> topics;
+    for (const auto& event : events) {
+        topics.insert(event.topic);
+    }
+    CHECK(topics.size() == 3);
+}
+
+// ============================================================================
+// Test: Error Message Processing
+// ============================================================================
+
+TEST_CASE("MessageHandler processes RaiseError messages", "[message_handler][error]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { tracker.record(topic, data.value("error_code", 0)); });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::SubscribeError, handler_func);
+
+    handler->register_handler("module/impl/error/#", test_handler);
+
+    ParsedMessage msg;
+    msg.topic = "module/impl/error/critical";
+    msg.data = {{"msg_type", "RaiseError"}, {"data", {{"error_code", 500}}}};
+
+    handler->add(msg);
+
+    tracker.wait_for_count(1);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == 1);
+    CHECK(events[0].sequence == 500);
+}
+
+TEST_CASE("MessageHandler processes ClearError messages", "[message_handler][error]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func =
+        std::make_shared<Handler>([&](const std::string& topic, const json& data) { tracker.record(topic, 0); });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::SubscribeError, handler_func);
+
+    handler->register_handler("module/impl/error/#", test_handler);
+
+    ParsedMessage msg;
+    msg.topic = "module/impl/error/critical";
+    msg.data = {{"msg_type", "ClearError"}, {"data", json{}}};
+
+    handler->add(msg);
+
+    tracker.wait_for_count(1);
+
+    auto events = tracker.get_events();
+    CHECK(events.size() == 1);
+}
+
+// ============================================================================
+// Test: GetConfig Message Processing
+// ============================================================================
+
+TEST_CASE("MessageHandler processes GetConfig messages", "[message_handler][config]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func =
+        std::make_shared<Handler>([&](const std::string& topic, const json& data) { tracker.record(topic, 1); });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::GetConfig, handler_func);
+
+    handler->register_handler("config/request", test_handler);
+
+    ParsedMessage msg;
+    msg.topic = "config/request";
+    msg.data = {{"msg_type", "GetConfig"}, {"data", json{}}};
+
+    handler->add(msg);
+
+    tracker.wait_for_count(1);
+
+    auto events = tracker.get_events();
+    CHECK(events.size() == 1);
+}
+
+// ============================================================================
+// Test: Mixed Message Types
+// ============================================================================
+
+// ============================================================================
+// Test: Ordering preserved when a handler throws
+// ============================================================================
+
+TEST_CASE("MessageHandler preserves per-topic ordering after handler exception",
+          "[message_handler][ordering][exception]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker tracker;
+
+    auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+        int seq = data.value("sequence", 0);
+        if (seq == 1) {
+            throw std::runtime_error("simulated handler failure");
+        }
+        tracker.record(topic, seq);
+    });
+    auto test_handler = std::make_shared<TypedHandler>(HandlerType::Call, handler_func);
+
+    handler->register_handler("test/topic", test_handler);
+
+    // Message 1 throws; messages 2 and 3 must still be processed in order.
+    handler->add(create_cmd_message("test/topic", 1));
+    handler->add(create_cmd_message("test/topic", 2));
+    handler->add(create_cmd_message("test/topic", 3));
+
+    tracker.wait_for_count(2);
+
+    auto events = tracker.get_events();
+    REQUIRE(events.size() == 2);
+    CHECK(events[0].sequence == 2);
+    CHECK(events[1].sequence == 3);
+}
+
+// ============================================================================
+// Test: Mixed Message Types
+// ============================================================================
+
+TEST_CASE("MessageHandler handles mixed message types concurrently", "[message_handler][mixed]") {
+    MessageHandlerFixture handler;
+    ExecutionTracker cmd_tracker;
+    ExecutionTracker var_tracker;
+    ExecutionTracker ext_tracker;
+
+    auto cmd_handler_func = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { cmd_tracker.record(topic, data.value("sequence", 0)); });
+    auto cmd_handler = std::make_shared<TypedHandler>(HandlerType::Call, cmd_handler_func);
+
+    auto var_handler_func = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { var_tracker.record(topic, data.value("sequence", 0)); });
+    auto var_handler = std::make_shared<TypedHandler>(HandlerType::SubscribeVar, var_handler_func);
+
+    auto ext_handler_func = std::make_shared<Handler>(
+        [&](const std::string& topic, const json& data) { ext_tracker.record(topic, data.value("sequence", 0)); });
+    auto ext_handler = std::make_shared<TypedHandler>(HandlerType::ExternalMQTT, ext_handler_func);
+
+    handler->register_handler("cmd/topic", cmd_handler);
+    handler->register_handler("var/topic", var_handler);
+    handler->register_handler("ext/topic", ext_handler);
+
+    // Send mixed message types
+    ParsedMessage cmd_msg = create_cmd_message("cmd/topic", 1);
+
+    ParsedMessage var_msg;
+    var_msg.topic = "var/topic";
+    var_msg.data = {{"msg_type", "Var"}, {"data", {{"data", {{"sequence", 2}}}}}};
+
+    ParsedMessage ext_msg;
+    ext_msg.topic = "ext/topic";
+    ext_msg.data = {{"sequence", 3}}; // ExternalMQTT uses data directly
+
+    handler->add(cmd_msg);
+    handler->add(var_msg);
+    handler->add(ext_msg);
+
+    cmd_tracker.wait_for_count(1);
+    var_tracker.wait_for_count(1);
+    ext_tracker.wait_for_count(1);
+
+    CHECK(cmd_tracker.get_events().size() == 1);
+    CHECK(var_tracker.get_events().size() == 1);
+    CHECK(ext_tracker.get_events().size() == 1);
+}


### PR DESCRIPTION
A thread pool for handling the operation worker was added so that
commands and vars don't accumulate in the queue and cause delays which
can lead to timeouts in certain parts of the code.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

