### PR TITLE
fix(lib): expose everest::run_application on non-EDM builds

### DIFF
--- a/lib/everest/run_application/CMakeLists.txt
+++ b/lib/everest/run_application/CMakeLists.txt
@@ -21,3 +21,20 @@ target_link_libraries(everest_run_application
         fmt::fmt
         everest::log
 )
+
+set_target_properties(everest_run_application PROPERTIES EXPORT_NAME run_application)
+
+if (DISABLE_EDM)
+    install(
+        TARGETS everest_run_application
+        EXPORT everest-core-targets
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        INCLUDES DESTINATION include
+    )
+
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/everest
+        TYPE INCLUDE
+    )
+endif()


### PR DESCRIPTION
This is required for use of everest::run_application in standalone module builds without EDM.

## Describe your changes
Expose via CMake `install()`, like other internal libs (e.g. everest::io, everest::gpio) do.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

