### PR TITLE
fix(e2e-tests): Prevent race condition in test_no_tls_after_secc_leaf deleted

### DIFF
--- a/tests/ocpp_tests/test_sets/ocpp201/plug_and_charge_tests201.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/plug_and_charge_tests201.py
@@ -620,13 +620,12 @@ class TestPlugAndCharge:
 
         await asyncio.sleep(10)  # wait for ISO process to start
 
-        test_controller.swipe("DEADBEEF")
-
         test_utility.messages.clear()
+        test_controller.swipe("DEADBEEF")
 
         # expect authorize.req
         authorize_req: call201.Authorize = call201.Authorize(
-            **await wait_for_and_validate(test_utility, charge_point, "Authorize", {})
+            **await wait_for_and_validate(test_utility, charge_point, "Authorize", {"idToken": {"type": "ISO14443"}})
         )
 
         assert validate_authorize_req(authorize_req, False, False)


### PR DESCRIPTION

## Describe your changes
fix(e2e-tests): Prevent race condition in test_no_tls_after_secc_leaf deleted by explicitly verifying the Authorize.req message. Before this change, the Authorize.conf could've been returned by wait_for_and_validate, causing the call201.Authorize to throw because of an unexpected keyword

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

