### PR TITLE
feat(EnergyNode): Enhancement to set per phase A limit when only W is set

### DIFF
--- a/modules/EnergyManagement/EnergyNode/CMakeLists.txt
+++ b/modules/EnergyManagement/EnergyNode/CMakeLists.txt
@@ -18,9 +18,15 @@ target_link_libraries(${MODULE_NAME}
 target_sources(${MODULE_NAME}
     PRIVATE
         "energy_grid/energyImpl.cpp"
+        "energy_grid/energy_schedule_utils.cpp"
         "external_limits/external_energy_limitsImpl.cpp"
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 # insert other things like install cmds etc here
+
+# Add tests subdirectory
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/EnergyManagement/EnergyNode/EnergyNode.hpp
+++ b/modules/EnergyManagement/EnergyNode/EnergyNode.hpp
@@ -29,6 +29,8 @@ namespace module {
 struct Conf {
     double fuse_limit_A;
     int phase_count;
+    bool enhance_external_schedule;
+    double nominal_voltage_V;
 };
 
 class EnergyNode : public Everest::ModuleBase {

--- a/modules/EnergyManagement/EnergyNode/energy_grid/energyImpl.cpp
+++ b/modules/EnergyManagement/EnergyNode/energy_grid/energyImpl.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 
 #include "energyImpl.hpp"
+#include "energy_schedule_utils.hpp"
 #include <chrono>
 #include <date/date.h>
 #include <date/tz.h>
@@ -11,24 +12,24 @@ namespace module {
 namespace energy_grid {
 
 void energyImpl::init() {
+    auto energy_state_handle = energy_state.handle();
 
-    // UUID must be unique also beyond this charging station -> will be handled on framework level and above later
-    energy_flow_request.uuid = mod->info.id;
-    energy_flow_request.node_type = types::energy::NodeType::Generic;
+    energy_state_handle->energy_flow_request.uuid = mod->info.id;
+    energy_state_handle->energy_flow_request.node_type = types::energy::NodeType::Generic;
 
     source_cfg = mod->info.id + "/module_config";
 
     // Initialize with sane defaults
-    energy_flow_request.schedule_import = get_local_schedule();
-    energy_flow_request.schedule_export = get_local_schedule();
+    energy_state_handle->energy_flow_request.schedule_import = get_local_schedule();
+    energy_state_handle->energy_flow_request.schedule_export = get_local_schedule();
 
     for (auto& entry : mod->r_energy_consumer) {
         entry->subscribe_energy_flow_request([this](types::energy::EnergyFlowRequest e) {
             // Received new energy_flow_request object from a child. Update in the cached object and republish.
-            std::scoped_lock lock(energy_mutex);
+            auto energy_state_handle = energy_state.handle();
 
             bool child_found = false;
-            for (auto& child : energy_flow_request.children) {
+            for (auto& child : energy_state_handle->energy_flow_request.children) {
                 if (child.uuid == e.uuid) {
                     child = e;
                     child_found = true;
@@ -36,19 +37,19 @@ void energyImpl::init() {
             }
 
             if (!child_found) {
-                energy_flow_request.children.push_back(e);
+                energy_state_handle->energy_flow_request.children.push_back(e);
             }
 
-            publish_complete_energy_object();
+            publish_complete_energy_object(*energy_state_handle);
         });
     }
 
     if (!mod->r_powermeter.empty()) {
         mod->r_powermeter[0]->subscribe_powermeter([this](types::powermeter::Powermeter p) {
             EVLOG_debug << "Incoming powermeter readings: " << p;
-            std::scoped_lock lock(energy_mutex);
-            energy_flow_request.energy_usage_root = p;
-            publish_complete_energy_object();
+            auto energy_state_handle = energy_state.handle();
+            energy_state_handle->energy_flow_request.energy_usage_root = p;
+            publish_complete_energy_object(*energy_state_handle);
         });
     }
 
@@ -56,15 +57,14 @@ void energyImpl::init() {
         mod->r_price_information[0]->subscribe_energy_pricing(
             [this](types::energy_price_information::EnergyPriceSchedule p) {
                 EVLOG_debug << "Incoming price schedule: " << p;
-                std::scoped_lock lock(energy_mutex);
-                energy_pricing = p;
-                publish_complete_energy_object();
+                auto energy_state_handle = energy_state.handle();
+                energy_state_handle->energy_pricing = p;
+                publish_complete_energy_object(*energy_state_handle);
             });
     }
 }
 
 types::energy::ScheduleReqEntry energyImpl::get_local_schedule_req_entry() {
-    // local schedule of this module
     types::energy::ScheduleReqEntry local_schedule;
     auto tp = date::utc_clock::now();
 
@@ -84,52 +84,39 @@ std::vector<types::energy::ScheduleReqEntry> energyImpl::get_local_schedule() {
 }
 
 void energyImpl::set_external_limits(types::energy::ExternalLimits& l) {
-    std::scoped_lock lock(energy_mutex);
+    auto energy_state_handle = energy_state.handle();
 
-    energy_flow_request.schedule_import = l.schedule_import;
-    if (not energy_flow_request.schedule_import.empty()) {
-        // add limits from our own fuse settings
-        for (auto& e : energy_flow_request.schedule_import) {
-            if (!e.limits_to_root.ac_max_current_A.has_value() ||
-                e.limits_to_root.ac_max_current_A.value().value > mod->config.fuse_limit_A)
-                e.limits_to_root.ac_max_current_A = {static_cast<float>(mod->config.fuse_limit_A), source_cfg};
-
-            if (!e.limits_to_root.ac_max_phase_count.has_value() ||
-                e.limits_to_root.ac_max_phase_count.value().value > mod->config.phase_count)
-                e.limits_to_root.ac_max_phase_count = {mod->config.phase_count, source_cfg};
-        }
+    // Process import schedule
+    energy_state_handle->energy_flow_request.schedule_import = l.schedule_import;
+    if (not energy_state_handle->energy_flow_request.schedule_import.empty()) {
+        module::energy_grid::process_schedule_with_limits(
+            energy_state_handle->energy_flow_request.schedule_import, source_cfg, mod->config.fuse_limit_A,
+            mod->config.phase_count, mod->config.nominal_voltage_V, mod->config.enhance_external_schedule);
     } else {
         // At least add our local config limit even if the external limit did not set an import schedule
-        energy_flow_request.schedule_import = get_local_schedule();
+        energy_state_handle->energy_flow_request.schedule_import = get_local_schedule();
     }
 
-    energy_flow_request.schedule_export = l.schedule_export;
-
-    if (not energy_flow_request.schedule_export.empty()) {
-        // add limits from our own fuse settings
-        for (auto& e : energy_flow_request.schedule_export) {
-            if (!e.limits_to_root.ac_max_current_A.has_value() ||
-                e.limits_to_root.ac_max_current_A.value().value > mod->config.fuse_limit_A)
-                e.limits_to_root.ac_max_current_A = {static_cast<float>(mod->config.fuse_limit_A), source_cfg};
-
-            if (!e.limits_to_root.ac_max_phase_count.has_value() ||
-                e.limits_to_root.ac_max_phase_count.value().value > mod->config.phase_count)
-                e.limits_to_root.ac_max_phase_count = {mod->config.phase_count, source_cfg};
-        }
+    // Process export schedule
+    energy_state_handle->energy_flow_request.schedule_export = l.schedule_export;
+    if (not energy_state_handle->energy_flow_request.schedule_export.empty()) {
+        module::energy_grid::process_schedule_with_limits(
+            energy_state_handle->energy_flow_request.schedule_export, source_cfg, mod->config.fuse_limit_A,
+            mod->config.phase_count, mod->config.nominal_voltage_V, mod->config.enhance_external_schedule);
     } else {
         // At least add our local config limit even if the external limit did not set an export schedule
-        energy_flow_request.schedule_export = get_local_schedule();
+        energy_state_handle->energy_flow_request.schedule_export = get_local_schedule();
     }
 
-    energy_flow_request.schedule_setpoints = l.schedule_setpoints;
+    energy_state_handle->energy_flow_request.schedule_setpoints = l.schedule_setpoints;
 }
 
-void energyImpl::publish_complete_energy_object() {
-    // join the different schedules to the complete array (with resampling)
-    types::energy::EnergyFlowRequest energy_complete = energy_flow_request;
+void energyImpl::publish_complete_energy_object(const EnergyState& state) {
+    // This method is always called from contexts that already hold the energy_state lock
+    types::energy::EnergyFlowRequest energy_complete = state.energy_flow_request;
 
-    if (not energy_flow_request.schedule_export.empty() and not energy_pricing.schedule_export.empty()) {
-        merge_price_into_schedule(energy_complete.schedule_export, energy_pricing.schedule_export);
+    if (not state.energy_flow_request.schedule_export.empty() and not state.energy_pricing.schedule_export.empty()) {
+        merge_price_into_schedule(energy_complete.schedule_export, state.energy_pricing.schedule_export);
     }
 
     publish_energy_flow_request(energy_complete);
@@ -181,16 +168,18 @@ void energyImpl::merge_price_into_schedule(std::vector<types::energy::ScheduleRe
 }
 
 void energyImpl::ready() {
+    auto energy_state_handle = energy_state.handle();
     // publish own limits at least once
-    publish_energy_flow_request(energy_flow_request);
+    publish_energy_flow_request(energy_state_handle->energy_flow_request);
     mod->signalExternalLimit.connect([this](types::energy::ExternalLimits& l) { set_external_limits(l); });
 }
 
 void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
+    auto energy_state_handle = energy_state.handle();
 
     // route to children if it is not for me
     // FIXME: this sends it to all children, we could do a lookup on which branch it actually is
-    if (value.uuid != energy_flow_request.uuid) {
+    if (value.uuid != energy_state_handle->energy_flow_request.uuid) {
         for (auto& entry : mod->r_energy_consumer) {
             entry->call_enforce_limits(value);
         }

--- a/modules/EnergyManagement/EnergyNode/energy_grid/energyImpl.hpp
+++ b/modules/EnergyManagement/EnergyNode/energy_grid/energyImpl.hpp
@@ -14,7 +14,7 @@
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
-#include <mutex>
+#include <everest/util/async/monitor.hpp>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {
@@ -48,27 +48,34 @@ private:
     virtual void ready() override;
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
-    std::mutex energy_mutex;
-    // subtree including children
-    types::energy::EnergyFlowRequest energy_flow_request;
+    // Energy state protected by monitor for thread-safe access
+    struct EnergyState {
+        // subtree including children
+        types::energy::EnergyFlowRequest energy_flow_request;
 
-    // contains only the pricing informations last update
-    types::energy_price_information::EnergyPriceSchedule energy_pricing;
+        // contains only the pricing informations last update
+        types::energy_price_information::EnergyPriceSchedule energy_pricing;
+    };
+
+    everest::lib::util::monitor<EnergyState> energy_state;
 
     types::energy::ScheduleReqEntry get_local_schedule_req_entry();
     std::vector<types::energy::ScheduleReqEntry> get_local_schedule();
 
-    void publish_complete_energy_object();
+    void publish_complete_energy_object(const EnergyState& state);
     void set_external_limits(types::energy::ExternalLimits& l);
     void merge_price_into_schedule(std::vector<types::energy::ScheduleReqEntry>& schedule,
                                    const std::vector<types::energy_price_information::PricePerkWh>& price);
-
     std::string source_cfg;
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 
 // ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
 // insert other definitions here
+// Standalone function for schedule processing (used by tests)
+void process_schedule_with_limits(std::vector<types::energy::ScheduleReqEntry>& schedule, const std::string& source,
+                                  double fuse_limit_A, int phase_count, double nominal_voltage_V,
+                                  bool enhance_with_current_limits);
 // ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
 
 } // namespace energy_grid

--- a/modules/EnergyManagement/EnergyNode/energy_grid/energy_schedule_utils.cpp
+++ b/modules/EnergyManagement/EnergyNode/energy_grid/energy_schedule_utils.cpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "energy_schedule_utils.hpp"
+
+namespace module {
+namespace energy_grid {
+
+void process_schedule_with_limits(std::vector<types::energy::ScheduleReqEntry>& schedule, const std::string& source,
+                                  double fuse_limit_A, int phase_count, double nominal_voltage_V,
+                                  bool enhance_with_current_limits) {
+
+    for (auto& entry : schedule) {
+        // Enhance with current limits from power if enabled
+        if (enhance_with_current_limits) {
+            // Determine phase count to use (schedule entry takes priority over module config)
+            int effective_phase_count = phase_count;
+
+            if (entry.limits_to_root.ac_max_phase_count.has_value() &&
+                entry.limits_to_root.ac_max_phase_count.value().value > 0) {
+                effective_phase_count = entry.limits_to_root.ac_max_phase_count.value().value;
+            } else if (entry.limits_to_leaves.ac_max_phase_count.has_value() &&
+                       entry.limits_to_leaves.ac_max_phase_count.value().value > 0) {
+                effective_phase_count = entry.limits_to_leaves.ac_max_phase_count.value().value;
+            }
+
+            // Default to 1 phase if no valid phase count is available
+            if (effective_phase_count <= 0) {
+                effective_phase_count = 1;
+            }
+
+            // Calculate current from power for limits_to_root (only if not already set)
+            if (entry.limits_to_root.total_power_W.has_value() &&
+                entry.limits_to_root.total_power_W.value().value > 0 && nominal_voltage_V > 0 &&
+                !entry.limits_to_root.ac_max_current_A.has_value()) {
+
+                float calculated_current = static_cast<float>(entry.limits_to_root.total_power_W.value().value /
+                                                              (nominal_voltage_V * effective_phase_count));
+                entry.limits_to_root.ac_max_current_A = {calculated_current, source};
+            }
+
+            // Note: limits_to_leaves current limits are not modified to match fuse limit behavior
+        }
+
+        // Apply fuse limit to limits_to_root (as a safety constraint)
+        if (!entry.limits_to_root.ac_max_current_A.has_value() ||
+            entry.limits_to_root.ac_max_current_A->value > fuse_limit_A) {
+            entry.limits_to_root.ac_max_current_A = {static_cast<float>(fuse_limit_A), source};
+        }
+
+        // Apply phase count limit to limits_to_root (as a safety constraint, same model as fuse limit)
+        if (phase_count > 0 && (!entry.limits_to_root.ac_max_phase_count.has_value() ||
+                                entry.limits_to_root.ac_max_phase_count->value > phase_count)) {
+            entry.limits_to_root.ac_max_phase_count = {phase_count, source};
+        }
+    }
+}
+
+} // namespace energy_grid
+} // namespace module

--- a/modules/EnergyManagement/EnergyNode/energy_grid/energy_schedule_utils.hpp
+++ b/modules/EnergyManagement/EnergyNode/energy_grid/energy_schedule_utils.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#ifndef ENERGY_SCHEDULE_UTILS_HPP
+#define ENERGY_SCHEDULE_UTILS_HPP
+
+#include <generated/types/energy.hpp>
+#include <string>
+#include <vector>
+
+namespace module {
+namespace energy_grid {
+
+/**
+ * @brief Processes energy schedule entries with limits and fuse constraints
+ *
+ * This function applies fuse limits to schedule entries and optionally enhances
+ * them with current limits calculated from power values.
+ *
+ * @param schedule The schedule entries to process
+ * @param source The source identifier for any modifications made
+ * @param fuse_limit_A The fuse limit in amperes to apply as a safety constraint
+ * @param phase_count The default phase count to use for calculations
+ * @param nominal_voltage_V The nominal voltage to use for power-to-current calculations
+ * @param enhance_with_current_limits If true, calculates current limits from power values
+ */
+void process_schedule_with_limits(std::vector<types::energy::ScheduleReqEntry>& schedule, const std::string& source,
+                                  double fuse_limit_A, int phase_count, double nominal_voltage_V,
+                                  bool enhance_with_current_limits);
+
+} // namespace energy_grid
+} // namespace module
+
+#endif // ENERGY_SCHEDULE_UTILS_HPP

--- a/modules/EnergyManagement/EnergyNode/manifest.yaml
+++ b/modules/EnergyManagement/EnergyNode/manifest.yaml
@@ -12,6 +12,23 @@ config:
     type: integer
     minimum: 0
     maximum: 3
+  enhance_external_schedule:
+    description: >-
+      When enabled, calculates per-phase current limits from total_power_W
+      and adds them to ac_max_current_A when processing external schedules.
+      ac_max_current_A is only enhanced in case it was not specified as part of
+      the external schedules. Uses nominal_voltage_V for calculations.
+    type: boolean
+    default: false
+  nominal_voltage_V:
+    description: >-
+      Nominal voltage in volts used for power to current calculations when
+      enhance_external_schedule is enabled.
+      This allows configuration for different regions (e.g., 120V, 230V, 400V).
+    type: number
+    minimum: 1.0
+    maximum: 1000.0
+    default: 230.0
 provides:
   energy_grid:
     description: This is the chain interface to build the energy supply tree

--- a/modules/EnergyManagement/EnergyNode/tests/CMakeLists.txt
+++ b/modules/EnergyManagement/EnergyNode/tests/CMakeLists.txt
@@ -1,0 +1,37 @@
+set(TEST_TARGET_NAME ${PROJECT_NAME}_energy_node_tests)
+# Compile the test file and the utility implementation
+add_executable(${TEST_TARGET_NAME})
+
+add_dependencies(${TEST_TARGET_NAME} ${MODULE_NAME})
+
+get_target_property(GENERATED_INCLUDE_DIR generate_cpp_files EVEREST_GENERATED_INCLUDE_DIR)
+
+set(INCLUDE_DIR
+    "${MODULE_DIR}/include"
+    "${MODULE_DIR}/tests"
+    ..
+    ${GENERATED_INCLUDE_DIR}
+    ${CMAKE_BINARY_DIR}/generated/modules/${MODULE_NAME}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_include_directories(${TEST_TARGET_NAME} PUBLIC
+    ${INCLUDE_DIR}
+    ${GENERATED_INCLUDE_DIR}
+)
+
+target_sources(${TEST_TARGET_NAME} PRIVATE
+    energy_node_tests.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../energy_grid/energy_schedule_utils.cpp
+)
+
+target_link_libraries(${TEST_TARGET_NAME} PRIVATE
+    GTest::gmock
+    GTest::gtest_main
+    everest::log
+    everest::framework
+    everest::util
+)
+
+add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})
+ev_register_test_target(${TEST_TARGET_NAME})

--- a/modules/EnergyManagement/EnergyNode/tests/energy_node_tests.cpp
+++ b/modules/EnergyManagement/EnergyNode/tests/energy_node_tests.cpp
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <generated/types/energy.hpp>
+
+#include <gtest/gtest.h>
+
+// Include the utility header
+#include "../energy_grid/energy_schedule_utils.hpp"
+
+// Helper function to create test schedule entries
+static types::energy::ScheduleReqEntry create_test_entry(double total_power = 0.0,
+                                                         std::optional<int> root_phase_count = std::nullopt,
+                                                         std::optional<int> leaves_phase_count = std::nullopt) {
+    types::energy::ScheduleReqEntry entry;
+    entry.timestamp = "2024-01-01T00:00:00Z"; // Required field
+
+    if (total_power > 0) {
+        entry.limits_to_root.total_power_W =
+            types::energy::NumberWithSource{static_cast<float>(total_power), "test_source"};
+        entry.limits_to_leaves.total_power_W =
+            types::energy::NumberWithSource{static_cast<float>(total_power), "test_source"};
+    }
+
+    if (root_phase_count.has_value()) {
+        entry.limits_to_root.ac_max_phase_count =
+            types::energy::IntegerWithSource{root_phase_count.value(), "test_source"};
+    }
+
+    if (leaves_phase_count.has_value()) {
+        entry.limits_to_leaves.ac_max_phase_count =
+            types::energy::IntegerWithSource{leaves_phase_count.value(), "test_source"};
+    }
+
+    return entry;
+}
+
+class EnergyNodeTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+    }
+    void TearDown() override {
+    }
+
+    void process_schedule_with_limits(std::vector<types::energy::ScheduleReqEntry>& schedule,
+                                      double fuse_limit_A = 32.0, int phase_count = 3, double nominal_voltage_V = 230.0,
+                                      bool enhance_with_current_limits = false) {
+        // Call the actual implementation function
+        module::energy_grid::process_schedule_with_limits(schedule, "test_source", fuse_limit_A, phase_count,
+                                                          nominal_voltage_V, enhance_with_current_limits);
+    }
+};
+
+/// Test enhancement feature disabled by default
+TEST_F(EnergyNodeTest, TestEnhancementDisabledByDefault) {
+    auto entry = create_test_entry(7000.0); // 7kW total power
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule);
+
+    // Enhancement should not be applied when disabled (no current limits from power calculation)
+    EXPECT_FALSE(schedule[0].limits_to_leaves.ac_max_current_A.has_value());
+
+    // But fuse limits should still be applied to limits_to_root
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_EQ(schedule[0].limits_to_root.ac_max_current_A->value, 32.0f);
+}
+
+/// Test enhancement feature when enabled
+TEST_F(EnergyNodeTest, TestEnhancementEnabled) {
+    auto entry = create_test_entry(7000.0); // 7kW total power
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule, 32.0, 3, 230.0, true);
+
+    // Calculate expected current: 7000W / (230V * 3 phases) = 10.25A
+    float expected_current = 7000.0f / (230.0f * 3.0f);
+
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_NEAR(schedule[0].limits_to_root.ac_max_current_A->value, expected_current, 0.01f);
+
+    // limits_to_leaves should not be modified (matching fuse limit behavior)
+    EXPECT_FALSE(schedule[0].limits_to_leaves.ac_max_current_A.has_value());
+}
+
+/// Test phase count priority: schedule entry over module config
+TEST_F(EnergyNodeTest, TestPhaseCountPriority) {
+    // Create entry with 1 phase specified
+    auto entry = create_test_entry(7000.0, 1, 1); // 1 phase in schedule entry
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule, 32.0, 3, 230.0, true);
+
+    // Should use 1 phase from schedule entry, not 3 from module config
+    // 7000W / (230V * 1 phase) = 30.43A
+    float expected_current = 7000.0f / (230.0f * 1.0f);
+
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_NEAR(schedule[0].limits_to_root.ac_max_current_A->value, expected_current, 0.01f);
+}
+
+/// Test fallback to module config when schedule has no phase count
+TEST_F(EnergyNodeTest, TestPhaseCountFallback) {
+    // Create entry without phase count
+    auto entry = create_test_entry(7000.0); // No phase count specified
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule, 32.0, 2, 230.0, true);
+
+    // Should use 2 phases from module config
+    // 7000W / (230V * 2 phases) = 15.22A
+    float expected_current = 7000.0f / (230.0f * 2.0f);
+
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_NEAR(schedule[0].limits_to_root.ac_max_current_A->value, expected_current, 0.01f);
+}
+
+/// Test default to 1 phase when no phase count available
+TEST_F(EnergyNodeTest, TestPhaseCountDefault) {
+    // Create entry without phase count
+    auto entry = create_test_entry(7000.0); // No phase count specified
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule, 32.0, 0, 230.0, true);
+
+    // Should default to 1 phase
+    // 7000W / (230V * 1 phase) = 30.43A
+    float expected_current = 7000.0f / (230.0f * 1.0f);
+
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_NEAR(schedule[0].limits_to_root.ac_max_current_A->value, expected_current, 0.01f);
+}
+
+/// Test that existing current limits are not overwritten
+TEST_F(EnergyNodeTest, TestPreserveExistingCurrentLimits) {
+    auto entry = create_test_entry(7000.0); // 7kW total power
+    entry.limits_to_root.ac_max_current_A =
+        types::energy::NumberWithSource{25.0f, "existing_source"}; // Pre-existing current limit
+    entry.limits_to_leaves.ac_max_current_A = types::energy::NumberWithSource{20.0f, "existing_source"};
+
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule, 32.0, 3, 230.0, true);
+
+    // Existing current limits should be preserved
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_EQ(schedule[0].limits_to_root.ac_max_current_A->value, 25.0f);
+
+    EXPECT_TRUE(schedule[0].limits_to_leaves.ac_max_current_A.has_value());
+    EXPECT_EQ(schedule[0].limits_to_leaves.ac_max_current_A->value, 20.0f);
+}
+
+/// Test fuse limit still applies when enhancement is enabled
+TEST_F(EnergyNodeTest, TestFuseLimitWithEnhancement) {
+    auto entry = create_test_entry(10000.0); // 10kW would calculate to ~14.5A with 3 phases
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule, 10.0, 3, 230.0, true);
+
+    // Calculated current would be ~14.5A, but fuse limit of 10A should be applied
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_EQ(schedule[0].limits_to_root.ac_max_current_A->value, 10.0f);
+}
+
+/// Test multiple schedule entries
+TEST_F(EnergyNodeTest, TestMultipleEntries) {
+    auto entry1 = create_test_entry(3000.0, 1); // 3kW, 1 phase
+    auto entry2 = create_test_entry(6000.0, 2); // 6kW, 2 phases
+    auto entry3 = create_test_entry(9000.0);    // 9kW, use module config (3 phases)
+
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry1, entry2, entry3};
+
+    process_schedule_with_limits(schedule, 32.0, 3, 230.0, true);
+
+    // Entry 1: 3000W / (230V * 1) = 13.04A
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_NEAR(schedule[0].limits_to_root.ac_max_current_A->value, 3000.0f / 230.0f, 0.01f);
+
+    // Entry 2: 6000W / (230V * 2) = 13.04A
+    EXPECT_TRUE(schedule[1].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_NEAR(schedule[1].limits_to_root.ac_max_current_A->value, 6000.0f / (230.0f * 2.0f), 0.01f);
+
+    // Entry 3: 9000W / (230V * 3) = 13.04A
+    EXPECT_TRUE(schedule[2].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_NEAR(schedule[2].limits_to_root.ac_max_current_A->value, 9000.0f / (230.0f * 3.0f), 0.01f);
+}
+
+/// Test configurable voltage - 120V (US standard)
+TEST_F(EnergyNodeTest, TestConfigurableVoltage120V) {
+    auto entry = create_test_entry(7000.0); // 7kW total power
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule, 32.0, 3, 120.0, true);
+
+    // Calculate expected current: 7000W / (120V * 3 phases) = 19.44A
+    float expected_current = 7000.0f / (120.0f * 3.0f);
+
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_NEAR(schedule[0].limits_to_root.ac_max_current_A->value, expected_current, 0.01f);
+}
+
+/// Test configurable voltage - 400V (3-phase industrial)
+TEST_F(EnergyNodeTest, TestConfigurableVoltage400V) {
+    auto entry = create_test_entry(22000.0); // 22kW total power
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule, 32.0, 3, 400.0, true);
+
+    // Calculate expected current: 22000W / (400V * 3 phases) = 18.33A
+    float expected_current = 22000.0f / (400.0f * 3.0f);
+
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_NEAR(schedule[0].limits_to_root.ac_max_current_A->value, expected_current, 0.01f);
+}
+
+/// Test configurable voltage - 240V (US split-phase)
+TEST_F(EnergyNodeTest, TestConfigurableVoltage240V) {
+    auto entry = create_test_entry(19200.0); // 19.2kW total power
+    std::vector<types::energy::ScheduleReqEntry> schedule = {entry};
+
+    process_schedule_with_limits(schedule, 40.0, 2, 240.0, true);
+
+    // Calculate expected current: 19200W / (240V * 2 phases) = 40A
+    float expected_current = 19200.0f / (240.0f * 2.0f);
+
+    EXPECT_TRUE(schedule[0].limits_to_root.ac_max_current_A.has_value());
+    EXPECT_EQ(schedule[0].limits_to_root.ac_max_current_A->value, expected_current);
+}


### PR DESCRIPTION
We can now configure the energy node to convert the total W power to a current per phase limit. This is only useful for top level energy nodes.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

