### PR TITLE
EvSlac: Broadcast sounding messages

### DIFF
--- a/lib/everest/slac/fsm/ev/include/everest/slac/fsm/ev/context.hpp
+++ b/lib/everest/slac/fsm/ev/include/everest/slac/fsm/ev/context.hpp
@@ -58,13 +58,14 @@ struct ContextCallbacks {
 };
 
 struct Context {
-    explicit Context(const ContextCallbacks& callbacks_) : callbacks(callbacks_){};
+    static constexpr std::array<uint8_t, ETH_ALEN> BROADCAST_MAC = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    static constexpr std::array<uint8_t, ETH_ALEN> EV_PLC_MAC = {0x00, 0xB0, 0x52, 0x00, 0x00, 0x01};
 
-    // MAC address of our PLC modem (EV side)
-    uint8_t plc_mac[ETH_ALEN] = {0x00, 0xB0, 0x52, 0x00, 0x00, 0x01};
+    Context(const ContextCallbacks& callbacks_, const std::array<uint8_t, ETH_ALEN>& mac) :
+        callbacks(callbacks_), ev_host_mac(mac) {
+    }
 
-    // MAC address to use for SET KEY req
-    uint8_t plc_mac_chip_commands[ETH_ALEN] = {0x00, 0xB0, 0x52, 0x00, 0x00, 0x01};
+    const std::array<uint8_t, ETH_ALEN> ev_host_mac{};
 
     // event specific payloads
     // FIXME (aw): due to the synchroneous nature of the fsm, this could be even a ptr/ref

--- a/lib/everest/slac/fsm/ev/src/states/others.cpp
+++ b/lib/everest/slac/fsm/ev/src/states/others.cpp
@@ -94,9 +94,7 @@ int InitSlacState::send_parm_req() {
     msg.security_type = 0x0;
     memcpy(msg.run_id, run_id, sizeof(msg.run_id));
 
-    const uint8_t broadcast_mac[ETH_ALEN] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-
-    ctx.send_slac_message(broadcast_mac, msg);
+    ctx.send_slac_message(ctx.BROADCAST_MAC.data(), msg);
 
     num_of_tries++;
 
@@ -199,7 +197,7 @@ int MatchRequestState::send_match_req() {
     msg.security_type = 0x0;
     msg.mvf_length = htole16(0x3e); // FIXME (aw) fixed constant
     memset(msg.pev_id, 0, sizeof(msg.pev_id));
-    memcpy(msg.pev_mac, ctx.plc_mac, sizeof(msg.pev_mac));
+    memcpy(msg.pev_mac, ctx.ev_host_mac.data(), sizeof(msg.pev_mac));
     memset(msg.evse_id, 0, sizeof(msg.evse_id));
     memcpy(msg.evse_mac, session_parameters.evse_mac, sizeof(msg.evse_mac));
     memcpy(msg.run_id, session_parameters.run_id, sizeof(msg.run_id));
@@ -250,7 +248,7 @@ void JoinNetworkState::enter() {
     msg.new_eks = slac::defs::CM_SET_KEY_REQ_PEKS_NMK_KNOWN_TO_STA;
     memcpy(msg.new_key, nmk, sizeof(msg.new_key));
 
-    ctx.send_slac_message(ctx.plc_mac_chip_commands, msg);
+    ctx.send_slac_message(ctx.EV_PLC_MAC.data(), msg);
 
     timeout = std::chrono::steady_clock::now() + std::chrono::milliseconds(SET_KEY_TIMEOUT_MS);
 }

--- a/lib/everest/slac/fsm/ev/src/states/sounding.cpp
+++ b/lib/everest/slac/fsm/ev/src/states/sounding.cpp
@@ -80,10 +80,10 @@ bool SoundingState::do_sounding() {
         msg.num_sounds = slac::defs::C_EV_MATCH_MNBC;
         msg.timeout = (slac::defs::TT_EVSE_MATCH_MNBC_MS + 99) / 100; // in multiples of 100ms!
         msg.resp_type = 0x01; // fixed value indicating 'other Green Phy station'
-        memcpy(msg.forwarding_sta, ctx.plc_mac, sizeof(msg.forwarding_sta));
+        memcpy(msg.forwarding_sta, ctx.ev_host_mac.data(), sizeof(msg.forwarding_sta));
         memcpy(msg.run_id, session_parameters.run_id, sizeof(msg.run_id));
 
-        ctx.send_slac_message(session_parameters.evse_mac, msg);
+        ctx.send_slac_message(ctx.BROADCAST_MAC.data(), msg);
 
         count_start_atten_char_sent++;
 
@@ -107,7 +107,7 @@ bool SoundingState::do_sounding() {
             random = dist256(rng);
         }
 
-        ctx.send_slac_message(session_parameters.evse_mac, msg);
+        ctx.send_slac_message(ctx.BROADCAST_MAC.data(), msg);
     }
 
     return (count_mnbc_sound_sent < slac::defs::C_EV_MATCH_MNBC);
@@ -140,8 +140,7 @@ bool SoundingState::handle_valid_atten_char_ind() {
     slac::messages::cm_atten_char_rsp response;
     response.application_type = 0x0;
     response.security_type = 0x0;
-    // FIXME (aw): here we need to supply ev mac, not the plc mac!!!
-    memcpy(response.source_address, ctx.plc_mac, sizeof(response.source_address));
+    memcpy(response.source_address, ctx.ev_host_mac.data(), sizeof(response.source_address));
     memcpy(response.run_id, atten_char.run_id, sizeof(response.run_id));
     memset(response.source_id, 0, sizeof(response.source_id));
     memset(response.resp_id, 0, sizeof(response.resp_id));

--- a/modules/EV/EvSlac/main/ev_slacImpl.cpp
+++ b/modules/EV/EvSlac/main/ev_slacImpl.cpp
@@ -58,11 +58,11 @@ void ev_slacImpl::run() {
     callbacks.log_warn = [](const std::string& text) { EVLOG_warning << "EvSlac: " << text; };
     callbacks.log_error = [](const std::string& text) { EVLOG_error << "EvSlac: " << text; };
 
-    auto fsm_ctx = slac::fsm::ev::Context(callbacks);
+    const uint8_t* if_mac = slac_io.get_mac_addr();
+    std::array<uint8_t, ETH_ALEN> ev_host_mac;
+    std::copy(if_mac, if_mac + ETH_ALEN, ev_host_mac.begin());
 
-    // Copy correct MAC address
-    memcpy(fsm_ctx.plc_mac, slac_io.get_mac_addr(), sizeof(fsm_ctx.plc_mac));
-
+    auto fsm_ctx = slac::fsm::ev::Context(callbacks, ev_host_mac);
     // fsm_ctx.slac_config.set_key_timeout_ms = config.set_key_timeout_ms;
     // fsm_ctx.slac_config.ac_mode_five_percent = config.ac_mode_five_percent;
     // fsm_ctx.slac_config.sounding_atten_adjustment = config.sounding_attenuation_adjustment;

--- a/modules/EV/EvSlac/main/ev_slacImpl.hpp
+++ b/modules/EV/EvSlac/main/ev_slacImpl.hpp
@@ -28,7 +28,8 @@ class ev_slacImpl : public ev_slacImplBase {
 public:
     ev_slacImpl() = delete;
     ev_slacImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<EvSlac>& mod, Conf& config) :
-        ev_slacImplBase(ev, "main"), mod(mod), config(config){};
+        ev_slacImplBase(ev, "main"), mod(mod), config(config) {
+    }
 
     // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
     // insert your public definitions here


### PR DESCRIPTION
ISO 15118-3 specifies that sounding messages should be broadcast until a match is made. This might be important for EVSEs developed for public charge banks, where there may be multiple chargers responding to sounding messages.

## Describe your changes
Broadcast SLAC sounding and implement some minor clean up.

## Issue ticket number and link
No issue for this raised

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

Testing:

Tested against an EVSE with commercial grade comms stack (7Stax). Packet captures before and after attached below.  

[slac_dumps.zip](https://github.com/user-attachments/files/25369346/slac_dumps.zip)