### PR TITLE
Fix(EvseManager): Introduce monitor for hw_capabilites and supported_energy_transfers

### DIFF
--- a/modules/EVSE/EvseManager/BUILD.bazel
+++ b/modules/EVSE/EvseManager/BUILD.bazel
@@ -16,6 +16,7 @@ cc_everest_module(
         "@pugixml//:pugixml",
         "@sigslot//:sigslot",
         "//lib/everest/helpers",
+        "//lib/everest/util",
     ],
     impls = IMPLS,
     srcs = glob(

--- a/modules/EVSE/EvseManager/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${MODULE_NAME}
 target_link_libraries(${MODULE_NAME}
     PRIVATE
         everest::helpers
+        everest::util
         Pal::Sigslot
         pugixml::pugixml
 )


### PR DESCRIPTION
fix(EvseManager,EvseV2G): Make supported_energy_transfer modes and hw_capabilites thread safe

* Added monitor utility to EvseManager to protect supported_energy_transfers and hw_capabilities
* Fix issue that occured at encoding ServiceDiscoveryRes message that occured when call_update_energy_transfer_modes was called with an empty vector. New helper get_supported_ac_energy_transfers() ensures that at least AC_single_phase_core is provided
* For hw_capabilities concurrent read and write operations could occur. The access is now protected by the monitor utility

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

