### PR TITLE
Fix(cmake): Add missing make_directory call when building docs

### DIFF
--- a/cmake/trailbook-ext-everest/generate-rst-from-manifest.cmake
+++ b/cmake/trailbook-ext-everest/generate-rst-from-manifest.cmake
@@ -73,6 +73,7 @@ macro(_trailbook_ev_generate_rst_from_manifest_generate_command)
             add_custom_command(
                 OUTPUT
                     "${INDEX_FILE}"
+                COMMAND ${CMAKE_COMMAND} -E make_directory "${CURRENT_DEST_DIRECTORY}"
                 COMMAND ${Python3_EXECUTABLE} "${CUSTOM_TEMPLATE_SUBSTITUTION_SCRIPT}"
                 DEPENDS
                     "${INDEX_TEMPLATE_FILE}"


### PR DESCRIPTION
## Describe your changes
The docs/README.md describes how to build the docs. However, the described procedure fails.

This is because the cmake code did not produce a functional build script for gnu-make. (the problem does not appear when using ninja as backend)

This PR adds a missing make_directory call in the CMake logic involved in building the html docs.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

