### PR TITLE
CMake: export standalone util lib

### DIFF
--- a/cmake/project-config.cmake.in
+++ b/cmake/project-config.cmake.in
@@ -8,10 +8,10 @@ find_package(everest-sqlite REQUIRED)
 find_package(everest-timer REQUIRED)
 find_package(everest-evse_security REQUIRED)
 find_package(everest-ocpp REQUIRED)
-find_package(everest-framework REQUIRED)
 
 include(${CMAKE_CURRENT_LIST_DIR}/ev-project-bootstrap.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/everest-core-targets.cmake)
+find_package(everest-framework REQUIRED)
 include(CMakeFindDependencyMacro)
 
 ev_add_project(

--- a/lib/everest/framework/CMakeLists.txt
+++ b/lib/everest/framework/CMakeLists.txt
@@ -181,6 +181,7 @@ if (FRAMEWORK_INSTALL)
         EXPORT framework-targets
         NAMESPACE everest
         ADDITIONAL_CONTENT
+            "find_dependency(everest-util)"
             "find_dependency(nlohmann_json)"
             "find_dependency(nlohmann_json_schema_validator)"
             "find_dependency(fmt)"

--- a/lib/everest/framework/config.cmake.in
+++ b/lib/everest/framework/config.cmake.in
@@ -1,0 +1,15 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(everest-util)
+find_dependency(nlohmann_json)
+find_dependency(nlohmann_json_schema_validator)
+find_dependency(fmt)
+find_dependency(date)
+
+set(EVEREST_SCHEMA_DIR "@PACKAGE_EVEREST_SCHEMA_DIR@")
+
+include(${CMAKE_CURRENT_LIST_DIR}/everest-framework-targets.cmake)
+
+check_required_components(everest-framework)

--- a/lib/everest/framework/lib/CMakeLists.txt
+++ b/lib/everest/framework/lib/CMakeLists.txt
@@ -77,7 +77,8 @@ target_link_libraries(framework
 
         everest::log
         everest::sqlite
-        everest::util
+        $<BUILD_INTERFACE:everest_util>
+        $<INSTALL_INTERFACE:everest::util>
         ${STD_FILESYSTEM_COMPAT_LIB}
     PRIVATE
         ${EVEREST_FRAMEWORK_BOOST_SYSTEM_LINK_LIBRARY}

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -38,7 +38,8 @@ target_include_directories(everest_io
 
 target_link_libraries(everest_io
     PUBLIC
-        everest::util
+        $<BUILD_INTERFACE:everest_util>
+        $<INSTALL_INTERFACE:everest::util>
 )
 
 include(CheckIncludeFile)

--- a/lib/everest/util/CMakeLists.txt
+++ b/lib/everest/util/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(everest_util INTERFACE)
 add_library(everest::util ALIAS everest_util)
 ev_register_library_target(everest_helpers)
 
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 set_target_properties(everest_util PROPERTIES
   VERSION 0.0.1
 )
@@ -15,6 +18,7 @@ target_include_directories(everest_util
 set_target_properties(everest_util
     PROPERTIES
         BUILD_INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        EXPORT_NAME util
 )
 
 install(TARGETS everest_util
@@ -29,6 +33,33 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/everest
     DESTINATION include
     FILES_MATCHING PATTERN "*.hpp"
 )
+
+if(DISABLE_EDM)
+    # Do not use evc_setup_package() here: it unconditionally installs an
+    # export file for the package, which would export everest_util a second
+    # time alongside everest-core-targets and break non-EDM consumers.
+    set(EVEREST_UTIL_CMAKE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/everest-util")
+
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/everest-util-config.cmake
+        INSTALL_DESTINATION ${EVEREST_UTIL_CMAKE_INSTALL_DIR}
+        PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+    )
+
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/everest-util-config-version.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY ExactVersion
+    )
+
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/everest-util-config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/everest-util-config-version.cmake
+        DESTINATION ${EVEREST_UTIL_CMAKE_INSTALL_DIR}
+    )
+endif()
 
 if (BUILD_TESTING)
     add_subdirectory(tests)

--- a/lib/everest/util/config.cmake.in
+++ b/lib/everest/util/config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET everest::util)
+    add_library(everest::util INTERFACE IMPORTED)
+    set_target_properties(everest::util PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@"
+    )
+endif()
+
+check_required_components(everest-util)


### PR DESCRIPTION
In non-EDM out-of-tree builds, CMake produced an error regarding referenced but missing `everest::everest_util`, even when it wasn't being used.

This fix works for both in-tree and out-of-tree builds, with and without EDM.

## Describe your changes

## Issue ticket number and link
Fixes https://github.com/EVerest/EVerest/issues/1968
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

