### PR TITLE
RsPaymentTerminal: fix log library resolution

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -134,6 +134,12 @@ everest_framework_crate_index.from_cargo(
     ],
 )
 
+everest_core_crate_index.annotation(
+    crate = "log",
+    repositories = ["everest_core_crate_index"],
+    override_target_lib = "@everest_framework_crate_index//:log",
+)
+
 use_repo(
     everest_framework_crate_index,
     "everest_framework_crate_index",


### PR DESCRIPTION
## Describe your changes

The monorepo refactoring broke the logging for the in repo modules since bazel would link against two logging crates (one from framework and one from module). This is for now fixed by pinning the log crate for all modules to be the same as in framework. The proper fix would be to refactor the rust setup and use one common workspace for framework and modules