### PR TITLE
rust/cmake: fix mismatch in cxxbridge version

### DIFF
--- a/lib/everest/framework/everestrs/CMakeLists.txt
+++ b/lib/everest/framework/everestrs/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CXXBRIDGE_VERSION 1.0.189) # Must be kept in sync with `everestrs/Cargo.toml`
+set(CXXBRIDGE_VERSION 1.0.194) # Must be kept in sync with `everestrs/Cargo.toml`
 set(CXXBRIDGE_INSTALL_PATH ${CMAKE_CURRENT_BINARY_DIR}/cargo/bin/cxxbridge)
 
 # Checks if the cxxbridge binary at CXXBRIDGE_PATH exists and matches the required version.


### PR DESCRIPTION
## Describe your changes

cxxbridge has recently been upgraded to 1.0.194 but not in the CMake support

This leads to build errors when building the Rust support with CMake

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

