### PR TITLE
Refactor/framework message handler

### DIFF
--- a/lib/everest/framework/include/utils/message_handler.hpp
+++ b/lib/everest/framework/include/utils/message_handler.hpp
@@ -4,18 +4,18 @@
 #pragma once
 
 #include <atomic>
-#include <condition_variable>
+#include <chrono>
 #include <map>
-#include <memory>
-#include <mutex>
-#include <queue>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include <everest/util/async/monitor.hpp>
 #include <everest/util/async/thread_pool_scaling.hpp>
+#include <everest/util/queue/thread_safe_queue.hpp>
+
 #include <utils/message_queue.hpp>
 #include <utils/types.hpp>
 
@@ -24,13 +24,19 @@ using CmdId = std::string;
 
 namespace Everest {
 
-constexpr int THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS = 50;
-constexpr int THREAD_POOL_SCALING_LATENCY_THREAD_IDLE_TIMEOUT_S = 2;
-constexpr int THREAD_POOL_SCALING_MIN_THREAD_COUNT = 1;
+constexpr std::size_t THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS = 50;
+constexpr std::chrono::seconds THREAD_POOL_SCALING_IDLE_TIMEOUT{2};
+constexpr std::size_t THREAD_POOL_SCALING_MIN_THREAD_COUNT = 1;
+constexpr std::size_t MAX_PENDING_MESSAGES_PER_TOPIC = 100;
 
-/// \brief Handles message dispatching and thread-safe queuing of different message types. This class uses two separate
-/// threads and message queues: one for operation messages (vars, cmds, errors, GetConfig, ModuleReady) and one for
-/// result messages (cmd results, GetConfig responses).
+/// \brief Handles message dispatching and thread-safe queuing of different message types.
+///
+/// Messages are routed to one of four channels based on their type:
+///   - operation_message_queue → operation_dispatcher_thread → operation_thread_pool
+///     (vars, cmds, errors, GetConfig, ModuleReady — parallel across topics, serial per topic)
+///   - result_message_queue    → result_worker_thread (cmd results, GetConfig responses — serial)
+///   - external_mqtt_message_queue → external_mqtt_worker_thread (external MQTT — serial)
+///   - GlobalReady             → ready_thread (one-shot, spawned per message)
 class MessageHandler {
 public:
     MessageHandler();
@@ -45,7 +51,31 @@ public:
     /// \brief Registers a \p handler for a specific \p topic
     void register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler);
 
+    using SharedTypedHandler = std::shared_ptr<TypedHandler>;
+    using SingleHandlerMap = std::map<MqttTopic, SharedTypedHandler>;
+    using MultiHandlerMap = std::map<MqttTopic, std::vector<SharedTypedHandler>>;
+
 private:
+    struct OperationTopics {
+        std::unordered_set<std::string> in_flight;
+        std::unordered_map<std::string, everest::lib::util::simple_queue<ParsedMessage>> pending_messages;
+    };
+
+    struct ResponseHandlers {
+        std::map<CmdId, std::shared_ptr<TypedHandler>> cmd; // cmd result handlers of module
+        std::shared_ptr<TypedHandler> config;               // get module config response handler of module
+    };
+
+    struct GenericHandlers {
+        MultiHandlerMap var;                // var handlers of module
+        SingleHandlerMap cmd;               // cmd handlers of module
+        MultiHandlerMap error;              // error handlers with wildcard support
+        SingleHandlerMap get_module_config; // get module config handler of manager
+        SharedTypedHandler global_ready;    // global ready handler of module
+        SingleHandlerMap module_ready;      // module ready handlers of manager
+        MultiHandlerMap external_var;       // external MQTT handlers of module
+    };
+
     void run_operation_dispatcher();
     void run_result_message_worker();
     void run_external_mqtt_worker();
@@ -67,66 +97,31 @@ private:
     void handle_cmd_result(const std::string& topic, const json& payload);
     void handle_get_config_response(const std::string& topic, const json& payload);
 
-    // Helper methods for handler execution
-    template <typename HandlerMap, typename ExecuteFn>
-    void execute_handlers_from_vector(HandlerMap& handlers, const std::string& topic, ExecuteFn execute_fn);
-
-    template <typename HandlerMap, typename ExecuteFn>
-    void execute_handlers_from_vector_with_wildcards(HandlerMap& handlers, const std::string& topic,
-                                                     ExecuteFn execute_fn);
-
-    template <typename HandlerMap, typename ExecuteFn>
-    void execute_single_handler(HandlerMap& handlers, const std::string& topic, ExecuteFn execute_fn);
-
     // Threads
     std::thread operation_dispatcher_thread; // processes vars, commands, external MQTT, errors, GetConfig and
                                              // ModuleReady messages
     std::thread result_worker_thread;        // processes cmd results and GetConfig responses
     std::thread external_mqtt_worker_thread; // processes external MQTT messages
-    std::thread ready_thread;                // runs the modules ready function
 
-    // Queues and sync primitives
-    std::unique_ptr<everest::lib::util::thread_pool_scaling<
-        everest::lib::util::LatencyScaling<THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS>>>
-        operation_thread_pool{std::make_unique<everest::lib::util::thread_pool_scaling<
-            everest::lib::util::LatencyScaling<THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS>>>(
-            THREAD_POOL_SCALING_MIN_THREAD_COUNT, std::thread::hardware_concurrency(),
-            std::chrono::seconds(THREAD_POOL_SCALING_LATENCY_THREAD_IDLE_TIMEOUT_S))};
-    std::queue<ParsedMessage> operation_message_queue;
-    std::queue<ParsedMessage> result_message_queue;
-    std::queue<ParsedMessage> external_mqtt_message_queue;
+    // Wrapped in a monitor so that concurrent GlobalReady arrivals in add() are safe:
+    // the steal-then-join pattern moves the previous thread out under the lock and joins
+    // outside the lock, preventing concurrent join/assignment races on the raw std::thread.
+    everest::lib::util::monitor<std::thread> ready;
 
-    std::mutex operation_queue_mutex;
-    std::condition_variable operation_cv;
+    using LatencyScaling = everest::lib::util::LatencyScaling<THREAD_POOL_SCALING_LATENCY_THRESHOLD_MS>;
+    using ThreadPool = everest::lib::util::thread_pool_scaling<LatencyScaling>;
+    std::unique_ptr<ThreadPool> operation_thread_pool;
 
-    std::mutex operation_topic_state_mutex;
-    std::unordered_set<std::string> operation_topics_in_flight;
-    std::unordered_map<std::string, std::queue<ParsedMessage>> pending_operation_messages_by_topic;
+    using MessageQueue = everest::lib::util::thread_safe_queue<ParsedMessage>;
+    MessageQueue operation_message_queue;
+    MessageQueue result_message_queue;
+    MessageQueue external_mqtt_message_queue;
 
-    std::mutex result_queue_mutex;
-    std::condition_variable result_cv;
-
-    std::mutex external_mqtt_queue_mutex;
-    std::condition_variable external_mqtt_cv;
-
-    std::mutex cmd_result_handler_mutex;
-    std::mutex handler_mutex;
+    everest::lib::util::monitor<OperationTopics> operations;
+    everest::lib::util::monitor<ResponseHandlers> responses;
+    everest::lib::util::monitor<GenericHandlers> handlers;
 
     std::atomic<bool> running = true;
-
-    // Handler data structures
-    std::map<MqttTopic, std::vector<std::shared_ptr<TypedHandler>>> var_handlers; // var handlers of module
-    std::map<MqttTopic, std::shared_ptr<TypedHandler>> cmd_handlers;              // cmd handlers of module
-    std::map<CmdId, std::shared_ptr<TypedHandler>> cmd_result_handlers;           // cmd result handlers of module
-    std::map<MqttTopic, std::vector<std::shared_ptr<TypedHandler>>>
-        error_handlers; // error handlers with wildcard support
-    std::map<MqttTopic, std::shared_ptr<TypedHandler>>
-        get_module_config_handlers;                        // get module config handler of manager
-    std::shared_ptr<TypedHandler> config_response_handler; // get module config response handler of module
-    std::shared_ptr<TypedHandler> global_ready_handler;    // global ready handler of module
-    std::map<MqttTopic, std::shared_ptr<TypedHandler>> module_ready_handlers; // module ready handlers of manager
-    std::map<MqttTopic, std::vector<std::shared_ptr<TypedHandler>>>
-        external_var_handlers; // external MQTT handlers of module
 };
 
 } // namespace Everest

