### PR TITLE
fix(docs): Fix broken links to module reference doc in how-to

### DIFF
--- a/docs/source/how-to-guides/security-best-practices.rst
+++ b/docs/source/how-to-guides/security-best-practices.rst
@@ -110,8 +110,8 @@ set the capabilities as needed.
    -A OUTPUT -o seth0 -p tcp -m tcp --sport 64109 -j ACCEPT
 
 According to the standard, port 15118 is used for SDP messages.
-:doc:`EvseV2G </reference/modules/EvseV2G>`  uses the following ports: TCP (61341), TLS (64109).
-:doc:`Evse15118D20 </reference/modules/Evse15118D20>` integrates libiso15118 which uses port 50000 for TCP and TLS1.2/1.3.
+:ref:`EvseV2G <everest_modules_EvseV2G>`  uses the following ports: TCP (61341), TLS (64109).
+:ref:`Evse15118D20 <everest_modules_Evse15118D20>` integrates libiso15118 which uses port 50000 for TCP and TLS1.2/1.3.
 
 General (non-EVerest-related) security aspects
 ====================================================================


### PR DESCRIPTION
## Describe your changes
Fix two broken links. They still had the format before the restructuring of the reference section and did not respect the hierarchy of the modules.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

