### PR TITLE
EvseSlac: Make TT_EVSE_SLAC_INIT_MS configurable

### DIFF
--- a/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
+++ b/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
@@ -165,6 +165,9 @@ struct EvseSlacConfig {
     // timeout for CM_SET_KEY.REQ
     int set_key_timeout_ms = 500;
 
+    // timeout for CM_SLAC_PARM.REQ
+    int slac_init_timeout_ms = slac::defs::TT_EVSE_SLAC_INIT_MS;
+
     // Settings CM_DEVICE_RESET.REQ
     struct chip_reset_struct {
         bool enabled = false;

--- a/lib/everest/slac/fsm/evse/src/states/matching.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/matching.cpp
@@ -62,7 +62,7 @@ void MatchingState::enter() {
     ctx.log_info("Entered Matching state, waiting for CM_SLAC_PARM_REQ");
     // timeout for getting CM_SLAC_PARM_REQ
     timeout_slac_parm_req =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(slac::defs::TT_EVSE_SLAC_INIT_MS);
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(ctx.slac_config.slac_init_timeout_ms);
 }
 
 FSMSimpleState::CallbackReturnType MatchingState::callback() {
@@ -161,7 +161,7 @@ FSMSimpleState::HandleEventReturnType MatchingState::handle_event(AllocatorType&
 
         // otherwise, reset timeout
         timeout_slac_parm_req =
-            std::chrono::steady_clock::now() + std::chrono::milliseconds(slac::defs::TT_EVSE_SLAC_INIT_MS);
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(ctx.slac_config.slac_init_timeout_ms);
         return sa.HANDLED_INTERNALLY;
     } else if (ev == Event::FAILED) {
         failed_count++;
@@ -172,7 +172,7 @@ FSMSimpleState::HandleEventReturnType MatchingState::handle_event(AllocatorType&
             sessions.clear();
             // timeout for getting CM_SLAC_PARM_REQ
             timeout_slac_parm_req =
-                std::chrono::steady_clock::now() + std::chrono::milliseconds(slac::defs::TT_EVSE_SLAC_INIT_MS);
+                std::chrono::steady_clock::now() + std::chrono::milliseconds(ctx.slac_config.slac_init_timeout_ms);
             seen_slac_parm_req = false;
             num_retries = 0;
 

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -84,6 +84,7 @@ void slacImpl::run() {
 
     auto fsm_ctx = slac::fsm::evse::Context(callbacks);
     fsm_ctx.slac_config.set_key_timeout_ms = config.set_key_timeout_ms;
+    fsm_ctx.slac_config.slac_init_timeout_ms = config.slac_init_timeout_ms;
     fsm_ctx.slac_config.ac_mode_five_percent = config.ac_mode_five_percent;
     fsm_ctx.slac_config.sounding_atten_adjustment = config.sounding_attenuation_adjustment;
 

--- a/modules/EVSE/EvseSlac/main/slacImpl.hpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.hpp
@@ -36,6 +36,7 @@ struct Conf {
     bool debug_simulate_failed_matching;
     bool reset_instead_of_fail;
     int startup_delay_ms;
+    int slac_init_timeout_ms;
 };
 
 class slacImpl : public slacImplBase {

--- a/modules/EVSE/EvseSlac/manifest.yaml
+++ b/modules/EVSE/EvseSlac/manifest.yaml
@@ -82,6 +82,14 @@ provides:
           On some hardware platforms with multiple EvseSlac modules loaded this can be necessary to ensure that the initial query of the device information does not happen at the same time.
         type: integer
         default: 0
+      slac_init_timeout_ms:
+        description: >-
+          Timeout for CM_SLAC_PARM.REQ. Values between 10000 and 20000 can be set at your own risk, as they
+          violate ISO15118-3. Experience has shown that this should not cause any problems.
+        type: integer
+        minimum: 10000
+        maximum: 50000
+        default: 40000
 metadata:
   base_license: https://directory.fsf.org/wiki/License:BSD-3-Clause-Clear
   license: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
## Describe your changes

Under the term “feature/dynamic_ac_config,” we at chargebyte want to integrate the feature for dynamic configuration of an AC session into everest-core in stages.

This PR introduces a configurable TT_EVSE_SLAC_INIT_MS in EvseSlac to improve Fake DC behavior.

Not all EV AC implementations support HLC and respond after applying 5% duty cycle. To ensure robust interoperability, a fast fallback to AC basic charging is important when no SLAC request is received.
The current default timeout of 40 seconds is too high for fallback scenarios. Therefore, this PR makes the SLAC init timeout configurable so EVSE's can use a shorter, appropriate fallback time.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements