### PR TITLE
fix: Auth ReservationHandler, clear timer map before stopping io context

### DIFF
--- a/modules/EVSE/Auth/lib/ReservationHandler.cpp
+++ b/modules/EVSE/Auth/lib/ReservationHandler.cpp
@@ -26,7 +26,9 @@ ReservationHandler::ReservationHandler(std::map<int, std::unique_ptr<module::EVS
 }
 
 ReservationHandler::~ReservationHandler() {
+    this->reservation_id_to_reservation_timeout_timer_map.clear();
     work->get_executor().context().stop();
+    (*work).reset(); // explicitly call underlying reset method, not the smart pointer reset
     io_context.stop();
     io_context_thread.join();
 }


### PR DESCRIPTION
Additionally reset the executor_work_guard in dtor before stopping the io_context

This fixes some invalid read errors reported by valgrind: ==4131335== Invalid read of size 8
==4131335==    at 0x688DB6: std::__atomic_base<long>::operator--() (atomic_base.h:406)
==4131335==    by 0x67C87B: boost::asio::detail::scheduler::work_finished() (scheduler.hpp:108)
==4131335==    by 0x68A45B: boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul>::on_work_finished() const (io_context.hpp:264)
==4131335==    by 0x691A23: boost::asio::executor_work_guard<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul>, void, void>::~executor_work_guard() (executor_work_guard.hpp:122)
==4131335==    by 0x70C228: boost::detail::sp_ms_deleter<boost::asio::executor_work_guard<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul>, void, void> >::destroy() (make_shared_object.hpp:55)
==4131335==    by 0x7144F7: boost::detail::sp_ms_deleter<boost::asio::executor_work_guard<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul>, void, void> >::operator()(boost::asio::executor_work_guard<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul>, void, void>*) (make_shared_object.hpp:89)
==4131335==    by 0x7141F0: boost::detail::sp_counted_impl_pd<boost::asio::executor_work_guard<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul>, void, void>*, boost::detail::sp_ms_deleter<boost::asio::executor_work_guard<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul>, void, void> > >::dispose() (sp_counted_impl.hpp:113)
==4131335==    by 0x564F0C: boost::detail::sp_counted_base::release() (sp_counted_base_std_atomic.hpp:118)
==4131335==    by 0x565012: boost::detail::shared_count::~shared_count() (shared_count.hpp:352)
==4131335==    by 0x6E7B1B: boost::shared_ptr<boost::asio::executor_work_guard<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul>, void, void> >::~shared_ptr() (shared_ptr.hpp:253)
==4131335==    by 0x6D107F: module::ReservationHandler::~ReservationHandler() (ReservationHandler.cpp:34)
==4131335==    by 0x715833: module::AuthHandler::~AuthHandler() (AuthHandler.cpp:59)

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

