### PR TITLE
Fix(EvseV2G): Make use of nominal power/current in ChargeParameterDiscoveryRes

### DIFF
--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -158,6 +158,7 @@ void ISO15118_chargerImpl::handle_set_charging_parameters(types::iso15118::Setup
     if (physical_values.ac_nominal_voltage.has_value()) {
         populate_physical_value_float(&v2g_ctx->evse_v2g_data.evse_nominal_voltage,
                                       physical_values.ac_nominal_voltage.value(), 1, iso2_unitSymbolType_V);
+        v2g_ctx->basic_config.evse_ac_nominal_voltage = physical_values.ac_nominal_voltage.value();
     }
 
     if (physical_values.dc_current_regulation_tolerance.has_value()) {
@@ -435,10 +436,11 @@ void ISO15118_chargerImpl::handle_update_ac_parameters(types::iso15118::AcParame
 }
 
 void ISO15118_chargerImpl::handle_update_ac_maximum_limits(types::iso15118::AcEvseMaximumPower& maximum_limits) {
-    static bool warning_shown = false;
-    if (not warning_shown) {
-        EVLOG_warning << "Ignoring handle_update_ac_maximum_limits call";
-        warning_shown = true;
+    if (v2g_ctx->basic_config.evse_ac_nominal_voltage > 0.0f) {
+        v2g_ctx->basic_config.evse_ac_nominal_current =
+            maximum_limits.charge_power.total / v2g_ctx->basic_config.evse_ac_nominal_voltage;
+    } else {
+        EVLOG_error << "Cannot compute nominal current: nominal voltage is 0";
     }
 }
 

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -1244,7 +1244,7 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
     if (conn->ctx->is_dc_charger == false) {
         /* Determin max current and nominal voltage */
         /* Setup default params (before the departure time overrides) */
-        float max_current = conn->ctx->basic_config.evse_ac_current_limit;
+        float max_current = conn->ctx->basic_config.evse_ac_nominal_current;
         int64_t voltage = conn->ctx->evse_v2g_data.evse_nominal_voltage.Value *
                           pow(10, conn->ctx->evse_v2g_data.evse_nominal_voltage.Multiplier); /* nominal voltage */
         pmax = max_current * voltage *
@@ -1330,7 +1330,7 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
         populate_ac_evse_status(conn->ctx, &res->AC_EVSEChargeParameter.AC_EVSEStatus);
 
         /* Max current */
-        float max_current = conn->ctx->basic_config.evse_ac_current_limit;
+        float max_current = conn->ctx->basic_config.evse_ac_nominal_current;
         populate_physical_value_float(&res->AC_EVSEChargeParameter.EVSEMaxCurrent, max_current, 1,
                                       iso2_unitSymbolType_A);
 

--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -230,8 +230,10 @@ struct v2g_context {
     pthread_condattr_t mqtt_attr;
 
     struct {
-        float evse_ac_current_limit; // default is 0
-    } basic_config;                  // This config will not reseted after beginning of a new charging session
+        float evse_ac_current_limit;   // default is 0
+        float evse_ac_nominal_current; // default is 0
+        float evse_ac_nominal_voltage; // default is 230
+    } basic_config;                    // This config will not reseted after beginning of a new charging session
 
     /* actual charging state */
     enum V2gMsgTypeId last_v2g_msg;    /* holds the current v2g msg type */

--- a/modules/EVSE/EvseV2G/v2g_ctx.cpp
+++ b/modules/EVSE/EvseV2G/v2g_ctx.cpp
@@ -294,6 +294,8 @@ struct v2g_context* v2g_ctx_create(ISO15118_chargerImplBase* p_chargerImplBase,
 
     /* This evse parameter will be initialized once */
     ctx->basic_config.evse_ac_current_limit = 0.0f;
+    ctx->basic_config.evse_ac_nominal_current = 0.0f;
+    ctx->basic_config.evse_ac_nominal_voltage = 230.0f;
 
     ctx->local_tcp_addr = NULL;
     ctx->local_tls_addr = NULL;


### PR DESCRIPTION
## Describe your changes

fix(EvseV2G): Compute AC nominal current from max power and nominal voltage. Use this value as part of the ChargeParameterDiscoveryResponse instead of the current that is currently available.

Before this change, EVSEMaxCurrent in a ChargeParameterRes was derived from the current that is currently available (applying EnergyManagement or BSP capability limits that could change at runtime). If no power is available, EVSEMaxCurrent was zero. The behavior is now in line with the handling for DC.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

