### PR TITLE
everest/io: suppress bogus g++ 11 warning

### DIFF
--- a/lib/everest/io/src/mdns/mdns.cpp
+++ b/lib/everest/io/src/mdns/mdns.cpp
@@ -147,7 +147,14 @@ void parse_mdns_PTR(const std::uint8_t* base, int record_data_offset, mDNS_disco
     encoded.push_back(0);
 
     std::vector<std::uint8_t> packet = {0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+#if defined(__GNUC__) && (__GNUC__ < 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
     packet.insert(packet.end(), encoded.begin(), encoded.end());
+#if defined(__GNUC__) && (__GNUC__ < 12)
+#pragma GCC diagnostic pop
+#endif
     packet.push_back(0x00);
     packet.push_back(0x0c);
     packet.push_back(0x00);


### PR DESCRIPTION
Fixes https://github.com/EVerest/everest-core/issues/1863

```
/usr/include/c++/11/ext/new_allocator.h: In function ‘std::vector<unsigned char> everest::lib::io::mdns::create_mdns_query(const string&)’:
/usr/include/c++/11/ext/new_allocator.h:127:48: note: at offset 12 into source object of size 12 allocated by ‘operator new’
```

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101361.

## Describe your changes
Disable the warning for g++ 11, instead of refactoring the code to do its vector expansion differently.
## Issue ticket number and link
https://github.com/EVerest/everest-core/issues/1863
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

