### PR TITLE
Fix(api): replyTo and header no longer required

### DIFF
--- a/docs/source/reference/EVerest_API/auth_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/auth_consumer_API.yaml
@@ -109,16 +109,18 @@ components:
       summary: 'Withdraw granted authorization.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/WithdrawAuthorizationRequest'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/WithdrawAuthorizationRequest'
       examples:
         - summary: ""
           payload:
@@ -137,7 +139,7 @@ components:
       summary: 'Reply to request to withdraw authorization.'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/WithdrawAuthorizationResult'
+        $ref: '#/components/schemas/WithdrawAuthorizationResult'
       examples:
         - summary: ""
           payload: "Accepted"

--- a/docs/source/reference/EVerest_API/auth_token_validator_API.yaml
+++ b/docs/source/reference/EVerest_API/auth_token_validator_API.yaml
@@ -104,16 +104,18 @@ components:
       summary: 'Request to validate token.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: 'auth_consumer_API.yaml#/components/schemas/ProvidedIdToken'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to.
+          payload:
+            $ref: 'auth_consumer_API.yaml#/components/schemas/ProvidedIdToken'
     send_reply_validate_token:
       name: send_reply_validate_token
       title: 'Reply validate token'

--- a/docs/source/reference/EVerest_API/display_message_API.yaml
+++ b/docs/source/reference/EVerest_API/display_message_API.yaml
@@ -144,13 +144,15 @@ components:
       contentType: application/json
       payload:
         type: object
+        required:
+          - payload
         properties:
           headers:
             type: object
             properties:
               replyTo:  # Address for the request to reply to
                 type: string
-                description: Address to send the response to.
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
           payload:
             $ref: '#/components/schemas/SetDisplayMessageRequest'
     send_reply_set_display_message:
@@ -173,13 +175,15 @@ components:
       contentType: application/json
       payload:
         type: object
+        required:
+          - payload
         properties:
           headers:
             type: object
             properties:
               replyTo:  # Address for the request to reply to
                 type: string
-                description: Address to send the response to.
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
           payload:
             $ref: '#/components/schemas/GetDisplayMessageRequest'
     send_reply_get_display_message:
@@ -213,13 +217,15 @@ components:
       contentType: application/json
       payload:
         type: object
+        required:
+          - payload
         properties:
           headers:
             type: object
             properties:
               replyTo:  # Address for the request to reply to
                 type: string
-                description: Address to send the response to.
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
           payload:
             $ref: '#/components/schemas/ClearDisplayMessageRequest'
     send_reply_clear_display_message:

--- a/docs/source/reference/EVerest_API/error_history_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/error_history_consumer_API.yaml
@@ -139,6 +139,8 @@ components:
       summary: 'Request the list of filtered errors.'
       payload:
         type: object
+        required:
+          - payload
         properties:
           headers:
             type: object
@@ -154,7 +156,7 @@ components:
       summary: 'Reply to the request to send the list of filtered errors'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/ErrorList'
+        $ref: '#/components/schemas/ErrorList'
     send_request_active_errors:
       name: send_request_active_errors
       title: 'Request the list of active errors'
@@ -179,21 +181,21 @@ components:
       summary: 'Reply to the request to send the list of active errors'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/ErrorList'
+        $ref: '#/components/schemas/ErrorList'
     receive_error_raised:
       name: receive_error_raised
       title: 'Receive newly raised error'
       summary: 'Notifies on every raised error'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/ErrorObject'
+        $ref: '#/components/schemas/ErrorObject'
     receive_error_cleared:
       name: receive_error_cleared
       title: 'Receive cleared error'
       summary: 'Notifies when an error is cleared'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/ErrorObject'
+        $ref: '#/components/schemas/ErrorObject'
 
 
     receive_heartbeat:

--- a/docs/source/reference/EVerest_API/ev_board_support_API.yaml
+++ b/docs/source/reference/EVerest_API/ev_board_support_API.yaml
@@ -55,8 +55,8 @@ channels:
   receive_set_three_phases:
     address: 'e2m/set_three_phases'
     messages:
