### PR TITLE
EvseManager: fix race condition with the last_cp_state

### DIFF
--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -83,8 +83,8 @@ IECStateMachine::IECStateMachine(const std::unique_ptr<evse_board_supportIntf>& 
                                  bool lock_connector_in_state_b_) :
     r_bsp(r_bsp_), lock_connector_in_state_b(lock_connector_in_state_b_) {
     // feed the state machine whenever the timer expires
-    timeout_state_c1.signal_reached.connect([this]() { feed_state_machine(last_cp_state); });
-    timeout_unlock_state_F.signal_reached.connect([this]() { feed_state_machine(last_cp_state); });
+    timeout_state_c1.signal_reached.connect([this]() { feed_state_machine(std::nullopt); });
+    timeout_unlock_state_F.signal_reached.connect([this]() { feed_state_machine(std::nullopt); });
 
     // Subscribe to bsp driver to receive BspEvents from the hardware
     r_bsp->subscribe_event([this](const types::board_support_common::BspEvent event) {
@@ -118,11 +118,12 @@ void IECStateMachine::process_bsp_event(const types::board_support_common::BspEv
                event);
 }
 
-void IECStateMachine::feed_state_machine(RawCPState cp_state) {
-    auto events = state_machine(cp_state);
+void IECStateMachine::feed_state_machine(std::optional<RawCPState> cp_state_opt) {
+    auto events = state_machine(cp_state_opt);
 
     // Process all events
     while (not events.empty()) {
+        EVLOG_debug << "CPEvent " << static_cast<int>(events.front());
         signal_event(events.front());
         events.pop();
     }
@@ -132,8 +133,13 @@ void IECStateMachine::feed_state_machine(RawCPState cp_state) {
 // - CP state changes (both events from hardware as well as duty cycle changes)
 // - Allow power on changes
 // - The C1 6s timer expires
-std::queue<CPEvent> IECStateMachine::state_machine(RawCPState cp_state) {
+std::queue<CPEvent> IECStateMachine::state_machine(std::optional<RawCPState> cp_state_opt) {
 
+    if (cp_state_opt) {
+        EVLOG_debug << "RawCPState " << static_cast<int>(cp_state_opt.value());
+    } else {
+        EVLOG_debug << "RawCPState not set";
+    }
     std::queue<CPEvent> events;
     auto timer_state_C1 = TimerControl::do_nothing;
     auto timer_unlock_state_F = TimerControl::do_nothing;
@@ -141,6 +147,8 @@ std::queue<CPEvent> IECStateMachine::state_machine(RawCPState cp_state) {
     {
         // mutex protected section
         Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::IEC_state_machine);
+
+        const auto cp_state = cp_state_opt.value_or(last_cp_state);
 
         if (cp_state not_eq RawCPState::F and last_cp_state == RawCPState::F) {
             timer_unlock_state_F = TimerControl::stop;
@@ -369,7 +377,7 @@ void IECStateMachine::set_pwm(double value) {
 
     r_bsp->call_pwm_on(value * 100);
 
-    feed_state_machine(last_cp_state);
+    feed_state_machine(std::nullopt);
 }
 
 // High level state machine sets state X1
@@ -380,7 +388,7 @@ void IECStateMachine::set_cp_state_X1() {
     }
     r_bsp->call_cp_state_X1();
     // Don't run the state machine in the callers context
-    feed_state_machine(last_cp_state);
+    feed_state_machine(std::nullopt);
 }
 
 // High level state machine sets state F
@@ -391,7 +399,7 @@ void IECStateMachine::set_cp_state_F() {
     }
     r_bsp->call_cp_state_F();
     // Don't run the state machine in the callers context
-    feed_state_machine(last_cp_state);
+    feed_state_machine(std::nullopt);
 }
 
 // The higher level state machine in Charger.cpp calls this to indicate it allows contactors to be switched on
@@ -408,7 +416,7 @@ void IECStateMachine::allow_power_on(bool value, types::evse_board_support::Reas
     }
     // The actual power on will be handled in the state machine to verify it is in the correct CP state etc.
     // Don't run the state machine in the callers context
-    feed_state_machine(last_cp_state);
+    feed_state_machine(std::nullopt);
 }
 
 // Private member function used to actually call the BSP driver's allow_power_on

--- a/modules/EVSE/EvseManager/IECStateMachine.hpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.hpp
@@ -24,6 +24,7 @@
 
 #include <chrono>
 #include <mutex>
+#include <optional>
 #include <queue>
 
 #include <generated/interfaces/evse_board_support/Interface.hpp>
@@ -131,8 +132,8 @@ private:
     AsyncTimeout timeout_unlock_state_F;
 
     Everest::timed_mutex_traceable state_machine_mutex;
-    void feed_state_machine(RawCPState cp_state);
-    std::queue<CPEvent> state_machine(RawCPState cp_state);
+    void feed_state_machine(std::optional<RawCPState> cp_state_opt);
+    std::queue<CPEvent> state_machine(std::optional<RawCPState> cp_state_opt);
 
     types::evse_board_support::Reason power_on_reason{types::evse_board_support::Reason::PowerOff};
     void call_allow_power_on_bsp(bool value);


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

The bug is that we would read the last_cp_state outside of the mutex and it would potentially overwrite valid last_cp_state inside the mutex with stale values. The solution is to never read the last_cp_state outside and only read it in the state_machine - under mutex protection

below are some logs showcasing the issue 
```
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.917911 [DEBG] software_relay  void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/software_relay/impl/connector_1/cmd/cp_state_X1 with data: {"data":{"args":null,"id":"20566958-06b8-442f-ac3f-c1e64ff91206","origin":"connector_1"},"msg_type":"Cmd"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.917967 [DEBG] software_relay  void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/auth/impl/main/var/token_validation_status with data: {"data":{"data":{"status":"UsedToStop","token":{"authorization_type":"RFID","connectors":[1],"id_token":{"type":"Local","value":"DEADBEEF"}}}},"msg_type":"Var"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.919152 [INFO] software_relay   rust/everest/RsSoftwareRelay/src/main.rs:136: [1] [FAKE] Publishing cp state: A while real is: C, because Session(TransactionFinished)

// here cp-state a arrives
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.919664 [DEBG] connector_1:Evs void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/software_relay/impl/connector_1/var/event with data: {"data":{"data":{"event":"A"}},"msg_type":"Var"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.919917 [DEBG] connector_1:Evs std::queue<module::CPEvent> module::IECStateMachine::state_machine(module::RawCPState) :: RawCPState 1
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.920273 [DEBG] qevhs           void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/qevhs/impl/connector_1/cmd/cp_state_X1 with data: {"data":{"args":{},"id":"eefc649b-d12e-4411-92a1-46664651be35","origin":"software_relay"},"msg_type":"Cmd"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.920718 [INFO] qevhs            rust/everest/RsQevhs/src/bin/RsQevhs/car_simulator.rs:507: cp_state_X1 for connector_1
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.930973 [DEBG] connector_2:Evs void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/qevhs/impl/powermeter_2/var/powermeter with data: {"data":{"data":{"current_A":{"L1":32.0,"L2":32.0,"L3":32.0},"energy_Wh_import":{"total":1242.1333333333334},"power_W":{"L1":7360.0,"L2":7360.0,"L3":7360.0,"total":22080.0},"timestamp":"2026-02-26T12:51:44.930263675+00:00","voltage_V":{"L1":230.0,"L2":230.0,"L3":230.0}}},"msg_type":"Var"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.932394 [DEBG] display_logic   void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/connector_2/impl/evse/var/powermeter with data: {"data":{"data":{"current_A":{"L1":32.0,"L2":32.0,"L3":32.0},"energy_Wh_import":{"total":1242.13330078125},"power_W":{"L1":7360.0,"L2":7360.0,"L3":7360.0,"total":22080.0},"timestamp":"2026-02-26T12:51:44.930263675+00:00","voltage_V":{"L1":230.0,"L2":230.0,"L3":230.0}}},"msg_type":"Var"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.960577 [DEBG] software_relay  void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/software_relay/impl/connector_1/cmd/cp_state_X1 with data: {"data":{"args":null,"id":"8017a3c0-c269-4fb9-8b52-4e5eb104e8a2","origin":"connector_1"},"msg_type":"Cmd"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.960813 [DEBG] software_relay  void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/qevhs/impl/connector_1/cmd/cp_state_X1/response/software_relay with data: {"data":{"data":{"id":"eefc649b-d12e-4411-92a1-46664651be35","origin":"qevhs","retval":null},"type":"result"},"msg_type":"CmdResult"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.961739 [INFO] software_relay   rust/everest/RsSoftwareRelay/src/main.rs:523: Got Token validation status: TokenValidationStatusMessage { messages: None, status: UsedToStop, token: ProvidedIdToken { authorization_type: RFID, certificate: None, connectors: Some([1]), id_token: IdToken { additional_info: None, type: Local, value: "DEADBEEF" }, iso_15118_certificate_hash_data: None, parent_id_token: None, prevalidated: None, request_id: None } }
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.961780 [INFO] software_relay   rust/everest/RsSoftwareRelay/src/main.rs:538: Current token for 1: None
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.961805 [INFO] software_relay   rust/everest/RsSoftwareRelay/src/main.rs:579: No conditions were met for connector [1] with incoming_token: TokenAndType { id_token: IdToken { additional_info: None, type: Local, value: "DEADBEEF" }, auth_type: RFID } and ValidationStatus UsedToStop
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.962575 [DEBG] connector_1:Evs void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/qevhs/impl/powermeter_1/var/powermeter with data: {"data":{"data":{"current_A":{"L1":0.0,"L2":0.0,"L3":0.0},"energy_Wh_import":{"total":1236.0},"power_W":{"L1":0.0,"L2":0.0,"L3":0.0,"total":0.0},"timestamp":"2026-02-26T12:51:44.929735562+00:00","voltage_V":{"L1":230.0,"L2":230.0,"L3":230.0}}},"msg_type":"Var"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.962837 [DEBG] connector_1:Evs void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/software_relay/impl/connector_1/cmd/cp_state_X1/response/connector_1 with data: {"data":{"data":{"id":"20566958-06b8-442f-ac3f-c1e64ff91206","origin":"software_relay","retval":null},"type":"result"},"msg_type":"CmdResult"}

// this is the rawcpstate which was stored in the last_cp_state but and will overwrite the correct one
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.963185 [DEBG] connector_1:Evs std::queue<module::CPEvent> module::IECStateMachine::state_machine(module::RawCPState) :: RawCPState 3
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.972680 [DEBG] qevhs           void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/qevhs/impl/connector_1/cmd/cp_state_X1 with data: {"data":{"args":{},"id":"b9f47f0a-3f1c-42b5-8a63-6d97d82ab776","origin":"software_relay"},"msg_type":"Cmd"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.973177 [INFO] qevhs            rust/everest/RsQevhs/src/bin/RsQevhs/car_simulator.rs:507: cp_state_X1 for connector_1
DEBUG    root:everest_core.py:209   2026-02-26 12:51:44.976556 [INFO] connector_2:Evs  :: EVSE IEC Soft overcurrent event (L1:32, L2:32, L3:32, limit 7.15), starting timer.
DEBUG    root:everest_core.py:209   2026-02-26 12:51:45.003126 [DEBG] software_relay  void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/qevhs/impl/connector_1/cmd/cp_state_X1/response/software_relay with data: {"data":{"data":{"id":"b9f47f0a-3f1c-42b5-8a63-6d97d82ab776","origin":"qevhs","retval":null},"type":"result"},"msg_type":"CmdResult"}
DEBUG    root:everest_core.py:209   2026-02-26 12:51:45.004326 [DEBG] connector_1:Evs void Everest::MessageHandler::add(const Everest::ParsedMessage&) :: Adding message to queue: everest_1e5fccc9b3094f6e9bbb4be2c3dc193c/modules/software_relay/impl/connector_1/cmd/cp_state_X1/response/connector_1 with data: {"data":{"data":{"id":"8017a3c0-c269-4fb9-8b52-4e5eb104e8a2","origin":"software_relay","retval":null},"type":"result"},"msg_type":"CmdResult"}
```