### PR TITLE
fix(EvseManager): Prevent sending the ignored DC supported transfer mode to EvseV2G

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -238,7 +238,7 @@ void EvseManager::init() {
             r_powersupply_DC[0]->subscribe_capabilities([this](const auto& caps) {
                 update_powersupply_capabilities(caps);
 
-                auto mode = types::iso15118::EnergyTransferMode::DC;
+                auto mode = types::iso15118::EnergyTransferMode::DC_extended;
                 auto bpt_mode = types::iso15118::EnergyTransferMode::DC_BPT;
 
                 if (connector_type.has_value() and


### PR DESCRIPTION
## Describe your changes
Changed `DC` to `DC_extended`. Now `EvseV2G` and `Evse15118D20` get the correct SupportedEnergyTransferModes.

## Issue ticket number and link
In the case of DIN/ISO-2, it may happen that the SupportedEnergyTransferModes are set to DC by the PowerSupply capabilities subscribe function and overrides the initial supported energy transfer modes. `EvseV2G` ignores DC because it is an D20 EnergyService.
It could happen that the session in the ServiceDiscover state is terminated because there are no EnergyTransferModes to send.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

