### PR TITLE
Fix ieee2023 lib testing configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TEST
     set(everest-sqlite_BUILD_TESTING ON)
     set(everest-timer_BUILD_TESTING ON)
     set(everest-log_BUILD_TESTING ON)
+    set(IEEE2030_BUILD_TESTING ON)
 endif()
 # This is a flag for building development tests, but not necessarily to run them, for expample in case
 # tests requires hardware.

--- a/lib/everest/ieee2030_1_1/test/charger/fsm/CMakeLists.txt
+++ b/lib/everest/ieee2030_1_1/test/charger/fsm/CMakeLists.txt
@@ -13,4 +13,9 @@ target_link_libraries(test_fsm_state_b
         Catch2::Catch2WithMain
 )
 
+target_compile_options(test_fsm_state_b
+    PRIVATE
+        "-Wno-error=maybe-uninitialized"
+)
+
 catch_discover_tests(test_fsm_state_b)


### PR DESCRIPTION
## Describe your changes
set IEEE2030_BUILD_TESTING to ON (otherwise unit tests won't build)
add -Wno-error=maybe-uninitialized to one of its unit tests, otherwise the test won't build with GCC 12

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

