### PR TITLE
Fix(API): Unify API internal/external enum conversion error messages

### DIFF
--- a/lib/everest/everest_api_types/src/everest_api_types/auth/wrapper.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/auth/wrapper.cpp
@@ -135,7 +135,7 @@ CertificateStatus_Internal to_internal_api(CertificateStatus_External const& val
     case SrcT::ContractCancelled:
         return TarT::ContractCancelled;
     }
-    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::CertifgicateStatus_External");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::CertificateStatus_External");
 }
 CertificateStatus_External to_external_api(CertificateStatus_Internal const& val) {
     using SrcT = CertificateStatus_Internal;
@@ -156,7 +156,7 @@ CertificateStatus_External to_external_api(CertificateStatus_Internal const& val
     case SrcT::ContractCancelled:
         return TarT::ContractCancelled;
     }
-    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::CertifgicateStatus_Internal");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::CertificateStatus_Internal");
 }
 
 TokenValidationStatus_Internal to_internal_api(TokenValidationStatus_External const& val) {
@@ -215,7 +215,7 @@ SelectionAlgorithm_Internal to_internal_api(SelectionAlgorithm_External const& v
     case SrcT::FindFirst:
         return TarT::FindFirst;
     }
-    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::SelectedAlgorithm_External");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::SelectionAlgorithm_External");
 }
 SelectionAlgorithm_External to_external_api(SelectionAlgorithm_Internal const& val) {
     using SrcT = SelectionAlgorithm_Internal;
@@ -228,7 +228,7 @@ SelectionAlgorithm_External to_external_api(SelectionAlgorithm_Internal const& v
     case SrcT::FindFirst:
         return TarT::FindFirst;
     }
-    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::SelectedAlgorithm_Internal");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::SelectionAlgorithm_Internal");
 }
 
 AuthorizationType_Internal to_internal_api(AuthorizationType_External const& val) {
@@ -246,7 +246,7 @@ AuthorizationType_Internal to_internal_api(AuthorizationType_External const& val
     case SrcT::BankCard:
         return TarT::BankCard;
     }
-    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::AuthoriozationType_External");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::AuthorizationType_External");
 }
 
 AuthorizationType_External to_external_api(AuthorizationType_Internal const& val) {
@@ -264,7 +264,7 @@ AuthorizationType_External to_external_api(AuthorizationType_Internal const& val
     case SrcT::BankCard:
         return TarT::BankCard;
     }
-    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::AuthoriozationType_Internal");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::auth::AuthorizationType_Internal");
 }
 
 IdTokenType_Internal to_internal_api(IdTokenType_External const& val) {

--- a/lib/everest/everest_api_types/src/everest_api_types/evse_manager/wrapper.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/evse_manager/wrapper.cpp
@@ -85,7 +85,8 @@ StopTransactionReason_Internal to_internal_api(StopTransactionReason_External co
     case SrcT::ReqEnergyTransferRejected:
         return TarT::ReqEnergyTransferRejected;
     }
-    throw std::out_of_range("Unexpected value for StopTransactionReason_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::StopTransactionReason_External");
 }
 
 StopTransactionReason_External to_external_api(StopTransactionReason_Internal const& val) {
@@ -138,7 +139,8 @@ StopTransactionReason_External to_external_api(StopTransactionReason_Internal co
     case SrcT::ReqEnergyTransferRejected:
         return TarT::ReqEnergyTransferRejected;
     }
-    throw std::out_of_range("Unexpected value for StopTransactionReason_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::StopTransactionReason_Internal");
 }
 
 StopTransactionRequest_Internal to_internal_api(StopTransactionRequest_External const& val) {
@@ -165,7 +167,8 @@ StartSessionReason_Internal to_internal_api(StartSessionReason_External const& v
         return TarT::Authorized;
     }
 
-    throw std::out_of_range("Unexpected value for StartSessionReason_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::StartSessionReason_External");
 }
 
 StartSessionReason_External to_external_api(StartSessionReason_Internal const& val) {
@@ -179,7 +182,8 @@ StartSessionReason_External to_external_api(StartSessionReason_Internal const& v
         return TarT::Authorized;
     }
 
-    throw std::out_of_range("Unexpected value for StartSessionReason_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::StartSessionReason_Internal");
 }
 
 SessionEventEnum_Internal to_internal_api(SessionEventEnum_External const& val) {
@@ -237,7 +241,8 @@ SessionEventEnum_Internal to_internal_api(SessionEventEnum_External const& val) 
         return TarT::SessionResumed;
     }
 
