### PR TITLE
fix(Auth): queue session events during init to prevent race condition

### DIFF
--- a/modules/EVSE/Auth/Auth.cpp
+++ b/modules/EVSE/Auth/Auth.cpp
@@ -21,14 +21,79 @@ void Auth::init() {
 
     for (const auto& token_provider : this->r_token_provider) {
         token_provider->subscribe_provided_token([this](ProvidedIdToken provided_token) {
+            {
+                auto state = this->event_state.handle();
+                if (!state->started) {
+                    EVLOG_warning << "Auth not fully initialized. Discarding provided token";
+                    return;
+                }
+            }
             std::thread t([this, provided_token]() { this->auth_handler->on_token(provided_token); });
             t.detach();
         });
     }
     for (const auto& token_validator : this->r_token_validator) {
         token_validator->subscribe_validate_result_update([this](ValidationResultUpdate validation_result_update) {
+            {
+                auto state = this->event_state.handle();
+                if (!state->started) {
+                    EVLOG_warning << "Auth not fully initialized. Discarding validation result update";
+                    return;
+                }
+            }
             this->auth_handler->handle_token_validation_result_update(validation_result_update);
         });
+    }
+
+    // Subscribe to session events and errors in init() so we don't miss any events
+    // Events received before ready() are queued.
+    int32_t evse_index = 0;
+    for (const auto& evse_manager : this->r_evse_manager) {
+        const int32_t evse_idx = evse_index;
+
+        evse_manager->subscribe_session_event([this, evse_idx](SessionEvent session_event) {
+            {
+                auto state = this->event_state.handle();
+                if (!state->started) {
+                    EVLOG_debug << "Auth not fully initialized, but received a session event on evse_index: "
+                                << evse_idx << " that will be queued up: " << session_event.event;
+                    state->event_queue.emplace(evse_idx, session_event);
+                    return;
+                }
+            }
+            this->auth_handler->handle_session_event(this->auth_handler->get_evse_id_by_index(evse_idx), session_event);
+        });
+
+        evse_manager->subscribe_error(
+            "evse_manager/Inoperative",
+            [this, evse_idx](const Everest::error::Error& error) {
+                {
+                    auto state = this->event_state.handle();
+                    if (!state->started) {
+                        EVLOG_debug << "Auth not fully initialized, queuing permanent fault raised for evse_index: "
+                                    << evse_idx;
+                        state->event_queue.emplace(evse_idx, PermanentFaultRaised{1});
+                        return;
+                    }
+                }
+                this->auth_handler->handle_permanent_fault_raised(this->auth_handler->get_evse_id_by_index(evse_idx),
+                                                                  1);
+            },
+            [this, evse_idx](const Everest::error::Error& error) {
+                {
+                    auto state = this->event_state.handle();
+                    if (!state->started) {
+                        EVLOG_debug << "Auth not fully initialized, queuing permanent fault cleared for evse_index: "
+                                    << evse_idx;
+                        state->event_queue.emplace(evse_idx, PermanentFaultCleared{1});
+                        return;
+                    }
+                }
+                this->auth_handler->handle_permanent_fault_cleared(this->auth_handler->get_evse_id_by_index(evse_idx),
+                                                                   1);
+            });
+
+        evse_index++;
     }
 }
 
@@ -46,21 +111,6 @@ void Auth::ready() {
         }
 
         this->auth_handler->init_evse(evse_id, evse_index, connectors);
-
-        evse_manager->subscribe_session_event([this, evse_id](SessionEvent session_event) {
-            this->auth_handler->handle_session_event(evse_id, session_event);
-        });
-
-        evse_manager->subscribe_error(
-            "evse_manager/Inoperative",
-            // If no connector id is given, it defaults to connector id 1.
-            [this, evse_id](const Everest::error::Error& error) {
-                this->auth_handler->handle_permanent_fault_raised(evse_id, 1);
-            },
-            // If no connector id is given, it defaults to connector id 1.
-            [this, evse_id](const Everest::error::Error& error) {
-                this->auth_handler->handle_permanent_fault_cleared(evse_id, 1);
-            });
 
         evse_index++;
     }
@@ -140,6 +190,31 @@ void Auth::ready() {
                 this->p_reservation->publish_reservation_update(status);
             }
         });
