### PR TITLE
Fix/api test file autogen error messages

### DIFF
--- a/lib/everest/everest_api_types/tests/CMakeLists.txt
+++ b/lib/everest/everest_api_types/tests/CMakeLists.txt
@@ -111,7 +111,7 @@ set(
     ${Python3_EXECUTABLE} -B "${PROJECT_SOURCE_DIR}/lib/everest/everest_api_types/tests/test_file_autogenerator/main.py"
      "${PROJECT_SOURCE_DIR}/lib/everest/everest_api_types/include/"
      "${PROJECT_SOURCE_DIR}/lib/everest/everest_api_types/tests/"
-     "${PROJECT_SOURCE_DIR}/lib/everest/everest_api_types/tests/test_file_autogenerator/disable.csv"
+     "${TEST_DISABLE_FILE}"
      "${GENERATED_TESTS_LOCATION}"
     VERBATIM
 )

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/helper.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/helper.py
@@ -15,14 +15,14 @@ class Helper(metaclass=ABCMeta):
         if namespace is None:
             namespace = [""]
         self.namespace = namespace
-        self.representation = representation
+        self.representation = self.sanitize(representation)
         self.test_helpers_code = ""
         self.test_helpers_headers_code = ""
         self.tests_code = ["%s"]
         across_file_generator.add_helper(self)
 
     def get_representation(self):
-        return self.sanitize(self.representation)
+        return self.representation
 
     @abstractmethod
     def get_value_generation(self, a, seed=""):
@@ -60,7 +60,7 @@ class Helper(metaclass=ABCMeta):
         return re.search(
             r"%s%s([A-z_][0-9A-z_]*)%s\{" % (self.get_regex_structure_type(),
                                    Helper.regex_whitespaces, Helper.regex_whitespaces),
-            self.get_representation()).group(1)
+            self.representation).group(1)
 
     @staticmethod
     def sanitize(file):

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/main.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/main.py
@@ -69,7 +69,6 @@ for root, dirs, files in os.walk(code_path):
         generator = FileTestGenerator(
             file_to_test, write_path, across_file_generator, code_path, license_header,
             get_single_deny_list(deny_lists, file_to_test))
-        generator.generate_code()
         generators.append(generator)
 if not api_files_found:
     raise FileNotFoundError(

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/structhelper.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/structhelper.py
@@ -106,9 +106,12 @@ class StructHelper(Helper):
 
     def generate_test_fields(self, fields, is_optional):
         code = ""
-        for i in fields:
-            code += self.value_generator.generate_corresponding_field_test(
-                i[1], i[0], self.get_namespace(), is_optional)
+        for field in fields:
+            try:
+                code += self.value_generator.generate_corresponding_field_test(
+                    field[1], field[0], self.get_namespace(), is_optional)
+            except TypeError as e:
+                raise TypeError(169*"/" + f"\n'{self.get_type_with_namespace()}::{field[1]}': {e}\n" + 180*"\\") from e
         return code
 
     def generate_test(self):

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/structhelper.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/structhelper.py
@@ -10,7 +10,7 @@ from valuegenerator import ValueGenerator
 class StructHelper(Helper):
     w = Helper.regex_whitespaces
     default_value = r"\{[A-z:_<>0-9\.]+\}?"
-    regex_single_field = r"([A-z:_<>0-9]+" + w + Helper.regex_field_or_class_name + \
+    regex_single_field = r"((?:[A-z:_<>0-9]+" + w + r")+" + Helper.regex_field_or_class_name + \
         r"(" + r"\{[A-z:_<>0-9\.]+\}?" + r")?" + r";)" + w
     regex_fields = r"(" + w + regex_single_field + r")*"
 
@@ -47,8 +47,10 @@ class StructHelper(Helper):
         for field in self.get_fields():
             if ("std::optional" not in field) == mandatory:
                 split = re.split(Helper.regex_whitespaces, field)
-                assert split.__len__() == 2
-                a.append((split[0], split[1]))
+                assert len(split) >= 2
+                type_string = " ".join(split[:-1])
+                field_name = split[-1]
+                a.append((type_string, field_name))
         return a
 
     def get_fields_optional(self):

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/structhelper.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/structhelper.py
@@ -84,9 +84,21 @@ class StructHelper(Helper):
         if signature_only:
             return code + ");\n"
         token = "generated_object"
-        code += ") { \n" + self.get_type() + " " + token + ";\n"
-        code += self.generate_set_fields(self.get_fields_mandatory(), token) + "if (set_optional_fields) {"
-        code += self.generate_set_fields(self.get_fields_optional(), token) + "}\n" + "return " + token + ";\n" + "}\n"
+        code += ") {\n"
+        code += "    thread_local static int depth = 0;\n"
+        code += "    depth++;\n"
+        code += "    " + self.get_type() + " " + token + "{};\n"
+        code += "    if (depth > 2) {\n"
+        code += "        depth--;\n"
+        code += "        return " + token + ";\n"
+        code += "    }\n"
+        code += self.generate_set_fields(self.get_fields_mandatory(), token)
+        code += "    if (set_optional_fields) {\n"
+        code += self.generate_set_fields(self.get_fields_optional(), token)
+        code += "    }\n"
+        code += "    depth--;\n"
+        code += "    return " + token + ";\n"
+        code += "}\n"
         return code
 
     def get_code_verify_function(self, signature_only=False):

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/valuegenerator.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/valuegenerator.py
@@ -106,6 +106,12 @@ def get_vector_variable_name(variable_name_suffix=""):
 class ValueGenerator:
     manual_generator = ManualGenerator()
     base_types = ["int32_t", "int64_t", "float", "std::string", "bool"]
+    unsupported_base_types = ["void",
+                              "char", "signed char", "unsigned char", "wchar_t", "char16_t", "char32_t", "char8_t",
+                              "short", "short int", "signed short", "signed short int", "unsigned short", "unsigned short int", "int", "signed", "signed int", "unsigned", "unsigned int", "long", "long int", "signed long", "signed long int", "unsigned long", "unsigned long int", "long long", "long long int", "signed long long", "signed long long int", "unsigned long long", "unsigned long long int",
+                              "double", "long double",
+                              "int8_t", "int16_t", "uint8_t", "uint16_t", "uint32_t", "uint64_t",
+                              "std::size_t", "std::byte", "std::int8_t", "std::int16_t", "std::int32_t", "std::int64_t", "std::uint8_t", "std::uint16_t", "std::uint32_t", "std::uint64_t"]
 
     def __init__(self, struct_name, struct_namespace, enum_map, across_file_struct_generator=None):
         if (across_file_struct_generator is None):
@@ -216,6 +222,8 @@ class ValueGenerator:
                                                 field_type, namespace, is_optional)
 
     def generate_corresponding_test(self, original_object, result_object, field_type, namespace, is_optional):
