### PR TITLE
fix(evse_security): correctly calculate total size of all cert store entries for garbage collection

### DIFF
--- a/lib/everest/evse_security/lib/evse_security/evse_security.cpp
+++ b/lib/everest/evse_security/lib/evse_security/evse_security.cpp
@@ -2387,7 +2387,7 @@ bool EvseSecurity::is_filesystem_full() {
 
     uintmax_t total_size_bytes = 0;
     for (const auto& path : unique_paths) {
-        total_size_bytes = fs::file_size(path);
+        total_size_bytes += fs::file_size(path);
     }
 
     EVLOG_debug << "Total bytes used: " << total_size_bytes;


### PR DESCRIPTION
## Describe your changes

This fixes a bug in `EvseSecurity::is_filesystem_full()` related to the calculation of the total size of all objects in the certificate store.

Previously, only the size of the final certificate in the set was being considered when comparing against the `max_fs_usage_bytes` limit, as the `total_size_bytes` accumulator was being overwritten at each iteration of the for loop.

With this fix, the accumulator accumulates as intended.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

