### PR TITLE
feat(PacketSniffer): enhance session logging path with timestamp and session ID, if config path is used

### DIFF
--- a/modules/Misc/PacketSniffer/PacketSniffer.cpp
+++ b/modules/Misc/PacketSniffer/PacketSniffer.cpp
@@ -71,10 +71,8 @@ void PacketSniffer::ready() {
 void PacketSniffer::capture(const std::string& logpath, const std::string& session_id) {
     already_started = true;
 
-    std::string fn;
-    if (config.session_logging_path.empty()) {
-        fn = fmt::format("{}/ethernet-traffic.pcap", logpath);
-    } else {
+    std::string fn = fmt::format("{}/ethernet-traffic.pcap", logpath);
+    if (not config.session_logging_path.empty()) {
         const auto now = std::chrono::system_clock::now();
         const auto time_t_now = std::chrono::system_clock::to_time_t(now);
         std::tm local_tm{};

--- a/modules/Misc/PacketSniffer/PacketSniffer.cpp
+++ b/modules/Misc/PacketSniffer/PacketSniffer.cpp
@@ -4,6 +4,8 @@
 
 #include <fmt/core.h>
 
+#include <fmt/chrono.h>
+
 namespace module {
 
 const bool PROMISC_MODE = true;
@@ -68,7 +70,18 @@ void PacketSniffer::ready() {
 
 void PacketSniffer::capture(const std::string& logpath, const std::string& session_id) {
     already_started = true;
-    const std::string fn = fmt::format("{}/ethernet-traffic.pcap", logpath);
+
+    std::string fn;
+    if (config.session_logging_path.empty()) {
+        fn = fmt::format("{}/ethernet-traffic.pcap", logpath);
+    } else {
+        const auto now = std::chrono::system_clock::now();
+        const auto time_t_now = std::chrono::system_clock::to_time_t(now);
+        std::tm local_tm{};
+        localtime_r(&time_t_now, &local_tm);
+        const auto timestamp = fmt::format("{:%Y-%m-%d_%H-%M-%S%z}", local_tm);
+        fn = fmt::format("{}/{}_{}.pcap", logpath, timestamp, session_id);
+    }
 
     EVLOG_info << fmt::format("Starting capturing to {}", fn);
 


### PR DESCRIPTION
## Describe your changes

This PR implements timestamp generation for pcap filenames in the PacketSniffer module. The code will be active if session_logging_path is set:

Example pcap filename: `2026-02-26_06-14-35+0100_7c2a986a-3d37-4cca-b1ca-c7ea48af10b0.pcap`

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements