### PR TITLE
Fix(EvseManager): Raising a cable check fault should not happen if a cancel_transaction (DeAuthorized) is triggered

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -2039,6 +2039,12 @@ void Charger::set_hlc_allow_close_contactor(bool on) {
     shared_context.hlc_allow_close_contactor = on;
 }
 
+std::optional<types::evse_manager::StopTransactionReason> Charger::get_last_stop_transaction_reason() {
+    Everest::scoped_lock_timeout lock(state_machine_mutex,
+                                      Everest::MutexDescription::Charger_get_last_stop_transaction);
+    return shared_context.last_stop_transaction_reason;
+}
+
 // this resets the BCB sequence (which may contain 1-3 toggle pulses)
 void Charger::bcb_toggle_reset() {
     internal_context.hlc_ev_pause_bcb_count = 0;

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -224,6 +224,8 @@ public:
         connector_type = t;
     }
 
+    std::optional<types::evse_manager::StopTransactionReason> get_last_stop_transaction_reason();
+
     void cleanup_transactions_on_startup();
     EventQueue<CPEvent> bsp_event_queue;
 

--- a/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
+++ b/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
@@ -55,6 +55,7 @@ enum class MutexDescription {
     Charger_errors_prevent_charging,
     Charger_set_max_current,
     Charger_switch_three_phases_while_charging,
+    Charger_get_last_stop_transaction,
     IEC_process_bsp_event,
     IEC_state_machine,
     IEC_set_pwm,
@@ -157,7 +158,7 @@ static std::string to_string(MutexDescription d) {
     case MutexDescription::Charger_dlink_pause:
         return "Charger.cpp: dlink_pause";
     case MutexDescription::Charger_dlink_terminate:
-        return "Charger.cpp: dlink_error";
+        return "Charger.cpp: dlink_dlink_terminate";
     case MutexDescription::Charger_dlink_error:
         return "Charger.cpp: dlink_error";
     case MutexDescription::Charger_set_hlc_charging_active:
@@ -170,6 +171,8 @@ static std::string to_string(MutexDescription d) {
         return "Charger.cpp: set max current";
     case MutexDescription::Charger_switch_three_phases_while_charging:
         return "Charger.cpp switch_three_phases_while_charging";
+    case MutexDescription::Charger_get_last_stop_transaction:
+        return "Charger.cpp get_last_stop_transaction";
     case MutexDescription::IEC_process_bsp_event:
         return "IECStateMachine::process_bsp_event";
     case MutexDescription::IEC_state_machine:


### PR DESCRIPTION
## Describe your changes
If the cancel transaction reason is DeAuthorize, then no cable check error is raised. In other cases the error will be raised

## Issue ticket number and link
During cable check a fault was raised if the cable check was interrupted due a start transaction (blocked id tag). EvseManager should not go into error mode.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

