### PR TITLE
fix(EvseManager): prevent delayed auth response from bypassing external cancellation

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1286,6 +1286,7 @@ bool Charger::cancel_transaction(const types::evse_manager::StopTransactionReque
             }
         }
 
+        shared_context.flag_externally_cancelled = true;
         shared_context.flag_authorized = false;
         shared_context.authorized_pnc = false;
         shared_context.last_stop_transaction_reason = request.reason;
@@ -1312,6 +1313,7 @@ void Charger::start_session(bool authfirst) {
 void Charger::stop_session() {
     shared_context.session_active = false;
     shared_context.flag_authorized = false;
+    shared_context.flag_externally_cancelled = false;
     shared_context.flag_paused_by_evse = false;
     signal_simple_event(types::evse_manager::SessionEventEnum::SessionFinished);
     shared_context.session_uuid.clear();
@@ -1543,6 +1545,14 @@ void Charger::authorize(bool a, const types::authorization::ProvidedIdToken& tok
                         const types::authorization::ValidationResult& result) {
     Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_authorize);
     if (a) {
+        if (shared_context.flag_externally_cancelled) {
+            EVLOG_warning
+                << "Received an authorization after the session was externally cancelled. Ignoring this authorization.";
+            // Ignore (delayed) authorization responses after an external cancellation
+            // Without this guard, a delayed auth could restore flag_authorized and prevent the state machine
+            // from routing to EvseState::Finished
+            return;
+        }
         shared_context.id_token = token;
         shared_context.validation_result = result;
         // First user interaction was auth? Then start session already here and not at plug in

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -298,6 +298,7 @@ private:
         types::authorization::ProvidedIdToken id_token;
         types::authorization::ValidationResult validation_result;
         std::atomic_bool flag_authorized{false};
+        std::atomic_bool flag_externally_cancelled{false};
         std::atomic_bool flag_paused_by_evse{false};
         std::atomic_bool flag_ev_plugged_in{false};
         // set to true if auth is from PnC, otherwise to false (EIM)

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -642,6 +642,39 @@ TEST_F(ChargerTest, EnableDisableSourceDisableEnable) {
     EXPECT_EQ(charger->current_state(), Charger::EvseState::Idle);
 }
 
+// tests for cancel_transaction() / authorize() interaction
+TEST_F(ChargerTest, DelayedAuthorizeAfterCancelTransactionIsIgnored) {
+    auto& ctx = charger->get_shared_context();
+
+    // Simulate an active charging session
+    ctx.flag_transaction_active = true;
+    ctx.session_active = true;
+    ctx.flag_authorized = true;
+
+    // External cancellation (e.g. OCPP RemoteStop)
+    types::evse_manager::StopTransactionRequest stop_request;
+    stop_request.reason = types::evse_manager::StopTransactionReason::Remote;
+    EXPECT_TRUE(charger->cancel_transaction(stop_request));
+
+    EXPECT_FALSE(ctx.flag_authorized);
+    EXPECT_TRUE(ctx.flag_externally_cancelled);
+
+    // Delayed authorization response arrives after the cancellation
+    types::authorization::ProvidedIdToken token;
+    token.id_token.value = "DELAYED_TOKEN";
+    token.id_token.type = types::authorization::IdTokenType::Central;
+    token.authorization_type = types::authorization::AuthorizationType::OCPP;
+
+    types::authorization::ValidationResult validation_result;
+    validation_result.authorization_status = types::authorization::AuthorizationStatus::Accepted;
+
+    charger->authorize(true, token, validation_result);
+
+    // The delayed response must not restore authorization
+    EXPECT_FALSE(ctx.flag_authorized);
+    EXPECT_TRUE(ctx.flag_externally_cancelled);
+}
+
 } // namespace
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION

## Describe your changes

A delayed authorization response arriving after cancel_transaction() could restore flag_authorized, preventing the state machine from routing to Finished and leaving the transaction open after a remote stop. Introduce flag_externally_cancelled to block authorize() from overriding the cancellation.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