-       receive_set_three_phases:
-         $ref: '#/components/messages/receive_set_three_phases'
+      receive_set_three_phases:
+        $ref: '#/components/messages/receive_set_three_phases'
   receive_set_rcd_error:
     address: 'e2m/set_rcd_error'
     messages:

--- a/docs/source/reference/EVerest_API/evse_board_support_API.yaml
+++ b/docs/source/reference/EVerest_API/evse_board_support_API.yaml
@@ -62,8 +62,8 @@ channels:
   receive_ac_switch_three_phases_while_charging:
     address: 'e2m/ac_switch_three_phases_while_charging'
     messages:
-       receive_ac_switch_three_phases_while_charging:
-         $ref: '#/components/messages/receive_ac_switch_three_phases_while_charging'
+      receive_ac_switch_three_phases_while_charging:
+        $ref: '#/components/messages/receive_ac_switch_three_phases_while_charging'
   receive_evse_replug:
     address: 'e2m/evse_replug'
     messages:

--- a/docs/source/reference/EVerest_API/evse_manager_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/evse_manager_consumer_API.yaml
@@ -472,14 +472,14 @@ components:
       summary: 'Request to get EVSE.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
+        type: object
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to.
       examples:
         - summary: ""
           payload:
@@ -491,23 +491,25 @@ components:
       summary: 'Reply to the request to get the EVSE.'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/Evse'
+        $ref: '#/components/schemas/Evse'
     send_request_enable_disable:
       name: send_request_enable_disable
       title: 'Request to enable or disable the EVSE'
       summary: 'Enables or disables the evse. Turns off PWM with error F. Charging is only possible if an EVSE is enabled.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/EnableDisableRequest'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/EnableDisableRequest'
       examples:
         - summary: ""
           payload:
@@ -532,14 +534,14 @@ components:
       summary: 'Request to pause charging.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
+        type: object
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
       examples:
         - summary: ""
           payload:
@@ -551,21 +553,21 @@ components:
       summary: 'Reply to the request to pause charging.'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/PauseChargingReply'
+        $ref: '#/components/schemas/PauseChargingReply'
     send_request_resume_charging:
       name: send_request_resume_charging
       title: 'Request resume charging'
       summary: 'Request to resume charging.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
+        type: object
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
       examples:
         - summary: ""
           payload:
@@ -577,23 +579,25 @@ components:
       summary: 'Reply to the request to resume charging.'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/ResumeChargingReply'
+        $ref: '#/components/schemas/ResumeChargingReply'
     send_request_stop_transaction:
       name: send_request_stop_transaction
       title: 'Request stop transaction'
       summary: 'Request to stop the current transaction.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/StopTransactionRequest'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/StopTransactionRequest'
       examples:
         - summary: ""
           payload:
@@ -607,23 +611,25 @@ components:
       summary: 'Reply to the request to stop the current transaction.'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/StopTransactionReply'
+        $ref: '#/components/schemas/StopTransactionReply'
     send_request_force_unlock:
       name: send_request_force_unlock
       title: 'Request force unlock'
       summary: 'Request to force unlock.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/ForceUnlockRequest'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/ForceUnlockRequest'
       examples:
         - summary: ""
           payload:
@@ -640,7 +646,7 @@ components:
         if explicitly requested by e.g. management cloud.
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/ForceUnlockReply'
+        $ref: '#/components/schemas/ForceUnlockReply'
     # update_allowed_energy_transfer_modes not implemented
 
     receive_session_event:
@@ -649,14 +655,14 @@ components:
       summary: 'Emits all events related to sessions'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/SessionEvent'
+        $ref: '#/components/schemas/SessionEvent'
     receive_ev_info:
       name: receive_ev_info
       title: 'Receive details about EV'
       summary: 'More details about the EV if available.'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/EVInfo'
+        $ref: '#/components/schemas/EVInfo'
     receive_session_info:
       name: receive_session_info
       title: 'Receive session and transaction information'
