### PR TITLE
feat(framework): retries for mqtt get()

### DIFF
--- a/lib/everest/framework/include/utils/mqtt_abstraction.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction.hpp
@@ -69,12 +69,12 @@ public:
     void clear_retained_topics();
 
     ///
-    /// \copydoc MQTTAbstractionImpl::get(const std::string&, QOS)
-    nlohmann::json get(const std::string& topic, QOS qos);
+    /// \copydoc MQTTAbstractionImpl::get(const std::string&, QOS, std::size_t)
+    nlohmann::json get(const std::string& topic, QOS qos, std::size_t retries = 0);
 
     ///
-    /// \copydoc MQTTAbstractionImpl::get(const MQTTRequest&)
-    nlohmann::json get(const MQTTRequest& request);
+    /// \copydoc MQTTAbstractionImpl::get(const MQTTRequest&, std::size_t)
+    nlohmann::json get(const MQTTRequest& request, std::size_t retries = 0);
 
     ///
     /// \brief Get MQTT topic prefix for the "everest" topic

--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -88,19 +88,6 @@ public:
 
     /// \brief Sends an MQTT request and waits for a JSON response.
     ///
-    /// This function registers a temporary response handler for the specified topic,
-    /// waits for a response message, and returns the received JSON data.
-    /// If no response is received within the configured timeout, it throws an
-    /// EverestTimeoutError.
-    ///
-    /// \param topic The MQTT topic to retrieve data from.
-    /// \param qos The Quality of Service (QoS) level for the request.
-    /// \return The JSON message received from the MQTT topic.
-    /// \throws EverestTimeoutError If no response is received within the timeout.
-    nlohmann::json get(const std::string& topic, QOS qos);
-
-    /// \brief Sends an MQTT request and waits for a JSON response.
-    ///
     /// This function registers a temporary handler for the response topic specified
     /// in the request, publishes a request message, and waits for the
     /// corresponding JSON response. If no response is received within the timeout,
@@ -108,9 +95,10 @@ public:
     ///
     /// \param request The MQTT request containing the response topic, request topic,
     ///                payload, QoS, and timeout.
+    /// \param retries How often the get should be retried if it failed, defaults to 0.
     /// \return The JSON response received from the MQTT broker.
     /// \throws EverestTimeoutError If no response is received within the specified timeout.
-    nlohmann::json get(const MQTTRequest& request);
+    nlohmann::json get(const MQTTRequest& request, std::size_t retries = 0);
 
     ///
     /// \brief Spawn a thread running the mqtt main loop
@@ -177,6 +165,7 @@ private:
     int mqtt_socket_fd{-1};
     int event_fd{-1};
     int disconnect_event_fd{-1};
+    nlohmann::json get_internal(const MQTTRequest& request);
 };
 } // namespace Everest
 

