### PR TITLE
feat(auth,ocpp): publish tariff messages on consumer APIs

### DIFF
--- a/docs/source/how-to-guides/index.rst
+++ b/docs/source/how-to-guides/index.rst
@@ -97,6 +97,12 @@ Have a look at this categorized list of all guides:
 
       How to get started with the Pionix Belay Box, an AC charging station dev kit based on EVerest.
 
+   .. grid-item-card:: Integrate Tariff and Cost
+      :link: integrate-tariff-and-cost
+      :link-type: doc
+
+      How to subscribe to tariff and session cost updates from the consumer APIs, including OCPP-specific configuration.
+
 .. toctree::
     :maxdepth: 1
     :hidden:
@@ -115,3 +121,4 @@ Have a look at this categorized list of all guides:
     bringup/index
     choosing-version-and-upgrading
     pionix-belay-box
+    integrate-tariff-and-cost

--- a/docs/source/how-to-guides/integrate-tariff-and-cost.rst
+++ b/docs/source/how-to-guides/integrate-tariff-and-cost.rst
@@ -1,0 +1,175 @@
+.. _htg_integrate_tariff_and_cost:
+
+#########################
+Integrate Tariff and Cost
+#########################
+
+This guide explains how to subscribe to tariff and session cost updates
+published by EVerest, and how the data flow differs between OCPP 1.6 and
+OCPP 2.x.
+
+*************
+Prerequisites
+*************
+
+- An EVerest deployment with an OCPP module (``OCPP`` for 1.6 or ``OCPP201``
+  for 2.x) and the ``Auth`` module.
+- An API client that connects via MQTT and subscribes to the relevant
+  consumer API topics.
+
+**********************
+Relevant Consumer APIs
+**********************
+
+Two consumer APIs carry tariff and cost information:
+
+- **Session cost consumer API** — provides the ``tariff_message`` and
+  ``session_cost`` variables on the ``session_cost`` interface.
+- **Auth consumer API** — provides ``token_validation_status``, which may
+  include tariff messages received at authorization time.
+
+At least the session cost consumer API must be subscribed to receive tariff and cost
+updates.
+
+See the :doc:`AsyncAPI reference </reference/EVerest_API/session_cost_consumer_API>`
+and :doc:`</reference/EVerest_API/auth_consumer_API>` for message schemas.
+
+.. note::
+    
+    The OCPP implementations follow the requirements of the OCA California
+    Pricing Whitepaper. Note that this whitepaper contains requirements for
+    displaying pricing information to the user, so in order to comply with it,
+    the tariff and session cost messages must be used to show the required
+    information on a charger display. The APIs only provide the necessary data.
+
+******************
+OCPP configuration
+******************
+
+If you plan to use session cost information from OCPP (e.g. according to the California
+Pricing requirements), you need to configure the OCPP modules to receive tariff and
+cost information from the CSMS.
+
+OCPP 1.6
+=========
+
+Enable the ``CostAndPrice`` profile in the OCPP 1.6 module configuration.
+Once enabled, the OCPP module registers the tariff message and session cost
+callbacks. Configure the configuration keys of the ``CostAndPrice`` profile
+as needed.
+
+OCPP 2.x
+========
+
+Enable the ``TariffCostCtrlr`` in the OCPP 2.x device model. The
+component variables ``TariffEnabled`` and ``CostEnabled`` control which
+features are active:
+
+- **TariffEnabled** — publishes tariff / pricing messages via the
+  ``tariff_message`` variable.
+- **CostEnabled** — publishes running and final session cost via the
+  ``session_cost`` variable.
+
+Both can be enabled independently. Also configure other variables of the
+``TariffCostCtrlr`` as needed.
+
+.. note::
+
+    Additional requirements of the OCPP 2.1 specification with respect to
+    tariff and costs have not yet been implemented. The implemented features
+    can still be used with OCPP 2.1.
+
+*******************
+Tariff message flow
+*******************
+
+Tariff messages contain human-readable pricing text in one or more
+languages. They are published on the ``tariff_message`` variable of the
+session cost consumer API.
+
+OCPP 1.6
+=========
+
+Tariff messages originate from a ``SetUserPrice`` DataTransfer message sent
+by the CSMS. The CSMS typically sends this message shortly after the
+``Authorize.conf``, so the tariff message is available close to
+authorization time.
+
+If the ``SetUserPrice`` DataTransfer is not received within the configured
+timeout, a default tariff message (if configured) is published instead.
+
+OCPP 2.x
+========
+
+Tariff messages are published at two points:
+
+1. **Authorization time** — from the ``personalMessage`` field in the
+   ``AuthorizeResponse``. The tariff message is also included in the
+   ``messages`` field of the ``token_validation_status`` on the auth
+   consumer API. At this point the ``identifier_type`` is ``IdToken`` and
+   the ``identifier_id`` is the token value, since no transaction exists
+   yet.
+
+2. **During the session** — from the ``updatedPersonalMessage`` field in
+   ``TransactionEventResponse`` messages. At this point the
+   ``identifier_type`` is ``TransactionId`` and the ``identifier_id`` is
+   the OCPP transaction ID.
+
+.. note::
+
+   To correlate auth-time tariff messages (keyed by ``IdToken``) with
+   in-session updates (keyed by ``TransactionId``), use the
+   ``token_validation_status`` message on the auth consumer API to capture
+   the token, then match it against the session information from the EVSE
+   manager consumer API.
+
+*****************
+Session cost flow
+*****************
+
+Session cost messages contain the accumulated cost of a charging session,
+broken down into cost chunks (energy, time, flat fees), with current and
+next-period pricing. They are published on the ``session_cost`` variable of
+the session cost consumer API.
+
+OCPP 1.6
+=========
+
+Session cost updates are triggered by ``RunningCost`` and ``FinalCost``
+DataTransfer messages from the CSMS.
+
+OCPP 2.x
+========
+
+Session cost updates are triggered by:
+
+- ``totalCost`` in a ``TransactionEventResponse`` — publishes a running
+  cost update with status ``Running`` or ``Idle``.
+- ``CostUpdated`` message — publishes a final cost update with status
+  ``Finished``.
+
+When both ``totalCost`` and ``updatedPersonalMessage`` are present in the
+same ``TransactionEventResponse``, the personal message appears in both the
+``tariff_message`` variable and the ``message`` field of the
+``session_cost`` record.
+
+*****************************
+Relationship between the APIs
+*****************************
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Event
+     - Auth consumer API
+     - Session cost consumer API
+   * - Token authorized with tariff
+     - ``token_validation_status`` includes ``messages``
+     - ``tariff_message`` published
+   * - In-session tariff update
+     - —
+     - ``tariff_message`` published
+   * - Running / final cost
+     - —
+     - ``session_cost`` published (may include ``message``)

--- a/docs/source/how-to-guides/integrate-tariff-and-cost.rst
+++ b/docs/source/how-to-guides/integrate-tariff-and-cost.rst
@@ -13,7 +13,7 @@ Prerequisites
 *************
 
 - An EVerest deployment with an OCPP module (``OCPP`` for 1.6 or ``OCPP201``
-  for 2.x) and the ``Auth`` module.
+  for 2.x) and the ``Auth`` module and the relevant API modules (see next section).
 - An API client that connects via MQTT and subscribes to the relevant
   consumer API topics.
 
@@ -31,8 +31,9 @@ Two consumer APIs carry tariff and cost information:
 At least the session cost consumer API must be subscribed to receive tariff and cost
 updates.
 
-See the :doc:`AsyncAPI reference </reference/EVerest_API/session_cost_consumer_API>`
-and :doc:`</reference/EVerest_API/auth_consumer_API>` for message schemas.
+See the AsyncAPI reference for the `auth_consumer_API <../reference/api/auth_consumer_API/index.html>`_
+and the `session_cost_consumer_API <../reference/api/session_cost_consumer_API/index.html>`_ for message schemas.
+
 
 .. note::
     

--- a/docs/source/reference/EVerest_API/auth_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/auth_consumer_API.yaml
@@ -5,8 +5,9 @@ info:
   title: 'EVerest API definition for auth consumer'
   version: 1.0.0
   description: >-
-    API to allow EVerest API clients to use the Auth module.
-
+    API for EVerest API clients that consume authorization events from an
+    Auth module. Provides token validation status updates and the ability
+    to withdraw previously granted authorizations.
   license:
     name: Apache-2.0
     url: https://opensource.org/licenses/Apache-2.0
@@ -85,7 +86,10 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_token_validation_status'
-    description: 'Direction: EVerest to Module'
+    description: >-
+      Published whenever the validation status of a token changes.
+      The message contains the token, its validation status, and an
+      optional array of tariff messages received at authorization time.
 
 
   receive_heartbeat:
@@ -147,7 +151,7 @@ components:
     receive_token_validation_status:
       name: receive_token_validation_status
       title: 'Receive token validation status message'
-      summary: 'Token validation status'
+      summary: 'Token validation status, optionally with tariff messages'
       contentType: application/json
       payload:
         $ref: '#/components/schemas/TokenValidationStatusMessage'
@@ -331,13 +335,22 @@ components:
     TokenValidationStatus:
       description: |
         Ongoing token validation status
-        - TimedOut Occurs when the token has been authorized but no connector is selected within connection_timeout seconds
+        - Processing: Validation is in progress
+        - Accepted: Token has been accepted
+        - Rejected: Token has been rejected
+        - TimedOut: Token was authorized but no connector was selected within connection_timeout seconds
+        - UsedToStart: Token was used to start a charging session
+        - UsedToStop: Token was used to stop a charging session
+        - Withdrawn: Authorization was withdrawn
       type: string
       enum:
         - Processing
         - Accepted
         - Rejected
         - TimedOut
+        - UsedToStart
+        - UsedToStop
+        - Withdrawn
     TokenValidationStatusMessage:
       description: The token validation status
       type: object
@@ -354,6 +367,9 @@ components:
           type: string
           $ref: '#/components/schemas/TokenValidationStatus'
         messages:
+          description: >-
+            Optional tariff or pricing messages received with the
+            authorization response.
           type: array
           items:
             type: object

--- a/docs/source/reference/EVerest_API/session_cost_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/session_cost_consumer_API.yaml
@@ -5,7 +5,10 @@ info:
   title: 'EVerest API definition for session cost consumer'
   version: 1.0.0
   description: >-
-    API for EVerest API clients which allows to access modules that implement session_cost.
+    API for EVerest API clients that consume session cost and tariff
+    information from the `session_cost` interface. See the
+    Integrate Tariff and Cost how-to guide for OCPP-specific
+    configuration and message flow details.
 
   license:
     name: Apache-2.0
@@ -57,11 +60,19 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_tariff_message'
+    description: >-
+      Published at authorization time and whenever the CSMS sends updated
+      pricing during a session. Contains human-readable price text in one
+      or more languages.
   receive_session_cost:
     title: 'Receive session cost'
     action: receive
     channel:
       $ref: '#/channels/receive_session_cost'
+    description: >-
+      Published periodically during a session and once when it ends.
+      Contains session cost broken down into chunks, current and upcoming
+      pricing, and optional display messages.
 
 
   receive_heartbeat:
@@ -82,14 +93,14 @@ components:
     receive_tariff_message:
       name: receive_tariff_message
       title: 'Receive tariff message'
-      summary: Message to show tariff information
+      summary: 'Tariff and pricing information for a charging session'
       contentType: application/json
       payload:
         $ref: 'session_cost_API.yaml#/components/schemas/TariffMessage'
     receive_session_cost:
       name: receive_session_cost
       title: 'Receive session cost'
-      summary: Message to show session cost
+      summary: 'Running or final cost of a charging session'
       contentType: application/json
       payload:
         $ref: 'session_cost_API.yaml#/components/schemas/SessionCost'

--- a/lib/everest/everest_api_types/src/everest_api_types/session_cost/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/session_cost/json_codec.cpp
@@ -6,6 +6,7 @@
 #include "session_cost/codec.hpp"
 
 #include "auth/json_codec.hpp"
