### PR TITLE
fix: expose 8 hidden OCPP 1.6 config keys via GetConfiguration

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
@@ -132,6 +132,10 @@ public:
 
     bool getEnableTLSKeylog() override;
     std::string getTLSKeylogFile() override;
+    KeyValue getEnableTLSKeylogKeyValue() override;
+    KeyValue getTLSKeylogFileKeyValue() override;
+    KeyValue getUseTPMKeyValue() override;
+    KeyValue getUseTPMSeccLeafCertificateKeyValue() override;
 
     bool getStopTransactionIfUnlockNotSupported() override;
     void setStopTransactionIfUnlockNotSupported(bool stop_transaction_if_unlock_not_supported) override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
@@ -210,7 +210,11 @@ public:
     KeyValue getSupportedCiphers12KeyValue() override;
     KeyValue getSupportedCiphers13KeyValue() override;
     KeyValue getSupportedMeasurandsKeyValue() override;
+    KeyValue getEnableTLSKeylogKeyValue() override;
+    KeyValue getTLSKeylogFileKeyValue() override;
     KeyValue getUseSslDefaultVerifyPathsKeyValue() override;
+    KeyValue getUseTPMKeyValue() override;
+    KeyValue getUseTPMSeccLeafCertificateKeyValue() override;
     KeyValue getVerifyCsmsAllowWildcardsKeyValue() override;
     KeyValue getVerifyCsmsCommonNameKeyValue() override;
     KeyValue getWaitForStopTransactionsOnResetTimeoutKeyValue() override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
@@ -132,7 +132,11 @@ public:
     virtual KeyValue getSupportedCiphers12KeyValue() = 0;
     virtual KeyValue getSupportedCiphers13KeyValue() = 0;
     virtual KeyValue getSupportedMeasurandsKeyValue() = 0;
+    virtual KeyValue getEnableTLSKeylogKeyValue() = 0;
+    virtual KeyValue getTLSKeylogFileKeyValue() = 0;
     virtual KeyValue getUseSslDefaultVerifyPathsKeyValue() = 0;
+    virtual KeyValue getUseTPMKeyValue() = 0;
+    virtual KeyValue getUseTPMSeccLeafCertificateKeyValue() = 0;
     virtual KeyValue getVerifyCsmsAllowWildcardsKeyValue() = 0;
     virtual KeyValue getVerifyCsmsCommonNameKeyValue() = 0;
     virtual KeyValue getWaitForStopTransactionsOnResetTimeoutKeyValue() = 0;

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -784,6 +784,38 @@ std::string ChargePointConfiguration::getTLSKeylogFile() {
     return this->config["Internal"]["TLSKeylogFile"];
 }
 
+KeyValue ChargePointConfiguration::getEnableTLSKeylogKeyValue() {
+    KeyValue kv;
+    kv.key = "EnableTLSKeylog";
+    kv.readonly = true;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getEnableTLSKeylog()));
+    return kv;
+}
+
+KeyValue ChargePointConfiguration::getTLSKeylogFileKeyValue() {
+    KeyValue kv;
+    kv.key = "TLSKeylogFile";
+    kv.readonly = true;
+    kv.value.emplace(this->getTLSKeylogFile());
+    return kv;
+}
+
+KeyValue ChargePointConfiguration::getUseTPMKeyValue() {
+    KeyValue kv;
+    kv.key = "UseTPM";
+    kv.readonly = true;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getUseTPM()));
+    return kv;
+}
+
+KeyValue ChargePointConfiguration::getUseTPMSeccLeafCertificateKeyValue() {
+    KeyValue kv;
+    kv.key = "UseTPMSeccLeafCertificate";
+    kv.readonly = true;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getUseTPMSeccLeafCertificate()));
+    return kv;
+}
+
 bool ChargePointConfiguration::getStopTransactionIfUnlockNotSupported() {
     return this->config["Internal"]["StopTransactionIfUnlockNotSupported"];
 }