@@ -675,7 +681,7 @@ components:
         the user is not authorized anymore.
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/SessionInfo'
+        $ref: '#/components/schemas/SessionInfo'
     # telemetry not implemented
     receive_powermeter:
       name: receive_powermeter
@@ -697,7 +703,7 @@ components:
       summary: 'EVSE ID'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/EvseId'
+        $ref: '#/components/schemas/EvseId'
     receive_hw_capabilities:
       name: receive_hw_capabilities
       title: 'Receive hardware capabilities and limits'
@@ -718,14 +724,14 @@ components:
       summary: 'EVSE ID'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/SelectedProtocol'
+        $ref: '#/components/schemas/SelectedProtocol'
     receive_supported_energy_transfer_modes:
       name: receive_supported_energy_transfer_modes
       title: 'Receive supported energy transfer modes'
       summary: 'The list of supported energy transfers e.g. AC mono/tri, DC, DC_BPT, etc.'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/SupportedEnergyTransferModeList'
+        $ref: '#/components/schemas/SupportedEnergyTransferModeList'
 
     ########## evse_board_support
     receive_ac_nr_of_phases_available:
@@ -818,7 +824,7 @@ components:
       summary: 'Random delay countdown'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/CountDown'
+        $ref: '#/components/schemas/CountDown'
 
 
     receive_heartbeat:

--- a/docs/source/reference/EVerest_API/generic_error_raiser_API.yaml
+++ b/docs/source/reference/EVerest_API/generic_error_raiser_API.yaml
@@ -87,11 +87,11 @@ components:
       payload:
         $ref: '#/components/schemas/Error'
       examples:
-          - summary: "Raise error example"
-            payload:
-                "type": "CommunicationFault"
-                "sub_type": "subtype"
-                "message": "message"
+        - summary: "Raise error example"
+          payload:
+              "type": "CommunicationFault"
+              "sub_type": "subtype"
+              "message": "message"
     send_clear_error:
       name: send_clear_error
       title: 'Send clear error'
@@ -100,11 +100,11 @@ components:
       payload:
         $ref: '#/components/schemas/Error'
       examples:
-          - summary: "Clear error example"
-            payload:
-                type: "CommunicationFault"
-                sub_type: "subtype"
-                message: "message"
+        - summary: "Clear error example"
+          payload:
+              type: "CommunicationFault"
+              sub_type: "subtype"
+              message: "message"
 
     receive_heartbeat:
       name: receive_heartbeat

--- a/docs/source/reference/EVerest_API/ocpp_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/ocpp_consumer_API.yaml
@@ -252,23 +252,25 @@ components:
       summary: 'Request data transfer.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/DataTransferRequest'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to.
+          payload:
+            $ref: '#/components/schemas/DataTransferRequest'
     send_reply_data_transfer_incoming:
       name: send_reply_data_transfer_incoming
       title: 'Reply to data transfer request'
       summary: 'Reply to the request to transfer data'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/DataTransferResponse'
+        $ref: '#/components/schemas/DataTransferResponse'
       examples:
         - summary: ""
           payload:
@@ -285,16 +287,18 @@ components:
       summary: 'Request data transfer.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/DataTransferRequest'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/DataTransferRequest'
       examples:
         - summary: ""
           payload:
@@ -313,7 +317,7 @@ components:
       summary: 'Reply to the request to transfer data'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/DataTransferResponse'
+        $ref: '#/components/schemas/DataTransferResponse'
 
     ########## ocpp
     send_request_get_variables:
@@ -321,16 +325,18 @@ components:
       summary: 'Request the variables.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/GetVariableRequestList'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to.
+          payload:
+            $ref: '#/components/schemas/GetVariableRequestList'
       examples:
         - summary: ""
           payload:
@@ -361,16 +367,18 @@ components:
       summary: 'Request setting the variables.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/SetVariablesArgs'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/SetVariablesArgs'
       examples:
         - summary: ""
           payload:
@@ -398,7 +406,7 @@ components:
       summary: 'Reply to the request to set the variables'
       contentType: application/json
       payload:
