### PR TITLE
fix(backport-label): use runtime GitHub App token for backport workflow

### DIFF
--- a/.github/workflows/on_label.yaml
+++ b/.github/workflows/on_label.yaml
@@ -27,6 +27,13 @@ jobs:
         with:
           permission: write
 
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -34,7 +41,7 @@ jobs:
         id: backport
         uses: korthout/backport-action@v4.2.0
         with:
-          github_token: ${{ secrets.EVEREST_CI_BACKPORT_PR_APP_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           merge_commits: "skip"
           add_author_as_assignee: true
           copy_requested_reviewers: true


### PR DESCRIPTION
## Describe your changes
Generate a short-lived installation token via actions/create-github-app-token instead of passing a static secret, which caused Bad Credentials errors

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