@@ -3187,6 +3219,30 @@ std::optional<KeyValue> ChargePointConfiguration::get(const CiString<50>& key) {
     }
     if (key == "StopTransactionIfUnlockNotSupported") {
         return this->getStopTransactionIfUnlockNotSupportedKeyValue();
+    }
+    if (key == "EnableTLSKeylog") {
+        return this->getEnableTLSKeylogKeyValue();
+    }
+    if (key == "LogRotation") {
+        return this->getLogRotationKeyValue();
+    }
+    if (key == "LogRotationDateSuffix") {
+        return this->getLogRotationDateSuffixKeyValue();
+    }
+    if (key == "LogRotationMaximumFileCount") {
+        return this->getLogRotationMaximumFileCountKeyValue();
+    }
+    if (key == "LogRotationMaximumFileSize") {
+        return this->getLogRotationMaximumFileSizeKeyValue();
+    }
+    if (key == "TLSKeylogFile") {
+        return this->getTLSKeylogFileKeyValue();
+    }
+    if (key == "UseTPM") {
+        return this->getUseTPMKeyValue();
+    }
+    if (key == "UseTPMSeccLeafCertificate") {
+        return this->getUseTPMSeccLeafCertificateKeyValue();
     }
 
     // Core Profile

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -1128,6 +1128,38 @@ bool ChargePointConfigurationDeviceModel::getUseTPMSeccLeafCertificate() {
     return get_value<bool>(*storage, keys::valid_keys::UseTPMSeccLeafCertificate);
 }
 
+KeyValue ChargePointConfigurationDeviceModel::getEnableTLSKeylogKeyValue() {
+    KeyValue kv;
+    kv.key = "EnableTLSKeylog";
+    kv.readonly = true;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getEnableTLSKeylog()));
+    return kv;
+}
+
+KeyValue ChargePointConfigurationDeviceModel::getTLSKeylogFileKeyValue() {
+    KeyValue kv;
+    kv.key = "TLSKeylogFile";
+    kv.readonly = true;
+    kv.value.emplace(this->getTLSKeylogFile());
+    return kv;
+}
+
+KeyValue ChargePointConfigurationDeviceModel::getUseTPMKeyValue() {
+    KeyValue kv;
+    kv.key = "UseTPM";
+    kv.readonly = true;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getUseTPM()));
+    return kv;
+}
+
+KeyValue ChargePointConfigurationDeviceModel::getUseTPMSeccLeafCertificateKeyValue() {
+    KeyValue kv;
+    kv.key = "UseTPMSeccLeafCertificate";
+    kv.readonly = true;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getUseTPMSeccLeafCertificate()));
+    return kv;
+}
+
 bool ChargePointConfigurationDeviceModel::getVerifyCsmsAllowWildcards() {
     return get_value<bool>(*storage, keys::valid_keys::VerifyCsmsAllowWildcards);
 }


### PR DESCRIPTION
## Summary

- Add `KeyValue` wrapper methods for `EnableTLSKeylog`, `TLSKeylogFile`, `UseTPM`, and `UseTPMSeccLeafCertificate` across the interface and both implementations
- Add 8 missing if-statements in `ChargePointConfiguration::get()` for all affected keys
- All keys marked `readonly = true` (internal config, not CSMS-settable)

## Root Cause

The `get()` method uses an if-chain to dispatch key lookups to `KeyValue` methods. These 8 keys had getter methods but were missing from the dispatch chain, making them invisible to the CSMS via `GetConfiguration`.

## Files Changed (5)

| File | Change |
|------|--------|
| `charge_point_configuration_interface.hpp` | 4 new pure virtual `KeyValue` declarations |
| `charge_point_configuration.hpp` | 4 new override declarations |
| `charge_point_configuration_devicemodel.hpp` | 4 new override declarations |
| `charge_point_configuration.cpp` | 4 `KeyValue` method implementations + 8 if-statements in `get()` |
| `charge_point_configuration_devicemodel.cpp` | 4 `KeyValue` method implementations |

## Test Plan

- [ ] Build passes (`cmake`)
- [ ] Existing unit tests pass (`ctest -R test_configuration`)
- [ ] Manual: OCPP 1.6 `GetConfiguration` returns values for all 8 keys

Closes #1796