--- a/lib/everest/framework/include/utils/types.hpp
+++ b/lib/everest/framework/include/utils/types.hpp
@@ -167,6 +167,7 @@ NLOHMANN_JSON_NAMESPACE_END
 
 namespace Everest {
 inline constexpr int mqtt_get_config_timeout_ms = 5000;
+inline constexpr std::size_t mqtt_get_config_retries = 1;
 
 /// \brief Errors than can happen related to commands
 enum class CmdErrorType {

--- a/lib/everest/framework/lib/config_service.cpp
+++ b/lib/everest/framework/lib/config_service.cpp
@@ -233,7 +233,7 @@ std::map<ModuleIdType, everest::config::ModuleConfigurationParameters> ConfigSer
     mqtt_request.request_data = json(get_request).dump();
 
     try {
-        Response response = mqtt_abstraction->get(mqtt_request);
+        Response response = mqtt_abstraction->get(mqtt_request, mqtt_get_config_retries);
         if (response.status != ResponseStatus::Ok) {
             EVLOG_error << "Could not get module configs via MQTT";
             return {};
@@ -269,7 +269,7 @@ std::map<std::string, ModuleTierMappings> ConfigServiceClient::get_mappings() {
     mqtt_request.request_data = json(get_request).dump();
 
     try {
-        Response response = mqtt_abstraction->get(mqtt_request);
+        Response response = mqtt_abstraction->get(mqtt_request, mqtt_get_config_retries);
         if (response.status != ResponseStatus::Ok) {
             EVLOG_error << "Could not get mappings configs via MQTT";
             return {};
@@ -308,7 +308,7 @@ ConfigServiceClient::set_config_value(const everest::config::ConfigurationParame
         mqtt_request.request_topic = fmt::format("{}config/request", mqtt_abstraction->get_everest_prefix());
         mqtt_request.request_data = json(request).dump();
 
-        const Response response = mqtt_abstraction->get(mqtt_request);
+        const Response response = mqtt_abstraction->get(mqtt_request, mqtt_get_config_retries);
         result.status = response.status;
         result.status_info = response.status_info;
         if (response.status == ResponseStatus::Ok) {
@@ -344,7 +344,7 @@ ConfigServiceClient::get_config_value(const everest::config::ConfigurationParame
             fmt::format("{}modules/{}/response", mqtt_abstraction->get_everest_prefix(), request.origin);
         mqtt_request.request_topic = fmt::format("{}config/request", mqtt_abstraction->get_everest_prefix());
         mqtt_request.request_data = json(request).dump();
-        const Response response = mqtt_abstraction->get(mqtt_request);
+        const Response response = mqtt_abstraction->get(mqtt_request, mqtt_get_config_retries);
         result.status = response.status;
         result.status_info = response.status_info;
         if (response.status == ResponseStatus::Ok) {

--- a/lib/everest/framework/lib/module_config.cpp
+++ b/lib/everest/framework/lib/module_config.cpp
@@ -76,25 +76,6 @@ json get_definitions(std::shared_ptr<MQTTAbstraction> mqtt) {
 json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string& module_id) {
     const auto& everest_prefix = mqtt->get_everest_prefix();
 
-    const auto get_config_topic = fmt::format("{}config/request", everest_prefix);
-    const auto response_config_topic = fmt::format("{}modules/{}/response", everest_prefix, module_id);
-    std::promise<json> res_promise;
-    std::future<json> res_future = res_promise.get_future();
-
-    const auto res_handler = [module_id, &res_promise](const std::string& /*topic*/, json json_response) {
-        EVLOG_verbose << fmt::format("Incoming config for {}", module_id);
-        config::Response response = json_response;
-        if (response.status == config::ResponseStatus::Ok and response.type.has_value() and
-            response.type.value() == config::Type::Get) {
-            auto get_response = std::get<config::GetResponse>(response.response);
-            res_promise.set_value(std::move(get_response.data));
-        }
-    };
-
-    const std::shared_ptr<TypedHandler> res_token =
-        std::make_shared<TypedHandler>(HandlerType::GetConfigResponse, std::make_shared<Handler>(res_handler));
-    mqtt->register_handler(response_config_topic, res_token, QOS::QOS2);
-
     config::GetRequest get_request;
     get_request.type = config::GetType::Module;
     config::Request request;
@@ -102,28 +83,20 @@ json get_module_config(std::shared_ptr<MQTTAbstraction> mqtt, const std::string&
     request.origin = module_id;
     request.type = config::Type::Get;
 
-    MqttMessagePayload payload{MqttMessageType::GetConfig, request};
-    mqtt->publish(get_config_topic, payload, QOS::QOS2);
-
-    // wait for result future
-    const std::chrono::time_point<std::chrono::steady_clock> res_wait =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(mqtt_get_config_timeout_ms);
-    std::future_status res_future_status = std::future_status::deferred;
-    do {
-        res_future_status = res_future.wait_until(res_wait);
-    } while (res_future_status == std::future_status::deferred);
+    MQTTRequest mqtt_request;
+    mqtt_request.response_topic = fmt::format("{}modules/{}/response", everest_prefix, module_id);
+    mqtt_request.request_topic = fmt::format("{}config/request", everest_prefix);
+    mqtt_request.request_data = json(request).dump();
 
     json result;
-    if (res_future_status == std::future_status::timeout) {
-        mqtt->unregister_handler(response_config_topic, res_token);
-        EVLOG_AND_THROW(
-            EverestTimeoutError(fmt::format("Timeout while waiting for result of get_config of {}", module_id)));
-    }
-    if (res_future_status == std::future_status::ready) {
-        result = res_future.get();
-    }
-    mqtt->unregister_handler(response_config_topic, res_token);
 
+    config::Response response = mqtt->get(mqtt_request, mqtt_get_config_retries);
+    EVLOG_verbose << fmt::format("Incoming config for {}", module_id);
+    if (response.status == config::ResponseStatus::Ok and response.type.has_value() and
+        response.type.value() == config::Type::Get) {
+        auto get_response = std::get<config::GetResponse>(response.response);
+        result = get_response.data;
+    }
     result.update(get_definitions(mqtt));
 
     return result;

--- a/lib/everest/framework/lib/module_config.cpp
+++ b/lib/everest/framework/lib/module_config.cpp
@@ -23,47 +23,47 @@ json get_definitions(std::shared_ptr<MQTTAbstraction> mqtt) {
 
     json result;
     const auto interface_names_topic = fmt::format("{}interfaces", everest_prefix);
-    const auto interface_names = mqtt->get(interface_names_topic, QOS::QOS2);
+    const auto interface_names = mqtt->get(interface_names_topic, QOS::QOS2, mqtt_get_config_retries);
     auto interface_definitions = json::object();
     for (const auto& interface : interface_names) {
         auto interface_topic = fmt::format("{}interface_definitions/{}", everest_prefix, interface.get<std::string>());
-        auto interface_definition = mqtt->get(interface_topic, QOS::QOS2);
+        auto interface_definition = mqtt->get(interface_topic, QOS::QOS2, mqtt_get_config_retries);
         interface_definitions[interface] = interface_definition;
     }
 
     result["interface_definitions"] = interface_definitions;
 
     const auto type_names_topic = fmt::format("{}types", everest_prefix);
-    const auto type_names = mqtt->get(type_names_topic, QOS::QOS2);
+    const auto type_names = mqtt->get(type_names_topic, QOS::QOS2, mqtt_get_config_retries);
     auto type_definitions = json::object();
     for (const auto& type_name : type_names) {
         // type_definition keys already start with a / so omit it in the topic name
         auto type_topic = fmt::format("{}type_definitions{}", everest_prefix, type_name.get<std::string>());
-        auto type_definition = mqtt->get(type_topic, QOS::QOS2);
+        auto type_definition = mqtt->get(type_topic, QOS::QOS2, mqtt_get_config_retries);
         type_definitions[type_name] = type_definition;
     }
 
     result["types"] = type_definitions;
 
     const auto settings_topic = fmt::format("{}settings", everest_prefix);
-    const auto settings = mqtt->get(settings_topic, QOS::QOS2);
+    const auto settings = mqtt->get(settings_topic, QOS::QOS2, mqtt_get_config_retries);
     result["settings"] = settings;
 
     const auto validate_schema = settings.value("validate_schema", json(false)).get<bool>();
     if (validate_schema) {
         const auto schemas_topic = fmt::format("{}schemas", everest_prefix);
-        const auto schemas = mqtt->get(schemas_topic, QOS::QOS2);
+        const auto schemas = mqtt->get(schemas_topic, QOS::QOS2, mqtt_get_config_retries);
         result["schemas"] = schemas;
     }
 
     const auto module_names_topic = fmt::format("{}module_names", everest_prefix);
-    const auto module_names = mqtt->get(module_names_topic, QOS::QOS2);
+    const auto module_names = mqtt->get(module_names_topic, QOS::QOS2, mqtt_get_config_retries);
     result["module_names"] = module_names;
 
     auto manifests = json::object();
     for (const auto& module_name : module_names) {
         auto manifest_topic = fmt::format("{}manifests/{}", everest_prefix, module_name.get<std::string>());
-        auto manifest = mqtt->get(manifest_topic, QOS::QOS2);
+        auto manifest = mqtt->get(manifest_topic, QOS::QOS2, mqtt_get_config_retries);
         manifests[module_name] = manifest;
     }
 

--- a/lib/everest/framework/lib/mqtt_abstraction.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
+#include <cstddef>
 #include <everest/logging.hpp>
 
 #include <utils/mqtt_abstraction.hpp>
@@ -78,14 +79,15 @@ void MQTTAbstraction::clear_retained_topics() {
     mqtt_abstraction->clear_retained_topics();
 }
 
-json MQTTAbstraction::get(const std::string& topic, QOS qos) {
+json MQTTAbstraction::get(const std::string& topic, QOS qos, std::size_t retries) {
     BOOST_LOG_FUNCTION();
-    return mqtt_abstraction->get(topic, qos);
+    const MQTTRequest request = {topic, qos};
+    return mqtt_abstraction->get(request, retries);
 }
 
-json MQTTAbstraction::get(const MQTTRequest& request) {
+json MQTTAbstraction::get(const MQTTRequest& request, std::size_t retries) {
     BOOST_LOG_FUNCTION();
-    return mqtt_abstraction->get(request);
+    return mqtt_abstraction->get(request, retries);
 }
 
 const std::string& MQTTAbstraction::get_everest_prefix() const {

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -244,45 +244,25 @@ void MQTTAbstractionImpl::clear_retained_topics() {
     retained_topics.clear();
 }
 
-json MQTTAbstractionImpl::get(const std::string& topic, QOS qos) {
+json MQTTAbstractionImpl::get(const MQTTRequest& request, std::size_t retries) {
     BOOST_LOG_FUNCTION();
-    std::lock_guard<std::mutex> lock(topic_request_mutex);
-
-    std::promise<json> res_promise;
-    std::future<json> res_future = res_promise.get_future();
-
-    const auto res_handler = [this, &res_promise](const std::string& /*topic*/, json data) {
-        res_promise.set_value(std::move(data));
-    };
-
-    const std::shared_ptr<TypedHandler> res_token =
-        std::make_shared<TypedHandler>(HandlerType::GetConfigResponse, std::make_shared<Handler>(res_handler));
-    this->register_handler(
-        topic, res_token,
-        QOS::QOS2); // without the lock guard, response handlers could be overriden if called from different threads
-
-    // wait for result future
-    const std::chrono::time_point<std::chrono::steady_clock> res_wait =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(mqtt_get_timeout_ms);
-    std::future_status res_future_status = std::future_status::deferred;
-    do {
-        res_future_status = res_future.wait_until(res_wait);
-    } while (res_future_status == std::future_status::deferred);
-
-    json result;
-    if (res_future_status == std::future_status::timeout) {
-        this->unregister_handler(topic, res_token);
-        EVLOG_AND_THROW(EverestTimeoutError(fmt::format("Timeout while waiting for result of get()")));
+    std::size_t attempt = 0;
+    while (attempt <= retries) {
+        try {
+            return this->get_internal(request);
+        } catch (const EverestTimeoutError& error) {
+            if (attempt < retries) {
+                attempt += 1;
+            } else {
+                std::rethrow_exception(std::current_exception());
+            }
+        }
     }
-    if (res_future_status == std::future_status::ready) {
-        result = res_future.get();
-    }
-    this->unregister_handler(topic, res_token);
-
-    return result;
+    EVLOG_AND_THROW(
+        EverestInternalError(fmt::format("Unknown error while waiting for result of get({})", request.response_topic)));
 }
 
-json MQTTAbstractionImpl::get(const MQTTRequest& request) {
+nlohmann::json MQTTAbstractionImpl::get_internal(const MQTTRequest& request) {
     BOOST_LOG_FUNCTION();
     std::lock_guard<std::mutex> lock(topic_request_mutex);
 


### PR DESCRIPTION
## Describe your changes
In some circumstances the first call to mqtt->get() might be unsuccessful because to topic you want isn't available yet.
This adds a retry mechanism to allow a certain number of failed attempts before finally failing

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