-    throw std::out_of_range("Unexpected value for SessionEventEnum_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::SessionEventEnum_External");
 }
 
 SessionEventEnum_External to_external_api(SessionEventEnum_Internal const& val) {
@@ -295,7 +300,8 @@ SessionEventEnum_External to_external_api(SessionEventEnum_Internal const& val) 
         return TarT::SessionResumed;
     }
 
-    throw std::out_of_range("Unexpected value for SessionEventEnum_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::SessionEventEnum_Internal");
 }
 
 SessionEvent_Internal to_internal_api(SessionEvent_External const& val) {
@@ -402,7 +408,8 @@ CarManufacturer_External to_external_api(CarManufacturer_Internal const& val) {
         return TarT::Unknown;
     }
 
-    throw std::out_of_range("Unexpected value for CarManufacturer_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::CarManufacturer_Internal");
 }
 
 CarManufacturer_Internal to_external_api(CarManufacturer_External const& val) {
@@ -418,7 +425,8 @@ CarManufacturer_Internal to_external_api(CarManufacturer_External const& val) {
         return TarT::Unknown;
     }
 
-    throw std::out_of_range("Unexpected value for CarManufacturer_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::CarManufacturer_External");
 }
 
 SessionStarted_Internal to_internal_api(SessionStarted_External const& val) {
@@ -571,7 +579,8 @@ ConnectorTypeEnum_Internal to_internal_api(ConnectorTypeEnum_External const& val
     case SrcT::Unknown:
         return TarT::Unknown;
     }
-    throw std::out_of_range("Unexpected value for ConnectorTypeEnum_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::ConnectorTypeEnum_External");
 }
 
 ConnectorTypeEnum_External to_external_api(ConnectorTypeEnum_Internal const& val) {
@@ -626,7 +635,8 @@ ConnectorTypeEnum_External to_external_api(ConnectorTypeEnum_Internal const& val
     case SrcT::Unknown:
         return TarT::Unknown;
     }
-    throw std::out_of_range("Unexpected value for ConnectorTypeEnum_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::ConnectorTypeEnum_Internal");
 }
 
 Connector_Internal to_internal_api(Connector_External const& val) {
@@ -684,7 +694,8 @@ EnableSourceEnum_Internal to_internal_api(EnableSourceEnum_External const& val) 
     case SrcT::CSMS:
         return TarT::CSMS;
     }
-    throw std::out_of_range("Unexpected value for EnableSourceEnum_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::EnableSourceEnum_External");
 }
 
 EnableSourceEnum_External to_external_api(EnableSourceEnum_Internal const& val) {
@@ -709,7 +720,8 @@ EnableSourceEnum_External to_external_api(EnableSourceEnum_Internal const& val) 
     case SrcT::CSMS:
         return TarT::CSMS;
     }
