### PR TITLE
fix(PacketSniffer): Make use of session_logging_path configuration parameter

### DIFF
--- a/modules/Misc/PacketSniffer/manifest.yaml
+++ b/modules/Misc/PacketSniffer/manifest.yaml
@@ -8,7 +8,10 @@ config:
     type: string
     default: eth1
   session_logging_path:
-    description: Output directory for session capture dump files
+    description: >-
+      Output directory for session capture dump files. Will be used only if not empty.
+      If empty, the logging path provided in the SessionStarted event will be used.
+      If no logging path is provided there either, no capture will be performed.
     type: string
     default: /tmp
 provides:


### PR DESCRIPTION

## Describe your changes
The `session_logging_path` parameter of the PacketSniffer module was not used.

This PR introduces and implements the following logic for the parameter:
Output directory for session capture dump files. Will be used only if not empty.
If empty, the logging path provided in the SessionStarted event will be used.
If no logging path is provided there either, no capture will be performed.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

