### PR TITLE
Bugfix/dco check for backport prs

### DIFF
--- a/.github/workflows/job_dco-check.yaml
+++ b/.github/workflows/job_dco-check.yaml
@@ -28,7 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          dco-check --default-branch main -v
+          dco-check --default-branch main -v --exclude-pattern ".*@users\.noreply\.github\.com"
       - name:  Check DCO merge_group
         if: github.event_name == 'merge_group'
         run: |


### PR DESCRIPTION
## Describe your changes

This pull request introduces an --exclude-patern flag for the dco check. So that commits with author email address that match the github noreply pattern pass the dco check.

This is mainly relevant for backport PRs where commits are cherry-picked from main as they are.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

