### PR TITLE
fix(EvseManager): Clear evse_manager/MREC5OverVoltage error on unplug

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -2182,6 +2182,7 @@ void Charger::clear_errors_on_unplug() {
     error_handling->clear_isolation_resistance_fault("Resistance");
     error_handling->clear_isolation_resistance_fault("VoltageToEarth");
     error_handling->clear_cable_check_fault();
+    error_handling->clear_over_voltage_error();
     error_handling->clear_voltage_plausibility_fault();
 }
 

--- a/modules/EVSE/EvseManager/ErrorHandling.cpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.cpp
@@ -133,6 +133,13 @@ void ErrorHandling::raise_over_voltage_error(Everest::error::Severity severity, 
     process_error();
 }
 
+void ErrorHandling::clear_over_voltage_error() {
+    if (p_evse->error_state_monitor->is_error_active("evse_manager/MREC5OverVoltage", "")) {
+        p_evse->clear_error("evse_manager/MREC5OverVoltage", "");
+    }
+    process_error();
+}
+
 // Find out if the current error set is fatal to charging or not
 void ErrorHandling::process_error() {
     const auto fatal = errors_prevent_charging();

--- a/modules/EVSE/EvseManager/ErrorHandling.hpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.hpp
@@ -80,6 +80,7 @@ public:
     void clear_overcurrent_error();
 
     void raise_over_voltage_error(Everest::error::Severity severity, const std::string& description);
+    void clear_over_voltage_error();
 
     void raise_internal_error(const std::string& description);
     void clear_internal_error();

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1161,11 +1161,14 @@ void EvseManager::ready() {
         if (not r_over_voltage_monitor.empty() and event == CPEvent::CarUnplugged) {
             r_over_voltage_monitor[0]->call_reset_over_voltage_error();
         }
-        if (internal_over_voltage_monitor and event == CPEvent::CarUnplugged) {
+        if (not r_over_voltage_monitor.empty() and (event == CPEvent::CarUnplugged or event == CPEvent::PowerOff)) {
+            r_over_voltage_monitor[0]->call_stop();
+        }
+        if (internal_over_voltage_monitor and (event == CPEvent::CarUnplugged or event == CPEvent::PowerOff)) {
             internal_over_voltage_monitor->stop_monitor();
             internal_over_voltage_monitor->reset();
         }
-        if (voltage_plausibility_monitor and event == CPEvent::CarUnplugged) {
+        if (voltage_plausibility_monitor and (event == CPEvent::CarUnplugged or event == CPEvent::PowerOff)) {
             voltage_plausibility_monitor->stop_monitor();
         }
 

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -757,6 +757,8 @@ void ErrorHandling::clear_overcurrent_error() {
 
 void ErrorHandling::raise_over_voltage_error(Everest::error::Severity severity, const std::string& description) {
 }
+void ErrorHandling::clear_over_voltage_error() {
+}
 
 void ErrorHandling::raise_internal_error(const std::string& description) {
 }

--- a/modules/EVSE/EvseManager/voltage_plausibility/VoltagePlausibilityMonitor.cpp
+++ b/modules/EVSE/EvseManager/voltage_plausibility/VoltagePlausibilityMonitor.cpp
@@ -33,14 +33,18 @@ VoltagePlausibilityMonitor::~VoltagePlausibilityMonitor() {
 }
 
 void VoltagePlausibilityMonitor::start_monitor() {
-    EVLOG_info << "VoltagePlausibilityMonitor, start monitoring";
+    if (!running_.load()) {
+        EVLOG_info << "VoltagePlausibilityMonitor, start monitoring";
+    }
     fault_latched_.store(false);
     cancel_fault_timer();
     running_.store(true);
 }
 
 void VoltagePlausibilityMonitor::stop_monitor() {
-    EVLOG_info << "VoltagePlausibilityMonitor, stop monitoring";
+    if (running_.load()) {
+        EVLOG_info << "VoltagePlausibilityMonitor, stop monitoring";
+    }
     running_.store(false);
     cancel_fault_timer();
 }


### PR DESCRIPTION
## Describe your changes

A software over voltage monitoring was raising an MREC5OverVoltage error but it was never cleared. This PR adds support in the error handling to clear an MREC5OverVoltage and clears it on unplug.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

