### PR TITLE
fix(OCPP16): remove brackets [] from MeterPublicKey format

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_base.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_base.hpp
@@ -64,7 +64,7 @@ public:
     bool isValidSupportedMeasurands(const std::string& csl) const;
     std::optional<MeasurandWithPhaseList> csvToMeasurandWithPhaseVector(const std::string& csl) const;
 
-    static std::optional<std::uint32_t> extractConnectorId(const std::string& str);
+    static std::optional<std::uint32_t> extractConnectorIdFromMeterPublicKey(const std::string& str);
     static std::string meterPublicKeyString(std::uint32_t connector_id);
 
     static bool toBool(const std::string& value);

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2899,7 +2899,7 @@ std::optional<KeyValue> ChargePointConfiguration::getPublicKeyKeyValue(const std
     }
 
     KeyValue kv;
-    kv.key = "MeterPublicKey[" + std::to_string(connector_id) + "]";
+    kv.key = "MeterPublicKey" + std::to_string(connector_id);
     kv.readonly = true;
     kv.value = keys_array.at(connector_id - 1).get<std::string>();
     return kv;
@@ -2920,7 +2920,7 @@ std::optional<std::vector<KeyValue>> ChargePointConfiguration::getAllMeterPublic
     const auto& keys_array = meter_public_keys;
     for (size_t i = 0; i < keys_array.size(); i++) {
         KeyValue kv;
-        kv.key = "MeterPublicKey[" + std::to_string(i + 1) + "]";
+        kv.key = "MeterPublicKey" + std::to_string(i + 1);
         kv.readonly = true;
         kv.value = keys_array.at(i).get<std::string>();
         key_values.push_back(kv);
@@ -3033,10 +3033,9 @@ ConfigurationStatus ChargePointConfiguration::setCustomKey(const CiString<50>& k
 }
 
 std::optional<uint32_t> parse_meter_public_key_index(const std::string& input) {
-    const std::string prefix = "MeterPublicKey[";
-    const std::string suffix = "]";
+    const std::string prefix = "MeterPublicKey";
 
-    if (input.size() <= prefix.size() + suffix.size()) {
+    if (input.size() <= prefix.size()) {
         return std::nullopt;
     }
 
@@ -3044,11 +3043,7 @@ std::optional<uint32_t> parse_meter_public_key_index(const std::string& input) {
         return std::nullopt;
     }
 
-    if (input.substr(input.size() - suffix.size()) != suffix) {
-        return std::nullopt;
-    }
-
-    std::string number_str = input.substr(prefix.size(), input.size() - prefix.size() - suffix.size());
+    std::string number_str = input.substr(prefix.size());
 
     if (number_str.empty()) {
         return std::nullopt;
@@ -3350,7 +3345,7 @@ std::optional<KeyValue> ChargePointConfiguration::get(const CiString<50>& key) {
     if (key == "WebSocketPingInterval") {
         return this->getWebsocketPingIntervalKeyValue();
     }
-    if (key.get().rfind("MeterPublicKey[", 0) == 0) {
+    if (key.get().rfind("MeterPublicKey", 0) == 0) {
         const std::string& s = key.get();
         const auto connector_id_opt = parse_meter_public_key_index(s);
 

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_base.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_base.cpp
@@ -258,11 +258,12 @@ ChargePointConfigurationBase::csvToMeasurandWithPhaseVector(const std::string& c
     return result;
 }
 
-std::optional<std::uint32_t> ChargePointConfigurationBase::extractConnectorId(const std::string& str) {
-    // example string "MeterPublicKey[1]"
+std::optional<std::uint32_t>
+ChargePointConfigurationBase::extractConnectorIdFromMeterPublicKey(const std::string& str) {
+    // example string "MeterPublicKey1"
 
     std::optional<std::uint32_t> result;
-    const std::regex id_regex(R"(^.+\[(\d+)\]$)");
+    const std::regex id_regex(R"(^MeterPublicKey(\d+)$)");
     std::smatch id_match;
 
     if (std::regex_match(str, id_match, id_regex)) {
@@ -281,7 +282,7 @@ std::optional<std::uint32_t> ChargePointConfigurationBase::extractConnectorId(co
 }
 
 std::string ChargePointConfigurationBase::meterPublicKeyString(std::uint32_t connector_id) {
-    return std::string{"MeterPublicKey["} + std::to_string(connector_id) + ']';
+    return std::string{"MeterPublicKey"} + std::to_string(connector_id);
 }
 
 bool ChargePointConfigurationBase::toBool(const std::string& value) {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -2603,7 +2603,7 @@ std::optional<KeyValue> ChargePointConfigurationDeviceModel::get(const CiString<
         if (supported_feature_profiles.find(SupportedFeatureProfiles::CostAndPrice) !=
             supported_feature_profiles.end()) {
             // check keys starting DefaultPriceText
-            if (key_str.find("DefaultPriceText") == 0) {
+            if (key_str.rfind("DefaultPriceText", 0) == 0) {
                 if (getCustomMultiLanguageMessagesEnabled().value_or(false)) {
                     const auto lang = utils::split_string(',', key_str);
                     if (lang.size() == 2) {
@@ -2613,9 +2613,9 @@ std::optional<KeyValue> ChargePointConfigurationDeviceModel::get(const CiString<
                 get_value = false;
             }
         }
-        // check keys starting MeterPublicKey[
-        if (key_str.find("MeterPublicKey[") == 0) {
-            auto id = extractConnectorId(key_str);
+        // check keys starting MeterPublicKey
+        if (key_str.rfind("MeterPublicKey", 0) == 0) {
+            auto id = extractConnectorIdFromMeterPublicKey(key_str);
             if (id) {
                 result = getPublicKeyKeyValue(id.value());
             }
@@ -2839,7 +2839,7 @@ std::optional<ConfigurationStatus> ChargePointConfigurationDeviceModel::set(cons
             result = ConfigurationStatus::NotSupported;
             break;
         case keys::valid_keys::MeterPublicKeys:
-            // should never match - connector ID expected: MeterPublicKey[1]
+            // should never match - connector ID expected: MeterPublicKey1
             EVLOG_error << R"(ChargePointConfiguration::set("MeterPublicKey", )" << value << R"(") not supported)";
             result = ConfigurationStatus::NotSupported;
             break;
@@ -2933,7 +2933,7 @@ std::optional<ConfigurationStatus> ChargePointConfigurationDeviceModel::set(cons
             break;
         }
     } else {
-        if (key_str.find("DefaultPriceText") == 0) {
+        if (key_str.rfind("DefaultPriceText", 0) == 0) {
             if (supported_feature_profiles.find(SupportedFeatureProfiles::CostAndPrice) !=
                 supported_feature_profiles.end()) {
                 // check keys starting DefaultPriceText
@@ -2941,7 +2941,7 @@ std::optional<ConfigurationStatus> ChargePointConfigurationDeviceModel::set(cons
             } else {
                 result = ConfigurationStatus::NotSupported;
             }
-        } else if (key_str.find("MeterPublicKey[") == 0) {
+        } else if (key_str.rfind("MeterPublicKey", 0) == 0) {
             // not setable
         } else {
             // custom key

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_config.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_config.cpp
@@ -18,25 +18,26 @@ INSTANTIATE_TEST_SUITE_P(Config, ConfigurationFull, testing::Values("sql", "json
 TEST(ConnectorID, Extract) {
     using CPCB = ocpp::v16::ChargePointConfigurationBase;
 
-    EXPECT_EQ(CPCB::extractConnectorId(""), std::nullopt);
-    EXPECT_EQ(CPCB::extractConnectorId("1234"), std::nullopt);
-    EXPECT_EQ(CPCB::extractConnectorId("[1234"), std::nullopt);
-    EXPECT_EQ(CPCB::extractConnectorId("1234]"), std::nullopt);
-    EXPECT_EQ(CPCB::extractConnectorId("[1]"), std::nullopt);
-    EXPECT_EQ(CPCB::extractConnectorId("A[]"), std::nullopt);
-    EXPECT_EQ(CPCB::extractConnectorId("A[1.3]"), std::nullopt);
-    EXPECT_EQ(CPCB::extractConnectorId("A[1]"), 1);
-    EXPECT_EQ(CPCB::extractConnectorId("A[12]"), 12);
-    EXPECT_EQ(CPCB::extractConnectorId("A[123]"), 123);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey(""), std::nullopt);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("1234"), std::nullopt);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("A"), std::nullopt);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("ABC"), std::nullopt);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("A1"), std::nullopt);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("A12"), std::nullopt);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("A123"), std::nullopt);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("MeterPublicKeyMeterPublicKey123"), std::nullopt);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("MeterPublicKey1"), 1);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("MeterPublicKey12"), 12);
+    EXPECT_EQ(CPCB::extractConnectorIdFromMeterPublicKey("MeterPublicKey123"), 123);
 }
 
 TEST(ConnectorID, Build) {
     using CPCB = ocpp::v16::ChargePointConfigurationBase;
 
-    EXPECT_EQ(CPCB::meterPublicKeyString(0), "MeterPublicKey[0]");
-    EXPECT_EQ(CPCB::meterPublicKeyString(1), "MeterPublicKey[1]");
-    EXPECT_EQ(CPCB::meterPublicKeyString(12), "MeterPublicKey[12]");
-    EXPECT_EQ(CPCB::meterPublicKeyString(123), "MeterPublicKey[123]");
+    EXPECT_EQ(CPCB::meterPublicKeyString(0), "MeterPublicKey0");
+    EXPECT_EQ(CPCB::meterPublicKeyString(1), "MeterPublicKey1");
+    EXPECT_EQ(CPCB::meterPublicKeyString(12), "MeterPublicKey12");
+    EXPECT_EQ(CPCB::meterPublicKeyString(123), "MeterPublicKey123");
 }
 
 TEST(ConnectorID, PhaseRotation) {

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
@@ -808,7 +808,7 @@ TEST_P(Configuration, PublicKey) {
 
     for (std::uint8_t i = 1; i <= max; i++) {
         SCOPED_TRACE(std::to_string(i));
-        auto key = std::string{"MeterPublicKey["} + std::to_string(i) + ']';
+        auto key = std::string{"MeterPublicKey"} + std::to_string(i);
         auto value = std::string{"Public Key: "} + std::to_string(i);
         EXPECT_TRUE(get()->setMeterPublicKey(i, value));
         auto kv = get()->getPublicKeyKeyValue(i);
@@ -822,7 +822,7 @@ TEST_P(Configuration, PublicKey) {
     ASSERT_TRUE(kvl);
     ASSERT_EQ(kvl.value().size(), 1);
     auto kv = kvl.value()[0];
-    EXPECT_EQ(kv.key, "MeterPublicKey[1]");
+    EXPECT_EQ(kv.key, "MeterPublicKey1");
     EXPECT_EQ(kv.value, "Public Key: 1");
     EXPECT_TRUE(kv.readonly);
 }

--- a/tests/ocpp_tests/test_sets/ocpp16/eichrecht.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/eichrecht.py
@@ -21,33 +21,33 @@ from ocpp.v16 import call_result
 async def test_meter_public_key(
     charge_point_v16: ChargePoint16, test_utility: TestUtility
 ):
-    await charge_point_v16.get_configuration_req(key=["MeterPublicKey[1]"])
+    await charge_point_v16.get_configuration_req(key=["MeterPublicKey1"])
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
         "GetConfiguration",
         call_result.GetConfiguration(
-            [{"key": "MeterPublicKey[1]", "readonly": True, "value": "TESTPUBLICKEY1"}]
+            [{"key": "MeterPublicKey1", "readonly": True, "value": "TESTPUBLICKEY1"}]
         ),
     )
 
-    await charge_point_v16.get_configuration_req(key=["MeterPublicKey[2]"])
+    await charge_point_v16.get_configuration_req(key=["MeterPublicKey2"])
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
         "GetConfiguration",
         call_result.GetConfiguration(
-            [{"key": "MeterPublicKey[2]", "readonly": True, "value": "TESTPUBLICKEY2"}]
+            [{"key": "MeterPublicKey2", "readonly": True, "value": "TESTPUBLICKEY2"}]
         ),
     )
 
-    await charge_point_v16.get_configuration_req(key=["MeterPublicKey[3]"])
+    await charge_point_v16.get_configuration_req(key=["MeterPublicKey3"])
 
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
         "GetConfiguration",
-        {"unknownKey": ["MeterPublicKey[3]"]}
+        {"unknownKey": ["MeterPublicKey3"]}
     )
 
     test_utility.messages.clear()
@@ -55,69 +55,69 @@ async def test_meter_public_key(
     response : call_result.GetConfiguration = await charge_point_v16.get_configuration_req()
 
     assert any(
-        entry['key'] == "MeterPublicKey[1]" and entry['value'] == "TESTPUBLICKEY1"
+        entry['key'] == "MeterPublicKey1" and entry['value'] == "TESTPUBLICKEY1"
         for entry in response.configuration_key)
 
     assert any(
-        entry['key'] == "MeterPublicKey[2]" and entry['value'] == "TESTPUBLICKEY2"
+        entry['key'] == "MeterPublicKey2" and entry['value'] == "TESTPUBLICKEY2"
         for entry in response.configuration_key)
     
-    await charge_point_v16.get_configuration_req(key=["MeterPublicKey[]"])
+    await charge_point_v16.get_configuration_req(key=["MeterPublicKey"])
 
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
         "GetConfiguration",
-        {"unknownKey": ["MeterPublicKey[]"]}
+        {"unknownKey": ["MeterPublicKey"]}
     )
 
-    await charge_point_v16.get_configuration_req(key=["MeterPublicKey[MeterPublicKey[1]]"])
+    await charge_point_v16.get_configuration_req(key=["MeterPublicKeyMeterPublicKey1"])
 
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
         "GetConfiguration",
-        {"unknownKey": ["MeterPublicKey[MeterPublicKey[1]]"]}
+        {"unknownKey": ["MeterPublicKeyMeterPublicKey1"]}
     )
     
-    await charge_point_v16.get_configuration_req(key=["MeterPublicKey[1X"])
+    await charge_point_v16.get_configuration_req(key=["MeterPublicKey1X"])
 
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
         "GetConfiguration",
-        {"unknownKey": ["MeterPublicKey[1X"]}
+        {"unknownKey": ["MeterPublicKey1X"]}
     )
 
-    await charge_point_v16.get_configuration_req(key=["MeterPublicKey[1X]"])
+    await charge_point_v16.get_configuration_req(key=["MeterPublicKey1X"])
 
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
         "GetConfiguration",
-        {"unknownKey": ["MeterPublicKey[1X]"]}
+        {"unknownKey": ["MeterPublicKey1X"]}
     )
 
-    await charge_point_v16.get_configuration_req(key=["MeterPublicKey[banana]"])
+    await charge_point_v16.get_configuration_req(key=["MeterPublicKeybanana"])
 
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
         "GetConfiguration",
-        {"unknownKey": ["MeterPublicKey[banana]"]}
+        {"unknownKey": ["MeterPublicKeybanana"]}
     )
 
-    await charge_point_v16.get_configuration_req(key=["MeterPublicKey[0]"])
+    await charge_point_v16.get_configuration_req(key=["MeterPublicKey0"])
 
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
         "GetConfiguration",
-        {"unknownKey": ["MeterPublicKey[0]"]}
+        {"unknownKey": ["MeterPublicKey0"]}
     )
 
     await charge_point_v16.change_configuration_req(
-        key="MeterPublicKey[1]", value="TEST"
+        key="MeterPublicKey1", value="TEST"
     )
     assert await wait_for_and_validate(
         test_utility,


### PR DESCRIPTION

## Describe your changes
Change MeterPublicKey[n] to MeterPublicKeyn to match the format used by the OCA Eichrecht Whitepaper

While the format wasn't specifically clear from the requirements of the whitepaper, the example indicates that a format without [n] shall be used.

<img width="1411" height="956" alt="image" src="https://github.com/user-attachments/assets/b9a6f0cb-5b2d-4ed8-a490-84fe0783f8a1" />

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

