### PR TITLE
yocto/kirkstone: update openssl patch

### DIFF
--- a/yocto/kirkstone/meta-everest/recipes-connectivity/openssl/openssl/openssl-3.0.19-feat-updates-to-support-status_request_v2.patch
+++ b/yocto/kirkstone/meta-everest/recipes-connectivity/openssl/openssl/openssl-3.0.19-feat-updates-to-support-status_request_v2.patch
@@ -1,0 +1,139 @@
+From 3c730e3e123d0bf1c128c7fbce7c2150bb2b25ea Mon Sep 17 00:00:00 2001
+From: James Chapman <james.chapman@pionix.de>
+Date: Fri, 21 Jun 2024 10:29:44 +0100
+Subject: [PATCH] feat: updates to support status_request_v2
+
+Signed-off-by: James Chapman <james.chapman@pionix.de>
+---
+ include/openssl/ssl.h.in     | 2 ++
+ include/openssl/tls1.h       | 7 +++++++
+ ssl/s3_lib.c                 | 8 ++++++++
+ ssl/statem/extensions_clnt.c | 3 ++-
+ ssl/statem/extensions_srvr.c | 4 ++++
+ ssl/statem/statem_clnt.c     | 3 ++-
+ 6 files changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/include/openssl/ssl.h.in b/include/openssl/ssl.h.in
+index a1791275f9..96cf194112 100644
+--- a/include/openssl/ssl.h.in
++++ b/include/openssl/ssl.h.in
+@@ -1255,6 +1255,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
+ #define SSL_CTRL_SET_TLSEXT_STATUS_REQ_IDS 69
+ #define SSL_CTRL_GET_TLSEXT_STATUS_REQ_OCSP_RESP 70
+ #define SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP 71
++# define SSL_CTRL_GET_TLSEXT_STATUS_EXPECTED        270
++# define SSL_CTRL_SET_TLSEXT_STATUS_EXPECTED        271
+ #ifndef OPENSSL_NO_DEPRECATED_3_0
+ #define SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB 72
+ #endif
+diff --git a/include/openssl/tls1.h b/include/openssl/tls1.h
+index bb949fbdea..ea90c49f35 100644
+--- a/include/openssl/tls1.h
++++ b/include/openssl/tls1.h
+@@ -159,6 +159,7 @@ extern "C" {
+ #define TLSEXT_NAMETYPE_host_name 0
+ /* status request value from RFC3546 */
+ #define TLSEXT_STATUSTYPE_ocsp 1
++#define TLSEXT_STATUSTYPE_ocsp_multi 2
+ 
+ /* ECPointFormat values from RFC4492 */
+ #define TLSEXT_ECPOINTFORMAT_first 0
+@@ -292,6 +293,12 @@ __owur int SSL_check_chain(SSL *s, X509 *x, EVP_PKEY *pk, STACK_OF(X509) *chain)
+ #define SSL_set_tlsext_status_ocsp_resp(ssl, arg, arglen) \
+     SSL_ctrl(ssl, SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP, arglen, arg)
+ 
++#define SSL_get_tlsext_status_expected(ssl) \
++    SSL_ctrl(ssl,SSL_CTRL_GET_TLSEXT_STATUS_EXPECTED,0,NULL)
++
++#define SSL_set_tlsext_status_expected(ssl, arg) \
++    SSL_ctrl(ssl,SSL_CTRL_SET_TLSEXT_STATUS_EXPECTED,arg,NULL)
++
+ #define SSL_CTX_set_tlsext_servername_callback(ctx, cb)           \
+     SSL_CTX_callback_ctrl(ctx, SSL_CTRL_SET_TLSEXT_SERVERNAME_CB, \
+         (void (*)(void))cb)
+diff --git a/ssl/s3_lib.c b/ssl/s3_lib.c
+index ff2037ceb4..e447998ded 100644
+--- a/ssl/s3_lib.c
++++ b/ssl/s3_lib.c
+@@ -3972,6 +3972,14 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
+         ret = 1;
+         break;
+ 
++    case SSL_CTRL_GET_TLSEXT_STATUS_EXPECTED:
++        return (long)s->ext.status_expected;
++
++    case SSL_CTRL_SET_TLSEXT_STATUS_EXPECTED:
++        s->ext.status_expected = larg;
++        ret = 1;
++        break;
++
+     case SSL_CTRL_CHAIN:
+         if (larg)
+             return ssl_cert_set1_chain(s, NULL, (STACK_OF(X509) *)parg);
+diff --git a/ssl/statem/extensions_clnt.c b/ssl/statem/extensions_clnt.c
+index 859d6bd647..cf8cc4c8f5 100644
+--- a/ssl/statem/extensions_clnt.c
++++ b/ssl/statem/extensions_clnt.c
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <openssl/ocsp.h>
++#include <openssl/tls1.h>
+ #include "../ssl_local.h"
+ #include "internal/cryptlib.h"
+ #include "statem_local.h"
+@@ -1394,7 +1395,7 @@ int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
+      * MUST only be sent if we've requested a status
+      * request message. In TLS <= 1.2 it must also be empty.
+      */
+-    if (s->ext.status_type != TLSEXT_STATUSTYPE_ocsp) {
++    if ((s->ext.status_type != TLSEXT_STATUSTYPE_ocsp) && (s->ext.status_type != TLSEXT_STATUSTYPE_ocsp_multi)) {
+         SSLfatal(s, SSL_AD_UNSUPPORTED_EXTENSION, SSL_R_BAD_EXTENSION);
+         return 0;
+     }
+diff --git a/ssl/statem/extensions_srvr.c b/ssl/statem/extensions_srvr.c
+index 2b586d61a3..f4935f2943 100644
+--- a/ssl/statem/extensions_srvr.c
++++ b/ssl/statem/extensions_srvr.c
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <openssl/ocsp.h>
++#include <openssl/tls1.h>
+ #include "../ssl_local.h"
+ #include "statem_local.h"
+ #include "internal/cryptlib.h"
+@@ -1438,6 +1439,9 @@ EXT_RETURN tls_construct_stoc_status_request(SSL *s, WPACKET *pkt,
+     if (!s->ext.status_expected)
+         return EXT_RETURN_NOT_SENT;
+ 
++    if (s->ext.status_type == TLSEXT_STATUSTYPE_ocsp_multi)
++        return EXT_RETURN_NOT_SENT;
++
+     if (SSL_IS_TLS13(s) && chainidx != 0)
+         return EXT_RETURN_NOT_SENT;
+ 
+diff --git a/ssl/statem/statem_clnt.c b/ssl/statem/statem_clnt.c
+index 4b5f966e5e..8f3bde0f9f 100644
+--- a/ssl/statem/statem_clnt.c
++++ b/ssl/statem/statem_clnt.c
+@@ -9,6 +9,7 @@
+  * https://www.openssl.org/source/license.html
+  */
+ 
++#include <openssl/tls1.h>
+ #include <stdio.h>
+ #include <time.h>
+ #include <assert.h>
+@@ -2639,7 +2640,7 @@ int tls_process_cert_status_body(SSL *s, PACKET *pkt)
+     unsigned int type;
+ 
+     if (!PACKET_get_1(pkt, &type)
+-        || type != TLSEXT_STATUSTYPE_ocsp) {
++        || (type != TLSEXT_STATUSTYPE_ocsp) && (type != TLSEXT_STATUSTYPE_ocsp_multi)) {
+         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_UNSUPPORTED_STATUS_TYPE);
+         return 0;
+     }
+-- 
+2.34.1
+

--- a/yocto/kirkstone/meta-everest/recipes-connectivity/openssl/openssl/openssl-3.0.8-feat-updates-to-support-status_request_v2.patch
+++ b/yocto/kirkstone/meta-everest/recipes-connectivity/openssl/openssl/openssl-3.0.8-feat-updates-to-support-status_request_v2.patch
@@ -1,0 +1,139 @@
+From 92125584f2fe87023cbfe96bba06358111ed8c13 Mon Sep 17 00:00:00 2001
+From: James Chapman <james.chapman@pionix.de>
+Date: Fri, 21 Jun 2024 10:29:44 +0100
+Subject: [PATCH 1/1] feat: updates to support status_request_v2
+
+Signed-off-by: James Chapman <james.chapman@pionix.de>
+---
+ include/openssl/ssl.h.in     | 2 ++
+ include/openssl/tls1.h       | 7 +++++++
+ ssl/s3_lib.c                 | 8 ++++++++
+ ssl/statem/extensions_clnt.c | 3 ++-
+ ssl/statem/extensions_srvr.c | 4 ++++
+ ssl/statem/statem_clnt.c     | 3 ++-
+ 6 files changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/include/openssl/ssl.h.in b/include/openssl/ssl.h.in
+index 105b4a4a3c..b29f65fbfa 100644
+--- a/include/openssl/ssl.h.in
++++ b/include/openssl/ssl.h.in
+@@ -1251,6 +1251,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
+ # define SSL_CTRL_SET_TLSEXT_STATUS_REQ_IDS      69
+ # define SSL_CTRL_GET_TLSEXT_STATUS_REQ_OCSP_RESP        70
+ # define SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP        71
++# define SSL_CTRL_GET_TLSEXT_STATUS_EXPECTED        270
++# define SSL_CTRL_SET_TLSEXT_STATUS_EXPECTED        271
+ # ifndef OPENSSL_NO_DEPRECATED_3_0
+ #  define SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB      72
+ # endif
+diff --git a/include/openssl/tls1.h b/include/openssl/tls1.h
+index d6e9331fa1..f0a8413703 100644
+--- a/include/openssl/tls1.h
++++ b/include/openssl/tls1.h
+@@ -160,6 +160,7 @@ extern "C" {
+ # define TLSEXT_NAMETYPE_host_name 0
+ /* status request value from RFC3546 */
+ # define TLSEXT_STATUSTYPE_ocsp 1
++# define TLSEXT_STATUSTYPE_ocsp_multi 2
+ 
+ /* ECPointFormat values from RFC4492 */
+ # define TLSEXT_ECPOINTFORMAT_first                      0
+@@ -291,6 +292,12 @@ __owur int SSL_check_chain(SSL *s, X509 *x, EVP_PKEY *pk, STACK_OF(X509) *chain)
+ # define SSL_set_tlsext_status_ocsp_resp(ssl, arg, arglen) \
+         SSL_ctrl(ssl,SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP,arglen,arg)
+ 
++# define SSL_get_tlsext_status_expected(ssl) \
++        SSL_ctrl(ssl,SSL_CTRL_GET_TLSEXT_STATUS_EXPECTED,0,NULL)
++
++# define SSL_set_tlsext_status_expected(ssl, arg) \
++        SSL_ctrl(ssl,SSL_CTRL_SET_TLSEXT_STATUS_EXPECTED,arg,NULL)
++
+ # define SSL_CTX_set_tlsext_servername_callback(ctx, cb) \
+         SSL_CTX_callback_ctrl(ctx,SSL_CTRL_SET_TLSEXT_SERVERNAME_CB,\
+                 (void (*)(void))cb)
+diff --git a/ssl/s3_lib.c b/ssl/s3_lib.c
+index 78d4f04056..ede3a56f2f 100644
+--- a/ssl/s3_lib.c
++++ b/ssl/s3_lib.c
+@@ -3556,6 +3556,14 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
+         ret = 1;
+         break;
+ 
++    case SSL_CTRL_GET_TLSEXT_STATUS_EXPECTED:
++        return (long)s->ext.status_expected;
++
++    case SSL_CTRL_SET_TLSEXT_STATUS_EXPECTED:
++        s->ext.status_expected = larg;
++        ret = 1;
++        break;
++
+     case SSL_CTRL_CHAIN:
+         if (larg)
+             return ssl_cert_set1_chain(s, NULL, (STACK_OF(X509) *)parg);
+diff --git a/ssl/statem/extensions_clnt.c b/ssl/statem/extensions_clnt.c
+index 842be0722b..b9d5493e72 100644
+--- a/ssl/statem/extensions_clnt.c
++++ b/ssl/statem/extensions_clnt.c
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <openssl/ocsp.h>
++#include <openssl/tls1.h>
+ #include "../ssl_local.h"
+ #include "internal/cryptlib.h"
+ #include "statem_local.h"
+@@ -1397,7 +1398,7 @@ int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
+      * MUST only be sent if we've requested a status
+      * request message. In TLS <= 1.2 it must also be empty.
+      */
+-    if (s->ext.status_type != TLSEXT_STATUSTYPE_ocsp) {
++    if ((s->ext.status_type != TLSEXT_STATUSTYPE_ocsp) && (s->ext.status_type != TLSEXT_STATUSTYPE_ocsp_multi)) {
+         SSLfatal(s, SSL_AD_UNSUPPORTED_EXTENSION, SSL_R_BAD_EXTENSION);
+         return 0;
+     }
+diff --git a/ssl/statem/extensions_srvr.c b/ssl/statem/extensions_srvr.c
+index 16765a5a5b..7fb67937bf 100644
+--- a/ssl/statem/extensions_srvr.c
++++ b/ssl/statem/extensions_srvr.c
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <openssl/ocsp.h>
++#include <openssl/tls1.h>
+ #include "../ssl_local.h"
+ #include "statem_local.h"
+ #include "internal/cryptlib.h"
+@@ -1421,6 +1422,9 @@ EXT_RETURN tls_construct_stoc_status_request(SSL *s, WPACKET *pkt,
+     if (!s->ext.status_expected)
+         return EXT_RETURN_NOT_SENT;
+ 
++    if (s->ext.status_type == TLSEXT_STATUSTYPE_ocsp_multi)
++        return EXT_RETURN_NOT_SENT;
++
+     if (SSL_IS_TLS13(s) && chainidx != 0)
+         return EXT_RETURN_NOT_SENT;
+ 
+diff --git a/ssl/statem/statem_clnt.c b/ssl/statem/statem_clnt.c
+index 3cd1ee2d3d..29a07bd413 100644
+--- a/ssl/statem/statem_clnt.c
++++ b/ssl/statem/statem_clnt.c
+@@ -9,6 +9,7 @@
+  * https://www.openssl.org/source/license.html
+  */
+ 
++#include <openssl/tls1.h>
+ #include <stdio.h>
+ #include <time.h>
+ #include <assert.h>
+@@ -2636,7 +2637,7 @@ int tls_process_cert_status_body(SSL *s, PACKET *pkt)
+     unsigned int type;
+ 
+     if (!PACKET_get_1(pkt, &type)
+-        || type != TLSEXT_STATUSTYPE_ocsp) {
++        || (type != TLSEXT_STATUSTYPE_ocsp) && (type != TLSEXT_STATUSTYPE_ocsp_multi)) {
+         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_UNSUPPORTED_STATUS_TYPE);
+         return 0;
+     }
+-- 
+2.34.1
+

--- a/yocto/kirkstone/meta-everest/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/yocto/kirkstone/meta-everest/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,3 +1,0 @@
-SRC_URI += "https://raw.githubusercontent.com/EVerest/everest-core/4c7b9f5f15a8adce2a38113926c09fe8ba486b21/lib/staging/tls/openssl-3.0.8-feat-updates-to-support-status_request_v2.patch;apply=yes;downloadfilename=everest-openssl.patch;name=everest-openssl-patch \
-           "
-SRC_URI[everest-openssl-patch.sha256sum] = "17626c6efd9568d761f219712b8d840026a5d2de54d8b75c86f32332af1c35e4"

--- a/yocto/kirkstone/meta-everest/recipes-connectivity/openssl/openssl_3.0.%.bbappend
+++ b/yocto/kirkstone/meta-everest/recipes-connectivity/openssl/openssl_3.0.%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+python __anonymous() {
+    pv = d.getVar("PV")
+
+    if bb.utils.vercmp_string_op(pv, "3.0.19", "<"):
+        d.appendVar("SRC_URI", " file://openssl-3.0.8-feat-updates-to-support-status_request_v2.patch")
+    else:
+        d.appendVar("SRC_URI", " file://openssl-3.0.19-feat-updates-to-support-status_request_v2.patch")
+}


### PR DESCRIPTION
The patch originally provided in lib/everest/tls (formerly lib/staging/tls) was for openssl-3.0.8, and no longer applies to openssl starting with version 3.0.19, which is currently used by poky kirkstone (post 4.0.33).

## Describe your changes
Convert the original SRC_URI from a URL pointing to a git blob to an actual patch file.
Create a rebased patch file for 3.0.19.

Apply the patches conditionally, depending on the openssl version.

Restrict the bbappend to openssl versions 3.0.x via file name scheme, as the patch does not apply to 3.y with y >= 1 either (which kirkstone will likely never package).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