-    throw std::out_of_range("Unexpected value for EnableSourceEnum_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::EnableSourceEnum_Internal");
 }
 
 EnableStateEnum_Internal to_internal_api(EnableStateEnum_External const& val) {
@@ -724,7 +736,8 @@ EnableStateEnum_Internal to_internal_api(EnableStateEnum_External const& val) {
     case SrcT::Enable:
         return TarT::Enable;
     }
-    throw std::out_of_range("Unexpected value for EnableStateEnum_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::EnableStateEnum_External");
 }
 
 EnableStateEnum_External to_external_api(EnableStateEnum_Internal const& val) {
@@ -739,7 +752,8 @@ EnableStateEnum_External to_external_api(EnableStateEnum_Internal const& val) {
     case SrcT::Enable:
         return TarT::Enable;
     }
-    throw std::out_of_range("Unexpected value for EnableStateEnum_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::evse_manager::EnableStateEnum_Internal");
 }
 
 EnableDisableSource_Internal to_internal_api(EnableDisableSource_External const& val) {

--- a/lib/everest/everest_api_types/src/everest_api_types/iso15118_charger/wrapper.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/iso15118_charger/wrapper.cpp
@@ -59,7 +59,8 @@ CertificateActionEnum_Internal to_internal_api(CertificateActionEnum_External co
         return TarT::Update;
     }
 
-    throw std::out_of_range("Unexpected value for CertificateActionEnum_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::iso15118_charger::CertificateActionEnum_External");
 }
 
 CertificateActionEnum_External to_external_api(CertificateActionEnum_Internal const& val) {
@@ -73,7 +74,8 @@ CertificateActionEnum_External to_external_api(CertificateActionEnum_Internal co
         return TarT::Update;
     }
 
-    throw std::out_of_range("Unexpected value for CertificateActionEnum_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::iso15118_charger::CertificateActionEnum_Internal");
 }
 
 EnergyTransferMode_Internal to_internal_api(EnergyTransferMode_External const& val) {
@@ -117,7 +119,8 @@ EnergyTransferMode_Internal to_internal_api(EnergyTransferMode_External const& v
         return TarT::MCS_BPT;
     }
 
-    throw std::out_of_range("Unexpected value for EnergyTransferMode_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::iso15118_charger::EnergyTransferMode_External");
 }
 
 EnergyTransferMode_External to_external_api(EnergyTransferMode_Internal const& val) {
@@ -161,7 +164,8 @@ EnergyTransferMode_External to_external_api(EnergyTransferMode_Internal const& v
         return TarT::MCS_BPT;
     }
 
-    throw std::out_of_range("Unexpected value for EnergyTransferMode_Internal");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::iso15118_charger::EnergyTransferMode_Internal");
 }
 
 Status_Internal to_internal_api(Status_External const& val) {
@@ -175,7 +179,7 @@ Status_Internal to_internal_api(Status_External const& val) {
         return TarT::Failed;
     }
 
-    throw std::out_of_range("Unexpected value for Status_External");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::iso15118_charger::Status_External");
 }
 
 Status_External to_external_api(Status_Internal const& val) {
@@ -189,7 +193,7 @@ Status_External to_external_api(Status_Internal const& val) {
         return TarT::Failed;
     }
 
-    throw std::out_of_range("Unexpected value for Status_Internal");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::iso15118_charger::Status_Internal");
 }
 
 RequestExiStreamSchema_Internal to_internal_api(RequestExiStreamSchema_External const& val) {

--- a/lib/everest/everest_api_types/src/everest_api_types/ocpp/wrapper.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/ocpp/wrapper.cpp
@@ -655,7 +655,7 @@ OperationMode_External to_external_api(OperationMode_Internal const& val) {
         enum_case(LocalFrequency);
         enum_case(LocalLoadBalancing);
     }
-    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::ocpp::Operation_mode");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::ocpp::OperationMode_Internal");
 }
 
 ChargingSchedulePeriod_Internal to_internal_api(ChargingSchedulePeriod_External const& val) {

--- a/lib/everest/everest_api_types/src/everest_api_types/power_supply_DC/wrapper.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/power_supply_DC/wrapper.cpp
@@ -62,7 +62,7 @@ Mode_External to_external_api(Mode_Internal mode_internal) {
         return Mode::Fault;
     }
 
-    throw std::out_of_range("No know conversion between internal and external mode API");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::power_supply_DC::Mode_Internal");
 }
 
 Mode_Internal to_internal_api(Mode_External mode_external) {
@@ -77,7 +77,7 @@ Mode_Internal to_internal_api(Mode_External mode_external) {
         return Mode_Internal::Fault;
     }
 
-    throw std::out_of_range("No know conversion between internal and external mode API");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::power_supply_DC::Mode_External");
 }
 
 ChargingPhase_External to_external_api(ChargingPhase_Internal val) {
@@ -92,7 +92,8 @@ ChargingPhase_External to_external_api(ChargingPhase_Internal val) {
         return ChargingPhase_External::Charging;
     }
 
-    throw std::out_of_range("No know conversion from internal to external ChargingPhase API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::power_supply_DC::ChargingPhase_Internal");
 }
 
 ChargingPhase_Internal to_internal_api(ChargingPhase_External val) {
@@ -107,7 +108,8 @@ ChargingPhase_Internal to_internal_api(ChargingPhase_External val) {
         return ChargingPhase_Internal::Charging;
     }
 
-    throw std::out_of_range("No know conversion from external and internal ChargingPhase API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::power_supply_DC::ChargingPhase_External");
 }
 
 VoltageCurrent_External to_external_api(VoltageCurrent_Internal const& internal) {

--- a/lib/everest/everest_api_types/src/everest_api_types/powermeter/wrapper.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/powermeter/wrapper.cpp
@@ -39,7 +39,8 @@ OCMFUserIdentificationStatus_Internal to_internal_api(OCMFUserIdentificationStat
     case OCMFUserIdentificationStatus_External::NOT_ASSIGNED:
         return OCMFUserIdentificationStatus_Internal::NOT_ASSIGNED;
     }
-    throw std::out_of_range("No know conversion between internal and external OCMFUserIdentificationStatus API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::OCMFUserIdentificationStatus_External");
 }
 
 OCMFUserIdentificationStatus_External to_external_api(OCMFUserIdentificationStatus_Internal const& val) {
@@ -49,7 +50,8 @@ OCMFUserIdentificationStatus_External to_external_api(OCMFUserIdentificationStat
     case OCMFUserIdentificationStatus_Internal::NOT_ASSIGNED:
         return OCMFUserIdentificationStatus_External::NOT_ASSIGNED;
     }
-    throw std::out_of_range("No know conversion between internal and external OCMFUserIdentificationStatus API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::OCMFUserIdentificationStatus_Internal");
 }
 
 OCMFIdentificationFlags_Internal to_internal_api(OCMFIdentificationFlags_External const& val) {
@@ -89,7 +91,8 @@ OCMFIdentificationFlags_Internal to_internal_api(OCMFIdentificationFlags_Externa
     case OCMFIdentificationFlags_External::PLMN_SMS:
         return OCMFIdentificationFlags_Internal::PLMN_SMS;
     }
-    throw std::out_of_range("No know conversion between internal and external OCMFIdentificationFlags API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::OCMFIdentificationFlags_External");
 }
 
 OCMFIdentificationFlags_External to_external_api(OCMFIdentificationFlags_Internal const& val) {
@@ -129,7 +132,8 @@ OCMFIdentificationFlags_External to_external_api(OCMFIdentificationFlags_Interna
     case OCMFIdentificationFlags_Internal::PLMN_SMS:
         return OCMFIdentificationFlags_External::PLMN_SMS;
     }
-    throw std::out_of_range("No know conversion between internal and external OCMFIdentificationFlags API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::OCMFIdentificationFlags_Internal");
 }
 
 OCMFIdentificationType_Internal to_internal_api(OCMFIdentificationType_External const& val) {
@@ -171,7 +175,8 @@ OCMFIdentificationType_Internal to_internal_api(OCMFIdentificationType_External 
     case OCMFIdentificationType_External::KEY_CODE:
         return OCMFIdentificationType_Internal::KEY_CODE;
     }
-    throw std::out_of_range("No know conversion between internal and external OCMFIdentificationType API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::OCMFIdentificationType_External");
 }
 
 OCMFIdentificationType_External to_external_api(OCMFIdentificationType_Internal const& val) {
@@ -213,7 +218,8 @@ OCMFIdentificationType_External to_external_api(OCMFIdentificationType_Internal 
     case OCMFIdentificationType_Internal::KEY_CODE:
         return OCMFIdentificationType_External::KEY_CODE;
     }
-    throw std::out_of_range("No know conversion between internal and external OCMFIdentificationType API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::OCMFIdentificationType_Internal");
 }
 
 OCMFIdentificationLevel_Internal to_internal_api(OCMFIdentificationLevel_External const& val) {
@@ -240,7 +246,8 @@ OCMFIdentificationLevel_Internal to_internal_api(OCMFIdentificationLevel_Externa
         return OCMFIdentificationLevel_Internal::UNKNOWN;
     }
 
-    throw std::out_of_range("No know conversion between internal and external OCMFIdentificationLevel API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::OCMFIdentificationLevel_External");
 }
 
 OCMFIdentificationLevel_External to_external_api(OCMFIdentificationLevel_Internal const& val) {
@@ -267,7 +274,8 @@ OCMFIdentificationLevel_External to_external_api(OCMFIdentificationLevel_Interna
         return OCMFIdentificationLevel_External::UNKNOWN;
     }
 
-    throw std::out_of_range("No know conversion between internal and external OCMFIdentificationLevel API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::OCMFIdentificationLevel_Internal");
 }
 
 Temperature_Internal to_internal_api(Temperature_External const& val) {
@@ -592,7 +600,8 @@ TransactionStatus_Internal to_internal_api(TransactionStatus_External const& val
         return TransactionStatus_Internal::UNEXPECTED_ERROR;
     }
 
-    throw std::out_of_range("No known conversion from external to internal TransactionStatus API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::TransactionStatus_External");
 }
 
 TransactionStatus_External to_external_api(TransactionStatus_Internal const& val) {
@@ -605,7 +614,8 @@ TransactionStatus_External to_external_api(TransactionStatus_Internal const& val
         return TransactionStatus_External::UNEXPECTED_ERROR;
     }
 
-    throw std::out_of_range("No known conversion from internal to external TransactionStatus API");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::powermeter::TransactionStatus_Internal");
 }
 
 ReplyStartTransaction_Internal to_internal_api(ReplyStartTransaction_External const& val) {

--- a/lib/everest/everest_api_types/src/everest_api_types/system/wrapper.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/system/wrapper.cpp
@@ -23,7 +23,8 @@ UpdateFirmwareResponse_Internal to_internal_api(UpdateFirmwareResponse_External 
     case SrcT::RevokedCertificate:
         return TarT::RevokedCertificate;
     }
-    throw std::out_of_range("Unexpected value for UpdateFirmwareResponse_Internal" + serialize(val));
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::UpdateFirmwareResponse_External");
 }
 UpdateFirmwareResponse_External to_external_api(UpdateFirmwareResponse_Internal const& val) {
     using SrcT = UpdateFirmwareResponse_Internal;
@@ -40,7 +41,8 @@ UpdateFirmwareResponse_External to_external_api(UpdateFirmwareResponse_Internal 
     case SrcT::RevokedCertificate:
         return TarT::RevokedCertificate;
     }
-    throw std::out_of_range("Unexpected value for UpdateFirmwareResponse_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::UpdateFirmwareResponse_Internal");
 }
 
 UploadLogsStatus_Internal to_internal_api(UploadLogsStatus_External const& val) {
@@ -54,7 +56,7 @@ UploadLogsStatus_Internal to_internal_api(UploadLogsStatus_External const& val) 
     case SrcT::AcceptedCanceled:
         return TarT::AcceptedCanceled;
     }