+
+    // Process any events that were queued during init before we were ready
+    {
+        auto state = this->event_state.handle();
+        while (!state->event_queue.empty()) {
+            auto queued_event = state->event_queue.front();
+            state->event_queue.pop();
+            const int32_t evse_id = this->auth_handler->get_evse_id_by_index(queued_event.evse_index);
+            if (std::holds_alternative<SessionEvent>(queued_event.data)) {
+                const auto& session_event = std::get<SessionEvent>(queued_event.data);
+                EVLOG_debug << "Processing queued session event for evse_id: " << evse_id
+                            << ", event: " << session_event.event;
+                this->auth_handler->handle_session_event(evse_id, session_event);
+            } else if (std::holds_alternative<PermanentFaultRaised>(queued_event.data)) {
+                const auto& fault = std::get<PermanentFaultRaised>(queued_event.data);
+                EVLOG_debug << "Processing queued permanent fault raised for evse_id: " << evse_id;
+                this->auth_handler->handle_permanent_fault_raised(evse_id, fault.connector_id);
+            } else if (std::holds_alternative<PermanentFaultCleared>(queued_event.data)) {
+                const auto& fault = std::get<PermanentFaultCleared>(queued_event.data);
+                EVLOG_debug << "Processing queued permanent fault cleared for evse_id: " << evse_id;
+                this->auth_handler->handle_permanent_fault_cleared(evse_id, fault.connector_id);
+            }
+        }
+        state->started = true;
+    }
 
     this->auth_handler->initialize();
 }

--- a/modules/EVSE/Auth/Auth.hpp
+++ b/modules/EVSE/Auth/Auth.hpp
@@ -23,10 +23,36 @@
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
 #include <AuthHandler.hpp>
+#include <everest/util/async/monitor.hpp>
 #include <memory>
+#include <queue>
+#include <variant>
 
 using namespace types::evse_manager;
 using namespace types::authorization;
+
+struct PermanentFaultRaised {
+    int32_t connector_id;
+};
+
+struct PermanentFaultCleared {
+    int32_t connector_id;
+};
+
+using AuthEvent = std::variant<SessionEvent, PermanentFaultRaised, PermanentFaultCleared>;
+
+struct EvseEvent {
+    int32_t evse_index;
+    AuthEvent data;
+
+    EvseEvent(int32_t evse_index_, AuthEvent data_) : evse_index(evse_index_), data(std::move(data_)) {
+    }
+};
+
+struct EventQueueState {
+    bool started{false};
+    std::queue<EvseEvent> event_queue;
+};
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {
@@ -99,6 +125,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+    everest::lib::util::monitor<EventQueueState> event_state;
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/EVSE/Auth/BUILD.bazel
+++ b/modules/EVSE/Auth/BUILD.bazel
@@ -14,6 +14,7 @@ cc_library(
         "//types:types_lib",
         "//interfaces:interfaces_lib",
         "//lib/everest/helpers",
+        "//lib/everest/util",
     ],
     # See https://github.com/HowardHinnant/date/issues/324
     local_defines = [

--- a/modules/EVSE/Auth/CMakeLists.txt
+++ b/modules/EVSE/Auth/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(${MODULE_NAME}
         date::date-tz
         everest::timer
         everest::helpers
+        everest::util
 )
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 

--- a/modules/EVSE/Auth/include/AuthHandler.hpp
+++ b/modules/EVSE/Auth/include/AuthHandler.hpp
@@ -78,6 +78,14 @@ public:
     void init_evse(const int evse_id, const int evse_index, const std::vector<Connector>& connectors);
 
     /**
+     * @brief Returns the evse_id for the given \p evse_index .
+     *
+     * @param evse_index
+     * @return int32_t evse_id
+     */
+    int32_t get_evse_id_by_index(const int evse_index);
+
+    /**
      * @brief Call when everything is initialized. This will call 'init' of the reservation handler.
      */
     void initialize();

--- a/modules/EVSE/Auth/lib/AuthHandler.cpp
+++ b/modules/EVSE/Auth/lib/AuthHandler.cpp
@@ -70,6 +70,16 @@ void AuthHandler::init_evse(const int evse_id, const int evse_index, const std::
     this->evses[evse_id] = std::make_unique<EVSEContext>(evse_id, evse_index, connectors);
 }
 
+int32_t AuthHandler::get_evse_id_by_index(const int evse_index) {
+    std::lock_guard<std::mutex> lock(this->event_mutex);
+    for (const auto& [evse_id, evse_context] : this->evses) {
+        if (evse_context->evse_index == evse_index) {
+            return evse_id;
+        }
+    }
+    throw std::out_of_range("No EVSE found for evse_index: " + std::to_string(evse_index));
+}
+
 void AuthHandler::initialize() {
     std::lock_guard<std::mutex> lock(this->event_mutex);
     this->reservation_handler.load_reservations();


### PR DESCRIPTION
## Describe your changes

Move session_event and error subscriptions from ready() to init() to avoid missing events. Events received before ready() completes are queued and replayed once initialization finishes. Token provider and validation callbacks are guarded to discard events before startup.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

