### PR TITLE
fix(config): drop obsolete keys

### DIFF
--- a/config/config-CB-EVAL-DC-SIM.yaml
+++ b/config/config-CB-EVAL-DC-SIM.yaml
@@ -40,8 +40,6 @@ active_modules:
       ev_receipt_required: false
       evse_id: DE*PNX*E12345*1
       has_ventilation: true
-      max_current_import_A: 16
-      max_current_export_A: 16
       payment_enable_contract: false
       payment_enable_eim: true
       session_logging: true

--- a/config/config-sil-rpcapi.yaml
+++ b/config/config-sil-rpcapi.yaml
@@ -88,8 +88,6 @@ active_modules:
       ev_receipt_required: false
       evse_id: DE*PNX*E12345*1
       has_ventilation: true
-      max_current_import_A: 32
-      max_current_export_A: 32
       payment_enable_contract: true
       payment_enable_eim: true
       session_logging: true


### PR DESCRIPTION
The config keys `max_current_import_A` and `max_current_export_A` were recently removed (in https://github.com/EVerest/everest-core/pull/1736), but were still to be found in configs introduced in newer pull requests.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