+#include "display_message/json_codec.hpp"
 #include "money/json_codec.hpp"
 #include "text_message/json_codec.hpp"
 

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -3607,6 +3607,9 @@ EnhancedIdTagInfo ChargePointImpl::authorize_id_token(CiString<20> id_token, con
                 } else {
                     EVLOG_warning << "Tariff message was not received within timeout for idToken " << id_token.get();
                     enhanced_id_tag_info.tariff_message = this->configuration.getDefaultTariffMessage(false);
+                    if (enhanced_id_tag_info.tariff_message.has_value()) {
+                        (void)this->tariff_message_callback(enhanced_id_tag_info.tariff_message.value());
+                    }
                 }
                 this->user_price_cvs.erase(id_token.get());
             }

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/tariff_and_cost.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/tariff_and_cost.cpp
@@ -49,9 +49,10 @@ void TariffAndCost::handle_cost_and_tariff(const TransactionEventResponse& respo
         const DisplayMessageContent message = message_content_to_display_message_content(personal_message);
         cost_messages.push_back(message);
 
-        // If cost is enabled, the message will be sent to the running cost callback. But if it is not enabled, the
-        // tariff message will be sent using the session cost message callback.
-        if (!cost_enabled and this->tariff_message_callback.has_value() and this->tariff_message_callback != nullptr) {
+        // Always publish the tariff message so the tariff_message variable on the session_cost interface is updated.
+        // When cost is also enabled, the message will additionally be included in the running cost callback below
+        // (if totalCost is present in the same response).
+        if (this->tariff_message_callback.has_value() and this->tariff_message_callback != nullptr) {
             TariffMessage tariff_message;
             tariff_message.message = cost_messages;
             tariff_message.ocpp_transaction_id = original_message.transactionInfo.transactionId;

--- a/modules/EVSE/Auth/Auth.cpp
+++ b/modules/EVSE/Auth/Auth.cpp
@@ -66,8 +66,9 @@ void Auth::ready() {
     }
 
     this->auth_handler->register_publish_token_validation_status_callback(
-        [this](const ProvidedIdToken& token, TokenValidationStatus status) {
-            this->p_main->publish_token_validation_status({token, status});
+        [this](const ProvidedIdToken& token, TokenValidationStatus status,
+               const std::vector<MessageContent>& tariff_messages) {
+            this->p_main->publish_token_validation_status({token, status, tariff_messages});
         });
 
     this->auth_handler->register_notify_evse_callback(

--- a/modules/EVSE/Auth/include/AuthHandler.hpp
+++ b/modules/EVSE/Auth/include/AuthHandler.hpp
@@ -16,6 +16,7 @@
 #include <generated/types/authorization.hpp>
 #include <generated/types/evse_manager.hpp>
 #include <generated/types/reservation.hpp>
+#include <generated/types/text_message.hpp>
 
 #include <Connector.hpp>
 #include <ReservationHandler.hpp>
@@ -23,6 +24,7 @@
 using namespace types::evse_manager;
 using namespace types::authorization;
 using namespace types::reservation;
+using namespace types::text_message;
 
 namespace types {
 namespace authorization {
@@ -243,7 +245,8 @@ public:
      * @param callback
      */
     void register_publish_token_validation_status_callback(
-        const std::function<void(const ProvidedIdToken&, TokenValidationStatus)>& callback);
+        const std::function<void(const ProvidedIdToken&, TokenValidationStatus, const std::vector<MessageContent>&)>&
+            callback);
 
     WithdrawAuthorizationResult handle_withdraw_authorization(const WithdrawAuthorizationRequest& request);
 
@@ -289,8 +292,12 @@ private:
     std::function<void(const std::optional<int>& evse_index, const int32_t reservation_id,
                        const types::reservation::ReservationEndReason reason, const bool send_reservation_update)>
         reservation_cancelled_callback;
-    std::function<void(const ProvidedIdToken& token, TokenValidationStatus status)>
+    std::function<void(const ProvidedIdToken& token, TokenValidationStatus status,
+                       const std::vector<MessageContent>& tariff_messages)>
         publish_token_validation_status_callback;
+
+    void publish_token_validation_status(const ProvidedIdToken& token, TokenValidationStatus status,
+                                         const std::vector<MessageContent>& tariff_messages = {});
 
     std::vector<int> get_referenced_evses(const ProvidedIdToken& provided_token);
     int used_for_transaction(const std::vector<int>& evse_ids, const std::string& id_token);

--- a/modules/EVSE/Auth/lib/AuthHandler.cpp
+++ b/modules/EVSE/Auth/lib/AuthHandler.cpp
@@ -92,7 +92,7 @@ TokenHandlingResult AuthHandler::on_token(const ProvidedIdToken& provided_token)
     if (!this->is_token_already_in_process(provided_token, referenced_evses)) {
         // process token if not already in process
         this->tokens_in_process.insert(provided_token);
-        this->publish_token_validation_status_callback(provided_token, TokenValidationStatus::Processing);
+        this->publish_token_validation_status(provided_token, TokenValidationStatus::Processing);
         result = this->handle_token(provided_token_copy, lk);
     } else {
         // do nothing if token is currently processed
@@ -105,20 +105,20 @@ TokenHandlingResult AuthHandler::on_token(const ProvidedIdToken& provided_token)
     case TokenHandlingResult::ALREADY_IN_PROCESS:
         break;
     case TokenHandlingResult::TIMEOUT: // Timeout means accepted but failed to pick contactor
-        this->publish_token_validation_status_callback(provided_token_copy, TokenValidationStatus::TimedOut);
+        this->publish_token_validation_status(provided_token_copy, TokenValidationStatus::TimedOut);
         break;
     case TokenHandlingResult::NO_CONNECTOR_AVAILABLE:
     case TokenHandlingResult::REJECTED:
-        this->publish_token_validation_status_callback(provided_token_copy, TokenValidationStatus::Rejected);
+        this->publish_token_validation_status(provided_token_copy, TokenValidationStatus::Rejected);
         break;
     case TokenHandlingResult::USED_TO_START_TRANSACTION:
-        this->publish_token_validation_status_callback(provided_token_copy, TokenValidationStatus::UsedToStart);
+        this->publish_token_validation_status(provided_token_copy, TokenValidationStatus::UsedToStart);
         break;
     case TokenHandlingResult::USED_TO_STOP_TRANSACTION:
-        this->publish_token_validation_status_callback(provided_token_copy, TokenValidationStatus::UsedToStop);
+        this->publish_token_validation_status(provided_token_copy, TokenValidationStatus::UsedToStop);
         break;
     case TokenHandlingResult::WITHDRAWN:
-        this->publish_token_validation_status_callback(provided_token_copy, TokenValidationStatus::Withdrawn);
+        this->publish_token_validation_status(provided_token_copy, TokenValidationStatus::Withdrawn);
         break;
     }
 
@@ -148,8 +148,8 @@ void AuthHandler::handle_token_validation_result_update(const ValidationResultUp
         provided_token.parent_id_token = validation_result_update.validation_result.parent_id_token;
         std::vector<int32_t> connectors_allowed{connector_id};
         provided_token.connectors = connectors_allowed;
-        this->publish_token_validation_status_callback(provided_token,
-                                                       types::authorization::TokenValidationStatus::Accepted);
+        this->publish_token_validation_status(provided_token, types::authorization::TokenValidationStatus::Accepted,
+                                              validation_result_update.validation_result.tariff_messages);
     } else {
         EVLOG_error << "Unknown evse#" << connector_id
                     << " or unknown authorization identifier on the evse for validation result update.";
@@ -329,8 +329,9 @@ TokenHandlingResult AuthHandler::handle_token(ProvidedIdToken& provided_token, s
                 if (validation_result.parent_id_token.has_value()) {
                     provided_token.parent_id_token = validation_result.parent_id_token.value();
                 }
-                this->publish_token_validation_status_callback(provided_token,
-                                                               types::authorization::TokenValidationStatus::Accepted);
+                this->publish_token_validation_status(provided_token,
+                                                      types::authorization::TokenValidationStatus::Accepted,
+                                                      validation_result.tariff_messages);
                 /* although validator accepts the authorization request, the Auth module still needs to
                     - select the evse for the authorization request
                     - process it against placed reservations
@@ -627,7 +628,7 @@ void AuthHandler::notify_evse(int evse_id, const ProvidedIdToken& provided_token
                 EVLOG_debug << "Authorization timeout for evse#" << evse_index;
                 evse->identifier.reset();
                 this->withdraw_authorization_callback(evse_index);
-                this->publish_token_validation_status_callback(provided_token, TokenValidationStatus::TimedOut);
+                this->publish_token_validation_status(provided_token, TokenValidationStatus::TimedOut);
                 evse->timeout_in_progress = false;
                 this->cv.notify_all();
             },
@@ -953,8 +954,14 @@ void AuthHandler::register_reservation_cancelled_callback(
 }
 
 void AuthHandler::register_publish_token_validation_status_callback(
-    const std::function<void(const ProvidedIdToken&, TokenValidationStatus)>& callback) {
+    const std::function<void(const ProvidedIdToken&, TokenValidationStatus, const std::vector<MessageContent>&)>&
+        callback) {
     this->publish_token_validation_status_callback = callback;
+}
+
+void AuthHandler::publish_token_validation_status(const ProvidedIdToken& token, TokenValidationStatus status,
+                                                  const std::vector<MessageContent>& tariff_messages) {
+    this->publish_token_validation_status_callback(token, status, tariff_messages);
 }
 
 WithdrawAuthorizationResult AuthHandler::handle_withdraw_authorization(const WithdrawAuthorizationRequest& request) {

--- a/modules/EVSE/Auth/tests/auth_tests.cpp
+++ b/modules/EVSE/Auth/tests/auth_tests.cpp
@@ -142,7 +142,10 @@ protected:
             });
 
         this->auth_handler->register_publish_token_validation_status_callback(
-            mock_publish_token_validation_status_callback.AsStdFunction());
+            [this](const ProvidedIdToken& token, TokenValidationStatus status,
+                   const std::vector<MessageContent>& /*tariff_messages*/) {
+                mock_publish_token_validation_status_callback.Call(token, status);
+            });
 
         this->auth_handler->init_evse(1, 0, {Connector(1, types::evse_manager::ConnectorTypeEnum::cCCS2)});
         this->auth_handler->init_evse(2, 1,

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -837,6 +837,11 @@ void OCPP201::ready() {
                 ocpp_conversions::create_session_cost(running_cost, number_of_decimals, currency);
             this->p_session_cost->publish_session_cost(cost);
         };
+
+        callbacks.tariff_message_callback = [this](const ocpp::TariffMessage& message) {
+            const types::session_cost::TariffMessage m = ocpp_conversions::to_everest_tariff_message(message);
+            this->p_session_cost->publish_tariff_message(m);
+        };
     }
 
     if (!this->r_data_transfer.empty()) {

--- a/modules/EVSE/OCPP201/auth_validator/auth_token_validatorImpl.cpp
+++ b/modules/EVSE/OCPP201/auth_validator/auth_token_validatorImpl.cpp
@@ -3,6 +3,7 @@
 
 #include <conversions.hpp>
 #include <generated/interfaces/ISO15118_charger/Implementation.hpp>
+#include <generated/types/session_cost.hpp>
 #include <ocpp/v2/messages/Authorize.hpp>
 
 #include "auth_token_validatorImpl.hpp"
@@ -43,6 +44,15 @@ auth_token_validatorImpl::handle_validate_token(types::authorization::ProvidedId
         // request response
         const auto response = this->mod->charge_point->validate_token(id_token, certificate_opt, ocsp_request_data_opt);
         validation_result = conversions::to_everest_validation_result(response);
+
+        // Publish tariff message on the session_cost interface
+        if (!validation_result.tariff_messages.empty()) {
+            types::session_cost::TariffMessage tariff_message;
+            tariff_message.messages = validation_result.tariff_messages;
+            tariff_message.identifier_id = provided_token.id_token.value;
+            tariff_message.identifier_type = types::display_message::IdentifierType::IdToken;
+            this->mod->p_session_cost->publish_tariff_message(tariff_message);
+        }
     } catch (const ocpp::StringConversionException& e) {
         EVLOG_warning << "Error converting id token to validate: " << e.what();
         validation_result.authorization_status = types::authorization::AuthorizationStatus::Unknown;


### PR DESCRIPTION

## Describe your changes

Extend the Auth module's token_validation_status with an optional tariff_messages array so API clients receive pricing info at authorization time.

OCPP 2.x:
- Register the missing tariff_message_callback in OCPP201
- Publish tariff_message from AuthorizeResponse personalMessage
- Always publish tariff_message when tariff is enabled, even when cost is also enabled

OCPP 1.6:
- Publish the default tariff message on timeout fallback

Additional:
- fix(api-types): add missing display_message/json_codec.hpp include
- docs(api): add tariff and cost integration guide


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

