### PR TITLE
EvseManager: Don't lock without auth

### DIFF
--- a/modules/EVSE/EvseManager/BUILD.bazel
+++ b/modules/EVSE/EvseManager/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//modules:module.bzl", "cc_everest_module")
 
 IMPLS = [
@@ -7,22 +8,97 @@ IMPLS = [
     "random_delay",
     "dc_external_derate",
     "over_voltage",
-    "voltage_plausibility"
+    "voltage_plausibility",
 ]
 
 cc_everest_module(
     name = "EvseManager",
-    deps = [
-        "@pugixml//:pugixml",
-        "@sigslot//:sigslot",
-        "//lib/everest/helpers",
-        "//lib/everest/util",
-    ],
-    impls = IMPLS,
     srcs = glob(
         [
             "*.cpp",
             "*.hpp",
         ],
     ),
+    impls = IMPLS,
+    deps = [
+        "//lib/everest/helpers",
+        "//lib/everest/util",
+        "@pugixml",
+        "@sigslot",
+    ],
+)
+
+cc_test(
+    name = "EvseManager_tests",
+    srcs = [
+        # Test sources
+        "tests/EventQueueTest.cpp",
+        "tests/ErrorHandlingTest.cpp",
+        "tests/IECStateMachineTest.cpp",
+        "tests/OverVoltageMonitorTest.cpp",
+        "tests/VoltagePlausibilityMonitorTest.cpp",
+        # Test stub headers
+        "tests/evse_board_supportIntfStub.hpp",
+        "tests/EvseManagerStub.hpp",
+        # Module sources needed by tests
+        "ErrorHandling.cpp",
+        "IECStateMachine.cpp",
+        "backtrace.cpp",
+        "over_voltage/OverVoltageMonitor.cpp",
+        "voltage_plausibility/VoltagePlausibilityMonitor.cpp",
+        # Module headers
+    ] + glob([
+        "*.hpp",
+        "over_voltage/*.hpp",
+        "voltage_plausibility/*.hpp",
+    ]) + [
+        # Generated ld-ev header only (not ld-ev.cpp which pulls in impl files)
+        "generated/modules/EvseManager/ld-ev.hpp",
+    ],
+    copts = ["-std=c++17"],
+    defines = ["BUILD_TESTING_MODULE_EVSE_MANAGER"],
+    includes = [
+        ".",
+        "generated/modules/EvseManager",
+        "tests",
+    ],
+    deps = [
+        "//interfaces:interfaces_lib",
+        "//lib/everest/framework",
+        "//lib/everest/helpers",
+        "//tests:module_adapter_stub",
+        "@googletest//:gtest_main",
+        "@sigslot",
+    ],
+)
+
+cc_test(
+    name = "EvseManagerCharger_tests",
+    srcs = [
+        # Test source
+        "tests/ChargerTest.cpp",
+        # Module source
+        "Charger.cpp",
+    ] + glob([
+        "*.hpp",
+    ]) + [
+        # Generated ld-ev header only
+        "generated/modules/EvseManager/ld-ev.hpp",
+    ],
+    copts = ["-std=c++17"],
+    defines = ["BUILD_TESTING_MODULE_EVSE_MANAGER"],
+    includes = [
+        ".",
+        "generated/modules/EvseManager",
+        "tests",
+    ],
+    deps = [
+        "//interfaces:interfaces_lib",
+        "//lib/everest/framework",
+        "//lib/everest/helpers",
+        "//tests:module_adapter_stub",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@sigslot",
+    ],
 )

--- a/modules/EVSE/EvseManager/BUILD.bazel
+++ b/modules/EVSE/EvseManager/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//modules:module.bzl", "cc_everest_module")
+load("//third-party/bazel/toolchains:defs.bzl", "CROSS_TEST_INCOMPATIBLE")
 
 IMPLS = [
     "energy_grid",
@@ -62,6 +63,7 @@ cc_test(
         "generated/modules/EvseManager",
         "tests",
     ],
+    target_compatible_with = CROSS_TEST_INCOMPATIBLE,
     deps = [
         "//interfaces:interfaces_lib",
         "//lib/everest/framework",
@@ -92,6 +94,7 @@ cc_test(
         "generated/modules/EvseManager",
         "tests",
     ],
+    target_compatible_with = CROSS_TEST_INCOMPATIBLE,
     deps = [
         "//interfaces:interfaces_lib",
         "//lib/everest/framework",

--- a/modules/EVSE/EvseManager/BUILD.bazel
+++ b/modules/EVSE/EvseManager/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
 load("//modules:module.bzl", "cc_everest_module")
+load("//third-party/bazel/toolchains:defs.bzl", "CROSS_TEST_INCOMPATIBLE")
 
 IMPLS = [
     "energy_grid",
@@ -7,22 +9,99 @@ IMPLS = [
     "random_delay",
     "dc_external_derate",
     "over_voltage",
-    "voltage_plausibility"
+    "voltage_plausibility",
 ]
 
 cc_everest_module(
     name = "EvseManager",
-    deps = [
-        "@pugixml//:pugixml",
-        "@sigslot//:sigslot",
-        "//lib/everest/helpers",
-        "//lib/everest/util",
-    ],
-    impls = IMPLS,
     srcs = glob(
         [
             "*.cpp",
             "*.hpp",
         ],
     ),
+    impls = IMPLS,
+    deps = [
+        "//lib/everest/helpers",
+        "//lib/everest/util",
+        "@pugixml",
+        "@sigslot",
+    ],
+)
+
+cc_test(
+    name = "EvseManager_tests",
+    srcs = [
+        # Test sources
+        "tests/EventQueueTest.cpp",
+        "tests/ErrorHandlingTest.cpp",
+        "tests/IECStateMachineTest.cpp",
+        "tests/OverVoltageMonitorTest.cpp",
+        "tests/VoltagePlausibilityMonitorTest.cpp",
+        # Test stub headers
+        "tests/evse_board_supportIntfStub.hpp",
+        "tests/EvseManagerStub.hpp",
+        # Module sources needed by tests
+        "ErrorHandling.cpp",
+        "IECStateMachine.cpp",
+        "backtrace.cpp",
+        "over_voltage/OverVoltageMonitor.cpp",
+        "voltage_plausibility/VoltagePlausibilityMonitor.cpp",
+        # Module headers
+    ] + glob([
+        "*.hpp",
+        "over_voltage/*.hpp",
+        "voltage_plausibility/*.hpp",
+    ]) + [
+        # Generated ld-ev header only (not ld-ev.cpp which pulls in impl files)
+        "generated/modules/EvseManager/ld-ev.hpp",
+    ],
+    copts = ["-std=c++17"],
+    defines = ["BUILD_TESTING_MODULE_EVSE_MANAGER"],
+    includes = [
+        ".",
+        "generated/modules/EvseManager",
+        "tests",
+    ],
+    target_compatible_with = CROSS_TEST_INCOMPATIBLE,
+    deps = [
+        "//interfaces:interfaces_lib",
+        "//lib/everest/framework",
+        "//lib/everest/helpers",
+        "//tests:module_adapter_stub",
+        "@googletest//:gtest_main",
+        "@sigslot",
+    ],
+)
+
+cc_test(
+    name = "EvseManagerCharger_tests",
+    srcs = [
+        # Test source
+        "tests/ChargerTest.cpp",
+        # Module source
+        "Charger.cpp",
+    ] + glob([
+        "*.hpp",
+    ]) + [
+        # Generated ld-ev header only
+        "generated/modules/EvseManager/ld-ev.hpp",
+    ],
+    copts = ["-std=c++17"],
+    defines = ["BUILD_TESTING_MODULE_EVSE_MANAGER"],
+    includes = [
+        ".",
+        "generated/modules/EvseManager",
+        "tests",
+    ],
+    target_compatible_with = CROSS_TEST_INCOMPATIBLE,
+    deps = [
+        "//interfaces:interfaces_lib",
+        "//lib/everest/framework",
+        "//lib/everest/helpers",
+        "//tests:module_adapter_stub",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@sigslot",
+    ],
 )

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1306,6 +1306,7 @@ void Charger::start_session(bool authfirst) {
         provided_id_token = shared_context.id_token;
     } else {
         shared_context.last_start_session_reason = types::evse_manager::StartSessionReason::EVConnected;
+        bsp->set_authorized(false);
     }
     signal_session_started_event(shared_context.last_start_session_reason, provided_id_token);
 }
@@ -1315,6 +1316,7 @@ void Charger::stop_session() {
     shared_context.flag_authorized = false;
     shared_context.flag_externally_cancelled = false;
     shared_context.flag_paused_by_evse = false;
+    bsp->set_authorized(false);
     signal_simple_event(types::evse_manager::SessionEventEnum::SessionFinished);
     shared_context.session_uuid.clear();
 }
@@ -1359,6 +1361,7 @@ bool Charger::start_transaction() {
 
 void Charger::stop_transaction() {
     shared_context.flag_transaction_active = false;
+    bsp->set_authorized(false);
 
     if (!shared_context.last_stop_transaction_reason.has_value()) {
         // if the stop transaction reason was already set (e.g. by cancel_transaction), we keep it, else we know it is
@@ -1560,6 +1563,7 @@ void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& tok
             start_session(true);
         }
         signal_simple_event(types::evse_manager::SessionEventEnum::Authorized);
+        bsp->set_authorized(true);
         shared_context.flag_authorized = true;
         shared_context.authorized_pnc =
             token.authorization_type == types::authorization::AuthorizationType::PlugAndCharge;
@@ -1567,6 +1571,7 @@ void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& tok
         if (shared_context.session_active) {
             stop_session();
         }
+        bsp->set_authorized(false);
         shared_context.flag_authorized = false;
     }
 }

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -45,6 +45,7 @@ Charger::Charger(const std::unique_ptr<IECStateMachine>& bsp, const std::unique_
     if (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket) {
         shared_context.max_current_cable = bsp->read_pp_ampacity();
     }
+    shared_context.flag_authorized.set_signal([&bsp](bool value) { bsp->set_authorized(value); });
     shared_context.flag_authorized = false;
 
     internal_context.update_pwm_last_duty_cycle = 0.;
@@ -1306,7 +1307,6 @@ void Charger::start_session(bool authfirst) {
         provided_id_token = shared_context.id_token;
     } else {
         shared_context.last_start_session_reason = types::evse_manager::StartSessionReason::EVConnected;
-        bsp->set_authorized(false);
     }
     signal_session_started_event(shared_context.last_start_session_reason, provided_id_token);
 }
@@ -1316,7 +1316,6 @@ void Charger::stop_session() {
     shared_context.flag_authorized = false;
     shared_context.flag_externally_cancelled = false;
     shared_context.flag_paused_by_evse = false;
-    bsp->set_authorized(false);
     signal_simple_event(types::evse_manager::SessionEventEnum::SessionFinished);
     shared_context.session_uuid.clear();
 }
@@ -1361,7 +1360,6 @@ bool Charger::start_transaction() {
 
 void Charger::stop_transaction() {
     shared_context.flag_transaction_active = false;
-    bsp->set_authorized(false);
 
     if (!shared_context.last_stop_transaction_reason.has_value()) {
         // if the stop transaction reason was already set (e.g. by cancel_transaction), we keep it, else we know it is
@@ -1563,7 +1561,6 @@ void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& tok
             start_session(true);
         }
         signal_simple_event(types::evse_manager::SessionEventEnum::Authorized);
-        bsp->set_authorized(true);
         shared_context.flag_authorized = true;
         shared_context.authorized_pnc =
             token.authorization_type == types::authorization::AuthorizationType::PlugAndCharge;
@@ -1571,7 +1568,6 @@ void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& tok
         if (shared_context.session_active) {
             stop_session();
         }
-        bsp->set_authorized(false);
         shared_context.flag_authorized = false;
     }
 }

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -45,6 +45,7 @@ Charger::Charger(const std::unique_ptr<IECStateMachine>& bsp, const std::unique_
     if (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket) {
         shared_context.max_current_cable = bsp->read_pp_ampacity();
     }
+    shared_context.flag_authorized.set_signal([&bsp](bool value) { bsp->set_authorized(value); });
     shared_context.flag_authorized = false;
 
     internal_context.update_pwm_last_duty_cycle = 0.;

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -281,6 +281,31 @@ private:
     // This mutex locks all variables related to the state machine
     Everest::timed_mutex_traceable state_machine_mutex;
 
+    /// Extension of the std::atomic_bool to allow to connect it to a signal and
+    /// fire on change.
+    struct SignalingBool : private std::atomic_bool {
+        using std::atomic_bool::atomic_bool;
+        using std::atomic_bool::operator bool;
+
+        /// @brief Signaling assign operator.
+        /// std::atomic_bool returns `bool` and not itself. See
+        /// https://en.cppreference.com/cpp/atomic/atomic/operator%3D
+        bool operator=(bool value) {
+            signal(value);
+            return std::atomic_bool::operator=(value);
+        }
+
+        /// @brief Register a new signal.
+        /// We just forward everything to signal's connect and let the compiler
+        /// complain if someone misuses.
+        template <typename... U> void set_signal(U&&... args) {
+            signal.connect(std::forward<U>(args)...);
+        }
+
+    private:
+        sigslot::signal<bool> signal;
+    };
+
     // used by different threads, complete main loop must be locked for write access
     struct SharedContext {
         // As per IEC61851-1 A.5.3
@@ -297,7 +322,7 @@ private:
             stop_transaction_id_token; // only set in case transaction was stopped locally
         types::authorization::ProvidedIdToken id_token;
         types::authorization::ValidationResult validation_result;
-        std::atomic_bool flag_authorized{false};
+        SignalingBool flag_authorized{false};
         std::atomic_bool flag_externally_cancelled{false};
         std::atomic_bool flag_paused_by_evse{false};
         std::atomic_bool flag_ev_plugged_in{false};

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -317,7 +317,7 @@ void EvseManager::init() {
 }
 
 void EvseManager::ready() {
-    bsp = std::make_unique<IECStateMachine>(r_bsp, config.lock_connector_in_state_b);
+    bsp = std::make_unique<IECStateMachine>(r_bsp, config.unlock_when_deauthorized);
 
     if (config.hack_simplified_mode_limit_10A) {
         bsp->set_ev_simplified_mode_evse_limit(true);
@@ -341,9 +341,9 @@ void EvseManager::ready() {
         },
         std::chrono::milliseconds(config.internal_over_voltage_duration_ms));
 
-    if (not config.lock_connector_in_state_b) {
-        EVLOG_warning << "Unlock connector in CP state B. This violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and "
-                         "should not be used in public environments!";
+    if (config.unlock_when_deauthorized) {
+        EVLOG_warning << "The config `unlock_when_deauthorized` is set to true. This violates "
+                         "IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!";
     }
 
     const auto hw_caps = *hw_capabilities.handle();
@@ -1529,7 +1529,8 @@ void EvseManager::ready_to_start_charging() {
     charger->enable_disable_initial_state_publish();
 
     this->p_evse->publish_ready(true);
-    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
+    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
+                              "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
     if (!initial_powermeter_value_received) {
         EVLOG_warning << "No powermeter value received yet!";
     }

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1529,8 +1529,7 @@ void EvseManager::ready_to_start_charging() {
     charger->enable_disable_initial_state_publish();
 
     this->p_evse->publish_ready(true);
-    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green),
-                              "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
+    EVLOG_info << fmt::format(fmt::emphasis::bold | fg(fmt::terminal_color::green), "🌀🌀🌀 Ready to start charging 🌀🌀🌀");
     if (!initial_powermeter_value_received) {
         EVLOG_warning << "No powermeter value received yet!";
     }

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -317,7 +317,7 @@ void EvseManager::init() {
 }
 
 void EvseManager::ready() {
-    bsp = std::make_unique<IECStateMachine>(r_bsp, config.lock_connector_in_state_b);
+    bsp = std::make_unique<IECStateMachine>(r_bsp, config.lock_connector_in_state_b, config.unlock_when_deauthorized);
 
     if (config.hack_simplified_mode_limit_10A) {
         bsp->set_ev_simplified_mode_evse_limit(true);
@@ -343,7 +343,12 @@ void EvseManager::ready() {
 
     if (not config.lock_connector_in_state_b) {
         EVLOG_warning << "Unlock connector in CP state B. This violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and "
-                         "should not be used in public environments!";
+                         "should not be used in public environments! This feature is deprecated.";
+    }
+
+    if (config.unlock_when_deauthorized) {
+        EVLOG_warning << "The config `unlock_when_deauthorized` is set to true. This violates "
+                         "IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!";
     }
 
     const auto hw_caps = *hw_capabilities.handle();

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -106,7 +106,7 @@ struct Conf {
     int switch_3ph1ph_delay_s;
     std::string switch_3ph1ph_cp_state;
     int soft_over_current_timeout_ms;
-    bool lock_connector_in_state_b;
+    bool unlock_when_deauthorized;
     int state_F_after_fault_ms;
     bool fail_on_powermeter_errors;
     bool raise_mrec9;

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -107,6 +107,7 @@ struct Conf {
     std::string switch_3ph1ph_cp_state;
     int soft_over_current_timeout_ms;
     bool lock_connector_in_state_b;
+    bool unlock_when_deauthorized;
     int state_F_after_fault_ms;
     bool fail_on_powermeter_errors;
     bool raise_mrec9;

--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -71,9 +71,8 @@ const std::string cpevent_to_string(CPEvent e) {
     throw std::out_of_range("No known string conversion for provided enum of type CPEvent");
 }
 
-IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_,
-                                 bool lock_connector_in_state_b_) :
-    r_bsp(r_bsp_), lock_connector_in_state_b(lock_connector_in_state_b_) {
+IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_, bool use_authorized_) :
+    r_bsp(r_bsp_), use_authorized(use_authorized_), authorized(!use_authorized_) {
     // feed the state machine whenever the timer expires
     timeout_state_c1.signal_reached.connect([this]() { feed_state_machine(std::nullopt); });
     timeout_unlock_state_F.signal_reached.connect([this]() { feed_state_machine(std::nullopt); });
@@ -181,11 +180,7 @@ std::queue<CPEvent> IECStateMachine::state_machine(std::optional<RawCPState> cp_
             // Table A.6: Sequence 7 EV stops charging
             // Table A.6: Sequence 8.2 EV supply equipment
             // responds to EV opens S2 (w/o PWM)
-            if (lock_connector_in_state_b) {
-                connector_lock();
-            } else {
-                connector_unlock();
-            }
+            connector_lock();
 
             if (last_cp_state != RawCPState::A && last_cp_state != RawCPState::B) {
 
@@ -509,7 +504,8 @@ void IECStateMachine::connector_force_unlock() {
 }
 
 void IECStateMachine::check_connector_lock() {
-    bool should_be_locked_considering_relais_and_force = relais_on or (should_be_locked and not force_unlocked);
+    bool should_be_locked_considering_relais_and_force =
+        relais_on or (should_be_locked and not force_unlocked and authorized);
 
     if (not is_locked and should_be_locked_considering_relais_and_force) {
         signal_lock();
@@ -518,6 +514,15 @@ void IECStateMachine::check_connector_lock() {
         signal_unlock();
         is_locked = false;
     }
+}
+
+void IECStateMachine::set_authorized(bool a) {
+    EVLOG_debug << "set_authorized - " << a;
+    if (!use_authorized) {
+        return;
+    }
+    authorized = a;
+    feed_state_machine(std::nullopt);
 }
 
 } // namespace module

--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -71,9 +71,12 @@ const std::string cpevent_to_string(CPEvent e) {
     throw std::out_of_range("No known string conversion for provided enum of type CPEvent");
 }
 
-IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_,
-                                 bool lock_connector_in_state_b_) :
-    r_bsp(r_bsp_), lock_connector_in_state_b(lock_connector_in_state_b_) {
+IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_, bool lock_connector_in_state_b_,
+                                 bool use_authorized_) :
+    r_bsp(r_bsp_),
+    lock_connector_in_state_b(lock_connector_in_state_b_),
+    use_authorized(use_authorized_),
+    authorized(!use_authorized_) {
     // feed the state machine whenever the timer expires
     timeout_state_c1.signal_reached.connect([this]() { feed_state_machine(std::nullopt); });
     timeout_unlock_state_F.signal_reached.connect([this]() { feed_state_machine(std::nullopt); });
@@ -509,7 +512,8 @@ void IECStateMachine::connector_force_unlock() {
 }
 
 void IECStateMachine::check_connector_lock() {
-    bool should_be_locked_considering_relais_and_force = relais_on or (should_be_locked and not force_unlocked);
+    bool should_be_locked_considering_relais_and_force =
+        relais_on or (should_be_locked and not force_unlocked and authorized);
 
     if (not is_locked and should_be_locked_considering_relais_and_force) {
         signal_lock();
@@ -518,6 +522,15 @@ void IECStateMachine::check_connector_lock() {
         signal_unlock();
         is_locked = false;
     }
+}
+
+void IECStateMachine::set_authorized(bool a) {
+    EVLOG_debug << "set_authorized - " << a;
+    if (!use_authorized) {
+        return;
+    }
+    authorized = a;
+    feed_state_machine(std::nullopt);
 }
 
 } // namespace module

--- a/modules/EVSE/EvseManager/IECStateMachine.hpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.hpp
@@ -74,7 +74,7 @@ enum class AcPhases {
 class IECStateMachine {
 public:
     // We need the r_bsp reference to be able to talk to the bsp driver module
-    IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_, bool lock_connector_in_state_b_);
+    IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_, bool use_authorized_);
     // Call when new events from BSP requirement come in. Will signal internal events
     void process_bsp_event(const types::board_support_common::BspEvent bsp_event);
     // Allow power on from Charger state machine
@@ -99,6 +99,8 @@ public:
 
     void connector_force_unlock();
 
+    void set_authorized(bool a);
+
     void set_ev_simplified_mode_evse_limit(bool l) {
         ev_simplified_mode_evse_limit = l;
     }
@@ -113,7 +115,6 @@ private:
     void connector_unlock();
     void check_connector_lock();
     const std::unique_ptr<evse_board_supportIntf>& r_bsp;
-    bool lock_connector_in_state_b{true};
 
     bool pwm_running{false};
     bool last_pwm_running{false};
@@ -141,6 +142,10 @@ private:
 
     types::evse_board_support::Reason power_on_reason{types::evse_board_support::Reason::PowerOff};
     void call_allow_power_on_bsp(bool value);
+
+    // If to pay attention to the authorized flag.
+    bool use_authorized{false};
+    std::atomic_bool authorized{false};
 
     std::atomic_bool is_locked{false};
     std::atomic_bool should_be_locked{false};

--- a/modules/EVSE/EvseManager/IECStateMachine.hpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.hpp
@@ -74,7 +74,8 @@ enum class AcPhases {
 class IECStateMachine {
 public:
     // We need the r_bsp reference to be able to talk to the bsp driver module
-    IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_, bool lock_connector_in_state_b_);
+    IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_, bool lock_connector_in_state_b_,
+                    bool use_authorized_);
     // Call when new events from BSP requirement come in. Will signal internal events
     void process_bsp_event(const types::board_support_common::BspEvent bsp_event);
     // Allow power on from Charger state machine
@@ -98,6 +99,8 @@ public:
     void enable(bool en);
 
     void connector_force_unlock();
+
+    void set_authorized(bool a);
 
     void set_ev_simplified_mode_evse_limit(bool l) {
         ev_simplified_mode_evse_limit = l;
@@ -141,6 +144,10 @@ private:
 
     types::evse_board_support::Reason power_on_reason{types::evse_board_support::Reason::PowerOff};
     void call_allow_power_on_bsp(bool value);
+
+    // If to pay attention to the authorized flag.
+    bool use_authorized{false};
+    std::atomic_bool authorized{false};
 
     std::atomic_bool is_locked{false};
     std::atomic_bool should_be_locked{false};

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -293,12 +293,13 @@ config:
     type: integer
     minimum: 6000
     default: 7000
-  lock_connector_in_state_b:
+  unlock_when_deauthorized:
     description: >-
-      Indicates if the connector lock should be locked in state B. If set to false, connector will remain unlocked in CP state B
-      and this violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!
+      Indicates if the connector lock should be locked in state B/C regardless of if a user authorized. If set to true,
+      connector will remain unlocked in CP state B/C if the relays are open and no user is authorized. This violates
+      violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!
     type: boolean
-    default: true
+    default: false
   state_F_after_fault_ms:
     description: >-
       Set state F after any fault that stops charging for the specified time in ms while in Charging mode (CX->F(300ms)->C1/B1).

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -297,8 +297,16 @@ config:
     description: >-
       Indicates if the connector lock should be locked in state B. If set to false, connector will remain unlocked in CP state B
       and this violates IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!
+      This feature is deprecated.
     type: boolean
     default: true
+  unlock_when_deauthorized:
+    description: >-
+      Indicates if the connector lock should be locked in state B/C regardless of if a user authorized. If set to true,
+      connector will remain unlocked in CP state B/C if the relays are open and no user is authorized. This violates
+      IEC61851-1:2019 D.6.5 Table D.9 line 4 and should not be used in public environments!
+    type: boolean
+    default: false
   state_F_after_fault_ms:
     description: >-
       Set state F after any fault that stops charging for the specified time in ms while in Charging mode (CX->F(300ms)->C1/B1).

--- a/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
+++ b/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
@@ -61,6 +61,7 @@ enum class MutexDescription {
     IEC_set_cp_state_F,
     IEC_allow_power_on,
     IEC_force_unlock,
+    IEC_set_authorized,
     EVSE_charger_ready,
     EVSE_set_ev_info,
     EVSE_publish_ev_info,
@@ -181,6 +182,8 @@ static std::string to_string(MutexDescription d) {
         return "IECStateMachine::allow_power_on";
     case MutexDescription::IEC_force_unlock:
         return "IECStateMachine::force_unlock";
+    case MutexDescription::IEC_set_authorized:
+        return "IECStateMachine::set_authorized";
     case MutexDescription::EVSE_charger_ready:
         return "EvseManager.cpp: charger_ready";
     case MutexDescription::EVSE_set_ev_info:

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -729,6 +729,9 @@ void IECStateMachine::enable(bool en) {
 void IECStateMachine::connector_force_unlock() {
 }
 
+void IECStateMachine::set_authorized(bool a) {
+}
+
 const std::string cpevent_to_string(CPEvent e) {
     switch (e) {
     case CPEvent::CarPluggedIn:

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -696,8 +696,8 @@ namespace module {
 
 // ----------------------------------------------------------------------------
 // IECStateMachine stub
-IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_,
-                                 bool lock_connector_in_state_b_) :
+IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& r_bsp_, bool lock_connector_in_state_b_,
+                                 bool use_authorized_) :
     r_bsp(r_bsp_) {
 }
 void IECStateMachine::process_bsp_event(const types::board_support_common::BspEvent bsp_event) {
@@ -727,6 +727,9 @@ void IECStateMachine::enable(bool en) {
 }
 
 void IECStateMachine::connector_force_unlock() {
+}
+
+void IECStateMachine::set_authorized(bool a) {
 }
 
 const std::string cpevent_to_string(CPEvent e) {

--- a/modules/EVSE/EvseManager/tests/IECStateMachineTest.cpp
+++ b/modules/EVSE/EvseManager/tests/IECStateMachineTest.cpp
@@ -334,4 +334,174 @@ TEST(IECStateMachine, deadlock_fix) {
     // if there is a deadlock the test won't finish
 }
 
+// ---------------------------------------------------------------------------
+// Tests for auth-aware connector locking
+//
+// When use_authorized is true, the connector should only lock in State B/C
+// once the session is authorized. This prevents trapping cables before
+// authorization while still keeping them locked during BMS pauses.
+
+struct ConnectorLockTest : public testing::Test {
+    BspStub bsp;
+    std::unique_ptr<evse_board_supportIntf> bsp_if;
+    int lock_count{0};
+    int unlock_count{0};
+
+    void reset_counts() {
+        lock_count = 0;
+        unlock_count = 0;
+    }
+
+    std::unique_ptr<module::IECStateMachine> create_state_machine(bool use_authorized) {
+        bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
+        auto sm = std::make_unique<module::IECStateMachine>(bsp_if, use_authorized);
+        sm->signal_lock.connect([this]() { lock_count++; });
+        sm->signal_unlock.connect([this]() { unlock_count++; });
+        sm->enable(true);
+        return sm;
+    }
+
+    // Drive the state machine to State B via A→B (simulates plug-in)
+    void plug_in() {
+        bsp.raise_event(Event::A);
+        bsp.raise_event(Event::B);
+    }
+
+    void plug_out() {
+        bsp.raise_event(Event::A);
+    }
+};
+
+TEST_F(ConnectorLockTest, use_authorized_false_always_locks) {
+    // Default behavior: use_authorized=false locks immediately in B
+    auto sm = create_state_machine(false);
+
+    plug_in();
+
+    EXPECT_GT(lock_count, 0) << "connector should lock in State B when use_authorized is false";
+}
+
+TEST_F(ConnectorLockTest, use_authorized_true_no_auth_stays_unlocked) {
+    // With use_authorized=true and no authorization,
+    // State B should NOT lock the connector (cable free to unplug)
+    auto sm = create_state_machine(true);
+
+    plug_in();
+
+    EXPECT_EQ(lock_count, 0) << "connector should not lock without authorization";
+
+    // Re-enter B to re-trigger the state machine evaluation
+    bsp.raise_event(Event::B);
+
+    EXPECT_EQ(lock_count, 0) << "connector should not lock in State B without authorization";
+}
+
+TEST_F(ConnectorLockTest, set_authorized_in_state_b_locks) {
+    // Car plugs in → State B → no lock → authorize → lock engages
+    auto sm = create_state_machine(true);
+
+    plug_in();
+
+    EXPECT_EQ(lock_count, 0) << "connector should not lock without authorization";
+
+    sm->set_authorized(true);
+
+    EXPECT_GT(lock_count, 0) << "connector should lock when authorized in State B";
+}
+
+TEST_F(ConnectorLockTest, set_authorized_first) {
+    // Car plugs in → State B → no lock → authorize → lock engages
+    auto sm = create_state_machine(true);
+
+    sm->set_authorized(true);
+
+    EXPECT_EQ(lock_count, 0) << "connector should not lock without authorization";
+
+    plug_in();
+
+    EXPECT_GT(lock_count, 0) << "connector should lock when authorized in State B";
+}
+
+TEST_F(ConnectorLockTest, set_deauthorized_in_state_b_unlocks) {
+    // After authorization, deauthorizing in State B should unlock
+    auto sm = create_state_machine(true);
+
+    sm->set_authorized(true);
+    plug_in();
+    reset_counts();
+
+    sm->set_authorized(false);
+
+    EXPECT_GT(unlock_count, 0) << "connector should unlock when deauthorized in State B";
+}
+
+TEST_F(ConnectorLockTest, bms_pause_stays_locked) {
+    // Authorized session: C→B (BMS pause) should keep the connector locked
+    auto sm = create_state_machine(true);
+
+    plug_in();
+    sm->set_authorized(true);
+
+    // Transition to State C (car requests power)
+    bsp.raise_event(Event::C);
+    reset_counts();
+
+    // BMS pause: car goes back to B
+    bsp.raise_event(Event::B);
+
+    // Lock should re-engage (or stay engaged), no unlock should fire
+    EXPECT_EQ(unlock_count, 0) << "connector should not unlock during BMS pause (C->B) while authorized";
+    EXPECT_EQ(lock_count, 0) << "connector already locked";
+}
+
+TEST_F(ConnectorLockTest, set_authorized_outside_state_b_no_lock_change) {
+    // Setting authorized while in State A should not trigger lock/unlock
+    auto sm = create_state_machine(true);
+
+    bsp.raise_event(Event::A);
+    reset_counts();
+
+    sm->set_authorized(true);
+
+    EXPECT_EQ(lock_count, 0) << "set_authorized in State A should not trigger lock";
+    EXPECT_EQ(unlock_count, 0) << "set_authorized in State A should not trigger unlock";
+}
+
+TEST_F(ConnectorLockTest, use_authorized_false_ignores_auth_state) {
+    // With use_authorized=false, authorization state is irrelevant
+    auto sm = create_state_machine(false);
+
+    plug_in();
+    EXPECT_GT(lock_count, 0);
+    reset_counts();
+
+    // Deauthorize should not unlock when use_authorized is false
+    sm->set_authorized(false);
+
+    EXPECT_EQ(unlock_count, 0) << "use_authorized=false should keep lock regardless of auth state";
+
+    // Authorize should also be a no-op (and not double-fire signal_lock)
+    sm->set_authorized(true);
+
+    EXPECT_EQ(lock_count, 0) << "use_authorized=false: set_authorized(true) should not re-fire lock";
+    EXPECT_EQ(unlock_count, 0) << "use_authorized=false: set_authorized(true) should not unlock";
+
+    plug_out();
+    EXPECT_GT(unlock_count, 0);
+}
+
+TEST_F(ConnectorLockTest, force_unlock_overrides_authorized) {
+    // connector_force_unlock must release the connector even while authorized
+    auto sm = create_state_machine(true);
+
+    plug_in();
+    sm->set_authorized(true);
+    ASSERT_GT(lock_count, 0) << "precondition: connector locked when authorized in State B";
+    reset_counts();
+
+    sm->connector_force_unlock();
+
+    EXPECT_GT(unlock_count, 0) << "connector_force_unlock should unlock even when authorized";
+}
+
 } // namespace

--- a/modules/EVSE/EvseManager/tests/IECStateMachineTest.cpp
+++ b/modules/EVSE/EvseManager/tests/IECStateMachineTest.cpp
@@ -85,7 +85,7 @@ TEST(IECStateMachine, init) {
     module::stub::ModuleAdapterStub module_adapter = module::stub::ModuleAdapterStub();
     std::unique_ptr<evse_board_supportIntf> bsp_if =
         std::make_unique<module::stub::evse_board_supportIntfStub>(module_adapter);
-    module::IECStateMachine state_machine(std::move(bsp_if), true);
+    module::IECStateMachine state_machine(std::move(bsp_if), true, false);
 }
 
 #if 0
@@ -215,7 +215,7 @@ TEST(IECStateMachine, deadlock_test) {
 
     BspStubDeadlock bsp;
     std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
-    module::IECStateMachine state_machine(std::move(bsp_if), true);
+    module::IECStateMachine state_machine(std::move(bsp_if), true, false);
 
     std::uint8_t signal_lock_count = 0;
 
@@ -281,7 +281,7 @@ TEST(IECStateMachine, deadlock_fix) {
 
     BspStubDeadlock bsp;
     std::unique_ptr<evse_board_supportIntf> bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
-    module::IECStateMachine state_machine(std::move(bsp_if), true);
+    module::IECStateMachine state_machine(std::move(bsp_if), true, false);
 
     std::uint8_t signal_lock_count = 0;
 
@@ -332,6 +332,176 @@ TEST(IECStateMachine, deadlock_fix) {
 
     std::this_thread::sleep_for(10s);
     // if there is a deadlock the test won't finish
+}
+
+// ---------------------------------------------------------------------------
+// Tests for auth-aware connector locking
+//
+// When use_authorized is true, the connector should only lock in State B/C
+// once the session is authorized. This prevents trapping cables before
+// authorization while still keeping them locked during BMS pauses.
+
+struct ConnectorLockTest : public testing::Test {
+    BspStub bsp;
+    std::unique_ptr<evse_board_supportIntf> bsp_if;
+    int lock_count{0};
+    int unlock_count{0};
+
+    void reset_counts() {
+        lock_count = 0;
+        unlock_count = 0;
+    }
+
+    std::unique_ptr<module::IECStateMachine> create_state_machine(bool use_authorized) {
+        bsp_if = std::make_unique<module::stub::evse_board_supportIntfStub>(bsp);
+        auto sm = std::make_unique<module::IECStateMachine>(bsp_if, true, use_authorized);
+        sm->signal_lock.connect([this]() { lock_count++; });
+        sm->signal_unlock.connect([this]() { unlock_count++; });
+        sm->enable(true);
+        return sm;
+    }
+
+    // Drive the state machine to State B via A→B (simulates plug-in)
+    void plug_in() {
+        bsp.raise_event(Event::A);
+        bsp.raise_event(Event::B);
+    }
+
+    void plug_out() {
+        bsp.raise_event(Event::A);
+    }
+};
+
+TEST_F(ConnectorLockTest, use_authorized_false_always_locks) {
+    // Default behavior: use_authorized=false locks immediately in B
+    auto sm = create_state_machine(false);
+
+    plug_in();
+
+    EXPECT_GT(lock_count, 0) << "connector should lock in State B when use_authorized is false";
+}
+
+TEST_F(ConnectorLockTest, use_authorized_true_no_auth_stays_unlocked) {
+    // With use_authorized=true and no authorization,
+    // State B should NOT lock the connector (cable free to unplug)
+    auto sm = create_state_machine(true);
+
+    plug_in();
+
+    EXPECT_EQ(lock_count, 0) << "connector should not lock without authorization";
+
+    // Re-enter B to re-trigger the state machine evaluation
+    bsp.raise_event(Event::B);
+
+    EXPECT_EQ(lock_count, 0) << "connector should not lock in State B without authorization";
+}
+
+TEST_F(ConnectorLockTest, set_authorized_in_state_b_locks) {
+    // Car plugs in → State B → no lock → authorize → lock engages
+    auto sm = create_state_machine(true);
+
+    plug_in();
+
+    EXPECT_EQ(lock_count, 0) << "connector should not lock without authorization";
+
+    sm->set_authorized(true);
+
+    EXPECT_GT(lock_count, 0) << "connector should lock when authorized in State B";
+}
+
+TEST_F(ConnectorLockTest, set_authorized_first) {
+    // Car plugs in → State B → no lock → authorize → lock engages
+    auto sm = create_state_machine(true);
+
+    sm->set_authorized(true);
+
+    EXPECT_EQ(lock_count, 0) << "connector should not lock without authorization";
+
+    plug_in();
+
+    EXPECT_GT(lock_count, 0) << "connector should lock when authorized in State B";
+}
+
+TEST_F(ConnectorLockTest, set_deauthorized_in_state_b_unlocks) {
+    // After authorization, deauthorizing in State B should unlock
+    auto sm = create_state_machine(true);
+
+    sm->set_authorized(true);
+    plug_in();
+    reset_counts();
+
+    sm->set_authorized(false);
+
+    EXPECT_GT(unlock_count, 0) << "connector should unlock when deauthorized in State B";
+}
+
+TEST_F(ConnectorLockTest, bms_pause_stays_locked) {
+    // Authorized session: C→B (BMS pause) should keep the connector locked
+    auto sm = create_state_machine(true);
+
+    plug_in();
+    sm->set_authorized(true);
+
+    // Transition to State C (car requests power)
+    bsp.raise_event(Event::C);
+    reset_counts();
+
+    // BMS pause: car goes back to B
+    bsp.raise_event(Event::B);
+
+    // Lock should re-engage (or stay engaged), no unlock should fire
+    EXPECT_EQ(unlock_count, 0) << "connector should not unlock during BMS pause (C->B) while authorized";
+    EXPECT_EQ(lock_count, 0) << "connector already locked";
+}
+
+TEST_F(ConnectorLockTest, set_authorized_outside_state_b_no_lock_change) {
+    // Setting authorized while in State A should not trigger lock/unlock
+    auto sm = create_state_machine(true);
+
+    bsp.raise_event(Event::A);
+    reset_counts();
+
+    sm->set_authorized(true);
+
+    EXPECT_EQ(lock_count, 0) << "set_authorized in State A should not trigger lock";
+    EXPECT_EQ(unlock_count, 0) << "set_authorized in State A should not trigger unlock";
+}
+
+TEST_F(ConnectorLockTest, use_authorized_false_ignores_auth_state) {
+    // With use_authorized=false, authorization state is irrelevant
+    auto sm = create_state_machine(false);
+
+    plug_in();
+    EXPECT_GT(lock_count, 0);
+    reset_counts();
+
+    // Deauthorize should not unlock when use_authorized is false
+    sm->set_authorized(false);
+
+    EXPECT_EQ(unlock_count, 0) << "use_authorized=false should keep lock regardless of auth state";
+
+    // Authorize should also be a no-op (and not double-fire signal_lock)
+    sm->set_authorized(true);
+
+    EXPECT_EQ(lock_count, 0) << "use_authorized=false: set_authorized(true) should not re-fire lock";
+    EXPECT_EQ(unlock_count, 0) << "use_authorized=false: set_authorized(true) should not unlock";
+
+    plug_out();
+    EXPECT_GT(unlock_count, 0);
+}
+
+TEST_F(ConnectorLockTest, force_unlock_overrides_authorized) {
+    // connector_force_unlock must release the connector even while authorized
+    auto sm = create_state_machine(true);
+
+    plug_in();
+    sm->set_authorized(true);
+    ASSERT_GT(lock_count, 0) << "precondition: connector locked when authorized in State B";
+    reset_counts();
+
+    sm->connector_force_unlock();
+
+    EXPECT_GT(unlock_count, 0) << "connector_force_unlock should unlock even when authorized";
 }
 
 } // namespace


### PR DESCRIPTION
## Describe your changes

We want to avoid locking the lock if the user is not authorized. This feature is gated behind the `unlock_when_deauthorized` config flag and is disabled by default. It also removes the `lock_connector_in_state_b` config which aimed to achieve similar but without much impact. 

The change adds transparently a new type `SignalingBool` which extends the `atomic_bool` and replaces the `flag_authorized` so we can signal it to our IEC state machine. In there we add the `authorized` flag so we can react on the authoziation

