### PR TITLE
fix(ocpp16): DataTransfer.req(GetInstalledCertificateIds) incorrectly reporting NotFound

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -4136,6 +4136,11 @@ void ChargePointImpl::handle_data_transfer_pnc_get_installed_certificates(Call<D
             std::vector<ocpp::CertificateType> certificate_types;
             if (req.certificateType.has_value()) {
                 certificate_types = ocpp::evse_security_conversions::from_ocpp_v2(req.certificateType.value());
+            } else {
+                // When omitted, all certificate types are requested
+                certificate_types.push_back(CertificateType::V2GRootCertificate);
+                certificate_types.push_back(CertificateType::MORootCertificate);
+                certificate_types.push_back(CertificateType::V2GCertificateChain);
             }
 
             ocpp::v2::GetInstalledCertificateIdsResponse get_certificate_ids_response;

--- a/tests/ocpp_tests/test_sets/ocpp16/plug_and_charge_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/plug_and_charge_tests.py
@@ -658,7 +658,7 @@ class TestPlugAndCharge:
     @pytest.mark.asyncio
     @pytest.mark.skip("Test does nothing yet")
     async def test_pnc_get_certificate_status(self, charge_point_v16: ChargePoint16):
-        await asyncio.sleep(30)
+        pass
 
     @pytest.mark.asyncio
     async def test_pnc_get_installed_certificate_ids(
@@ -702,7 +702,6 @@ class TestPlugAndCharge:
         assert data_transfer_response.status == "Rejected"
 
     @pytest.mark.asyncio
-    @pytest.mark.source_certs_dir(Path(__file__).parent.parent / "everest-aux")
     async def test_pnc_get_installed_certificate_ids_empty_not_found(
         self, charge_point_v16: ChargePoint16
     ):
@@ -718,6 +717,19 @@ class TestPlugAndCharge:
 
         assert data_transfer_response.status == "Accepted"
         assert json.loads(data_transfer_response.data) == {
+            "status": "NotFound"}
+        
+        # when omitted all installed certificates should be returned
+        get_installed_certificate_ids_req = {}
+
+        data_transfer_response = await charge_point_v16.data_transfer_req(
+            vendor_id="org.openchargealliance.iso15118pnc",
+            message_id="GetInstalledCertificateIds",
+            data=json.dumps(get_installed_certificate_ids_req),
+        )
+
+        assert data_transfer_response.status == "Accepted"
+        assert not json.loads(data_transfer_response.data) == {
             "status": "NotFound"}
 
     @pytest.mark.asyncio


### PR DESCRIPTION

## Describe your changes

If certificateType was omitted, we were incorrectly responding with NotFound. The specification requires to report all installed certificates in this case. This is fixed in this PR.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