-    throw std::out_of_range("Unexpected value for UploadLogsStatus_Internal" + serialize(val));
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::UploadLogsStatus_External");
 }
 UploadLogsStatus_External to_external_api(UploadLogsStatus_Internal const& val) {
     using SrcT = UploadLogsStatus_Internal;
@@ -67,7 +69,7 @@ UploadLogsStatus_External to_external_api(UploadLogsStatus_Internal const& val) 
     case SrcT::AcceptedCanceled:
         return TarT::AcceptedCanceled;
     }
-    throw std::out_of_range("Unexpected value for UploadLogsStatus_External");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::UploadLogsStatus_Internal");
 }
 
 LogStatusEnum_Internal to_internal_api(LogStatusEnum_External const& val) {
@@ -91,7 +93,7 @@ LogStatusEnum_Internal to_internal_api(LogStatusEnum_External const& val) {
     case SrcT::AcceptedCanceled:
         return TarT::AcceptedCanceled;
     }
-    throw std::out_of_range("Unexpected value for LogStatusEnum_Internal" + serialize(val));
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::LogStatusEnum_External");
 }
 LogStatusEnum_External to_external_api(LogStatusEnum_Internal const& val) {
     using SrcT = LogStatusEnum_Internal;
@@ -114,7 +116,7 @@ LogStatusEnum_External to_external_api(LogStatusEnum_Internal const& val) {
     case SrcT::AcceptedCanceled:
         return TarT::AcceptedCanceled;
     }
-    throw std::out_of_range("Unexpected value for LogStatusEnum_External");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::LogStatusEnum_Internal");
 }
 
 FirmwareUpdateStatusEnum_Internal to_internal_api(FirmwareUpdateStatusEnum_External const& val) {
@@ -150,7 +152,8 @@ FirmwareUpdateStatusEnum_Internal to_internal_api(FirmwareUpdateStatusEnum_Exter
     case SrcT::SignatureVerified:
         return TarT::SignatureVerified;
     }
-    throw std::out_of_range("Unexpected value for FirmwareUpdateStatusEnum_Internal" + serialize(val));
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::FirmwareUpdateStatusEnum_External");
 }
 FirmwareUpdateStatusEnum_External to_external_api(FirmwareUpdateStatusEnum_Internal const& val) {
     using SrcT = FirmwareUpdateStatusEnum_Internal;
@@ -185,7 +188,8 @@ FirmwareUpdateStatusEnum_External to_external_api(FirmwareUpdateStatusEnum_Inter
     case SrcT::SignatureVerified:
         return TarT::SignatureVerified;
     }
-    throw std::out_of_range("Unexpected value for FirmwareUpdateStatusEnum_External");
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::FirmwareUpdateStatusEnum_Internal");
 }
 
 ResetType_Internal to_internal_api(ResetType_External const& val) {
@@ -199,7 +203,7 @@ ResetType_Internal to_internal_api(ResetType_External const& val) {
     case SrcT::NotSpecified:
         return TarT::NotSpecified;
     }
-    throw std::out_of_range("Unexpected value for ResetType_Internal" + serialize(val));
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::ResetType_External");
 }
 ResetType_External to_external_api(ResetType_Internal const& val) {
     using SrcT = ResetType_Internal;
@@ -212,7 +216,7 @@ ResetType_External to_external_api(ResetType_Internal const& val) {
     case SrcT::NotSpecified:
         return TarT::NotSpecified;
     }
-    throw std::out_of_range("Unexpected value for ResetType_External");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::ResetType_Internal");
 }
 
 BootReason_Internal to_internal_api(BootReason_External const& val) {
@@ -238,7 +242,7 @@ BootReason_Internal to_internal_api(BootReason_External const& val) {
     case SrcT::Watchdog:
         return TarT::Watchdog;
     }
-    throw std::out_of_range("Unexpected value for BootReason_Internal" + serialize(val));
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::BootReason_External");
 }
 BootReason_External to_external_api(BootReason_Internal const& val) {
     using SrcT = BootReason_Internal;
@@ -263,7 +267,7 @@ BootReason_External to_external_api(BootReason_Internal const& val) {
     case SrcT::Watchdog:
         return TarT::Watchdog;
     }
-    throw std::out_of_range("Unexpected value for BootReason_External");
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::BootReason_Internal");
 }
 
 FirmwareUpdateRequest_Internal to_internal_api(FirmwareUpdateRequest_External const& val) {


### PR DESCRIPTION
## Describe your changes
The exception messages for invalid conversions between internal/external types where inconsistent and partly wrong.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