-         $ref: '#/components/schemas/SetVariableResultList'
+        $ref: '#/components/schemas/SetVariableResultList'
     send_request_monitor_variables:
       title: 'Monitor variables'
       summary: 'Monitor the variables.'

--- a/docs/source/reference/EVerest_API/over_voltage_monitor_API.yaml
+++ b/docs/source/reference/EVerest_API/over_voltage_monitor_API.yaml
@@ -177,12 +177,12 @@ components:
       payload:
         $ref: '#/components/schemas/OverVoltageLimits'
       examples:
-          - summary: ""
-            payload:
-              {
-              "emergency_limit_V": 600,
-              "error_limit_V": 500
-              }
+        - summary: ""
+          payload:
+            {
+            "emergency_limit_V": 600,
+            "error_limit_V": 500
+            }
     receive_start:
       name: receive_start
       title: Receive start over voltage monitoring command
@@ -212,8 +212,8 @@ components:
       payload:
         $ref: '#/components/schemas/VoltageMeasurementV'
       examples:
-          - summary: ""
-            payload: 500
+        - summary: ""
+          payload: 500
 
 
     send_raise_error:
@@ -224,12 +224,12 @@ components:
       payload:
         $ref: '#/components/schemas/Error'
       examples:
-          - summary: "Raise error example"
-            payload:
-                "type": "MREC5OverVoltage"
-                "sub_type": "subtype"
-                "message": "message"
-                "severity": "High"
+        - summary: "Raise error example"
+          payload:
+              "type": "MREC5OverVoltage"
+              "sub_type": "subtype"
+              "message": "message"
+              "severity": "High"
     send_clear_error:
       name: send_clear_error
       title: 'Send clear error'
@@ -238,11 +238,11 @@ components:
       payload:
         $ref: '#/components/schemas/Error'
       examples:
-          - summary: "Clear error example"
-            payload:
-                "type": "CommunicationFault"
-                "sub_type": "subtype"
-                "message": "message"
+        - summary: "Clear error example"
+          payload:
+              "type": "CommunicationFault"
+              "sub_type": "subtype"
+              "message": "message"
     receive_heartbeat:
       name: receive_heartbeat
       title: 'Receive heartbeat'

--- a/docs/source/reference/EVerest_API/power_supply_DC_API.yaml
+++ b/docs/source/reference/EVerest_API/power_supply_DC_API.yaml
@@ -230,11 +230,11 @@ components:
       payload:
         $ref: '#/components/schemas/Error'
       examples:
-          - summary: "Raise error example"
-            payload:
-                "type": "CommunicationFault"
-                "sub_type": "string"
-                "message": "string"
+        - summary: "Raise error example"
+          payload:
+              "type": "CommunicationFault"
+              "sub_type": "string"
+              "message": "string"
     send_clear_error:
       name: send_clear_error
       title: 'Send clear error'
@@ -243,11 +243,11 @@ components:
       payload:
         $ref: '#/components/schemas/Error'
       examples:
-          - summary: "Raise error example"
-            payload:
-                "type": "CommunicationFault"
-                "sub_type": "string"
-                "message": "string"
+        - summary: "Raise error example"
+          payload:
+              "type": "CommunicationFault"
+              "sub_type": "string"
+              "message": "string"
 
 
     receive_heartbeat:

--- a/docs/source/reference/EVerest_API/powermeter_API.yaml
+++ b/docs/source/reference/EVerest_API/powermeter_API.yaml
@@ -152,17 +152,14 @@ components:
         type: object
         additionalProperties: true
         required:
-          - headers
           - payload
         properties:
           headers:
             type: object
-            required:
-              - replyTo
             properties:
               replyTo:
                 type: string
-                description: 'The topic to which to send the reply'
+                description: 'The topic to which to send the reply. If this information is missing, the command will still be accepted, but no response will be sent.'
           payload:
             $ref: '#/components/schemas/StartTransactionRequest'
     send_reply_start_transaction:
@@ -188,17 +185,14 @@ components:
         type: object
         additionalProperties: true
         required:
-          - headers
           - payload
         properties:
           headers:
             type: object
-            required:
-              - replyTo
             properties:
               replyTo:
                 type: string
-                description: 'The topic to which to send the reply'
+                description: 'The topic to which to send the reply. If this information is missing, the command will still be accepted, but no response will be sent.'
           payload:
             type: object
             additionalProperties: true

--- a/docs/source/reference/EVerest_API/system_API.yaml
+++ b/docs/source/reference/EVerest_API/system_API.yaml
@@ -245,16 +245,18 @@ components:
       summary: 'Request to update the firmware.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/FirmwareUpdateRequest'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/FirmwareUpdateRequest'
     send_reply_update_firmware:
       name: send_reply_update_firmware
       title: 'Reply update firmware'
@@ -272,16 +274,18 @@ components:
       summary: 'Request to upload logs.'
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/UploadLogsRequest'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/UploadLogsRequest'
     send_reply_upload_logs:
       name: send_reply_upload_logs
       title: 'Reply upload logs'
@@ -292,8 +296,8 @@ components:
       examples:
         - summary: "Upload logs"
           payload:
-              file_name: "string"
-              upload_logs_status: "Accepted"
+            file_name: "string"
+            upload_logs_status: "Accepted"
     receive_request_is_reset_allowed:
       name: receive_request_is_reset_allowed
       title: 'Request if reset is allowed'
@@ -303,6 +307,8 @@ components:
       contentType: application/json
       payload:
         type: object
+        required:
+          - payload
         properties:
           headers:
             type: object
@@ -329,16 +335,18 @@ components:
       summary:  Call to set the system time
       contentType: application/json
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
-            payload:
-              $ref: '#/components/schemas/SystemTime'
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/SystemTime'
     send_reply_set_system_time:
       name: send_reply_set_system_time
       title: 'Reply to is reset allowed'
@@ -355,14 +363,14 @@ components:
       title: 'Receive get boot reason request'
       summary:  Call to get the boot reason
       payload:
-          type: object
-          properties:
-            headers:
-              type: object
-              properties:
-                replyTo:  # Address for the request to reply to
-                  type: string
-                  description: Address to send the response to.
+        type: object
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to.
     send_reply_get_boot_reason:
       name: send_reply_get_boot_reason
       title: 'Reply to get boot reason'

--- a/lib/everest/everest_api_types/src/everest_api_types/generic/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/generic/json_codec.cpp
@@ -21,7 +21,12 @@ void to_json(json& j, RequestReply const& k) {
 }
 
 void from_json(json const& j, RequestReply& k) {
-    k.replyTo = j.at("headers").at("replyTo");
+    if (j.contains("headers") and j["headers"].contains("replyTo")) {
+        k.replyTo = j["headers"]["replyTo"];
+    } else {
+        k.replyTo = "";
+    }
+
     if (j.contains("payload")) {
         k.payload = j["payload"].dump();
     } else {

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -137,6 +137,10 @@ void MQTTAbstractionImpl::publish(const std::string& topic, const std::string& d
 void MQTTAbstractionImpl::publish(const std::string& topic, const std::string& data, QOS qos, bool retain) {
     BOOST_LOG_FUNCTION();
 
+    if (topic.empty()) {
+        return;
+    }
+
     auto publish_flags = 0;
     switch (qos) {
     case QOS::QOS0:


### PR DESCRIPTION
## Describe your changes
EVerest could be crashed by sending certain inputs to the any API.
Setting replyTo to "" would lead the corresponding API module to call mqtt.publish(...) with an empty topic.

Upon failure to send to this invalid topic, the underlying mqtt implementation would incorrectly infer that the mqtt broker was down and terminate EVerest.
This PR turns calls to mqtt.publish into a silent no-op. This likely doesn't interfere with the internal mqtt communication used by the everest-framework.

This PR also clarifies the AsyncAPI yaml descriptions: In a request-reply pattern, "payload" is always required (if there is a payload field) but "headers"/"replyTo" may be omitted.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

