### PR TITLE
fix(EvseV2G): prevent use-after-free in EvseV2G on init/ready failure:

### DIFF
--- a/modules/EVSE/EvseV2G/EvseV2G.cpp
+++ b/modules/EVSE/EvseV2G/EvseV2G.cpp
@@ -9,8 +9,8 @@
 #include <everest/logging.hpp>
 
 #include <csignal>
-#include <stdexcept>
 #include <everest/tls/openssl_util.hpp>
+#include <stdexcept>
 namespace {
 void log_handler(openssl::log_level_t level, const std::string& str) {
     switch (level) {

--- a/modules/EVSE/EvseV2G/EvseV2G.cpp
+++ b/modules/EVSE/EvseV2G/EvseV2G.cpp
@@ -9,6 +9,7 @@
 #include <everest/logging.hpp>
 
 #include <csignal>
+#include <stdexcept>
 #include <everest/tls/openssl_util.hpp>
 namespace {
 void log_handler(openssl::log_level_t level, const std::string& str) {
@@ -44,8 +45,9 @@ void EvseV2G::init() {
     /* create v2g context */
     v2g_ctx = v2g_ctx_create(p_charger.get(), p_extensions.get(), r_security.get(), r_vas);
 
-    if (v2g_ctx == nullptr)
-        return;
+    if (v2g_ctx == nullptr) {
+        throw std::runtime_error("Failed to create v2g context");
+    }
 
     (void)openssl::set_log_handler(log_handler);
     tls::Server::configure_signal_handler(SIGUSR1);
@@ -116,7 +118,7 @@ void EvseV2G::ready() {
     return;
 
 err_out:
-    v2g_ctx_free(v2g_ctx);
+    throw std::runtime_error("Could not initialise EvseV2G module");
 }
 
 EvseV2G::~EvseV2G() {

--- a/modules/EVSE/EvseV2G/v2g_ctx.cpp
+++ b/modules/EVSE/EvseV2G/v2g_ctx.cpp
@@ -348,6 +348,10 @@ free_out:
 }
 
 void v2g_ctx_free(struct v2g_context* ctx) {
+    if (ctx == nullptr) {
+        return;
+    }
+
     if (ctx->event_base) {
         event_base_loopbreak(ctx->event_base);
         event_base_free(ctx->event_base);


### PR DESCRIPTION
## Describe your changes
* Throw std::runtime_error instead of freeing v2g_ctx and continuing which could left cmd handlers accessing freed memory
* Add nullptr check to v2g_ctx_free

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

