### PR TITLE
ci: add backport workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 # .github
 /.github/ @pietfried @corneliusclaussen
 /.github/workflows/ @pietfried @corneliusclaussen @andistorm
+/.github/workflows/on_label.yaml @andistorm @nzbr
 
 # applications
 /applications/pionix_chargebridge @djchhp @corneliusclaussen

--- a/.github/workflows/on_label.yaml
+++ b/.github/workflows/on_label.yaml
@@ -1,0 +1,40 @@
+# Inspired by:
+# Nixpkgs: https://github.com/NixOS/nixpkgs/blob/a698ac1214cd924d4394ca9cd2691618765aa03c/.github/workflows/backport.yml
+# NixOS-WSL: https://github.com/nix-community/NixOS-WSL/blob/be894604b2aa2184c0b3d3b44995acd0da14dc0c/.github/workflows/on_label.yml
+
+name: "Backport"
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    if: github.event.pull_request.labels && contains(join(github.event.pull_request.labels.*.name, ', '), 'backport ')
+    name: Backport PR 🔙
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      created_pull_numbers: ${{ steps.backport.outputs.created_pull_numbers }}
+    steps:
+      - name: Check actor permissions
+        id: check-permissions
+        uses: prince-chrismc/check-actor-permissions-action@v3.0.2
+        with:
+          permission: write
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Create backport PR
+        id: backport
+        uses: korthout/backport-action@v4.2.0
+        with:
+          github_token: ${{ secrets.EVEREST_CI_BACKPORT_PR_APP_TOKEN }}
+          merge_commits: "skip"
+          add_author_as_assignee: true
+          copy_requested_reviewers: true

--- a/docs/source/project/contributing.rst
+++ b/docs/source/project/contributing.rst
@@ -20,7 +20,7 @@ provides general project oversight.
 
 If you just need help or have a question, refer to the :doc:`Community Channels </project/community>`.
 
-To contribute code to the project, first read over the :doc:`Governance Policy </project/governance/governance>` 
+To contribute code to the project, first read over the :doc:`Governance Policy </project/governance/governance>`
 page to understand the roles involved.
 
 Discussing and Communication
@@ -96,10 +96,13 @@ GitHub labels help organize issues and pull requests. EVerest does not yet have
 a standardized label system. When contributing:
 
 - Browse existing labels in the repository and use them consistently
-- Common labels to look for: ``bug``, ``enhancement``, ``documentation``, 
+- Common labels to look for: ``bug``, ``enhancement``, ``documentation``,
   ``help-wanted``, ``good-first-issue``
 - Backport workflow: Use ``backport-candidate`` to mark PRs that should be
-  considered for backporting to stable releases
+  considered for backporting to stable releases. To trigger the automated
+  backport workflow, maintainers can add a label in the format ``backport <branch>`` (e.g. ``backport stable/2026.02``). This will automatically create
+  a cherry-pick PR targeting the specified branch once the original PR is merged. If the cherry-pick does not apply cleanly, the workflow will comment on the
+  original PR and the backport must be performed manually.
 
 If you need a label that doesn't exist, discuss with maintainers before creating it.
 


### PR DESCRIPTION
## Describe your changes

Adds a Github Actions workflow that creates backport PRs from closed PRs with the `backport ...` label

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