--- a/lib/everest/framework/lib/message_handler.cpp
+++ b/lib/everest/framework/lib/message_handler.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
-
+#include "everest/util/misc/bind.hpp"
+#include "everest/util/misc/container.hpp"
 #include <utils/message_handler.hpp>
 
 #include <everest/logging.hpp>
@@ -61,9 +62,68 @@ bool check_topic_matches(const std::string& full_topic, const std::string& wildc
 
     return full_split.size() == wildcard_split.size();
 }
+
+// Pure function: collects all handlers whose registered topic (with MQTT wildcard support)
+// matches the incoming topic. Kept outside MessageHandler to signal it has no dependency
+// on class state; callers must hold the handler map lock before passing data.
+std::vector<MessageHandler::SharedTypedHandler>
+copy_shared_handler_wildcard(std::map<std::string, std::vector<MessageHandler::SharedTypedHandler>> const& data,
+                             std::string const& topic) {
+    std::vector<MessageHandler::SharedTypedHandler> handler_copy;
+    for (const auto& [wildcard_topic, handlers_vec] : data) {
+        if (check_topic_matches(topic, wildcard_topic)) {
+            handler_copy.insert(handler_copy.end(), handlers_vec.begin(), handlers_vec.end());
+        }
+    }
+    return handler_copy;
+}
+
+std::vector<MessageHandler::SharedTypedHandler> copy_shared_handler(MessageHandler::MultiHandlerMap const& data,
+                                                                    std::string const& topic) {
+    std::vector<MessageHandler::SharedTypedHandler> handler_copy;
+    auto const* ptr = everest::lib::util::find_ptr(data, topic);
+    if (ptr != nullptr) {
+        handler_copy = ptr->second;
+    }
+    return handler_copy;
+}
+
+MessageHandler::SharedTypedHandler copy_shared_handler(MessageHandler::SingleHandlerMap const& data,
+                                                       std::string const& topic) {
+    MessageHandler::SharedTypedHandler handler_copy;
+    auto const* ptr = everest::lib::util::find_ptr(data, topic);
+    if (ptr != nullptr) {
+        handler_copy = ptr->second;
+    }
+    return handler_copy;
+}
+
+template <class FtorT, class... Args>
+void try_action_and_log(FtorT const& action, std::string const& error_source, std::string const& topic,
+                        Args&&... args) {
+    try {
+        action(topic, std::forward<Args>(args)...);
+    } catch (const std::exception& e) {
+        EVLOG_error << "Exception in " << error_source << " for topic '" << topic << "': " << e.what();
+    } catch (...) {
+        EVLOG_error << "Unknown exception in " << error_source << " for topic '" << topic << "'";
+    }
+}
+
+void warn_on_high_queue_size(everest::lib::util::simple_queue<ParsedMessage> const& queue, std::string const& topic) {
+    if (queue.size() >= MAX_PENDING_MESSAGES_PER_TOPIC) {
+        EVLOG_warning << "Pending message queue for topic '" << topic << "' has reached the limit ("
+                      << MAX_PENDING_MESSAGES_PER_TOPIC << "). Handler may be stuck or too slow.";
+    }
+}
+
 } // namespace
 
