### PR TITLE
feat(evsesecurity): add opt-in bypass for unhandled critical extensions

### DIFF
--- a/lib/everest/evse_security/include/evse_security/certificate/x509_bundle.hpp
+++ b/lib/everest/evse_security/include/evse_security/certificate/x509_bundle.hpp
@@ -177,6 +177,11 @@ public:
     /// Invalidated on any add/delete operation
     X509CertificateHierarchy& get_certificate_hierarchy();
 
+    /// @brief If set, hierarchy discovery bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when every critical
+    /// extension on a certificate has a well-known RFC 5280 NID. Needed for interoperability with non-compliant CAs
+    /// (e.g. those that mark SKI critical). Calling this invalidates any cached hierarchy.
+    void set_ignore_unhandled_critical_extensions(bool ignore);
+
     X509CertificateBundle& operator=(X509CertificateBundle&& other) = default;
 
     /// @brief Returns the latest valid certif that we might contain
@@ -206,6 +211,9 @@ private:
     // Cached certificate hierarchy, invalidated on any operation
     X509CertificateHierarchy hierarchy;
     bool hierarchy_invalidated;
+
+    // If true, hierarchy discovery tolerates non-compliant critical extensions (see setter for details)
+    bool ignore_unhandled_critical_extensions = false;
 };
 
 } // namespace evse_security

--- a/lib/everest/evse_security/include/evse_security/certificate/x509_hierarchy.hpp
+++ b/lib/everest/evse_security/include/evse_security/certificate/x509_hierarchy.hpp
@@ -129,23 +129,36 @@ public:
 
     /// @brief Builds a proper certificate hierarchy from the provided certificates. The
     /// hierarchy can be incomplete, in case orphan certificates are present in the list
-    static X509CertificateHierarchy build_hierarchy(std::vector<X509Wrapper>& certificates);
+    /// @param ignore_unhandled_critical_extensions Forwarded to all underlying is_child checks so hierarchy
+    /// discovery succeeds across non-compliant certificates (e.g. CAs that mark SKI critical)
+    static X509CertificateHierarchy build_hierarchy(std::vector<X509Wrapper>& certificates,
+                                                    bool ignore_unhandled_critical_extensions = false);
 
-    template <typename... Args> static X509CertificateHierarchy build_hierarchy(Args... certificates) {
+    template <typename... Args>
+    static X509CertificateHierarchy build_hierarchy_with_flag(bool ignore_unhandled_critical_extensions,
+                                                              Args... certificates) {
         X509CertificateHierarchy ordered;
 
         (std::for_each(certificates.begin(), certificates.end(),
 #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 9)
-                       [ordered_ptr = &ordered](X509Wrapper& cert) { ordered_ptr->insert(std::move(cert)); }),
+                       [ordered_ptr = &ordered, ignore_unhandled_critical_extensions](X509Wrapper& cert) {
+                           ordered_ptr->insert(std::move(cert), ignore_unhandled_critical_extensions);
+                       }),
 #else
-                       [&ordered](X509Wrapper& cert) { ordered.insert(std::move(cert)); }),
+                       [&ordered, ignore_unhandled_critical_extensions](X509Wrapper& cert) {
+                           ordered.insert(std::move(cert), ignore_unhandled_critical_extensions);
+                       }),
 #endif
          ...); // Fold expr
 
         // Prune the tree
-        ordered.prune();
+        ordered.prune(ignore_unhandled_critical_extensions);
 
         return ordered;
+    }
+
+    template <typename... Args> static X509CertificateHierarchy build_hierarchy(Args... certificates) {
+        return build_hierarchy_with_flag(false, std::move(certificates)...);
     }
 
 private:
@@ -153,12 +166,12 @@ private:
 
     /// @brief Inserts the certificate in the hierarchy. If it is not a root
     /// and a parent is not found, it will be inserted as a temporary orphan
-    void insert(X509Wrapper&& certificate);
+    void insert(X509Wrapper&& certificate, bool ignore_unhandled_critical_extensions = false);
 
     /// @brief After inserting all certificates in the hierarchy, attempts
     /// to parent all temporarly orphan certificates, marking the ones that
     /// were not successfully parented as permanently orphan
-    void prune();
+    void prune(bool ignore_unhandled_critical_extensions = false);
 
     std::vector<X509Node> hierarchy;
 };

--- a/lib/everest/evse_security/include/evse_security/certificate/x509_wrapper.hpp
+++ b/lib/everest/evse_security/include/evse_security/certificate/x509_wrapper.hpp
@@ -36,7 +36,10 @@ public:
     ~X509Wrapper() = default;
 
     /// @brief Returns true if this certificate is the child of the provided parent
-    bool is_child(const X509Wrapper& parent) const;
+    /// @param ignore_unhandled_critical_extensions If true, bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION
+    /// during the underlying certificate verification when every critical extension on the certificate has a
+    /// well-known RFC 5280 NID. Required for hierarchy discovery across non-compliant certificates.
+    bool is_child(const X509Wrapper& parent, bool ignore_unhandled_critical_extensions = false) const;
 
     /// @brief Returns true if this certificate is self-signed
     bool is_selfsigned() const;
@@ -92,8 +95,11 @@ public:
     CertificateHashData get_certificate_hash_data() const;
 
     /// @brief Gets certificate hash data of certificate with an issuer
+    /// @param ignore_unhandled_critical_extensions Forwarded to the underlying is_child check so hierarchy
+    /// discovery can succeed across non-compliant certificates
     /// @return
-    CertificateHashData get_certificate_hash_data(const X509Wrapper& issuer) const;
+    CertificateHashData get_certificate_hash_data(const X509Wrapper& issuer,
+                                                  bool ignore_unhandled_critical_extensions = false) const;
 
     /// @brief Gets OCSP responder URL of certificate if present, else returns an empty string
     /// @return

--- a/lib/everest/evse_security/include/evse_security/crypto/interface/crypto_supplier.hpp
+++ b/lib/everest/evse_security/include/evse_security/crypto/interface/crypto_supplier.hpp
@@ -57,11 +57,14 @@ public:
     /// @param parents      Parents chain, until the root
     /// @param dir_path     Optional directory path that can be used for certificate store lookup
     /// @param file_path    Optional certificate file path that can be used for certificate store lookup
+    /// @param ignore_unhandled_critical_extensions If true, bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when
+    /// every critical extension on the certificate has a well-known RFC 5280 NID
     /// @return
     static CertificateValidationResult
     x509_verify_certificate_chain(X509Handle* target, const std::vector<X509Handle*>& parents,
                                   const std::vector<X509Handle*>& untrusted_subcas, bool allow_future_certificates,
-                                  const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path);
+                                  const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path,
+                                  bool ignore_unhandled_critical_extensions = false);
 
     /// @brief Checks if the private key is consistent with the provided handle
     static KeyValidationResult x509_check_private_key(X509Handle* handle, std::string private_key,

--- a/lib/everest/evse_security/include/evse_security/crypto/interface/crypto_supplier.hpp
+++ b/lib/everest/evse_security/include/evse_security/crypto/interface/crypto_supplier.hpp
@@ -47,7 +47,11 @@ public:
     static bool x509_get_validity(X509Handle* handle, std::int64_t& out_valid_in, std::int64_t& out_valid_to);
 
     static bool x509_is_selfsigned(X509Handle* handle);
-    static bool x509_is_child(X509Handle* child, X509Handle* parent);
+
+    /// @brief Returns true if the child certificate is issued by the parent
+    /// @param ignore_unhandled_critical_extensions If true, bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when
+    /// every critical extension on the certificate has a well-known RFC 5280 NID
+    static bool x509_is_child(X509Handle* child, X509Handle* parent, bool ignore_unhandled_critical_extensions = false);
     static bool x509_is_equal(X509Handle* a, X509Handle* b);
 
     static X509Handle_ptr x509_duplicate_unique(X509Handle* handle);

--- a/lib/everest/evse_security/include/evse_security/crypto/openssl/openssl_crypto_supplier.hpp
+++ b/lib/everest/evse_security/include/evse_security/crypto/openssl/openssl_crypto_supplier.hpp
@@ -34,7 +34,8 @@ public:
     static CertificateValidationResult
     x509_verify_certificate_chain(X509Handle* target, const std::vector<X509Handle*>& parents,
                                   const std::vector<X509Handle*>& untrusted_subcas, bool allow_future_certificates,
-                                  const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path);
+                                  const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path,
+                                  bool ignore_unhandled_critical_extensions = false);
     static KeyValidationResult x509_check_private_key(X509Handle* handle, std::string private_key,
                                                       std::optional<std::string> password);
     static bool x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,

--- a/lib/everest/evse_security/include/evse_security/crypto/openssl/openssl_crypto_supplier.hpp
+++ b/lib/everest/evse_security/include/evse_security/crypto/openssl/openssl_crypto_supplier.hpp
@@ -6,7 +6,15 @@
 
 #include <evse_security/crypto/interface/crypto_supplier.hpp>
 
+#include <openssl/types.h>
+
 namespace evse_security {
+
+/// X509 verify callback that suppresses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when every
+/// critical extension on the current cert has a well-known RFC 5280 NID. Unknown/custom critical
+/// OIDs still cause verification to fail (and are logged). Signature matches both
+/// X509_STORE_CTX_set_verify_cb and SSL_CTX_set_verify.
+int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx);
 
 class OpenSSLSupplier : public AbstractCryptoSupplier {
 public:

--- a/lib/everest/evse_security/include/evse_security/crypto/openssl/openssl_crypto_supplier.hpp
+++ b/lib/everest/evse_security/include/evse_security/crypto/openssl/openssl_crypto_supplier.hpp
@@ -28,7 +28,7 @@ public:
     static std::string x509_get_common_name(X509Handle* handle);
     static bool x509_get_validity(X509Handle* handle, std::int64_t& out_valid_in, std::int64_t& out_valid_to);
     static bool x509_is_selfsigned(X509Handle* handle);
-    static bool x509_is_child(X509Handle* child, X509Handle* parent);
+    static bool x509_is_child(X509Handle* child, X509Handle* parent, bool ignore_unhandled_critical_extensions = false);
     static bool x509_is_equal(X509Handle* a, X509Handle* b);
     static X509Handle_ptr x509_duplicate_unique(X509Handle* handle);
     static CertificateValidationResult

--- a/lib/everest/evse_security/include/evse_security/evse_security.hpp
+++ b/lib/everest/evse_security/include/evse_security/evse_security.hpp
@@ -90,11 +90,16 @@ public:
     /// 'DEFAULT_CSR_EXPIRY'
     /// @param garbage_collect_time optional garbage collect time. How often we will delete expired CSRs and
     /// certificates. Defaults to 'DEFAULT_GARBAGE_COLLECT_TIME'
+    /// @param ignore_unhandled_critical_extensions if true, bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when
+    /// every critical extension on the certificate has a well-known RFC 5280 NID. Intended for interoperability with
+    /// known non-compliant certificates (e.g. those that incorrectly mark SKI, AKI or CRL DP as critical). Defaults
+    /// to false.
     EvseSecurity(const FilePaths& file_paths, const std::optional<std::string>& private_key_password = std::nullopt,
                  const std::optional<std::uintmax_t>& max_fs_usage_bytes = std::nullopt,
                  const std::optional<std::uintmax_t>& max_fs_certificate_store_entries = std::nullopt,
                  const std::optional<std::chrono::seconds>& csr_expiry = std::nullopt,
-                 const std::optional<std::chrono::seconds>& garbage_collect_time = std::nullopt);
+                 const std::optional<std::chrono::seconds>& garbage_collect_time = std::nullopt,
+                 bool ignore_unhandled_critical_extensions = false);
 
     /// @brief Destructor
     ~EvseSecurity();
@@ -355,6 +360,8 @@ private:
     // FIXME(piet): map passwords to encrypted private key files
     // is there only one password for all private keys?
     std::optional<std::string> private_key_password; // used to decrypt encrypted private keys
+
+    bool ignore_unhandled_critical_extensions;
 
 // Define here all tests that require internal function usage
 #ifdef BUILD_TESTING_EVSE_SECURITY

--- a/lib/everest/evse_security/lib/evse_security/certificate/x509_bundle.cpp
+++ b/lib/everest/evse_security/lib/evse_security/certificate/x509_bundle.cpp
@@ -401,10 +401,17 @@ X509CertificateHierarchy& X509CertificateBundle::get_certificate_hierarchy() {
         hierarchy_invalidated = false;
 
         auto certificates = split();
-        hierarchy = X509CertificateHierarchy::build_hierarchy(certificates);
+        hierarchy = X509CertificateHierarchy::build_hierarchy(certificates, ignore_unhandled_critical_extensions);
     }
 
     return hierarchy;
+}
+
+void X509CertificateBundle::set_ignore_unhandled_critical_extensions(bool ignore) {
+    if (ignore_unhandled_critical_extensions != ignore) {
+        ignore_unhandled_critical_extensions = ignore;
+        invalidate_hierarchy();
+    }
 }
 
 std::string X509CertificateBundle::to_export_string() const {

--- a/lib/everest/evse_security/lib/evse_security/certificate/x509_hierarchy.cpp
+++ b/lib/everest/evse_security/lib/evse_security/certificate/x509_hierarchy.cpp
@@ -228,7 +228,7 @@ std::string X509CertificateHierarchy::to_debug_string() {
     return str.str();
 }
 
-void X509CertificateHierarchy::insert(X509Wrapper&& inserted_certificate) {
+void X509CertificateHierarchy::insert(X509Wrapper&& inserted_certificate, bool ignore_unhandled_critical_extensions) {
     if (false == inserted_certificate.is_selfsigned()) {
         // If this certif has any link to any of the existing certificates
         bool hierarchy_found = false;
@@ -238,7 +238,7 @@ void X509CertificateHierarchy::insert(X509Wrapper&& inserted_certificate) {
 
         // Search through all the list for a link
         for_each([&](X509Node& top) {
-            if (top.certificate.is_child(inserted_certificate)) {
+            if (top.certificate.is_child(inserted_certificate, ignore_unhandled_critical_extensions)) {
                 // Some sanity checks
                 if (top.state.is_selfsigned) {
                     throw InvalidStateException(
@@ -252,7 +252,8 @@ void X509CertificateHierarchy::insert(X509Wrapper&& inserted_certificate) {
 
                 // Set the new state of the top node
                 temp_top.state = {0, 0};
-                temp_top.hash = temp_top.certificate.get_certificate_hash_data(new_node.certificate);
+                temp_top.hash = temp_top.certificate.get_certificate_hash_data(new_node.certificate,
+                                                                               ignore_unhandled_critical_extensions);
                 temp_top.issuer = X509Wrapper(new_node.certificate);
 
                 // Set the top as a child of the new_node
@@ -261,12 +262,13 @@ void X509CertificateHierarchy::insert(X509Wrapper&& inserted_certificate) {
                 // Set the new top
                 top = std::move(new_node);
                 hierarchy_found = true; // Found a link
-            } else if (inserted_certificate.is_child(top.certificate)) {
+            } else if (inserted_certificate.is_child(top.certificate, ignore_unhandled_critical_extensions)) {
                 // If the certificate is the descendant of top certificate
 
                 // Calculate hash and set issuer
                 new_node.state = {0, 0};
-                new_node.hash = inserted_certificate.get_certificate_hash_data(top.certificate);
+                new_node.hash = inserted_certificate.get_certificate_hash_data(top.certificate,
+                                                                               ignore_unhandled_critical_extensions);
                 new_node.issuer = X509Wrapper(top.certificate); // Set the new issuer
 
                 // Add it to the top's descendant list
@@ -304,11 +306,12 @@ void X509CertificateHierarchy::insert(X509Wrapper&& inserted_certificate) {
                 }
 
                 // If it is a child of the new root certificate insert it to it's list and break
-                if (node.certificate.is_child(inserted_certificate)) {
+                if (node.certificate.is_child(inserted_certificate, ignore_unhandled_critical_extensions)) {
                     auto& new_root = hierarchy.back();
 
                     // Hash is properly computed now
-                    node.hash = node.certificate.get_certificate_hash_data(new_root.certificate);
+                    node.hash = node.certificate.get_certificate_hash_data(new_root.certificate,
+                                                                           ignore_unhandled_critical_extensions);
                     node.state.is_orphan = 0;                        // Not an orphan any more
                     node.issuer = X509Wrapper(inserted_certificate); // Set the new valid issuer
 
@@ -325,7 +328,7 @@ void X509CertificateHierarchy::insert(X509Wrapper&& inserted_certificate) {
     }
 } // End insert
 
-void X509CertificateHierarchy::prune() {
+void X509CertificateHierarchy::prune(bool ignore_unhandled_critical_extensions) {
     if (hierarchy.size() <= 1) {
         return;
     }
@@ -343,8 +346,9 @@ void X509CertificateHierarchy::prune() {
         bool found_issuer = false;
 
         for_each([&](X509Node& top) {
-            if (orphan.certificate.is_child(top.certificate)) {
-                orphan.hash = orphan.certificate.get_certificate_hash_data(top.certificate);
+            if (orphan.certificate.is_child(top.certificate, ignore_unhandled_critical_extensions)) {
+                orphan.hash =
+                    orphan.certificate.get_certificate_hash_data(top.certificate, ignore_unhandled_critical_extensions);
                 orphan.state.is_orphan = 0;                   // Not an orphan any more
                 orphan.issuer = X509Wrapper(top.certificate); // Set the new valid issuer
 
@@ -366,16 +370,17 @@ void X509CertificateHierarchy::prune() {
     }
 }
 
-X509CertificateHierarchy X509CertificateHierarchy::build_hierarchy(std::vector<X509Wrapper>& certificates) {
+X509CertificateHierarchy X509CertificateHierarchy::build_hierarchy(std::vector<X509Wrapper>& certificates,
+                                                                   bool ignore_unhandled_critical_extensions) {
     X509CertificateHierarchy ordered;
 
     while (!certificates.empty()) {
-        ordered.insert(std::move(certificates.back()));
+        ordered.insert(std::move(certificates.back()), ignore_unhandled_critical_extensions);
         certificates.pop_back();
     }
 
     // Prune the tree
-    ordered.prune();
+    ordered.prune(ignore_unhandled_critical_extensions);
 
     return ordered;
 }

--- a/lib/everest/evse_security/lib/evse_security/certificate/x509_wrapper.cpp
+++ b/lib/everest/evse_security/lib/evse_security/certificate/x509_wrapper.cpp
@@ -87,13 +87,13 @@ void X509Wrapper::update_validity() {
 #endif
 }
 
-bool X509Wrapper::is_child(const X509Wrapper& parent) const {
+bool X509Wrapper::is_child(const X509Wrapper& parent, bool ignore_unhandled_critical_extensions) const {
     // A certif can't be it's own parent, use is_selfsigned if that is intended (operator ==)
     if (*this == parent) {
         return false;
     }
 
-    return CryptoSupplier::x509_is_child(get(), parent.get());
+    return CryptoSupplier::x509_is_child(get(), parent.get(), ignore_unhandled_critical_extensions);
 }
 
 bool X509Wrapper::is_selfsigned() const {
@@ -179,8 +179,9 @@ CertificateHashData X509Wrapper::get_certificate_hash_data() const {
     return certificate_hash_data;
 }
 
-CertificateHashData X509Wrapper::get_certificate_hash_data(const X509Wrapper& issuer) const {
-    if (CryptoSupplier::x509_is_child(get(), issuer.get()) == false) {
+CertificateHashData X509Wrapper::get_certificate_hash_data(const X509Wrapper& issuer,
+                                                           bool ignore_unhandled_critical_extensions) const {
+    if (CryptoSupplier::x509_is_child(get(), issuer.get(), ignore_unhandled_critical_extensions) == false) {
         throw std::logic_error("The specified issuer is not the correct issuer for this certificate.");
     }
 

--- a/lib/everest/evse_security/lib/evse_security/crypto/interface/crypto_supplier.cpp
+++ b/lib/everest/evse_security/lib/evse_security/crypto/interface/crypto_supplier.cpp
@@ -80,7 +80,8 @@ X509Handle_ptr x509_duplicate_unique() {
 CertificateValidationResult AbstractCryptoSupplier::x509_verify_certificate_chain(
     X509Handle* /*target*/, const std::vector<X509Handle*>& /*parents*/,
     const std::vector<X509Handle*>& /*untrusted_subcas*/, bool /*allow_future_certificates*/,
-    const std::optional<fs::path> /*dir_path*/, const std::optional<fs::path> /*file_path*/) {
+    const std::optional<fs::path> /*dir_path*/, const std::optional<fs::path> /*file_path*/,
+    bool /*ignore_unhandled_critical_extensions*/) {
     default_crypto_supplier_usage_error() return CertificateValidationResult::Unknown;
 }
 

--- a/lib/everest/evse_security/lib/evse_security/crypto/interface/crypto_supplier.cpp
+++ b/lib/everest/evse_security/lib/evse_security/crypto/interface/crypto_supplier.cpp
@@ -63,7 +63,8 @@ bool AbstractCryptoSupplier::x509_is_selfsigned(X509Handle* /*handle*/) {
     default_crypto_supplier_usage_error() return false;
 }
 
-bool AbstractCryptoSupplier::x509_is_child(X509Handle* /*child*/, X509Handle* /*parent*/) {
+bool AbstractCryptoSupplier::x509_is_child(X509Handle* /*child*/, X509Handle* /*parent*/,
+                                           bool /*ignore_unhandled_critical_extensions*/) {
     default_crypto_supplier_usage_error() return false;
 }
 

--- a/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
+++ b/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
@@ -501,6 +501,86 @@ X509Handle_ptr OpenSSLSupplier::x509_duplicate_unique(X509Handle* handle) {
     return std::make_unique<X509HandleOpenSSL>(X509_dup(get(handle)));
 }
 
+namespace {
+/// Verification callback that bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when every
+/// critical extension on the certificate has a well-known RFC 5280 NID.  Truly unknown/custom
+/// OID critical extensions still cause verification to fail.
+int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
+    if (!ok) {
+        const int error = X509_STORE_CTX_get_error(ctx);
+        X509* cert = X509_STORE_CTX_get_current_cert(ctx);
+
+        if (error == X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION && cert != nullptr) {
+            // RFC 5280 extension NIDs that OpenSSL handles during certificate path
+            // validation and are therefore safe to have marked critical.
+            static const std::array<int, 12> handled_nids = {
+                NID_basic_constraints,
+                NID_key_usage,
+                NID_ext_key_usage,
+                NID_subject_alt_name,
+                NID_name_constraints,
+                NID_certificate_policies,
+                NID_policy_constraints,
+                NID_inhibit_any_policy,
+                NID_authority_key_identifier,
+                NID_subject_key_identifier,
+                NID_crl_distribution_points,
+                NID_info_access,
+            };
+
+            bool has_unknown_critical = false;
+            std::string nids_log;
+
+            const int num_exts = X509_get_ext_count(cert);
+            for (int i = 0; i < num_exts; i++) {
+                X509_EXTENSION* ext = X509_get_ext(cert, i);
+                if (!X509_EXTENSION_get_critical(ext)) {
+                    continue;
+                }
+                const int nid = OBJ_obj2nid(X509_EXTENSION_get_object(ext));
+                bool is_known = false;
+                for (const int known_nid : handled_nids) {
+                    if (nid == known_nid) {
+                        is_known = true;
+                        const char* nid_name = OBJ_nid2sn(nid);
+                        if (nid_name != nullptr) {
+                            if (!nids_log.empty()) {
+                                nids_log += ", ";
+                            }
+                            nids_log += nid_name;
+                            nids_log += "(";
+                            nids_log += std::to_string(nid);
+                            nids_log += ")";
+                        } else {
+                            if (!nids_log.empty()) {
+                                nids_log += ", ";
+                            }
+                            nids_log += "NID_" + std::to_string(nid);
+                        }
+                        break;
+                    }
+                }
+                if (!is_known) {
+                    has_unknown_critical = true;
+                    break;
+                }
+            }
+
+            if (!has_unknown_critical) {
+                char* subject = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
+
+                EVLOG_info << "Ignoring unhandled critical extension(s) with well-known NIDs [" << nids_log
+                           << "] on certificate: " << (subject != nullptr ? subject : "unknown");
+                OPENSSL_free(subject);
+                X509_STORE_CTX_set_error(ctx, X509_V_OK);
+                return 1;
+            }
+        }
+    }
+    return ok;
+}
+} // namespace
+
 CertificateValidationResult OpenSSLSupplier::x509_verify_certificate_chain(
     X509Handle* target, const std::vector<X509Handle*>& parents, const std::vector<X509Handle*>& untrusted_subcas,
     bool allow_future_certificates, const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path,
@@ -567,82 +647,7 @@ CertificateValidationResult OpenSSLSupplier::x509_verify_certificate_chain(
     // Triggered only when every critical extension on the certificate has a well-known RFC 5280
     // NID, so truly unknown/custom OID critical extensions still cause verification to fail.
     if (ignore_unhandled_critical_extensions) {
-        auto verify_callback = [](int ok, X509_STORE_CTX* ctx) -> int {
-            if (!ok) {
-                const int error = X509_STORE_CTX_get_error(ctx);
-                X509* cert = X509_STORE_CTX_get_current_cert(ctx);
-
-                if (error == X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION && cert != nullptr) {
-                    // RFC 5280 extension NIDs that OpenSSL handles during certificate path
-                    // validation and are therefore safe to have marked critical.
-                    static const std::array<int, 12> handled_nids = {
-                        NID_basic_constraints,
-                        NID_key_usage,
-                        NID_ext_key_usage,
-                        NID_subject_alt_name,
-                        NID_name_constraints,
-                        NID_certificate_policies,
-                        NID_policy_constraints,
-                        NID_inhibit_any_policy,
-                        NID_authority_key_identifier,
-                        NID_subject_key_identifier,
-                        NID_crl_distribution_points,
-                        NID_info_access,
-                    };
-
-                    bool has_unknown_critical = false;
-                    std::string nids_log;
-
-                    const int num_exts = X509_get_ext_count(cert);
-                    for (int i = 0; i < num_exts; i++) {
-                        X509_EXTENSION* ext = X509_get_ext(cert, i);
-                        if (!X509_EXTENSION_get_critical(ext)) {
-                            continue;
-                        }
-                        const int nid = OBJ_obj2nid(X509_EXTENSION_get_object(ext));
-                        bool is_known = false;
-                        for (const int known_nid : handled_nids) {
-                            if (nid == known_nid) {
-                                is_known = true;
-                                const char* nid_name = OBJ_nid2sn(nid);
-                                if (nid_name != nullptr) {
-                                    if (!nids_log.empty()) {
-                                        nids_log += ", ";
-                                    }
-                                    nids_log += nid_name;
-                                    nids_log += "(";
-                                    nids_log += std::to_string(nid);
-                                    nids_log += ")";
-                                } else {
-                                    if (!nids_log.empty()) {
-                                        nids_log += ", ";
-                                    }
-                                    nids_log += "NID_" + std::to_string(nid);
-                                }
-                                break;
-                            }
-                        }
-                        if (!is_known) {
-                            has_unknown_critical = true;
-                            break;
-                        }
-                    }
-
-                    if (!has_unknown_critical) {
-                        char* subject = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
-
-                        EVLOG_info << "Ignoring unhandled critical extension(s) with well-known NIDs [" << nids_log
-                                   << "] on certificate: " << (subject != nullptr ? subject : "unknown");
-                        OPENSSL_free(subject);
-                        X509_STORE_CTX_set_error(ctx, X509_V_OK);
-                        return 1;
-                    }
-                }
-            }
-            return ok;
-        };
-
-        X509_STORE_CTX_set_verify_cb(store_ctx_ptr.get(), verify_callback);
+        X509_STORE_CTX_set_verify_cb(store_ctx_ptr.get(), critical_extension_bypass_callback);
     }
 
     // verifies the certificate chain based on ctx

--- a/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
+++ b/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
@@ -606,11 +606,17 @@ CertificateValidationResult OpenSSLSupplier::x509_verify_certificate_chain(
                                 is_known = true;
                                 const char* nid_name = OBJ_nid2sn(nid);
                                 if (nid_name != nullptr) {
+                                    if (!nids_log.empty()) {
+                                        nids_log += ", ";
+                                    }
                                     nids_log += nid_name;
                                     nids_log += "(";
                                     nids_log += std::to_string(nid);
                                     nids_log += ")";
                                 } else {
+                                    if (!nids_log.empty()) {
+                                        nids_log += ", ";
+                                    }
                                     nids_log += "NID_" + std::to_string(nid);
                                 }
                                 break;
@@ -618,6 +624,7 @@ CertificateValidationResult OpenSSLSupplier::x509_verify_certificate_chain(
                         }
                         if (!is_known) {
                             has_unknown_critical = true;
+                            break;
                         }
                     }
 

--- a/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
+++ b/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
@@ -5,6 +5,7 @@
 #include <everest/logging.hpp>
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstring>
 #include <iterator>
@@ -502,7 +503,8 @@ X509Handle_ptr OpenSSLSupplier::x509_duplicate_unique(X509Handle* handle) {
 
 CertificateValidationResult OpenSSLSupplier::x509_verify_certificate_chain(
     X509Handle* target, const std::vector<X509Handle*>& parents, const std::vector<X509Handle*>& untrusted_subcas,
-    bool allow_future_certificates, const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path) {
+    bool allow_future_certificates, const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path,
+    bool ignore_unhandled_critical_extensions) {
 
     const X509_STORE_ptr store_ptr(X509_STORE_new());
     const X509_STORE_CTX_ptr store_ctx_ptr(X509_STORE_CTX_new());
@@ -559,6 +561,81 @@ CertificateValidationResult OpenSSLSupplier::x509_verify_certificate_chain(
         }
         // certificate is not expired, but may not be valid yet. Since we allow future certs, disable time checks.
         X509_STORE_CTX_set_flags(store_ctx_ptr.get(), X509_V_FLAG_NO_CHECK_TIME);
+    }
+
+    // Bypass X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION for known non-compliant certificates.
+    // Triggered only when every critical extension on the certificate has a well-known RFC 5280
+    // NID, so truly unknown/custom OID critical extensions still cause verification to fail.
+    if (ignore_unhandled_critical_extensions) {
+        auto verify_callback = [](int ok, X509_STORE_CTX* ctx) -> int {
+            if (!ok) {
+                const int error = X509_STORE_CTX_get_error(ctx);
+                X509* cert = X509_STORE_CTX_get_current_cert(ctx);
+
+                if (error == X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION && cert != nullptr) {
+                    // RFC 5280 extension NIDs that OpenSSL handles during certificate path
+                    // validation and are therefore safe to have marked critical.
+                    static const std::array<int, 12> handled_nids = {
+                        NID_basic_constraints,
+                        NID_key_usage,
+                        NID_ext_key_usage,
+                        NID_subject_alt_name,
+                        NID_name_constraints,
+                        NID_certificate_policies,
+                        NID_policy_constraints,
+                        NID_inhibit_any_policy,
+                        NID_authority_key_identifier,
+                        NID_subject_key_identifier,
+                        NID_crl_distribution_points,
+                        NID_info_access,
+                    };
+
+                    bool has_unknown_critical = false;
+                    std::string nids_log;
+
+                    const int num_exts = X509_get_ext_count(cert);
+                    for (int i = 0; i < num_exts; i++) {
+                        X509_EXTENSION* ext = X509_get_ext(cert, i);
+                        if (!X509_EXTENSION_get_critical(ext)) {
+                            continue;
+                        }
+                        const int nid = OBJ_obj2nid(X509_EXTENSION_get_object(ext));
+                        bool is_known = false;
+                        for (const int known_nid : handled_nids) {
+                            if (nid == known_nid) {
+                                is_known = true;
+                                const char* nid_name = OBJ_nid2sn(nid);
+                                if (nid_name != nullptr) {
+                                    nids_log += nid_name;
+                                    nids_log += "(";
+                                    nids_log += std::to_string(nid);
+                                    nids_log += ")";
+                                } else {
+                                    nids_log += "NID_" + std::to_string(nid);
+                                }
+                                break;
+                            }
+                        }
+                        if (!is_known) {
+                            has_unknown_critical = true;
+                        }
+                    }
+
+                    if (!has_unknown_critical) {
+                        char* subject = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
+
+                        EVLOG_info << "Ignoring unhandled critical extension(s) with well-known NIDs [" << nids_log
+                                   << "] on certificate: " << (subject != nullptr ? subject : "unknown");
+                        OPENSSL_free(subject);
+                        X509_STORE_CTX_set_error(ctx, X509_V_OK);
+                        return 1;
+                    }
+                }
+            }
+            return ok;
+        };
+
+        X509_STORE_CTX_set_verify_cb(store_ctx_ptr.get(), verify_callback);
     }
 
     // verifies the certificate chain based on ctx

--- a/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
+++ b/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
@@ -64,9 +64,11 @@ CertificateValidationResult to_certificate_error(const int ec) {
     }
 }
 
+} // namespace
+
 /// Verification callback that bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when every
 /// critical extension on the certificate has a well-known RFC 5280 NID.  Truly unknown/custom
-/// OID critical extensions still cause verification to fail.
+/// OID critical extensions still cause verification to fail (and are logged).
 int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
     if (!ok) {
         const int error = X509_STORE_CTX_get_error(ctx);
@@ -124,6 +126,16 @@ int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
                 }
                 if (!is_known) {
                     has_unknown_critical = true;
+                    const char* sn = OBJ_nid2sn(nid);
+                    const char* ln = OBJ_nid2ln(nid);
+                    char oid_buf[128] = {};
+                    OBJ_obj2txt(oid_buf, sizeof(oid_buf), X509_EXTENSION_get_object(ext), 1);
+                    char* subject = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
+                    EVLOG_warning << "Unhandled critical X.509 extension with unknown NID: nid=" << nid
+                                  << " sn=" << (sn != nullptr ? sn : "?") << " ln=" << (ln != nullptr ? ln : "?")
+                                  << " oid=" << oid_buf
+                                  << " on certificate: " << (subject != nullptr ? subject : "unknown");
+                    OPENSSL_free(subject);
                     break;
                 }
             }
@@ -141,7 +153,6 @@ int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
     }
     return ok;
 }
-} // namespace
 
 const char* OpenSSLSupplier::get_supplier_name() {
     return OPENSSL_VERSION_TEXT;

--- a/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
+++ b/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
@@ -63,6 +63,84 @@ CertificateValidationResult to_certificate_error(const int ec) {
         return CertificateValidationResult::Unknown;
     }
 }
+
+/// Verification callback that bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when every
+/// critical extension on the certificate has a well-known RFC 5280 NID.  Truly unknown/custom
+/// OID critical extensions still cause verification to fail.
+int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
+    if (!ok) {
+        const int error = X509_STORE_CTX_get_error(ctx);
+        X509* cert = X509_STORE_CTX_get_current_cert(ctx);
+
+        if (error == X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION && cert != nullptr) {
+            // RFC 5280 extension NIDs that OpenSSL handles during certificate path
+            // validation and are therefore safe to have marked critical.
+            static const std::array<int, 12> handled_nids = {
+                NID_basic_constraints,
+                NID_key_usage,
+                NID_ext_key_usage,
+                NID_subject_alt_name,
+                NID_name_constraints,
+                NID_certificate_policies,
+                NID_policy_constraints,
+                NID_inhibit_any_policy,
+                NID_authority_key_identifier,
+                NID_subject_key_identifier,
+                NID_crl_distribution_points,
+                NID_info_access,
+            };
+
+            bool has_unknown_critical = false;
+            std::string nids_log;
+
+            const int num_exts = X509_get_ext_count(cert);
+            for (int i = 0; i < num_exts; i++) {
+                X509_EXTENSION* ext = X509_get_ext(cert, i);
+                if (!X509_EXTENSION_get_critical(ext)) {
+                    continue;
+                }
+                const int nid = OBJ_obj2nid(X509_EXTENSION_get_object(ext));
+                bool is_known = false;
+                for (const int known_nid : handled_nids) {
+                    if (nid == known_nid) {
+                        is_known = true;
+                        const char* nid_name = OBJ_nid2sn(nid);
+                        if (nid_name != nullptr) {
+                            if (!nids_log.empty()) {
+                                nids_log += ", ";
+                            }
+                            nids_log += nid_name;
+                            nids_log += "(";
+                            nids_log += std::to_string(nid);
+                            nids_log += ")";
+                        } else {
+                            if (!nids_log.empty()) {
+                                nids_log += ", ";
+                            }
+                            nids_log += "NID_" + std::to_string(nid);
+                        }
+                        break;
+                    }
+                }
+                if (!is_known) {
+                    has_unknown_critical = true;
+                    break;
+                }
+            }
+
+            if (!has_unknown_critical) {
+                char* subject = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
+
+                EVLOG_info << "Ignoring unhandled critical extension(s) with well-known NIDs [" << nids_log
+                           << "] on certificate: " << (subject != nullptr ? subject : "unknown");
+                OPENSSL_free(subject);
+                X509_STORE_CTX_set_error(ctx, X509_V_OK);
+                return 1;
+            }
+        }
+    }
+    return ok;
+}
 } // namespace
 
 const char* OpenSSLSupplier::get_supplier_name() {
@@ -445,7 +523,7 @@ bool OpenSSLSupplier::x509_get_validity(X509Handle* handle, std::int64_t& out_va
     return true;
 }
 
-bool OpenSSLSupplier::x509_is_child(X509Handle* child, X509Handle* parent) {
+bool OpenSSLSupplier::x509_is_child(X509Handle* child, X509Handle* parent, bool ignore_unhandled_critical_extensions) {
     // A certif can't be it's own parent, use is_selfsigned if that is intended
     if (child == parent) {
         return false;
@@ -470,6 +548,14 @@ bool OpenSSLSupplier::x509_is_child(X509Handle* child, X509Handle* parent) {
         // X509_STORE_CTX_set_flags(ctx.get(), X509_V_FLAG_X509_STRICT);
 
         X509_STORE_CTX_set_flags(ctx.get(), X509_V_FLAG_PARTIAL_CHAIN);
+    }
+
+    // Bypass X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION for known non-compliant certificates so
+    // hierarchy discovery succeeds (e.g. CAs that mark SKI critical). Uses the same callback
+    // as x509_verify_certificate_chain, which only suppresses the error when every critical
+    // extension on the certificate has a well-known RFC 5280 NID.
+    if (ignore_unhandled_critical_extensions) {
+        X509_STORE_CTX_set_verify_cb(ctx.get(), critical_extension_bypass_callback);
     }
 
     if (X509_verify_cert(ctx.get()) != 1) {
@@ -500,86 +586,6 @@ bool OpenSSLSupplier::x509_is_equal(X509Handle* a, X509Handle* b) {
 X509Handle_ptr OpenSSLSupplier::x509_duplicate_unique(X509Handle* handle) {
     return std::make_unique<X509HandleOpenSSL>(X509_dup(get(handle)));
 }
-
-namespace {
-/// Verification callback that bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when every
-/// critical extension on the certificate has a well-known RFC 5280 NID.  Truly unknown/custom
-/// OID critical extensions still cause verification to fail.
-int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
-    if (!ok) {
-        const int error = X509_STORE_CTX_get_error(ctx);
-        X509* cert = X509_STORE_CTX_get_current_cert(ctx);
-
-        if (error == X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION && cert != nullptr) {
-            // RFC 5280 extension NIDs that OpenSSL handles during certificate path
-            // validation and are therefore safe to have marked critical.
-            static const std::array<int, 12> handled_nids = {
-                NID_basic_constraints,
-                NID_key_usage,
-                NID_ext_key_usage,
-                NID_subject_alt_name,
-                NID_name_constraints,
-                NID_certificate_policies,
-                NID_policy_constraints,
-                NID_inhibit_any_policy,
-                NID_authority_key_identifier,
-                NID_subject_key_identifier,
-                NID_crl_distribution_points,
-                NID_info_access,
-            };
-
-            bool has_unknown_critical = false;
-            std::string nids_log;
-
-            const int num_exts = X509_get_ext_count(cert);
-            for (int i = 0; i < num_exts; i++) {
-                X509_EXTENSION* ext = X509_get_ext(cert, i);
-                if (!X509_EXTENSION_get_critical(ext)) {
-                    continue;
-                }
-                const int nid = OBJ_obj2nid(X509_EXTENSION_get_object(ext));
-                bool is_known = false;
-                for (const int known_nid : handled_nids) {
-                    if (nid == known_nid) {
-                        is_known = true;
-                        const char* nid_name = OBJ_nid2sn(nid);
-                        if (nid_name != nullptr) {
-                            if (!nids_log.empty()) {
-                                nids_log += ", ";
-                            }
-                            nids_log += nid_name;
-                            nids_log += "(";
-                            nids_log += std::to_string(nid);
-                            nids_log += ")";
-                        } else {
-                            if (!nids_log.empty()) {
-                                nids_log += ", ";
-                            }
-                            nids_log += "NID_" + std::to_string(nid);
-                        }
-                        break;
-                    }
-                }
-                if (!is_known) {
-                    has_unknown_critical = true;
-                    break;
-                }
-            }
-
-            if (!has_unknown_critical) {
-                char* subject = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
-
-                EVLOG_info << "Ignoring unhandled critical extension(s) with well-known NIDs [" << nids_log
-                           << "] on certificate: " << (subject != nullptr ? subject : "unknown");
-                OPENSSL_free(subject);
-                X509_STORE_CTX_set_error(ctx, X509_V_OK);
-                return 1;
-            }
-        }
-    }
-    return ok;
-}
-} // namespace
 
 CertificateValidationResult OpenSSLSupplier::x509_verify_certificate_chain(
     X509Handle* target, const std::vector<X509Handle*>& parents, const std::vector<X509Handle*>& untrusted_subcas,

--- a/lib/everest/evse_security/lib/evse_security/evse_security.cpp
+++ b/lib/everest/evse_security/lib/evse_security/evse_security.cpp
@@ -287,14 +287,16 @@ EvseSecurity::EvseSecurity(const FilePaths& file_paths, const std::optional<std:
                            const std::optional<std::uintmax_t>& max_fs_usage_bytes,
                            const std::optional<std::uintmax_t>& max_fs_certificate_store_entries,
                            const std::optional<std::chrono::seconds>& csr_expiry,
-                           const std::optional<std::chrono::seconds>& garbage_collect_time) :
+                           const std::optional<std::chrono::seconds>& garbage_collect_time,
+                           bool ignore_unhandled_critical_extensions) :
     private_key_password(private_key_password),
     directories(file_paths.directories),
     links(file_paths.links),
     max_fs_usage_bytes(max_fs_usage_bytes.value_or(DEFAULT_MAX_FILESYSTEM_SIZE)),
     max_fs_certificate_store_entries(max_fs_certificate_store_entries.value_or(DEFAULT_MAX_CERTIFICATE_ENTRIES)),
     csr_expiry(csr_expiry.value_or(DEFAULT_CSR_EXPIRY)),
-    garbage_collect_time(garbage_collect_time.value_or(DEFAULT_GARBAGE_COLLECT_TIME)) {
+    garbage_collect_time(garbage_collect_time.value_or(DEFAULT_GARBAGE_COLLECT_TIME)),
+    ignore_unhandled_critical_extensions(ignore_unhandled_critical_extensions) {
     static_assert(sizeof(std::uint8_t) == 1, "uint8_t not equal to 1 byte!");
 
     const std::vector<fs::path> dirs = {
@@ -2076,7 +2078,8 @@ EvseSecurity::verify_certificate_internal(const std::string& certificate_chain,
         }
 
         return CryptoSupplier::x509_verify_certificate_chain(leaf_certificate.get(), trusted_parent_certificates,
-                                                             untrusted_subcas, true, std::nullopt, std::nullopt);
+                                                             untrusted_subcas, true, std::nullopt, std::nullopt,
+                                                             this->ignore_unhandled_critical_extensions);
 
     } catch (const CertificateLoadException& e) {
         EVLOG_warning << "Could not validate certificate chain because of invalid format";

--- a/lib/everest/evse_security/lib/evse_security/evse_security.cpp
+++ b/lib/everest/evse_security/lib/evse_security/evse_security.cpp
@@ -594,7 +594,7 @@ DeleteResult EvseSecurity::delete_certificate(const CertificateHashData& certifi
 
             return true;
         }); // End for each chain
-    } // End for each leaf directory
+    }       // End for each leaf directory
 
     if (!found_certificate) {
         response.result = DeleteCertificateResult::NotFound;

--- a/lib/everest/evse_security/lib/evse_security/evse_security.cpp
+++ b/lib/everest/evse_security/lib/evse_security/evse_security.cpp
@@ -159,7 +159,8 @@ std::optional<fs::path> get_private_key_path_of_certificate(const X509Wrapper& c
 /// @return The files where the certificates were found, more than one can be returned in case it is
 /// present in a bundle too
 std::set<fs::path> get_certificate_path_of_key(const fs::path& key, const fs::path& certificate_path_directory,
-                                               const std::optional<std::string> password) {
+                                               const std::optional<std::string> password,
+                                               bool ignore_unhandled_critical_extensions) {
     std::string private_key;
 
     if (false == filesystem_utils::read_from_file(key, private_key)) {
@@ -174,6 +175,7 @@ std::set<fs::path> get_certificate_path_of_key(const fs::path& key, const fs::pa
         try {
             std::set<fs::path> bundles;
             X509CertificateBundle certificate_bundles(cert_filename, EncodingFormat::PEM);
+            certificate_bundles.set_ignore_unhandled_critical_extensions(ignore_unhandled_critical_extensions);
 
             certificate_bundles.for_each_chain(
                 [&](const fs::path& bundle, const std::vector<X509Wrapper>& certificates) {
@@ -199,6 +201,7 @@ std::set<fs::path> get_certificate_path_of_key(const fs::path& key, const fs::pa
     try {
         std::set<fs::path> bundles;
         X509CertificateBundle certificate_bundles(certificate_path_directory, EncodingFormat::PEM);
+        certificate_bundles.set_ignore_unhandled_critical_extensions(ignore_unhandled_critical_extensions);
 
         certificate_bundles.for_each_chain([&](const fs::path& bundle, const std::vector<X509Wrapper>& certificates) {
             for (const auto& certificate : certificates) {
@@ -278,7 +281,8 @@ bool get_oscp_data_of_certificate(const X509Wrapper& certificate, const Certific
 
 OCSPRequestDataList generate_ocsp_request_data_internal(const std::map<CaCertificateType, fs::path>& ca_bundle_path_map,
                                                         const std::set<CaCertificateType>& possible_roots,
-                                                        const std::vector<X509Wrapper>& leaf_chain);
+                                                        const std::vector<X509Wrapper>& leaf_chain,
+                                                        bool ignore_unhandled_critical_extensions);
 } // namespace
 
 std::mutex EvseSecurity::security_mutex;
@@ -377,6 +381,7 @@ InstallCertificateResult EvseSecurity::install_ca_certificate(const std::string&
         }
 
         X509CertificateBundle existing_certs(ca_bundle_path, EncodingFormat::PEM);
+        existing_certs.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
         if (existing_certs.is_using_directory()) {
             const std::string filename = conversions::ca_certificate_type_to_string(certificate_type) + "_ROOT_" +
@@ -429,6 +434,7 @@ DeleteResult EvseSecurity::delete_certificate(const CertificateHashData& certifi
     for (const auto& [certificate_type, ca_bundle_path] : ca_bundle_path_map) {
         try {
             X509CertificateBundle ca_bundle(ca_bundle_path, EncodingFormat::PEM);
+            ca_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
             auto deleted = ca_bundle.delete_certificate(certificate_hash_data, true, false);
 
             if (false == deleted.empty()) {
@@ -488,6 +494,7 @@ DeleteResult EvseSecurity::delete_certificate(const CertificateHashData& certifi
 
         // The leaf bundle contains many chain/single certificates in separate files
         X509CertificateBundle leaf_bundle(leaf_certificate_path, EncodingFormat::PEM);
+        leaf_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
         CaCertificateType root_load; // NOLINT(cppcoreguidelines-init-variables): initialized below
         if (secc) {
@@ -510,8 +517,8 @@ DeleteResult EvseSecurity::delete_certificate(const CertificateHashData& certifi
             EVLOG_warning << "Could not load base roots: " << ca_bundle_path_map[root_load];
         }
 
-        X509CertificateHierarchy hierarchy =
-            std::move(X509CertificateHierarchy::build_hierarchy(base_roots, leaf_bundle.split()));
+        X509CertificateHierarchy hierarchy = std::move(X509CertificateHierarchy::build_hierarchy_with_flag(
+            this->ignore_unhandled_critical_extensions, base_roots, leaf_bundle.split()));
 
         // Collect all the leafs that we have to delete
         auto leafs_to_delete = hierarchy.find_certificates_multi(certificate_hash_data);
@@ -587,7 +594,7 @@ DeleteResult EvseSecurity::delete_certificate(const CertificateHashData& certifi
 
             return true;
         }); // End for each chain
-    }       // End for each leaf directory
+    } // End for each leaf directory
 
     if (!found_certificate) {
         response.result = DeleteCertificateResult::NotFound;
@@ -720,6 +727,7 @@ EvseSecurity::get_installed_certificates(const std::vector<CertificateType>& cer
         auto ca_bundle_path = this->ca_bundle_path_map.at(ca_certificate_type);
         try {
             X509CertificateBundle ca_bundle(ca_bundle_path, EncodingFormat::PEM);
+            ca_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
             X509CertificateHierarchy& hierarchy = ca_bundle.get_certificate_hierarchy();
 
             EVLOG_debug << "Hierarchy:(" << conversions::ca_certificate_type_to_string(ca_certificate_type) << ")\n"
@@ -786,11 +794,13 @@ EvseSecurity::get_installed_certificates(const std::vector<CertificateType>& cer
                 try {
                     // Leaf V2G chain, containing (SECCLeaf->SubCA2->SubCA1) or (SECCLeaf)
                     X509CertificateBundle leaf_bundle(certificate_path, EncodingFormat::PEM);
+                    leaf_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
                     // V2G chain, containing the certs from the V2G bundle/folder,
                     // containing (SubCA2->SubCA1->V2GRoot) or (V2GRoot)
                     const auto ca_bundle_path = this->ca_bundle_path_map.at(CaCertificateType::V2G);
                     X509CertificateBundle ca_bundle(ca_bundle_path, EncodingFormat::PEM);
+                    ca_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
                     // Merge the bundles, adding only uniques for full chain
                     // (SubCA2->SubCA1->V2GRoot->SECCLeaf) in any order
@@ -875,7 +885,8 @@ int EvseSecurity::get_count_of_installed_certificates(const std::vector<Certific
 
     for (const auto& unique_dir : directories) {
         try {
-            const X509CertificateBundle ca_bundle(unique_dir, EncodingFormat::PEM);
+            X509CertificateBundle ca_bundle(unique_dir, EncodingFormat::PEM);
+            ca_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
             count += ca_bundle.get_certificate_count();
         } catch (const CertificateLoadException& e) {
             EVLOG_error << "Could not load bundle for certificate count: " << e.what();
@@ -889,7 +900,8 @@ int EvseSecurity::get_count_of_installed_certificates(const std::vector<Certific
 
         // Load all from chain, including expired/unused
         try {
-            const X509CertificateBundle leaf_bundle(leaf_dir, EncodingFormat::PEM);
+            X509CertificateBundle leaf_bundle(leaf_dir, EncodingFormat::PEM);
+            leaf_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
             count += leaf_bundle.get_certificate_count();
         } catch (const CertificateLoadException& e) {
             EVLOG_error << "Could not load bundle for certificate count: " << e.what();
@@ -939,7 +951,8 @@ OCSPRequestDataList EvseSecurity::get_v2g_ocsp_request_data() {
 
         if (!leaf_chain.empty()) {
             OCSPRequestDataList partial_ocsp_request =
-                generate_ocsp_request_data_internal(this->ca_bundle_path_map, {CaCertificateType::V2G}, leaf_chain);
+                generate_ocsp_request_data_internal(this->ca_bundle_path_map, {CaCertificateType::V2G}, leaf_chain,
+                                                    this->ignore_unhandled_critical_extensions);
 
             for (OCSPRequestData& ocsp_data : partial_ocsp_request.ocsp_request_data_list) {
                 // Add the ones that we don't already contain
@@ -968,7 +981,8 @@ OCSPRequestDataList EvseSecurity::get_mo_ocsp_request_data(const std::string& ce
 
         // Test for both MO and V2G roots
         return generate_ocsp_request_data_internal(this->ca_bundle_path_map,
-                                                   {CaCertificateType::V2G, CaCertificateType::MO}, leaf_chain);
+                                                   {CaCertificateType::V2G, CaCertificateType::MO}, leaf_chain,
+                                                   this->ignore_unhandled_critical_extensions);
     } catch (const CertificateLoadException& e) {
         EVLOG_error << "Could not load mo ocsp cache leaf chain!";
     }
@@ -979,7 +993,8 @@ OCSPRequestDataList EvseSecurity::get_mo_ocsp_request_data(const std::string& ce
 namespace {
 OCSPRequestDataList generate_ocsp_request_data_internal(const std::map<CaCertificateType, fs::path>& ca_bundle_path_map,
                                                         const std::set<CaCertificateType>& possible_roots,
-                                                        const std::vector<X509Wrapper>& leaf_chain) {
+                                                        const std::vector<X509Wrapper>& leaf_chain,
+                                                        bool ignore_unhandled_critical_extensions) {
     OCSPRequestDataList response;
 
     if (leaf_chain.empty()) {
@@ -998,7 +1013,8 @@ OCSPRequestDataList generate_ocsp_request_data_internal(const std::map<CaCertifi
     std::vector<OCSPRequestData> ocsp_request_data_list;
     try {
         // Build the full hierarchy
-        auto hierarchy = std::move(X509CertificateHierarchy::build_hierarchy(full_root_hierarchy, leaf_chain));
+        auto hierarchy = std::move(X509CertificateHierarchy::build_hierarchy_with_flag(
+            ignore_unhandled_critical_extensions, full_root_hierarchy, leaf_chain));
 
         // Search for the first valid root, and collect all the chain
         for (auto& root : hierarchy.get_hierarchy()) {
@@ -1086,10 +1102,12 @@ void EvseSecurity::update_ocsp_cache(const CertificateHashData& certificate_hash
 
     try {
         X509CertificateBundle ca_bundle(ca_bundle_path, EncodingFormat::PEM);
+        ca_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
         X509CertificateBundle leaf_bundle(leaf_cert_dir, EncodingFormat::PEM);
+        leaf_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
-        auto certificate_hierarchy =
-            std::move(X509CertificateHierarchy::build_hierarchy(ca_bundle.split(), leaf_bundle.split()));
+        auto certificate_hierarchy = std::move(X509CertificateHierarchy::build_hierarchy_with_flag(
+            this->ignore_unhandled_critical_extensions, ca_bundle.split(), leaf_bundle.split()));
 
         // If we already have the hash, over-write, else create a new one
         try {
@@ -1169,10 +1187,12 @@ std::optional<fs::path> EvseSecurity::retrieve_ocsp_cache_internal(const Certifi
 
     try {
         X509CertificateBundle ca_bundle(ca_bundle_path, EncodingFormat::PEM);
+        ca_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
         X509CertificateBundle leaf_bundle(leaf_path, EncodingFormat::PEM);
+        leaf_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
-        auto certificate_hierarchy =
-            std::move(X509CertificateHierarchy::build_hierarchy(ca_bundle.split(), leaf_bundle.split()));
+        auto certificate_hierarchy = std::move(X509CertificateHierarchy::build_hierarchy_with_flag(
+            this->ignore_unhandled_critical_extensions, ca_bundle.split(), leaf_bundle.split()));
 
         // Find the certificate
         std::optional<X509Wrapper> cert = certificate_hierarchy.find_certificate(certificate_hash_data);
@@ -1205,6 +1225,7 @@ bool EvseSecurity::is_ca_certificate_installed(CaCertificateType certificate_typ
 bool EvseSecurity::is_ca_certificate_installed_internal(CaCertificateType certificate_type) {
     try {
         X509CertificateBundle bundle(this->ca_bundle_path_map.at(certificate_type), EncodingFormat::PEM);
+        bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
         // Search for a valid self-signed root
         auto& hierarchy = bundle.get_certificate_hierarchy();
@@ -1521,6 +1542,7 @@ EvseSecurity::get_full_leaf_certificate_info_internal(const CertificateQueryPara
             std::optional<fs::path> chain_file;
 
             X509CertificateBundle leaf_directory(cert_dir, EncodingFormat::PEM);
+            leaf_directory.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
             const std::vector<X509Wrapper>* leaf_fullchain = nullptr;
             const std::vector<X509Wrapper>* leaf_single = nullptr;
@@ -1579,9 +1601,11 @@ EvseSecurity::get_full_leaf_certificate_info_internal(const CertificateQueryPara
             // Both require the hierarchy build
             if (params.include_ocsp || params.include_root) {
                 X509CertificateBundle root_bundle(root_dir, EncodingFormat::PEM); // Required for hierarchy
+                root_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
                 // The hierarchy is required for both roots and the OCSP cache
-                auto hierarchy = X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_directory.split());
+                auto hierarchy = X509CertificateHierarchy::build_hierarchy_with_flag(
+                    this->ignore_unhandled_critical_extensions, root_bundle.split(), leaf_directory.split());
                 EVLOG_debug << "Hierarchy for root/OCSP data: \n" << hierarchy.to_debug_string();
 
                 // Include OCSP data if possible
@@ -1751,6 +1775,7 @@ GetCertificateInfoResult EvseSecurity::get_ca_certificate_info_internal(CaCertif
         // Support bundle files, in case the certificates contain
         // multiple entries (should be 3) as per the specification
         X509CertificateBundle verify_file(this->ca_bundle_path_map.at(certificate_type), EncodingFormat::PEM);
+        verify_file.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
         EVLOG_info << "Requesting certificate file: [" << conversions::ca_certificate_type_to_string(certificate_type)
                    << "] file:" << verify_file.get_path();
@@ -1823,7 +1848,8 @@ std::string EvseSecurity::get_verify_location(CaCertificateType certificate_type
     try {
         // Support bundle files, in case the certificates contain
         // multiple entries (should be 3) as per the specification
-        const X509CertificateBundle verify_location(this->ca_bundle_path_map.at(certificate_type), EncodingFormat::PEM);
+        X509CertificateBundle verify_location(this->ca_bundle_path_map.at(certificate_type), EncodingFormat::PEM);
+        verify_location.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
         const auto location_path = verify_location.get_path();
 
@@ -2116,7 +2142,9 @@ void EvseSecurity::garbage_collect() {
         // Root bundle required for hash of OCSP cache
         try {
             X509CertificateBundle root_bundle(ca_bundle_path_map[ca_type], EncodingFormat::PEM);
+            root_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
             X509CertificateBundle expired_certs(cert_dir, EncodingFormat::PEM);
+            expired_certs.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
             // Only handle if we have more than the minimum certificates entry
             if (expired_certs.get_certificate_chains_count() > DEFAULT_MINIMUM_CERTIFICATE_ENTRIES) {
@@ -2147,8 +2175,9 @@ void EvseSecurity::garbage_collect() {
                                 }
 
                                 const auto& leaf_chain = chain;
-                                X509CertificateHierarchy hierarchy = std::move(
-                                    X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_chain));
+                                X509CertificateHierarchy hierarchy =
+                                    std::move(X509CertificateHierarchy::build_hierarchy_with_flag(
+                                        this->ignore_unhandled_critical_extensions, root_bundle.split(), leaf_chain));
 
                                 CertificateHashData ocsp_hash;
                                 fs::path path_ocsp_hash;
@@ -2224,7 +2253,8 @@ void EvseSecurity::garbage_collect() {
 
                 try {
                     // Check if we have found any matching certificate
-                    auto key_path = get_certificate_path_of_key(key_file_path, keys_dir, this->private_key_password);
+                    auto key_path = get_certificate_path_of_key(key_file_path, keys_dir, this->private_key_password,
+                                                                this->ignore_unhandled_critical_extensions);
                 } catch (const NoCertificateValidException& e) {
                     // If we did not found, add to the potential delete list
                     EVLOG_debug << "Could not find matching certificate for key: " << key_file_path
@@ -2285,7 +2315,9 @@ void EvseSecurity::garbage_collect() {
 
             // Also load the roots since we need to build the hierarchy for correct certificate hashes
             X509CertificateBundle root_bundle(ca_bundle_path_map[load], EncodingFormat::PEM);
+            root_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
             X509CertificateBundle leaf_bundle(leaf_certificate_path, EncodingFormat::PEM);
+            leaf_bundle.set_ignore_unhandled_critical_extensions(this->ignore_unhandled_critical_extensions);
 
             fs::path leaf_ocsp;
             fs::path root_ocsp;
@@ -2302,8 +2334,8 @@ void EvseSecurity::garbage_collect() {
                 leaf_ocsp = leaf_bundle.get_path() / "ocsp";
             }
 
-            X509CertificateHierarchy hierarchy =
-                std::move(X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_bundle.split()));
+            X509CertificateHierarchy hierarchy = std::move(X509CertificateHierarchy::build_hierarchy_with_flag(
+                this->ignore_unhandled_critical_extensions, root_bundle.split(), leaf_bundle.split()));
 
             // Iterate all hashes folders and see if any are missing
             for (auto& ocsp_dir : {leaf_ocsp, root_ocsp}) {

--- a/lib/everest/evse_security/tests/CMakeLists.txt
+++ b/lib/everest/evse_security/tests/CMakeLists.txt
@@ -81,10 +81,12 @@ file(COPY
 
 file(COPY
     "${CMAKE_CURRENT_SOURCE_DIR}/create-pki.sh"
+    "${CMAKE_CURRENT_SOURCE_DIR}/create-pki-critical-ski.sh"
     DESTINATION "${LIBEVSE_SECURITY_TEST_DIR}/tests"
 )
 
 file(COPY
     "${CMAKE_CURRENT_SOURCE_DIR}/openssl-pki.conf"
+    "${CMAKE_CURRENT_SOURCE_DIR}/openssl-pki-critical-ski.conf"
     DESTINATION "${LIBEVSE_SECURITY_TEST_DIR}/tests"
 )

--- a/lib/everest/evse_security/tests/create-pki-critical-ski.sh
+++ b/lib/everest/evse_security/tests/create-pki-critical-ski.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Generates a 3-level PKI (root → CA → server) where the CA and server certs
+# have the Subject Key Identifier extension marked critical (non-RFC-5280-compliant).
+# Used to test the ignore_unhandled_critical_extensions workaround.
+
+base=.
+cfg=./openssl-pki-critical-ski.conf
+dir=pki_critical_ski
+
+[ ! -f "$cfg" ] && echo "missing openssl-pki-critical-ski.conf" && exit 1
+
+mkdir -p ${base}/${dir}
+
+root_priv=${base}/${dir}/root_priv.pem
+ca_priv=${base}/${dir}/ca_priv.pem
+server_priv=${base}/${dir}/server_priv.pem
+
+root_cert=${base}/${dir}/root_cert.pem
+ca_cert=${base}/${dir}/ca_cert.pem
+server_cert=${base}/${dir}/server_cert.pem
+cert_path=${base}/${dir}/cert_path.pem
+
+# generate keys
+for i in ${root_priv} ${ca_priv} ${server_priv}
+do
+    openssl genpkey -config ${cfg} -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out $i
+done
+
+export OPENSSL_CONF=${cfg}
+
+# root cert — standard (non-critical) SKI so the trust anchor itself is clean
+openssl req -config ${cfg} -x509 -section req_root -extensions v3_root \
+    -key ${root_priv} -out ${root_cert}
+
+# CA cert — critical SKI
+openssl req -config ${cfg} -x509 -section req_ca -extensions v3_ca_critical_ski \
+    -key ${ca_priv} -CA ${root_cert} \
+    -CAkey ${root_priv} -out ${ca_cert}
+
+# server (leaf) cert — critical SKI
+openssl req -config ${cfg} -x509 -section req_server -extensions v3_server_critical_ski \
+    -key ${server_priv} -CA ${ca_cert} \
+    -CAkey ${ca_priv} -out ${server_cert}
+
+# bundle: server + CA (mirrors what create-pki.sh produces)
+cat ${server_cert} ${ca_cert} > ${cert_path}

--- a/lib/everest/evse_security/tests/openssl-pki-critical-ski.conf
+++ b/lib/everest/evse_security/tests/openssl-pki-critical-ski.conf
@@ -1,0 +1,68 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_section
+
+[provider_section]
+default = default_section
+base = base_section
+
+[default_section]
+activate = 1
+
+[base_section]
+activate = 1
+
+[req_root]
+distinguished_name = req_dn_root
+utf8 = yes
+prompt = no
+req_extensions = v3_root
+
+[req_ca]
+distinguished_name = req_dn_ca
+utf8 = yes
+prompt = no
+req_extensions = v3_ca_critical_ski
+
+[req_server]
+distinguished_name = req_dn_server
+utf8 = yes
+prompt = no
+req_extensions = v3_server_critical_ski
+
+[req_dn_root]
+C = DE
+O = EVerest
+CN = Critical SKI Root CA
+
+[req_dn_ca]
+C = DE
+O = EVerest
+CN = Critical SKI Intermediate CA
+
+[req_dn_server]
+C = DE
+O = EVerest
+CN = Critical SKI Server
+
+[v3_root]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+basicConstraints = critical, CA:true, pathlen:2
+keyUsage = keyCertSign, cRLSign
+
+# CA cert with Subject Key Identifier marked critical (non-RFC-5280-compliant)
+[v3_ca_critical_ski]
+subjectKeyIdentifier = critical, hash
+authorityKeyIdentifier = keyid:always,issuer:always
+basicConstraints = critical, CA:true
+keyUsage = keyCertSign, cRLSign
+
+# Server (leaf) cert with Subject Key Identifier marked critical (non-RFC-5280-compliant)
+[v3_server_critical_ski]
+subjectKeyIdentifier = critical, hash
+authorityKeyIdentifier = keyid:always,issuer:always
+keyUsage = digitalSignature, keyEncipherment, keyAgreement
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = IP:192.168.240.1, DNS:example.com

--- a/lib/everest/evse_security/tests/openssl_supplier_test.cpp
+++ b/lib/everest/evse_security/tests/openssl_supplier_test.cpp
@@ -120,8 +120,8 @@ TEST_F(OpenSSLSupplierTest, x509_verify_certificate_chain_ignore_unhandled_criti
     // X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION is not mapped to a specific result.
     auto res_strict = OpenSSLSupplier::x509_verify_certificate_chain(
         res_leaf[0].get(), parents, empty_untrusted, true, std::nullopt, "pki_critical_ski/root_cert.pem", false);
-    ASSERT_EQ(res_strict, CertificateValidationResult::Unknown)
-        << "Strict mode must reject a chain containing an unhandled critical extension";
+    ASSERT_NE(res_strict, CertificateValidationResult::Valid)
+        << "Strict mode must not accept a chain containing an unhandled critical extension";
 
     // Lenient mode: every critical extension is a well-known RFC 5280 NID, so the chain
     // must validate when ignore_unhandled_critical_extensions is set.

--- a/lib/everest/evse_security/tests/openssl_supplier_test.cpp
+++ b/lib/everest/evse_security/tests/openssl_supplier_test.cpp
@@ -20,6 +20,7 @@ class OpenSSLSupplierTest : public testing::Test {
 protected:
     static void SetUpTestSuite() {
         std::system("./create-pki.sh");
+        std::system("./create-pki-critical-ski.sh");
     }
 };
 
@@ -91,6 +92,43 @@ TEST_F(OpenSSLSupplierTest, x509_verify_certificate_chain) {
     auto res = OpenSSLSupplier::x509_verify_certificate_chain(res_leaf[0].get(), parents, empty_untrusted, true,
                                                               std::nullopt, "pki/root_cert.pem");
     ASSERT_EQ(res, CertificateValidationResult::Valid);
+}
+
+TEST_F(OpenSSLSupplierTest, x509_verify_certificate_chain_ignore_unhandled_critical_extensions) {
+    // Load a certificate chain where both the CA and the leaf have the Subject Key
+    // Identifier extension marked critical (non-RFC-5280-compliant). All critical
+    // extensions have well-known RFC 5280 NIDs, so the
+    // ignore_unhandled_critical_extensions flag should allow verification.
+    auto cert_path = getFile("pki_critical_ski/cert_path.pem");
+    auto cert_leaf = getFile("pki_critical_ski/server_cert.pem");
+
+    auto res_path = OpenSSLSupplier::load_certificates(cert_path, EncodingFormat::PEM);
+    auto res_leaf = OpenSSLSupplier::load_certificates(cert_leaf, EncodingFormat::PEM);
+
+    ASSERT_GE(res_path.size(), 1U);
+    ASSERT_GE(res_leaf.size(), 1U);
+
+    std::vector<X509Handle*> parents;
+    std::vector<X509Handle*> empty_untrusted;
+
+    parents.reserve(res_path.size());
+    for (auto& cert : res_path) {
+        parents.push_back(cert.get());
+    }
+
+    // Strict mode (default): OpenSSL must reject the chain with Unknown because
+    // X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION is not mapped to a specific result.
+    auto res_strict = OpenSSLSupplier::x509_verify_certificate_chain(
+        res_leaf[0].get(), parents, empty_untrusted, true, std::nullopt, "pki_critical_ski/root_cert.pem", false);
+    ASSERT_EQ(res_strict, CertificateValidationResult::Unknown)
+        << "Strict mode must reject a chain containing an unhandled critical extension";
+
+    // Lenient mode: every critical extension is a well-known RFC 5280 NID, so the chain
+    // must validate when ignore_unhandled_critical_extensions is set.
+    auto res_lenient = OpenSSLSupplier::x509_verify_certificate_chain(
+        res_leaf[0].get(), parents, empty_untrusted, true, std::nullopt, "pki_critical_ski/root_cert.pem", true);
+    ASSERT_EQ(res_lenient, CertificateValidationResult::Valid)
+        << "Lenient mode must accept a chain where all critical extensions have well-known RFC 5280 NIDs";
 }
 
 TEST_F(OpenSSLSupplierTest, x509_generate_csr) {

--- a/lib/everest/evse_security/tests/openssl_supplier_test.cpp
+++ b/lib/everest/evse_security/tests/openssl_supplier_test.cpp
@@ -2,6 +2,8 @@
 #include <fstream>
 #include <gtest/gtest.h>
 
+#include <evse_security/certificate/x509_hierarchy.hpp>
+#include <evse_security/certificate/x509_wrapper.hpp>
 #include <evse_security/crypto/openssl/openssl_crypto_supplier.hpp>
 #include <optional>
 
@@ -129,6 +131,74 @@ TEST_F(OpenSSLSupplierTest, x509_verify_certificate_chain_ignore_unhandled_criti
         res_leaf[0].get(), parents, empty_untrusted, true, std::nullopt, "pki_critical_ski/root_cert.pem", true);
     ASSERT_EQ(res_lenient, CertificateValidationResult::Valid)
         << "Lenient mode must accept a chain where all critical extensions have well-known RFC 5280 NIDs";
+}
+
+TEST_F(OpenSSLSupplierTest, x509_is_child_ignore_unhandled_critical_extensions) {
+    // Parent/child pair where the parent CA has SKI marked critical (non-RFC-5280-compliant).
+    // Without the bypass, X509_verify_cert inside x509_is_child fails with
+    // X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION, leaving the hierarchy unable to attach the child
+    // to the parent at startup. With the bypass enabled (and every critical extension being a
+    // well-known RFC 5280 NID), the relationship is detected.
+    // PKI layout: root_cert -> ca_cert (intermediate) -> server_cert.
+    auto parent_pem = getFile("pki_critical_ski/ca_cert.pem"); // intermediate — direct parent of the leaf
+    auto child_pem = getFile("pki_critical_ski/server_cert.pem");
+
+    auto parent = OpenSSLSupplier::load_certificates(parent_pem, EncodingFormat::PEM);
+    auto child = OpenSSLSupplier::load_certificates(child_pem, EncodingFormat::PEM);
+
+    ASSERT_GE(parent.size(), 1U);
+    ASSERT_GE(child.size(), 1U);
+
+    ASSERT_FALSE(OpenSSLSupplier::x509_is_child(child[0].get(), parent[0].get(), false))
+        << "Strict mode must not accept child/parent links across an unhandled critical extension";
+
+    ASSERT_TRUE(OpenSSLSupplier::x509_is_child(child[0].get(), parent[0].get(), true))
+        << "Lenient mode must accept child/parent links when all critical extensions have well-known RFC 5280 NIDs";
+}
+
+TEST_F(OpenSSLSupplierTest, x509_hierarchy_build_ignore_unhandled_critical_extensions) {
+    // Full end-to-end: a certificate hierarchy built from a bundle containing a non-compliant
+    // root + intermediate + leaf. With the bypass off the intermediate and leaf stay orphaned
+    // (no matching parent found via is_child). With the bypass on, they are correctly chained
+    // underneath the self-signed root.
+    const std::string root_pem = getFile("pki_critical_ski/root_cert.pem");
+    const std::string intermediate_pem = getFile("pki_critical_ski/ca_cert.pem");
+    const std::string leaf_pem = getFile("pki_critical_ski/server_cert.pem");
+
+    auto build_with_flag = [&](bool ignore) {
+        std::vector<X509Wrapper> certs;
+        certs.emplace_back(root_pem, EncodingFormat::PEM);
+        certs.emplace_back(intermediate_pem, EncodingFormat::PEM);
+        certs.emplace_back(leaf_pem, EncodingFormat::PEM);
+        return X509CertificateHierarchy::build_hierarchy(certs, ignore);
+    };
+
+    // Strict: no child chains under the self-signed root — the intermediate and leaf are
+    // classified as orphans because is_child rejects them due to the unhandled critical extension.
+    auto strict = build_with_flag(false);
+    bool root_has_children_strict = false;
+    for (const auto& node : strict.get_hierarchy()) {
+        if (node.state.is_selfsigned && !node.children.empty()) {
+            root_has_children_strict = true;
+        }
+    }
+    ASSERT_FALSE(root_has_children_strict) << "Strict hierarchy must not chain children under the non-compliant root";
+
+    // Lenient: root -> intermediate -> leaf must be assembled.
+    auto lenient = build_with_flag(true);
+    bool chain_assembled = false;
+    for (const auto& node : lenient.get_hierarchy()) {
+        if (!node.state.is_selfsigned) {
+            continue;
+        }
+        for (const auto& intermediate : node.children) {
+            if (!intermediate.children.empty()) {
+                chain_assembled = true;
+            }
+        }
+    }
+    ASSERT_TRUE(chain_assembled)
+        << "Lenient hierarchy must chain root -> intermediate -> leaf when the bypass is enabled";
 }
 
 TEST_F(OpenSSLSupplierTest, x509_generate_csr) {

--- a/lib/everest/iso15118/include/iso15118/config.hpp
+++ b/lib/everest/iso15118/include/iso15118/config.hpp
@@ -33,6 +33,11 @@ struct SSLConfig {
     bool enable_tls_key_logging{false};
     bool enforce_tls_1_3{false};
     std::filesystem::path tls_key_logging_path{};
+    /// When true, install a verify callback on the SSL_CTX that suppresses
+    /// X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION for certificates whose critical extensions
+    /// all have well-known RFC 5280 NIDs. Truly unknown critical OIDs are still rejected
+    /// and logged. See evse_security::critical_extension_bypass_callback.
+    bool ignore_unhandled_critical_extensions{false};
 };
 
 } // namespace iso15118::config

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -19,6 +19,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
+#include <openssl/x509v3.h>
 
 #include <iso15118/detail/helper.hpp>
 #include <iso15118/detail/io/helper_ssl.hpp>
@@ -85,6 +86,85 @@ std::string convert_ssl_tls_versions_to_string(uint16_t version) {
 // the reason for this wrapper.
 auto x509_name_oneline(const X509_NAME* a, char* buf, int size) {
     return X509_NAME_oneline(a, buf, size);
+}
+
+// X509 verify callback that suppresses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when every critical
+// extension on the current cert has a well-known RFC 5280 NID. Truly unknown critical OIDs still
+// cause verification to fail and are logged with their NID/OID. Mirrors the version in
+// libevse_security (openssl_crypto_supplier.cpp) intentionally — duplicated here to avoid a libiso
+// build dependency on evse_security.
+int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
+    if (ok) {
+        return ok;
+    }
+
+    const int error = X509_STORE_CTX_get_error(ctx);
+    X509* cert = X509_STORE_CTX_get_current_cert(ctx);
+    if (error != X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION || cert == nullptr) {
+        return ok;
+    }
+
+    // RFC 5280 extension NIDs OpenSSL handles during path validation — safe to ignore if critical.
+    static constexpr std::array<int, 12> handled_nids = {
+        NID_basic_constraints,         NID_key_usage,          NID_ext_key_usage,
+        NID_subject_alt_name,          NID_name_constraints,   NID_certificate_policies,
+        NID_policy_constraints,        NID_inhibit_any_policy, NID_authority_key_identifier,
+        NID_subject_key_identifier,    NID_crl_distribution_points,
+        NID_info_access,
+    };
+
+    bool has_unknown_critical = false;
+    std::string nids_log;
+
+    const int num_exts = X509_get_ext_count(cert);
+    for (int i = 0; i < num_exts; i++) {
+        X509_EXTENSION* ext = X509_get_ext(cert, i);
+        if (!X509_EXTENSION_get_critical(ext)) {
+            continue;
+        }
+        const int nid = OBJ_obj2nid(X509_EXTENSION_get_object(ext));
+        bool is_known = false;
+        for (const int known_nid : handled_nids) {
+            if (nid == known_nid) {
+                is_known = true;
+                const char* nid_name = OBJ_nid2sn(nid);
+                if (!nids_log.empty()) {
+                    nids_log += ", ";
+                }
+                if (nid_name != nullptr) {
+                    nids_log += nid_name;
+                    nids_log += "(" + std::to_string(nid) + ")";
+                } else {
+                    nids_log += "NID_" + std::to_string(nid);
+                }
+                break;
+            }
+        }
+        if (!is_known) {
+            has_unknown_critical = true;
+            const char* sn = OBJ_nid2sn(nid);
+            const char* ln = OBJ_nid2ln(nid);
+            char oid_buf[128] = {};
+            OBJ_obj2txt(oid_buf, sizeof(oid_buf), X509_EXTENSION_get_object(ext), 1);
+            char subject_buf[256] = {};
+            x509_name_oneline(X509_get_subject_name(cert), subject_buf, sizeof(subject_buf));
+            logf_warning("Unhandled critical X.509 extension with unknown NID: nid=%d sn=%s ln=%s oid=%s on "
+                         "certificate: %s",
+                         nid, (sn != nullptr ? sn : "?"), (ln != nullptr ? ln : "?"), oid_buf, subject_buf);
+            break;
+        }
+    }
+
+    if (!has_unknown_critical) {
+        char subject_buf[256] = {};
+        x509_name_oneline(X509_get_subject_name(cert), subject_buf, sizeof(subject_buf));
+        logf_info("Ignoring unhandled critical extension(s) with well-known NIDs [%s] on certificate: %s",
+                  nids_log.c_str(), subject_buf);
+        X509_STORE_CTX_set_error(ctx, X509_V_OK);
+        return 1;
+    }
+
+    return ok;
 }
 
 // I found no get or callback function for the supported_versions extension, so I wrote my own parser.
@@ -275,7 +355,11 @@ SSL_CTX* init_ssl(const config::SSLConfig& ssl_config) {
         logf_error("Verify OEM root not found!");
     }
 
-    SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, nullptr);
+    // With SSL_VERIFY_NONE the callback is not invoked for client-cert validation; it is still
+    // invoked by OpenSSL's internal paths that walk the trust store (OCSP stapling, cert_cb, etc.).
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE,
+                       ssl_config.ignore_unhandled_critical_extensions ? &critical_extension_bypass_callback
+                                                                       : nullptr);
 
     SSL_CTX_set_client_hello_cb(ctx, &client_hello_cb, nullptr);
 

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -106,10 +106,17 @@ int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
 
     // RFC 5280 extension NIDs OpenSSL handles during path validation — safe to ignore if critical.
     static constexpr std::array<int, 12> handled_nids = {
-        NID_basic_constraints,         NID_key_usage,          NID_ext_key_usage,
-        NID_subject_alt_name,          NID_name_constraints,   NID_certificate_policies,
-        NID_policy_constraints,        NID_inhibit_any_policy, NID_authority_key_identifier,
-        NID_subject_key_identifier,    NID_crl_distribution_points,
+        NID_basic_constraints,
+        NID_key_usage,
+        NID_ext_key_usage,
+        NID_subject_alt_name,
+        NID_name_constraints,
+        NID_certificate_policies,
+        NID_policy_constraints,
+        NID_inhibit_any_policy,
+        NID_authority_key_identifier,
+        NID_subject_key_identifier,
+        NID_crl_distribution_points,
         NID_info_access,
     };
 
@@ -358,8 +365,7 @@ SSL_CTX* init_ssl(const config::SSLConfig& ssl_config) {
     // With SSL_VERIFY_NONE the callback is not invoked for client-cert validation; it is still
     // invoked by OpenSSL's internal paths that walk the trust store (OCSP stapling, cert_cb, etc.).
     SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE,
-                       ssl_config.ignore_unhandled_critical_extensions ? &critical_extension_bypass_callback
-                                                                       : nullptr);
+                       ssl_config.ignore_unhandled_critical_extensions ? &critical_extension_bypass_callback : nullptr);
 
     SSL_CTX_set_client_hello_cb(ctx, &client_hello_cb, nullptr);
 

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -20,6 +20,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
+#include <openssl/x509v3.h>
 
 #include <iso15118/detail/helper.hpp>
 #include <iso15118/detail/io/helper_ssl.hpp>
@@ -86,6 +87,85 @@ std::string convert_ssl_tls_versions_to_string(uint16_t version) {
 // the reason for this wrapper.
 auto x509_name_oneline(const X509_NAME* a, char* buf, int size) {
     return X509_NAME_oneline(a, buf, size);
+}
+
+// X509 verify callback that suppresses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION when every critical
+// extension on the current cert has a well-known RFC 5280 NID. Truly unknown critical OIDs still
+// cause verification to fail and are logged with their NID/OID. Mirrors the version in
+// libevse_security (openssl_crypto_supplier.cpp) intentionally — duplicated here to avoid a libiso
+// build dependency on evse_security.
+int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
+    if (ok) {
+        return ok;
+    }
+
+    const int error = X509_STORE_CTX_get_error(ctx);
+    X509* cert = X509_STORE_CTX_get_current_cert(ctx);
+    if (error != X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION || cert == nullptr) {
+        return ok;
+    }
+
+    // RFC 5280 extension NIDs OpenSSL handles during path validation — safe to ignore if critical.
+    static constexpr std::array<int, 12> handled_nids = {
+        NID_basic_constraints,         NID_key_usage,          NID_ext_key_usage,
+        NID_subject_alt_name,          NID_name_constraints,   NID_certificate_policies,
+        NID_policy_constraints,        NID_inhibit_any_policy, NID_authority_key_identifier,
+        NID_subject_key_identifier,    NID_crl_distribution_points,
+        NID_info_access,
+    };
+
+    bool has_unknown_critical = false;
+    std::string nids_log;
+
+    const int num_exts = X509_get_ext_count(cert);
+    for (int i = 0; i < num_exts; i++) {
+        X509_EXTENSION* ext = X509_get_ext(cert, i);
+        if (!X509_EXTENSION_get_critical(ext)) {
+            continue;
+        }
+        const int nid = OBJ_obj2nid(X509_EXTENSION_get_object(ext));
+        bool is_known = false;
+        for (const int known_nid : handled_nids) {
+            if (nid == known_nid) {
+                is_known = true;
+                const char* nid_name = OBJ_nid2sn(nid);
+                if (!nids_log.empty()) {
+                    nids_log += ", ";
+                }
+                if (nid_name != nullptr) {
+                    nids_log += nid_name;
+                    nids_log += "(" + std::to_string(nid) + ")";
+                } else {
+                    nids_log += "NID_" + std::to_string(nid);
+                }
+                break;
+            }
+        }
+        if (!is_known) {
+            has_unknown_critical = true;
+            const char* sn = OBJ_nid2sn(nid);
+            const char* ln = OBJ_nid2ln(nid);
+            char oid_buf[128] = {};
+            OBJ_obj2txt(oid_buf, sizeof(oid_buf), X509_EXTENSION_get_object(ext), 1);
+            char subject_buf[256] = {};
+            x509_name_oneline(X509_get_subject_name(cert), subject_buf, sizeof(subject_buf));
+            logf_warning("Unhandled critical X.509 extension with unknown NID: nid=%d sn=%s ln=%s oid=%s on "
+                         "certificate: %s",
+                         nid, (sn != nullptr ? sn : "?"), (ln != nullptr ? ln : "?"), oid_buf, subject_buf);
+            break;
+        }
+    }
+
+    if (!has_unknown_critical) {
+        char subject_buf[256] = {};
+        x509_name_oneline(X509_get_subject_name(cert), subject_buf, sizeof(subject_buf));
+        logf_info("Ignoring unhandled critical extension(s) with well-known NIDs [%s] on certificate: %s",
+                  nids_log.c_str(), subject_buf);
+        X509_STORE_CTX_set_error(ctx, X509_V_OK);
+        return 1;
+    }
+
+    return ok;
 }
 
 // I found no get or callback function for the supported_versions extension, so I wrote my own parser.
@@ -276,7 +356,11 @@ SSL_CTX* init_ssl(const config::SSLConfig& ssl_config) {
         logf_error("Verify OEM root not found!");
     }
 
-    SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, nullptr);
+    // With SSL_VERIFY_NONE the callback is not invoked for client-cert validation; it is still
+    // invoked by OpenSSL's internal paths that walk the trust store (OCSP stapling, cert_cb, etc.).
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE,
+                       ssl_config.ignore_unhandled_critical_extensions ? &critical_extension_bypass_callback
+                                                                       : nullptr);
 
     SSL_CTX_set_client_hello_cb(ctx, &client_hello_cb, nullptr);
 

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -107,10 +107,17 @@ int critical_extension_bypass_callback(int ok, X509_STORE_CTX* ctx) {
 
     // RFC 5280 extension NIDs OpenSSL handles during path validation — safe to ignore if critical.
     static constexpr std::array<int, 12> handled_nids = {
-        NID_basic_constraints,         NID_key_usage,          NID_ext_key_usage,
-        NID_subject_alt_name,          NID_name_constraints,   NID_certificate_policies,
-        NID_policy_constraints,        NID_inhibit_any_policy, NID_authority_key_identifier,
-        NID_subject_key_identifier,    NID_crl_distribution_points,
+        NID_basic_constraints,
+        NID_key_usage,
+        NID_ext_key_usage,
+        NID_subject_alt_name,
+        NID_name_constraints,
+        NID_certificate_policies,
+        NID_policy_constraints,
+        NID_inhibit_any_policy,
+        NID_authority_key_identifier,
+        NID_subject_key_identifier,
+        NID_crl_distribution_points,
         NID_info_access,
     };
 
@@ -359,8 +366,7 @@ SSL_CTX* init_ssl(const config::SSLConfig& ssl_config) {
     // With SSL_VERIFY_NONE the callback is not invoked for client-cert validation; it is still
     // invoked by OpenSSL's internal paths that walk the trust store (OCSP stapling, cert_cb, etc.).
     SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE,
-                       ssl_config.ignore_unhandled_critical_extensions ? &critical_extension_bypass_callback
-                                                                       : nullptr);
+                       ssl_config.ignore_unhandled_critical_extensions ? &critical_extension_bypass_callback : nullptr);
 
     SSL_CTX_set_client_hello_cb(ctx, &client_hello_cb, nullptr);
 

--- a/lib/everest/ocpp/include/ocpp/common/evse_security_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/evse_security_impl.hpp
@@ -25,6 +25,8 @@ struct SecurityConfiguration {
     fs::path secc_leaf_key_link;
     fs::path cpo_cert_chain_link;
     std::optional<std::string> private_key_password;
+    // TODO: add ignore_unhandled_critical_extensions (bool, default false) and forward it to
+    // EvseSecurity
 };
 
 class EvseSecurityImpl : public EvseSecurity {

--- a/lib/everest/tls/include/everest/tls/openssl_util.hpp
+++ b/lib/everest/tls/include/everest/tls/openssl_util.hpp
@@ -363,21 +363,27 @@ certificate_list load_certificates(const std::vector<const char*>& filenames);
  * \param[in] leaf_file is the server certificate
  * \param[in] chain_file is the file of intermediate certificates
  * \param[in] root_file is the self signed trust anchor
+ * \param[in] ignore_unhandled_critical_extensions when true, suppress
+ *            X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION for certs whose
+ *            critical extensions all carry well-known RFC 5280 NIDs
  * \return the certificate chain. chain_info_t::leaf will be nullptr when a chain
  *         cannot be built
  * \note when leaf_file is null pointer the server certificate is the first certificate in the chain_file
  */
-chain_info_t load_certificates(const char* leaf_file, const char* chain_file, const char* root_file);
+chain_info_t load_certificates(const char* leaf_file, const char* chain_file, const char* root_file,
+                               bool ignore_unhandled_critical_extensions = false);
 
 /**
  * \brief load a PKI chain from leaf to root
  * \param[in] chain is the structure containing the three filenames
+ * \param[in] ignore_unhandled_critical_extensions see the file-based overload
  * \return the certificate chain. chain_info_t::leaf will be nullptr when a chain
  *         cannot be built
  * \note when leaf_file is null pointer the server certificate is the first certificate in the chain_file
  */
-static inline chain_info_t load_certificates(const chain_filenames_t& chain) {
-    return load_certificates(chain.leaf, chain.chain, chain.root);
+static inline chain_info_t load_certificates(const chain_filenames_t& chain,
+                                             bool ignore_unhandled_critical_extensions = false) {
+    return load_certificates(chain.leaf, chain.chain, chain.root, ignore_unhandled_critical_extensions);
 }
 
 /**
@@ -398,17 +404,20 @@ bool verify_certificate_key(const x509_st* cert, const evp_pkey_st* pkey);
 /**
  * \brief verify a certificate chain from leaf to trust anchor(s)
  * \param[in] chain the structure containing the certificates
+ * \param[in] ignore_unhandled_critical_extensions when true, accept certs whose
+ *            critical extensions all carry well-known RFC 5280 NIDs
  * \return true when there is a valid chain
  */
-bool verify_chain(const chain_info_t& chain);
+bool verify_chain(const chain_info_t& chain, bool ignore_unhandled_critical_extensions = false);
 
 /**
  * \brief verify a certificate chain from leaf to trust anchor(s) and that
  *        the private key is associated with the leaf certificate
  * \param[in] chain the structure containing the certificates and private key
+ * \param[in] ignore_unhandled_critical_extensions see the chain_info_t overload
  * \return true when there is a valid chain and the key matches
  */
-bool verify_chain(const chain_t& chain);
+bool verify_chain(const chain_t& chain, bool ignore_unhandled_critical_extensions = false);
 
 /**
  * \brief apply the certificates and private key to the SSL session
@@ -454,9 +463,16 @@ DER certificate_to_der(const x509_st* cert);
  *            intermediate CAs
  * \param[in] untrusted intermediate CAs needed to form a chain from the leaf
  *            certificate to one of the supplied trust anchors
+ * \param[in] ignore_unhandled_critical_extensions when true, install the
+ *            evse_security bypass callback so certs whose critical extensions
+ *            all carry well-known RFC 5280 NIDs (basicConstraints, keyUsage,
+ *            subjectKeyIdentifier, ...) no longer trigger
+ *            X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION. Intended for interop
+ *            with non-compliant trust anchors.
  */
 verify_result_t verify_certificate(const x509_st* cert, const certificate_list& trust_anchors,
-                                   const certificate_list& untrusted);
+                                   const certificate_list& untrusted,
+                                   bool ignore_unhandled_critical_extensions = false);
 
 /**
  * \brief extract the certificate subject as a dictionary of name/value pairs

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -402,9 +402,9 @@ public:
         std::vector<certificate_config_t> chains; //!< server certificate chains - must be at least one
         //!< one or more trust anchor PEM certificates for client certificate verification
         ConfigItem verify_locations_file{nullptr};
-        ConfigItem verify_locations_path{nullptr}; //!< for client certificate
-        std::int32_t io_timeout_ms{-1};            //!< socket timeout in milliseconds (recommend > 1 sec)
-        bool verify_client{true};                  //!< client certificate required
+        ConfigItem verify_locations_path{nullptr};        //!< for client certificate
+        std::int32_t io_timeout_ms{-1};                   //!< socket timeout in milliseconds (recommend > 1 sec)
+        bool verify_client{true};                         //!< client certificate required
         bool ignore_unhandled_critical_extensions{false}; //!< when true, install a verify callback that
                                                           //!< suppresses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION
                                                           //!< for certs whose critical extensions all have

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -405,6 +405,11 @@ public:
         ConfigItem verify_locations_path{nullptr}; //!< for client certificate
         std::int32_t io_timeout_ms{-1};            //!< socket timeout in milliseconds (recommend > 1 sec)
         bool verify_client{true};                  //!< client certificate required
+        bool ignore_unhandled_critical_extensions{false}; //!< when true, install a verify callback that
+                                                          //!< suppresses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION
+                                                          //!< for certs whose critical extensions all have
+                                                          //!< well-known RFC 5280 NIDs. Intended for diagnosing
+                                                          //!< non-compliant EV / V2G test certs.
 
         // config not used on update()
         ConfigItem host{nullptr};    //!< see BIO_lookup_ex()
@@ -633,6 +638,7 @@ public:
         bool status_request{false};                  //!< include a status request extension in the client hello
         bool status_request_v2{false};               //!< include a status request v2 extension in the client hello
         bool trusted_ca_keys{false};                 //!< include a trusted ca keys extension in the client hello
+        bool ignore_unhandled_critical_extensions{false}; //!< see Server::config_t
     };
 
     using ConnectionPtr = std::unique_ptr<ClientConnection>;

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -473,9 +473,14 @@ private:
     /**
      * \brief initialise server certificate chains
      * \param[in] chain_files server certificate chains
+     * \param[in] ignore_unhandled_critical_extensions when true, the init-time
+     *            chain self-check (openssl::verify_chain) accepts certs whose
+     *            critical extensions all carry well-known RFC 5280 NIDs. Mirrors
+     *            the handshake-time bypass installed in init_ssl().
      * \return true on success
      */
-    bool init_certificates(const std::vector<certificate_config_t>& chain_files);
+    bool init_certificates(const std::vector<certificate_config_t>& chain_files,
+                           bool ignore_unhandled_critical_extensions = false);
 
     /**
      * \brief unconfigure SSL certificates

--- a/lib/everest/tls/src/openssl_util.cpp
+++ b/lib/everest/tls/src/openssl_util.cpp
@@ -11,6 +11,7 @@
 
 #include <everest/tls/openssl_util.hpp>
 
+#include <evse_security/crypto/openssl/openssl_crypto_supplier.hpp>
 #include <evse_security/crypto/openssl/openssl_provider.hpp>
 
 #include <openssl/bio.h>
@@ -537,7 +538,8 @@ certificate_list load_certificates(const std::vector<const char*>& filenames) {
     return result;
 }
 
-chain_info_t load_certificates(const char* leaf_file, const char* chain_file, const char* root_file) {
+chain_info_t load_certificates(const char* leaf_file, const char* chain_file, const char* root_file,
+                               bool ignore_unhandled_critical_extensions) {
     certificate_ptr leaf_cert{nullptr, nullptr};
     auto leaf = load_certificates(leaf_file);
     auto chain = load_certificates(chain_file);
@@ -553,7 +555,8 @@ chain_info_t load_certificates(const char* leaf_file, const char* chain_file, co
     }
 
     if (leaf_cert && !root.empty()) {
-        if (verify_certificate(leaf_cert.get(), root, chain) == verify_result_t::Verified) {
+        if (verify_certificate(leaf_cert.get(), root, chain, ignore_unhandled_critical_extensions) ==
+            verify_result_t::Verified) {
             return {std::move(leaf_cert), std::move(chain), std::move(root)};
         }
     }
@@ -574,12 +577,13 @@ bool verify_certificate_key(const X509* cert, const EVP_PKEY* pkey) {
     return X509_check_private_key(cert, pkey) == 1;
 }
 
-bool verify_chain(const chain_info_t& chain) {
-    return verify_certificate(chain.leaf.get(), chain.trust_anchors, chain.chain) == verify_result_t::Verified;
+bool verify_chain(const chain_info_t& chain, bool ignore_unhandled_critical_extensions) {
+    return verify_certificate(chain.leaf.get(), chain.trust_anchors, chain.chain,
+                              ignore_unhandled_critical_extensions) == verify_result_t::Verified;
 }
 
-bool verify_chain(const chain_t& chain) {
-    bool result = verify_chain(chain.chain);
+bool verify_chain(const chain_t& chain, bool ignore_unhandled_critical_extensions) {
+    bool result = verify_chain(chain.chain, ignore_unhandled_critical_extensions);
     result = result && verify_certificate_key(chain.chain.leaf.get(), chain.private_key.get());
     return result;
 }
@@ -666,7 +670,7 @@ DER certificate_to_der(const x509_st* cert) {
 }
 
 verify_result_t verify_certificate(const X509* cert, const certificate_list& trust_anchors,
-                                   const certificate_list& untrusted) {
+                                   const certificate_list& untrusted, bool ignore_unhandled_critical_extensions) {
     verify_result_t result = verify_result_t::Verified;
     auto* store_ctx = X509_STORE_CTX_new();
     auto* ta_store = X509_STORE_new();
@@ -718,6 +722,9 @@ verify_result_t verify_certificate(const X509* cert, const certificate_list& tru
         if (X509_STORE_CTX_init(store_ctx, ta_store, target, chain) != 1) {
             log_error("X509_STORE_CTX_init");
         } else {
+            if (ignore_unhandled_critical_extensions) {
+                X509_STORE_CTX_set_verify_cb(store_ctx, &evse_security::critical_extension_bypass_callback);
+            }
             if (X509_STORE_CTX_verify(store_ctx) != 1) {
                 const auto err = X509_STORE_CTX_get_error(store_ctx);
                 if (err != X509_V_OK) {

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -6,6 +6,7 @@
 #include <everest/tls/openssl_util.hpp>
 #include <everest/tls/tls.hpp>
 
+#include <evse_security/crypto/openssl/openssl_crypto_supplier.hpp>
 #include <evse_security/crypto/openssl/openssl_provider.hpp>
 
 #include <arpa/inet.h>
@@ -986,7 +987,10 @@ bool Server::init_ssl(const config_t& cfg) {
                     result = false;
                 }
             }
-            SSL_CTX_set_verify(ctx, mode, nullptr);
+            SSL_CTX_set_verify(ctx, mode,
+                               cfg.ignore_unhandled_critical_extensions
+                                   ? &evse_security::critical_extension_bypass_callback
+                                   : nullptr);
 
             result = result && m_status_request_v2.init_ssl(ctx);
             result = result && m_server_trusted_ca_keys.init_ssl(ctx);
@@ -1363,7 +1367,10 @@ bool Client::init(const config_t& cfg, const override_t& override) {
             }
         }
 
-        SSL_CTX_set_verify(ctx, mode, nullptr);
+        SSL_CTX_set_verify(ctx, mode,
+                           cfg.ignore_unhandled_critical_extensions
+                               ? &evse_security::critical_extension_bypass_callback
+                               : nullptr);
         if (cfg.status_request) {
             if (SSL_CTX_set_tlsext_status_type(ctx, TLSEXT_STATUSTYPE_ocsp) != 1) {
                 log_error("SSL_CTX_set_tlsext_status_type");

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -1010,7 +1010,8 @@ void Server::deinit_ssl() {
     m_context = std::make_unique<server_ctx>();
 }
 
-bool Server::init_certificates(const std::vector<certificate_config_t>& chain_files) {
+bool Server::init_certificates(const std::vector<certificate_config_t>& chain_files,
+                               bool ignore_unhandled_critical_extensions) {
     std::vector<OcspCache::ocsp_entry_t> entries;
     openssl::chain_list chains;
 
@@ -1058,7 +1059,7 @@ bool Server::init_certificates(const std::vector<certificate_config_t>& chain_fi
                 chain.chain.trust_anchors = std::move(tas);
                 chain.private_key = std::move(pkey);
 
-                if (openssl::verify_chain(chain)) {
+                if (openssl::verify_chain(chain, ignore_unhandled_critical_extensions)) {
                     chains.emplace_back(std::move(chain));
                 }
             } else {
@@ -1214,7 +1215,7 @@ bool Server::update(const config_t& cfg) {
 
     m_timeout_ms = cfg.io_timeout_ms;
     // always try init_certificates() and init_ssl()
-    bool result = init_certificates(cfg.chains);
+    bool result = init_certificates(cfg.chains, cfg.ignore_unhandled_critical_extensions);
     if (!init_ssl(cfg)) {
         result = false;
     }

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -1368,9 +1368,8 @@ bool Client::init(const config_t& cfg, const override_t& override) {
         }
 
         SSL_CTX_set_verify(ctx, mode,
-                           cfg.ignore_unhandled_critical_extensions
-                               ? &evse_security::critical_extension_bypass_callback
-                               : nullptr);
+                           cfg.ignore_unhandled_critical_extensions ? &evse_security::critical_extension_bypass_callback
+                                                                    : nullptr);
         if (cfg.status_request) {
             if (SSL_CTX_set_tlsext_status_type(ctx, TLSEXT_STATUSTYPE_ocsp) != 1) {
                 log_error("SSL_CTX_set_tlsext_status_type");

--- a/lib/everest/tls/tests/CMakeLists.txt
+++ b/lib/everest/tls/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ target_include_directories(${TLS_MAIN_NAME} PRIVATE
 
 target_compile_definitions(${TLS_MAIN_NAME} PRIVATE
     -DUNIT_TEST
+    -DLIBEVSE_CRYPTO_SUPPLIER_OPENSSL
 )
 
 target_sources(${TLS_MAIN_NAME} PRIVATE
@@ -107,6 +108,7 @@ target_include_directories(${TLS_CLIENT_NAME} PRIVATE
 
 target_compile_definitions(${TLS_CLIENT_NAME} PRIVATE
     -DUNIT_TEST
+    -DLIBEVSE_CRYPTO_SUPPLIER_OPENSSL
 )
 
 target_sources(${TLS_CLIENT_NAME} PRIVATE
@@ -137,6 +139,7 @@ target_include_directories(${TLS_PATCH_NAME} PRIVATE
 
 target_compile_definitions(${TLS_PATCH_NAME} PRIVATE
     -DUNIT_TEST
+    -DLIBEVSE_CRYPTO_SUPPLIER_OPENSSL
 )
 
 target_sources(${TLS_PATCH_NAME} PRIVATE

--- a/lib/everest/tls/tests/openssl_util_test.cpp
+++ b/lib/everest/tls/tests/openssl_util_test.cpp
@@ -691,6 +691,24 @@ TEST(certificate, verifyFailWrongChain) {
     EXPECT_NE(::openssl::verify_certificate(client[0].get(), root, chain), openssl::verify_result_t::Verified);
 }
 
+TEST(certificate, verifyIgnoresUnhandledCriticalExtensions) {
+    auto leaf = ::openssl::load_certificates("server_critical_ski_cert.pem");
+    auto chain = ::openssl::load_certificates("server_ca_critical_ski_cert.pem");
+    auto root = ::openssl::load_certificates("server_root_cert.pem");
+
+    ASSERT_EQ(leaf.size(), 1);
+    ASSERT_EQ(chain.size(), 1);
+    ASSERT_EQ(root.size(), 1);
+
+    // strict mode: OpenSSL rejects the chain because the CA's critical
+    // subjectKeyIdentifier has no in-built handler.
+    EXPECT_NE(::openssl::verify_certificate(leaf[0].get(), root, chain), openssl::verify_result_t::Verified);
+
+    // lenient mode: the evse_security bypass callback accepts well-known
+    // RFC 5280 NIDs (subjectKeyIdentifier among them) and verification passes.
+    EXPECT_EQ(::openssl::verify_certificate(leaf[0].get(), root, chain, true), openssl::verify_result_t::Verified);
+}
+
 TEST(certificate, subjectName) {
     auto chain = ::openssl::load_certificates("client_chain.pem");
     EXPECT_GT(chain.size(), 0);

--- a/lib/everest/tls/tests/pki/openssl-pki.conf
+++ b/lib/everest/tls/tests/pki/openssl-pki.conf
@@ -80,6 +80,22 @@ keyUsage = digitalSignature, keyEncipherment, keyAgreement
 extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = IP:192.168.245.1, DNS:evse.pionix.de
 
+# variants with subjectKeyIdentifier marked critical (non-RFC-5280-compliant).
+# Used to exercise the ignore_unhandled_critical_extensions bypass on the
+# init-time X509_STORE_CTX_verify path.
+[v3_server_ca_critical_ski]
+subjectKeyIdentifier = critical, hash
+authorityKeyIdentifier = keyid:always,issuer:always
+basicConstraints = critical, CA:true
+keyUsage = keyCertSign, cRLSign
+
+[v3_server_critical_ski]
+subjectKeyIdentifier = critical, hash
+authorityKeyIdentifier = keyid:always
+keyUsage = digitalSignature, keyEncipherment, keyAgreement
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = IP:192.168.245.1, DNS:evse.pionix.de
+
 # client section
 # ==============
 [req_client]

--- a/lib/everest/tls/tests/pki/pki.sh
+++ b/lib/everest/tls/tests/pki/pki.sh
@@ -76,5 +76,19 @@ openssl req \
     -key "${base}${server_ca_priv}" -CA "${base}${client_root_cert}" \
     -CAkey "${base}${client_root_priv}" -out cross_ca_cert.pem
 
+# critical-SKI chain: server_root (clean) -> ca_critical_ski -> server_critical_ski.
+# Used by the ignore_unhandled_critical_extensions bypass test. Re-uses the
+# existing EC keys so no extra keypair generation is needed.
+echo "Generate server_ca_critical_ski"
+openssl req \
+    -config "${cfg}" -x509 -section req_server_ca -extensions v3_server_ca_critical_ski \
+    -key "${server_ca_priv}" -CA "${server_root_cert}" \
+    -CAkey "${server_root_priv}" -out server_ca_critical_ski_cert.pem
+echo "Generate server_critical_ski"
+openssl req \
+    -config "${cfg}" -x509 -section req_server -extensions v3_server_critical_ski \
+    -key "${server_priv}" -CA server_ca_critical_ski_cert.pem \
+    -CAkey "${server_ca_priv}" -out server_critical_ski_cert.pem
+
 # convert iso key to PEM
 openssl asn1parse -genconf iso_pkey.asn1 -noout -out -| openssl pkey -inform der -out iso_priv.pem

--- a/modules/EVSE/Evse15118D20/Evse15118D20.hpp
+++ b/modules/EVSE/Evse15118D20/Evse15118D20.hpp
@@ -32,6 +32,7 @@ struct Conf {
     bool enable_ssl_logging;
     bool enable_tls_key_logging;
     std::string tls_key_logging_path;
+    bool tls_bypass_unhandled_critical_extensions;
     bool enable_sdp_server;
     bool supported_dynamic_mode;
     bool supported_mobility_needs_mode_provided_by_secc;

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -210,16 +210,16 @@ void ISO15118_chargerImpl::ready() {
     const iso15118::TbdConfig tbd_config = {
         {
             iso15118::config::CertificateBackend::EVEREST_LAYOUT,
-            {},                                 ///< config_string
-            path_chain,                         ///< path_certificate_chain
-            certificate_info.key,               ///< path_certificate_key
-            certificate_info.password,          ///< private_key_password
-            v2g_root_cert_path,                 ///< path_certificate_v2g_root
-            mo_root_cert_path,                  ///< path_certificate_mo_root
-            mod->config.enable_ssl_logging,     ///< enable_ssl_logging
-            mod->config.enable_tls_key_logging, ///< enable_tls_key_logging
-            mod->config.enforce_tls_1_3,        ///< enforce_tls_1_3
-            mod->config.tls_key_logging_path,   ///< tls_key_logging_path
+            {},                                                   ///< config_string
+            path_chain,                                           ///< path_certificate_chain
+            certificate_info.key,                                 ///< path_certificate_key
+            certificate_info.password,                            ///< private_key_password
+            v2g_root_cert_path,                                   ///< path_certificate_v2g_root
+            mo_root_cert_path,                                    ///< path_certificate_mo_root
+            mod->config.enable_ssl_logging,                       ///< enable_ssl_logging
+            mod->config.enable_tls_key_logging,                   ///< enable_tls_key_logging
+            mod->config.enforce_tls_1_3,                          ///< enforce_tls_1_3
+            mod->config.tls_key_logging_path,                     ///< tls_key_logging_path
             mod->config.tls_bypass_unhandled_critical_extensions, ///< ignore_unhandled_critical_extensions
         },
         mod->config.device,

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -220,6 +220,7 @@ void ISO15118_chargerImpl::ready() {
             mod->config.enable_tls_key_logging, ///< enable_tls_key_logging
             mod->config.enforce_tls_1_3,        ///< enforce_tls_1_3
             mod->config.tls_key_logging_path,   ///< tls_key_logging_path
+            mod->config.tls_bypass_unhandled_critical_extensions, ///< ignore_unhandled_critical_extensions
         },
         mod->config.device,
         convert_tls_negotiation_strategy(mod->config.tls_negotiation_strategy),

--- a/modules/EVSE/Evse15118D20/manifest.yaml
+++ b/modules/EVSE/Evse15118D20/manifest.yaml
@@ -39,6 +39,16 @@ config:
       Output directory for the TLS key log file
     type: string
     default: /tmp
+  tls_bypass_unhandled_critical_extensions:
+    description: >-
+      When true, the libiso TLS server context installs a verify callback that suppresses
+      X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION for certificates whose critical extensions all
+      have well-known RFC 5280 NIDs. Enables interoperability with EV / V2G certificates
+      that mark extensions critical in ways OpenSSL's path-validation machinery doesn't
+      natively handle. Certificates carrying truly unknown critical OIDs are still rejected
+      and logged with the offending NID/OID. Mirrors the EvseV2G option of the same name.
+    type: boolean
+    default: false
   enable_sdp_server:
     description: >-
       Enable the built-in SDP server

--- a/modules/EVSE/EvseSecurity/EvseSecurity.hpp
+++ b/modules/EVSE/EvseSecurity/EvseSecurity.hpp
@@ -29,6 +29,7 @@ struct Conf {
     std::string secc_leaf_cert_directory;
     std::string secc_leaf_key_directory;
     std::string private_key_password;
+    bool ignore_unhandled_critical_extensions;
 };
 
 class EvseSecurity : public Everest::ModuleBase {

--- a/modules/EVSE/EvseSecurity/EvseSecurity.hpp
+++ b/modules/EVSE/EvseSecurity/EvseSecurity.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
-#ifndef EVSE_SECURITY_FS_HPP
-#define EVSE_SECURITY_FS_HPP
+#ifndef EVSE_SECURITY_HPP
+#define EVSE_SECURITY_HPP
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
@@ -29,6 +29,7 @@ struct Conf {
     std::string secc_leaf_cert_directory;
     std::string secc_leaf_key_directory;
     std::string private_key_password;
+    bool ignore_unhandled_critical_extensions;
 };
 
 class EvseSecurity : public Everest::ModuleBase {
@@ -65,4 +66,4 @@ private:
 
 } // namespace module
 
-#endif // EVSE_SECURITY_FS_HPP
+#endif // EVSE_SECURITY_HPP

--- a/modules/EVSE/EvseSecurity/main/evse_securityImpl.cpp
+++ b/modules/EVSE/EvseSecurity/main/evse_securityImpl.cpp
@@ -24,7 +24,13 @@ void evse_securityImpl::init() {
         private_key_password = this->mod->config.private_key_password;
     }
 
-    this->evse_security = std::make_unique<evse_security::EvseSecurity>(file_paths, private_key_password);
+    this->evse_security =
+        std::make_unique<evse_security::EvseSecurity>(file_paths, private_key_password,
+                                                      std::nullopt, // max_fs_usage_bytes
+                                                      std::nullopt, // max_fs_certificate_store_entries
+                                                      std::nullopt, // csr_expiry
+                                                      std::nullopt, // garbage_collect_time
+                                                      this->mod->config.ignore_unhandled_critical_extensions);
 }
 
 void evse_securityImpl::ready() {

--- a/modules/EVSE/EvseSecurity/manifest.yaml
+++ b/modules/EVSE/EvseSecurity/manifest.yaml
@@ -38,10 +38,18 @@ config:
     description: Password for encrypted private keys.
     type: string
     default: ""
+  ignore_unhandled_critical_extensions:
+    description: >-
+      If true, bypasses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION during certificate validation
+      when every critical extension on the certificate has a well-known RFC 5280 NID (e.g. SKI,
+      AKI, CRL Distribution Points). Enable only for interoperability with known non-compliant
+      certificates.
+    type: boolean
+    default: false
 provides:
   main:
     description: Implementation of the evse_security interface
-    interface: evse_security 
+    interface: evse_security
 enable_telemetry: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0

--- a/modules/EVSE/EvseV2G/EvseV2G.hpp
+++ b/modules/EVSE/EvseV2G/EvseV2G.hpp
@@ -39,6 +39,7 @@ struct Conf {
     int auth_timeout_pnc;
     int auth_timeout_eim;
     bool enable_sdp_server;
+    bool tls_bypass_unhandled_critical_extensions;
 };
 
 class EvseV2G : public Everest::ModuleBase {

--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -54,6 +54,13 @@ void ISO15118_chargerImpl::init() {
 
     v2g_ctx->tls_key_logging = mod->config.tls_key_logging;
     v2g_ctx->tls_key_logging_path = mod->config.tls_key_logging_path;
+    v2g_ctx->tls_bypass_unhandled_critical_extensions = mod->config.tls_bypass_unhandled_critical_extensions;
+
+    if (mod->config.tls_bypass_unhandled_critical_extensions) {
+        dlog(DLOG_LEVEL_INFO,
+             "TLS X.509 well-known-NID critical-extension bypass ENABLED. "
+             "Truly unknown critical OIDs are still rejected and logged.");
+    }
 
     if (mod->config.tls_key_logging == true) {
         dlog(DLOG_LEVEL_DEBUG, "tls-key-logging enabled (path: %s)", mod->config.tls_key_logging_path.c_str());

--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -57,9 +57,8 @@ void ISO15118_chargerImpl::init() {
     v2g_ctx->tls_bypass_unhandled_critical_extensions = mod->config.tls_bypass_unhandled_critical_extensions;
 
     if (mod->config.tls_bypass_unhandled_critical_extensions) {
-        dlog(DLOG_LEVEL_INFO,
-             "TLS X.509 well-known-NID critical-extension bypass ENABLED. "
-             "Truly unknown critical OIDs are still rejected and logged.");
+        dlog(DLOG_LEVEL_INFO, "TLS X.509 well-known-NID critical-extension bypass ENABLED. "
+                              "Truly unknown critical OIDs are still rejected and logged.");
     }
 
     if (mod->config.tls_key_logging == true) {

--- a/modules/EVSE/EvseV2G/connection/tls_connection.cpp
+++ b/modules/EVSE/EvseV2G/connection/tls_connection.cpp
@@ -291,6 +291,7 @@ bool build_config(tls::Server::config_t& config, struct v2g_context* ctx) {
 
     config.tls_key_logging = ctx->tls_key_logging;
     config.tls_key_logging_path = ctx->tls_key_logging_path;
+    config.ignore_unhandled_critical_extensions = ctx->tls_bypass_unhandled_critical_extensions;
     config.host = ctx->if_name;
 
     // information from libevse-security

--- a/modules/EVSE/EvseV2G/manifest.yaml
+++ b/modules/EVSE/EvseV2G/manifest.yaml
@@ -75,6 +75,19 @@ config:
       Enable the built-in SDP server
     type: boolean
     default: true
+  tls_bypass_unhandled_critical_extensions:
+    description: >-
+      When true, the TLS server and client contexts install a verify callback that
+      suppresses X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION for certificates whose critical
+      extensions all have well-known RFC 5280 NIDs (basicConstraints, keyUsage,
+      extKeyUsage, subjectAltName, nameConstraints, certificatePolicies, policyConstraints,
+      inhibitAnyPolicy, authorityKeyIdentifier, subjectKeyIdentifier, crlDistributionPoints,
+      authorityInformationAccess). Enables interoperability with EV / V2G certificates
+      that mark extensions critical in ways OpenSSL's path-validation machinery doesn't
+      natively handle. Certificates carrying truly unknown critical OIDs are still
+      rejected and logged with the offending NID/OID.
+    type: boolean
+    default: false
 provides:
   charger:
     interface: ISO15118_charger

--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -226,6 +226,7 @@ struct v2g_context {
     tls::Server* tls_server;
 
     bool tls_key_logging;
+    bool tls_bypass_unhandled_critical_extensions;
 
     pthread_mutex_t mqtt_lock;
     pthread_cond_t mqtt_cond;

--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -224,6 +224,7 @@ struct v2g_context {
     tls::Server* tls_server;
 
     bool tls_key_logging;
+    bool tls_bypass_unhandled_critical_extensions;
 
     pthread_mutex_t mqtt_lock;
     pthread_cond_t mqtt_cond;

--- a/modules/EVSE/EvseV2G/v2g_ctx.cpp
+++ b/modules/EVSE/EvseV2G/v2g_ctx.cpp
@@ -301,6 +301,7 @@ struct v2g_context* v2g_ctx_create(ISO15118_chargerImplBase* p_chargerImplBase,
     ctx->tcp_socket = -1;
     ctx->tls_socket.fd = -1;
     ctx->tls_key_logging = false;
+    ctx->tls_bypass_unhandled_critical_extensions = false;
     ctx->debugMode = false;
 
     /* according to man page, both functions never return an error */


### PR DESCRIPTION
Adds ignore_unhandled_critical_extensions to x509_verify_certificate_chain and the EvseSecurity module config. When enabled, X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION is suppressed only if every critical extension on the certificate has a well-known RFC 5280 NID. Intended for interoperability with non-compliant CAs that mark some extensions as critical.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