+        if field_type in self.unsupported_base_types:
+            raise TypeError(f"Unsupported type {field_type!r}, supported base types are: {self.base_types}")
         is_simple = field_type in self.base_types or field_type in self.enum_map.keys(
         ) or self.namespace_cleanup(field_type) in self.enum_map.keys()
         if is_simple:
@@ -230,9 +238,9 @@ class ValueGenerator:
                 result_object + ".has_value());\nif (" + result_object + \
                 ".has_value()) {"
             optional_wrapper_rear = "}\n"
-        wraped = self.generate_corresponding_test_unsafe(
+        wrapped = self.generate_corresponding_test_unsafe(
             original_object, result_object, field_type, namespace, is_optional)
-        return optional_wrapper_front + wraped + optional_wrapper_rear
+        return optional_wrapper_front + wrapped + optional_wrapper_rear
 
     def generate_corresponding_test_unsafe(self, original_object, result_object, field_type, namespace, is_optional):
         if "std::vector<" in field_type:

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/valuegenerator.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/valuegenerator.py
@@ -106,12 +106,6 @@ def get_vector_variable_name(variable_name_suffix=""):
 class ValueGenerator:
     manual_generator = ManualGenerator()
     base_types = ["int32_t", "int64_t", "float", "std::string", "bool"]
-    unsupported_base_types = ["void",
-                              "char", "signed char", "unsigned char", "wchar_t", "char16_t", "char32_t", "char8_t",
-                              "short", "short int", "signed short", "signed short int", "unsigned short", "unsigned short int", "int", "signed", "signed int", "unsigned", "unsigned int", "long", "long int", "signed long", "signed long int", "unsigned long", "unsigned long int", "long long", "long long int", "signed long long", "signed long long int", "unsigned long long", "unsigned long long int",
-                              "double", "long double",
-                              "int8_t", "int16_t", "uint8_t", "uint16_t", "uint32_t", "uint64_t",
-                              "std::size_t", "std::byte", "std::int8_t", "std::int16_t", "std::int32_t", "std::int64_t", "std::uint8_t", "std::uint16_t", "std::uint32_t", "std::uint64_t"]
 
     def __init__(self, struct_name, struct_namespace, enum_map, across_file_struct_generator=None):
         if (across_file_struct_generator is None):
@@ -222,8 +216,6 @@ class ValueGenerator:
                                                 field_type, namespace, is_optional)
 
     def generate_corresponding_test(self, original_object, result_object, field_type, namespace, is_optional):
-        if field_type in self.unsupported_base_types:
-            raise TypeError(f"Unsupported type {field_type!r}, supported base types are: {self.base_types}")
         is_simple = field_type in self.base_types or field_type in self.enum_map.keys(
         ) or self.namespace_cleanup(field_type) in self.enum_map.keys()
         if is_simple:
@@ -243,6 +235,8 @@ class ValueGenerator:
         return optional_wrapper_front + wrapped + optional_wrapper_rear
 
     def generate_corresponding_test_unsafe(self, original_object, result_object, field_type, namespace, is_optional):
+        original_field_type = field_type
+
         if "std::vector<" in field_type:
             vector_type = self.namespace_cleanup(get_vector_type(field_type))
             assign_a = "= " + original_object
@@ -279,7 +273,10 @@ class ValueGenerator:
                 field_type)
             return self.generate_corresponding_test(original_object, result_object, type_in_different_namespace, different_namespace, False)
 
-        return self.manual_generator.get_tester(field_type, original_object, result_object) + ";\n"
+        raise TypeError(
+            f"Unrecognized type '{original_field_type}'. It is not a supported API base type, "
+            "a parsed enum/struct, or explicitly registered for manual generation."
+        )
 
     @staticmethod
     def generics_extractor(generic_call, whole_call):


### PR DESCRIPTION
## Describe your changes
Improves the error message during autogenerating tests for the EVerest_API-types.

Adding a new type to the EVerestAPI requires changing of/creating a new lib/everest/everest_api_types/include/.../API.hpp.
Unit-test for (de-)serialization of these tests are auto-generated during the build.
Auto-generation fails for unsupported base-types. The resulting error-message did not point to the actual problem.

The change allows the auto-generator to name the data-structure that caused the problem and clearly states which type cannot be used (e.g. use of an int instead of int32_t).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