+using everest::lib::util::bind_obj;
+
 MessageHandler::MessageHandler() {
+    operation_thread_pool = std::make_unique<ThreadPool>(
+        THREAD_POOL_SCALING_MIN_THREAD_COUNT, std::thread::hardware_concurrency(), THREAD_POOL_SCALING_IDLE_TIMEOUT);
     operation_dispatcher_thread = std::thread([this] { run_operation_dispatcher(); });
     result_worker_thread = std::thread([this] { run_result_message_worker(); });
     external_mqtt_worker_thread = std::thread([this] { run_external_mqtt_worker(); });
@@ -84,43 +144,47 @@ void MessageHandler::add(const ParsedMessage& message) {
 
     if (msg_type == MqttMessageType::CmdResult || msg_type == MqttMessageType::GetConfigResponse) {
         EVLOG_verbose << "Pushing cmd_result message to queue: " << message.data;
-        {
-            std::lock_guard<std::mutex> lock(result_queue_mutex);
-            result_message_queue.push(message);
-        }
-        result_cv.notify_all();
+        result_message_queue.push(message);
     } else if (msg_type == MqttMessageType::GlobalReady) {
         const auto topic_copy = message.topic;
         const auto data_copy = message.data.at("data");
 
-        ready_thread =
-            std::thread([this, topic_copy, data_copy] { (*global_ready_handler->handler)(topic_copy, data_copy); });
+        // Steal the previous ready thread under the monitor lock, then join it outside.
+        // Using steal-then-join avoids holding the lock during join(), which could block
+        // other add() calls for an arbitrary duration while the handler runs.
+        std::thread old_ready;
+        {
+            auto handle = ready.handle();
+            old_ready = std::move(*handle);
+            *handle = std::thread([this, topic_copy, data_copy] {
+                SharedTypedHandler action;
+                {
+                    auto handle = handlers.handle();
+                    action = handle->global_ready;
+                }
+                if (action) {
+                    try_action_and_log(*(action->handler), "global_ready", topic_copy, data_copy);
+                }
+            });
+        } // release ready monitor lock before joining
+        if (old_ready.joinable()) {
+            old_ready.join();
+        }
     } else if (msg_type == MqttMessageType::ExternalMQTT) {
-        {
-            std::lock_guard<std::mutex> lock(external_mqtt_queue_mutex);
-            external_mqtt_message_queue.push(message);
-        }
-        external_mqtt_cv.notify_all();
+        external_mqtt_message_queue.push(message);
     } else {
-        {
-            std::lock_guard<std::mutex> lock(operation_queue_mutex);
-            operation_message_queue.push(message);
-        }
-        operation_cv.notify_all();
+        operation_message_queue.push(message);
     }
 }
 
 void MessageHandler::stop() {
-    {
-        std::lock_guard<std::mutex> lock1(operation_queue_mutex);
-        std::lock_guard<std::mutex> lock2(result_queue_mutex);
-        std::lock_guard<std::mutex> lock3(external_mqtt_queue_mutex);
-        running = false;
+    if (!running.exchange(false)) {
+        return; // Already stopped
     }
 
-    operation_cv.notify_all();
-    result_cv.notify_all();
-    external_mqtt_cv.notify_all();
+    operation_message_queue.stop();
+    result_message_queue.stop();
+    external_mqtt_message_queue.stop();
 
     // Join the dispatcher first: it must not be able to call schedule_operation_message()
     // (which dereferences operation_thread_pool) after the pool is destroyed.
@@ -135,57 +199,49 @@ void MessageHandler::stop() {
     if (external_mqtt_worker_thread.joinable()) {
         external_mqtt_worker_thread.join();
     }
-    if (ready_thread.joinable()) {
-        ready_thread.join();
+    std::thread ready_to_join;
+    {
+        auto handle = ready.handle();
+        ready_to_join = std::move(*handle);
+    }
+    if (ready_to_join.joinable()) {
+        ready_to_join.join();
     }
 }
 
 void MessageHandler::run_operation_dispatcher() {
-    while (true) {
-        std::unique_lock<std::mutex> lock(operation_queue_mutex);
-        operation_cv.wait(lock, [this] { return !operation_message_queue.empty() || !running; });
-        if (!running)
-            return;
-
-        ParsedMessage message = std::move(operation_message_queue.front());
-        operation_message_queue.pop();
-        lock.unlock();
-
-        dispatch_operation_message(std::move(message));
+    while (auto message = operation_message_queue.wait_and_pop()) {
+        dispatch_operation_message(std::move(message.value()));
     }
+
     EVLOG_info << "Operation dispatcher thread stopped";
 }
 
 void MessageHandler::dispatch_operation_message(ParsedMessage&& message) {
     {
-        std::lock_guard<std::mutex> lock(operation_topic_state_mutex);
-        if (operation_topics_in_flight.find(message.topic) != operation_topics_in_flight.end()) {
-            pending_operation_messages_by_topic[message.topic].push(std::move(message));
+        auto handle = operations.handle();
+        if (everest::lib::util::exists(handle->in_flight, message.topic)) {
+            auto& pending_queue = handle->pending_messages[message.topic];
+            warn_on_high_queue_size(pending_queue, message.topic);
+            pending_queue.push(std::move(message));
             return;
         }
-
-        operation_topics_in_flight.insert(message.topic);
+        handle->in_flight.insert(message.topic);
     }
 
     schedule_operation_message(std::move(message));
 }
 
-// NOLINTNEXTLINE(misc-no-recursion)
 void MessageHandler::schedule_operation_message(ParsedMessage&& message) {
-    // NOLINTNEXTLINE(misc-no-recursion)
-    auto operation = [this, message = std::move(message)]() {
+    auto handle_operation_message_ftor = bind_obj(&MessageHandler::handle_operation_message, this);
+    auto on_operation_message_done_ftor = bind_obj(&MessageHandler::on_operation_message_done, this);
+    auto operation = [handle = std::move(handle_operation_message_ftor),
+                      done = std::move(on_operation_message_done_ftor), message = std::move(message)]() {
         // Wrap in try-catch so that on_operation_message_done is always called: an exception in
         // the handler must not leave the topic permanently stuck in operation_topics_in_flight,
         // which would block all subsequent messages for that topic.
-        try {
-            handle_operation_message(message.topic, message.data);
-        } catch (const std::exception& e) {
-            EVLOG_error << "Exception while handling operation message on topic '" << message.topic
-                        << "': " << e.what();
-        } catch (...) {
-            EVLOG_error << "Unknown exception while handling operation message on topic '" << message.topic << "'";
-        }
-        on_operation_message_done(message.topic);
+        try_action_and_log(handle, "handling operation message", message.topic, message.data);
+        try_action_and_log(done, "on_operation_message_done", message.topic);
     };
 
     if (operation_thread_pool) {
@@ -193,63 +249,51 @@ void MessageHandler::schedule_operation_message(ParsedMessage&& message) {
     }
 }
 
-// NOLINTNEXTLINE(misc-no-recursion)
 void MessageHandler::on_operation_message_done(const std::string& topic) {
     std::optional<ParsedMessage> next_message;
     {
-        std::lock_guard<std::mutex> lock(operation_topic_state_mutex);
+        auto handle = operations.handle();
         if (!running) {
             // Shutting down: stop scheduling and release the in-flight slot.
-            operation_topics_in_flight.erase(topic);
+            handle->in_flight.erase(topic);
             return;
         }
-        auto pending_it = pending_operation_messages_by_topic.find(topic);
-        if (pending_it != pending_operation_messages_by_topic.end() && !pending_it->second.empty()) {
-            next_message = std::move(pending_it->second.front());
-            pending_it->second.pop();
 
-            if (pending_it->second.empty()) {
-                pending_operation_messages_by_topic.erase(pending_it);
-            }
-        } else {
-            operation_topics_in_flight.erase(topic);
+        auto opt_pending_it = everest::lib::util::find_optional(handle->pending_messages, topic);
+        if (not opt_pending_it.has_value()) {
+            handle->in_flight.erase(topic);
             return;
+        }
+        auto& pending_it = opt_pending_it.value();
+        auto& pending_messages = pending_it->second;
+        next_message = pending_messages.pop();
+        if (pending_messages.empty()) {
+            handle->pending_messages.erase(pending_it);
         }
     }
 
+    if (!next_message.has_value()) {
+        EVLOG_error << "Internal error: pending_messages queue for topic '" << topic
+                    << "' was empty when expected to contain a message";
+        auto handle = operations.handle();
+        handle->in_flight.erase(topic);
+        return;
+    }
     schedule_operation_message(std::move(*next_message));
 }
 
 void MessageHandler::run_result_message_worker() {
-    while (true) {
-        std::unique_lock<std::mutex> lock(result_queue_mutex);
-        result_cv.wait(lock, [this] { return !result_message_queue.empty() || !running; });
-        if (!running) {
-            return;
-        }
-
-        ParsedMessage message = std::move(result_message_queue.front());
-        result_message_queue.pop();
-        lock.unlock();
-
-        handle_result_message(message.topic, message.data);
+    while (auto message = result_message_queue.wait_and_pop()) {
+        try_action_and_log(bind_obj(&MessageHandler::handle_result_message, this), "result worker", message->topic,
+                           message->data);
     }
     EVLOG_info << "Cmd result worker thread stopped";
 }
 
 void MessageHandler::run_external_mqtt_worker() {
-    while (true) {
-        std::unique_lock<std::mutex> lock(external_mqtt_queue_mutex);
-        external_mqtt_cv.wait(lock, [this] { return !external_mqtt_message_queue.empty() || !running; });
-        if (!running) {
-            return;
-        }
-
-        ParsedMessage message = std::move(external_mqtt_message_queue.front());
-        external_mqtt_message_queue.pop();
-        lock.unlock();
-
-        handle_external_mqtt_message(message.topic, message.data);
+    auto callback = bind_obj(&MessageHandler::handle_external_mqtt_message, this);
+    while (auto message = external_mqtt_message_queue.wait_and_pop()) {
+        try_action_and_log(callback, "External MQTT worker", message->topic, message->data);
     }
     EVLOG_info << "External MQTT worker thread stopped";
 }
@@ -314,48 +358,48 @@ void MessageHandler::handle_result_message(const std::string& topic, const json&
 void MessageHandler::register_handler(const std::string& topic, std::shared_ptr<TypedHandler> handler) {
     switch (handler->type) {
     case HandlerType::Call: {
-        std::lock_guard<std::mutex> lg(handler_mutex);
-        cmd_handlers[topic] = handler;
+        auto lock = handlers.handle();
+        lock->cmd[topic] = handler;
         break;
     }
     case HandlerType::Result: {
-        std::lock_guard<std::mutex> lock(cmd_result_handler_mutex);
-        cmd_result_handlers[handler->id] = handler;
+        auto lock = responses.handle();
+        lock->cmd[handler->id] = handler;
         break;
     }
     case HandlerType::SubscribeVar: {
-        std::lock_guard<std::mutex> lg(handler_mutex);
-        var_handlers[topic].push_back(handler);
+        auto lock = handlers.handle();
+        lock->var[topic].push_back(handler);
         break;
     }
     case HandlerType::SubscribeError: {
-        std::lock_guard<std::mutex> lg(handler_mutex);
-        error_handlers[topic].push_back(handler);
+        auto lock = handlers.handle();
+        lock->error[topic].push_back(handler);
         break;
     }
     case HandlerType::ExternalMQTT: {
-        std::lock_guard<std::mutex> lg(handler_mutex);
-        external_var_handlers[topic].push_back(handler);
+        auto lock = handlers.handle();
+        lock->external_var[topic].push_back(handler);
         break;
     }
     case HandlerType::GetConfig: {
-        std::lock_guard<std::mutex> lg(handler_mutex);
-        get_module_config_handlers[topic] = handler;
+        auto lock = handlers.handle();
+        lock->get_module_config[topic] = handler;
         break;
     }
     case HandlerType::GetConfigResponse: {
-        std::lock_guard<std::mutex> lg(cmd_result_handler_mutex);
-        config_response_handler = handler;
+        auto lock = responses.handle();
+        lock->config = handler;
         break;
     }
     case HandlerType::ModuleReady: {
-        std::lock_guard<std::mutex> lg(handler_mutex);
-        module_ready_handlers[topic] = handler;
+        auto lock = handlers.handle();
+        lock->module_ready[topic] = handler;
         break;
     }
     case HandlerType::GlobalReady: {
-        std::lock_guard<std::mutex> lg(handler_mutex);
-        global_ready_handler = handler;
+        auto lock = handlers.handle();
+        lock->global_ready = handler;
         break;
     }
     default:
@@ -366,32 +410,75 @@ void MessageHandler::register_handler(const std::string& topic, std::shared_ptr<
 
 // Private message handler methods
 void MessageHandler::handle_var_message(const std::string& topic, const json& data) {
-    execute_handlers_from_vector(var_handlers, topic,
-                                 [&](const auto& handler) { (*handler->handler)(topic, data.at("data")); });
+    std::vector<SharedTypedHandler> handler_copy;
+    {
+        auto handle = handlers.handle();
+        handler_copy = copy_shared_handler(handle->var, topic);
+    }
+
+    for (const auto& handler : handler_copy) {
+        (*handler->handler)(topic, data.at("data"));
+    }
 }
 
 void MessageHandler::handle_cmd_message(const std::string& topic, const json& data) {
-    execute_single_handler(cmd_handlers, topic, [&](const auto& handler) { (*handler->handler)(topic, data); });
+    SharedTypedHandler handler_copy;
+    {
+        auto handle = handlers.handle();
+        handler_copy = copy_shared_handler(handle->cmd, topic);
+    }
+
+    if (handler_copy) {
+        (*handler_copy->handler)(topic, data);
+    }
 }
 
 void MessageHandler::handle_external_mqtt_message(const std::string& topic, const json& data) {
-    execute_handlers_from_vector_with_wildcards(external_var_handlers, topic,
-                                                [&](const auto& handler) { (*handler->handler)(topic, data); });
+    std::vector<SharedTypedHandler> handler_copy;
+    {
+        auto handle = handlers.handle();
+        handler_copy = copy_shared_handler_wildcard(handle->external_var, topic);
+    }
+
+    for (const auto& handler : handler_copy) {
+        (*handler->handler)(topic, data);
+    }
 }
 
 void MessageHandler::handle_error_message(const std::string& topic, const json& data) {
-    execute_handlers_from_vector_with_wildcards(error_handlers, topic,
-                                                [&](const auto& handler) { (*handler->handler)(topic, data); });
+    std::vector<SharedTypedHandler> handler_copy;
+    {
+        auto handle = handlers.handle();
+        handler_copy = copy_shared_handler_wildcard(handle->error, topic);
+    }
+
+    for (const auto& handler : handler_copy) {
+        (*handler->handler)(topic, data);
+    }
 }
 
 void MessageHandler::handle_get_config_message(const std::string& topic, const json& data) {
-    execute_single_handler(get_module_config_handlers, topic,
-                           [&](const auto& handler) { (*handler->handler)(topic, data); });
+    SharedTypedHandler handler_copy;
+    {
+        auto handle = handlers.handle();
+        handler_copy = copy_shared_handler(handle->get_module_config, topic);
+    }
+
+    if (handler_copy) {
+        (*handler_copy->handler)(topic, data);
+    }
 }
 
 void MessageHandler::handle_module_ready_message(const std::string& topic, const json& data) {
-    execute_single_handler(module_ready_handlers, topic,
-                           [&](const auto& handler) { (*handler->handler)(topic, data); });
+    SharedTypedHandler handler_copy;
+    {
+        auto handle = handlers.handle();
+        handler_copy = copy_shared_handler(handle->module_ready, topic);
+    }
+
+    if (handler_copy) {
+        (*handler_copy->handler)(topic, data);
+    }
 }
 
 void MessageHandler::handle_cmd_result(const std::string& topic, const json& payload) {
@@ -400,11 +487,11 @@ void MessageHandler::handle_cmd_result(const std::string& topic, const json& pay
 
     std::shared_ptr<TypedHandler> handler_copy;
     {
-        std::lock_guard<std::mutex> lock(cmd_result_handler_mutex);
-        auto it = cmd_result_handlers.find(id);
-        if (it != cmd_result_handlers.end()) {
+        auto handle = responses.handle();
+        auto it = handle->cmd.find(id);
+        if (it != handle->cmd.end()) {
             handler_copy = it->second;
-            cmd_result_handlers.erase(it);
+            handle->cmd.erase(it);
         }
     }
 
@@ -416,62 +503,13 @@ void MessageHandler::handle_cmd_result(const std::string& topic, const json& pay
 void MessageHandler::handle_get_config_response(const std::string& topic, const json& payload) {
     std::shared_ptr<TypedHandler> handler_copy;
     {
-        std::lock_guard<std::mutex> lock(cmd_result_handler_mutex);
-        if (config_response_handler) {
-            handler_copy = config_response_handler;
+        auto handle = responses.handle();
+        if (handle->config) {
+            handler_copy = handle->config;
         }
     }
     if (handler_copy) {
         (*handler_copy->handler)(topic, payload.at("data"));
-    }
-}
-
-// Helper methods for handler execution
-template <typename HandlerMap, typename ExecuteFn>
-void MessageHandler::execute_handlers_from_vector(HandlerMap& handlers, const std::string& topic,
-                                                  ExecuteFn execute_fn) {
-    std::vector<std::shared_ptr<TypedHandler>> handlers_copy;
-    {
-        std::lock_guard<std::mutex> lock(handler_mutex);
-        const auto it = handlers.find(topic);
-        if (it != handlers.end()) {
-            handlers_copy = it->second;
-        }
-    }
-    for (const auto& handler : handlers_copy) {
-        execute_fn(handler);
-    }
-}
-
-template <typename HandlerMap, typename ExecuteFn>
-void MessageHandler::execute_handlers_from_vector_with_wildcards(HandlerMap& handlers, const std::string& topic,
-                                                                 ExecuteFn execute_fn) {
-    std::vector<std::shared_ptr<TypedHandler>> handlers_copy;
-    {
-        std::lock_guard<std::mutex> lock(handler_mutex);
-        for (const auto& [wildcard_topic, handlers_vec] : handlers) {
-            if (check_topic_matches(topic, wildcard_topic)) {
-                handlers_copy.insert(handlers_copy.end(), handlers_vec.begin(), handlers_vec.end());
-            }
-        }
-    }
-    for (const auto& handler : handlers_copy) {
-        execute_fn(handler);
-    }
-}
-
-template <typename HandlerMap, typename ExecuteFn>
-void MessageHandler::execute_single_handler(HandlerMap& handlers, const std::string& topic, ExecuteFn execute_fn) {
-    std::shared_ptr<TypedHandler> handler_copy;
-    {
-        std::lock_guard<std::mutex> lock(handler_mutex);
-        const auto it = handlers.find(topic);
-        if (it != handlers.end()) {
-            handler_copy = it->second;
-        }
-    }
-    if (handler_copy) {
-        execute_fn(handler_copy);
     }
 }
 

--- a/lib/everest/framework/tests/test_message_handler.cpp
+++ b/lib/everest/framework/tests/test_message_handler.cpp
@@ -476,13 +476,15 @@ TEST_CASE("MessageHandler processes result messages separately", "[message_handl
 TEST_CASE("MessageHandler shuts down gracefully with pending messages", "[message_handler][shutdown]") {
     ExecutionTracker tracker;
     std::atomic<int> processing_count{0};
+    std::atomic<bool> handler_started{false};
 
     {
         MessageHandlerFixture handler;
 
         auto handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
-            // Simulate some processing time but don't block indefinitely
             processing_count++;
+            handler_started.store(true);
+            // Simulate some processing time but don't block indefinitely
             std::this_thread::sleep_for(20ms);
             tracker.record(topic, data.value("sequence", 0));
         });
@@ -501,12 +503,16 @@ TEST_CASE("MessageHandler shuts down gracefully with pending messages", "[messag
         std::this_thread::sleep_for(10ms);
 
         // At this point, message 1 should be processing and 2-5 should be queued
-        // Shutdown should handle this gracefully
+        REQUIRE(handler_started.load()); // Verify first message started
     }
+    // Destructor calls stop(), which sets running=false
 
-    // If we get here without hanging, the test passed
-    INFO("Processed " << processing_count.load() << " messages before shutdown");
-    SUCCEED("Shutdown completed without crash or hang");
+    // Verify that pending messages (2-5) were NOT processed after shutdown was initiated.
+    // Only message 1 (in-flight) and any that completed before running=false should be in the tracker.
+    // Since we sleep 10ms and give the handler ~20ms, at most message 1 completes.
+    // Messages 2-5 should be abandoned when shutdown is requested.
+    CHECK(tracker.count() <= 1);
+    INFO("Processed " << processing_count.load() << " messages total");
 }
 
 // ============================================================================
@@ -887,4 +893,119 @@ TEST_CASE("MessageHandler handles mixed message types concurrently", "[message_h
     CHECK(cmd_tracker.get_events().size() == 1);
     CHECK(var_tracker.get_events().size() == 1);
     CHECK(ext_tracker.get_events().size() == 1);
+}
+
+TEST_CASE("MessageHandler: GlobalReady arrives before register_handler") {
+    auto handler = std::make_unique<MessageHandler>();
+
+    ExecutionTracker tracker;
+    bool handler_called = false;
+
+    // Send GlobalReady BEFORE registering the handler (critical race condition)
+    ParsedMessage ready_msg;
+    ready_msg.topic = "global";
+    ready_msg.data = {{"msg_type", "GlobalReady"}, {"data", {{"ready_data", true}}}};
+    handler->add(ready_msg);
+
+    // Give the ready_thread a moment to execute (it should find no handler registered)
+    std::this_thread::sleep_for(100ms);
+
+    // Now register the handler - too late, the ready_thread has already exited
+    auto ready_handler_func = std::make_shared<Handler>([&](const std::string& topic, const json& data) {
+        handler_called = true;
+        tracker.record(topic, 1);
+    });
+    auto ready_handler = std::make_shared<TypedHandler>(HandlerType::GlobalReady, ready_handler_func);
+    handler->register_handler("global", ready_handler);
+
+    // Wait briefly to ensure no deferred execution
+    std::this_thread::sleep_for(100ms);
+
+    // Handler should NOT have been called since it was registered after the message arrived
+    CHECK(handler_called == false);
+    CHECK(tracker.count() == 0);
+
+    handler->stop();
+}
+
+TEST_CASE("MessageHandler: Per-topic mutual exclusion (at most one in-flight per topic)") {
+    auto handler = std::make_unique<MessageHandler>();
+
+    // Track concurrent execution for each topic
+    std::map<std::string, std::atomic<int>> in_flight_count;
+    std::map<std::string, int> max_concurrent;
+    std::mutex concurrent_mutex;
+
+    ExecutionTracker tracker;
+
+    auto create_blocking_handler = [&](const std::string& topic) {
+        auto handler_func = std::make_shared<Handler>([&, topic](const std::string& msg_topic, const json& data) {
+            // Increment in-flight count for this topic
+            in_flight_count[topic]++;
+            int current = in_flight_count[topic];
+
+            // Record the start of execution
+            tracker.record(msg_topic, data.value("sequence", 0));
+
+            {
+                std::lock_guard<std::mutex> lock(concurrent_mutex);
+                max_concurrent[topic] = std::max(max_concurrent[topic], current);
+            }
+
+            // Simulate work with a delay
+            std::this_thread::sleep_for(50ms);
+
+            // Decrement in-flight count
+            in_flight_count[topic]--;
+        });
+        return std::make_shared<TypedHandler>(HandlerType::SubscribeVar, handler_func);
+    };
+
+    // Register handlers for multiple topics
+    handler->register_handler("topic/A", create_blocking_handler("topic/A"));
+    handler->register_handler("topic/B", create_blocking_handler("topic/B"));
+
+    // Send 3 messages for topic A (should be queued, not concurrent)
+    for (int i = 1; i <= 3; ++i) {
+        ParsedMessage msg = create_var_message("topic/A", i);
+        handler->add(msg);
+    }
+
+    // Send 3 messages for topic B (should also not be concurrent with each other)
+    for (int i = 1; i <= 3; ++i) {
+        ParsedMessage msg = create_var_message("topic/B", i);
+        handler->add(msg);
+    }
+
+    // Wait for all messages to be processed
+    tracker.wait_for_count(6, 10000ms);
+
+    // Verify both topics processed all 3 messages
+    auto events = tracker.get_events();
+    std::map<std::string, int> processed_count;
+    for (const auto& event : events) {
+        processed_count[event.topic]++;
+    }
+
+    CHECK(processed_count["topic/A"] == 3);
+    CHECK(processed_count["topic/B"] == 3);
+
+    // Verify at most 1 message in-flight per topic at any time
+    CHECK(max_concurrent["topic/A"] <= 1);
+    CHECK(max_concurrent["topic/B"] <= 1);
+
+    // Verify ordering is preserved within each topic
+    int last_seq_A = 0;
+    int last_seq_B = 0;
+    for (const auto& event : events) {
+        if (event.topic == "topic/A") {
+            CHECK(event.sequence > last_seq_A);
+            last_seq_A = event.sequence;
+        } else if (event.topic == "topic/B") {
+            CHECK(event.sequence > last_seq_B);
+            last_seq_B = event.sequence;
+        }
+    }
+
+    handler->stop();
 }

--- a/lib/everest/util/include/everest/util/misc/bind.hpp
+++ b/lib/everest/util/include/everest/util/misc/bind.hpp
@@ -12,8 +12,55 @@ namespace everest::lib::util {
  * @param[in] ptr to object (likely this)
  */
 
-template <typename R, typename C, typename... Args> std::function<R(Args...)> bind_obj(R (C::*func)(Args...), C* obj) {
+template <typename R, typename C, typename... Args>
+std::function<R(Args...)> function_bind_obj(R (C::*func)(Args...), C* obj) {
     return [func, obj](Args... args) -> R { return (obj->*func)(std::forward<Args>(args)...); };
+}
+
+/**
+ * @brief Binds a member function to a specific object instance without std::function overhead.
+ *
+ * This utility creates a lightweight lambda closure that captures a member function pointer
+ * and an object pointer.
+ *
+ * @tparam R     The return type of the member function.
+ * @tparam C     The class type owning the member function.
+ * @tparam Args  The argument types expected by the member function.
+ *
+ * @param func   A pointer to the member function (e.g., &MyClass::handle_data).
+ * @param obj    A pointer to the instance the function should be called on.
+ *
+ * @return A lambda closure that, when called, invokes the member function on @p obj.
+ *
+ * @note By returning 'auto', this function avoids the type-erasure overhead of std::function.
+ * The compiler can often inline the resulting call entirely. It remains implicitly
+ * convertible to std::function if required by an API.
+ *
+ * @par Example:
+ * @code
+ * auto processor = bind_obj(&MyCalss::handle_data, this);
+ * consume(queue, processor);
+ * @endcode
+ */
+template <typename R, typename C, typename... Args> auto bind_obj(R (C::*func)(Args...), C* obj) {
+    return [func, obj](Args&&... args) -> R { return (obj->*func)(std::forward<Args>(args)...); };
+}
+
+/**
+ * @brief Const-qualified version of bind_obj.
+ *
+ * Overload to support binding to member functions marked with 'const'.
+ * @tparam R     The return type of the member function.
+ * @tparam C     The class type owning the member function.
+ * @tparam Args  The argument types expected by the member function.
+ *
+ * @param func   A pointer to the const member function.
+ * @param obj    A pointer to the const instance.
+ *
+ * @return A lambda closure that invokes the const member function on @p obj.
+ */
+template <typename R, typename C, typename... Args> auto bind_obj(R (C::*func)(Args...) const, const C* obj) {
+    return [func, obj](Args&&... args) -> R { return (obj->*func)(std::forward<Args>(args)...); };
 }
 
 } // namespace everest::lib::util

--- a/lib/everest/util/include/everest/util/misc/container.hpp
+++ b/lib/everest/util/include/everest/util/misc/container.hpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <algorithm>
+#include <iterator>
+#include <optional>
+#include <type_traits>
+
+/**
+ * @file container_utils.hpp
+ * @brief Utility functions for generic STL container operations.
+ */
+
+namespace everest::lib::util {
+
+/**
+ * @brief Internal type trait to detect if a container has a .find() member function.
+ * @tparam T The container type to check.
+ * @tparam Value The type of the value to search for.
+ */
+template <typename T, typename Value, typename = void> struct has_find : std::false_type {};
+
+template <typename T, typename Value>
+struct has_find<T, Value, std::void_t<decltype(std::declval<const T&>().find(std::declval<const Value&>()))>>
+    : std::true_type {};
+
+/**
+ * @brief Checks if a value exists in a sequence container (vector, list, etc.).
+ * @note Internal implementation using O(n) linear search.
+ */
+template <typename Container, typename T> auto exists_impl(const Container& c, const T& val, std::false_type) -> bool {
+    return std::find(std::begin(c), std::end(c), val) != std::end(c);
+}
+
+/**
+ * @brief Checks if a value exists in an associative container (set, map, etc.).
+ * @note Internal implementation using the container's optimized .find() method.
+ */
+template <typename Container, typename T> auto exists_impl(const Container& c, const T& val, std::true_type) -> bool {
+    return c.find(val) != c.end();
+}
+
+/**
+ * @brief Generically checks if a specific item exists within a container.
+ * * This function automatically selects the most efficient search algorithm
+ * available for the provided container type at compile-time.
+ * This is supposed to be a replacement for C++20 'contains' method
+ * * @tparam Container The type of the STL-compatible container.
+ * @tparam T The type of the value to search for.
+ * @param c The constant reference to the container to search.
+ * @param val The value to look for.
+ * @return true if the item is found, false otherwise.
+ * * @par Complexity:
+ * - **O(log n)** for associative containers (std::set, std::map).
+ * - **O(1)** average for unordered containers (std::unordered_set/map).
+ * - **O(n)** for sequence containers (std::vector, std::list).
+ */
+template <typename Container, typename T> bool exists(const Container& c, const T& val) {
+    return exists_impl(c, val, has_find<Container, T>{});
+}
+
+/**
+ * @brief Implementation for sequence containers (vector, list, etc.).
+ * @return Pointer to the found element or nullptr.
+ */
+template <typename Container, typename T> auto find_ptr_impl(Container& c, const T& val, std::false_type) {
+    auto it = std::find(std::begin(c), std::end(c), val);
+    return (it != std::end(c)) ? &(*it) : nullptr;
+}
+
+/**
+ * @brief Implementation for associative containers (set, map, etc.).
+ * @return Pointer to the found element or nullptr.
+ */
+template <typename Container, typename T> auto find_ptr_impl(Container& c, const T& val, std::true_type) {
+    auto it = c.find(val);
+    return (it != std::end(c)) ? &(*it) : nullptr;
+}
+
+/**
+ * @brief Generically finds an item and returns a pointer to it.
+ * * This utility provides a unified interface to find an element across different
+ * STL containers. It returns a pointer to the element if found, allowing
+ * for both existence checking and immediate access.
+ * * @tparam Container The STL container type.
+ * @tparam T The type of the value/key to search for.
+ * @param c The container (can be const or non-const).
+ * @param val The value to search for.
+ * @return A pointer to the element within the container, or `nullptr` if not found.
+ * * @example
+ * if (auto* item = utils::find_ptr(my_vector, 42)) {
+ * *item = 43; // Modify if non-const
+ * }
+ */
+template <typename Container, typename T> auto find_ptr(Container& c, const T& val) {
+    return find_ptr_impl(c, val, has_find<Container, T>{});
+}
+
+/**
+ * @brief Searches for an element and returns an optional iterator.
+ * * This function abstracts the difference between sequence containers (like vector)
+ * and associative containers (like set/map) to provide the most efficient
+ * lookup possible.
+ * * @tparam Container The STL container type.
+ * @tparam T The value or key to search for.
+ * @param c The container to search within.
+ * @param val The value/key to find.
+ * @return std::optional wrapping the iterator. Returns std::nullopt if not found.
+ * * @note If found, the iterator can be used to access the element (*it) or
+ * pass to c.erase(it) for efficient deletion.
+ */
+template <typename Container, typename T>
+auto find_optional(Container& c, const T& val) -> std::optional<decltype(std::begin(c))> {
+    if constexpr (has_find<Container, T>::value) {
+        auto it = c.find(val);
+        if (it != std::end(c))
+            return it;
+    } else {
+        auto it = std::find(std::begin(c), std::end(c), val);
+        if (it != std::end(c))
+            return it;
+    }
+    return std::nullopt;
+}
+
+} // namespace everest::lib::util


### PR DESCRIPTION
## Describe your changes
This refactors the message handler in the EVerest framework to rely on the async utilities form lib/everest/util

It removes the explicit use of mutex and condition_var completely. thread_safe_queue and monitor are used instead.


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

