### PR TITLE
Fix(libiso15118): CMake finds edm again for local build

### DIFF
--- a/lib/everest/iso15118/cmake/local-build.cmake
+++ b/lib/everest/iso15118/cmake/local-build.cmake
@@ -17,7 +17,7 @@ ev_setup_python_executable(
 )
 get_filename_component(EVC_LIB_DIR ${EVC_EVEREST_LIB_DIR} DIRECTORY)
 get_filename_component(EVC_DIR ${EVC_LIB_DIR} DIRECTORY)
-set(EVC_EDM_DIR "${EVC_DIR}/applications/dev-environment")
+set(EVC_EDM_DIR "${EVC_DIR}/applications/dependency_manager")
 
 # use edm from everest-core
 add_subdirectory("${EVC_EDM_DIR}" edm_tool)


### PR DESCRIPTION
## Describe your changes
Changed `EVC_EDM_DIR` to the new dir.

## Issue ticket number and link
Because of #1688 `edm` was not found anymore if building libiso15118 standalone locally

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

