### PR TITLE
Use max power capabilities in PMaxSchedule

### DIFF
--- a/modules/EVSE/EvseV2G/din_server.cpp
+++ b/modules/EVSE/EvseV2G/din_server.cpp
@@ -590,11 +590,11 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
 
     if ((unsigned int)1 == res->DC_EVSEChargeParameter.EVSEMaximumPowerLimit_isUsed) {
         res->SAScheduleList.SAScheduleTuple.array[0].PMaxSchedule.PMaxScheduleEntry.array[0].PMax =
-            (SHRT_MAX < (conn->ctx->evse_v2g_data.evse_maximum_power_limit.Value *
-                         pow(10, conn->ctx->evse_v2g_data.evse_maximum_power_limit.Multiplier)))
+            (SHRT_MAX < (conn->ctx->evse_v2g_data.power_capabilities.max_power.Value *
+                         pow(10, conn->ctx->evse_v2g_data.power_capabilities.max_power.Multiplier)))
                 ? SHRT_MAX
-                : (conn->ctx->evse_v2g_data.evse_maximum_power_limit.Value *
-                   pow(10, conn->ctx->evse_v2g_data.evse_maximum_power_limit.Multiplier));
+                : (conn->ctx->evse_v2g_data.power_capabilities.max_power.Value *
+                   pow(10, conn->ctx->evse_v2g_data.power_capabilities.max_power.Multiplier));
     } else {
         res->SAScheduleList.SAScheduleTuple.array[0].PMaxSchedule.PMaxScheduleEntry.array[0].PMax = SHRT_MAX;
     }

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -1292,7 +1292,7 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
             } else {
                 conn->ctx->evse_v2g_data.evse_sa_schedule_list.SAScheduleTuple.array[0]
                     .PMaxSchedule.PMaxScheduleEntry.array[0]
-                    .PMax = conn->ctx->evse_v2g_data.evse_maximum_power_limit;
+                    .PMax = conn->ctx->evse_v2g_data.power_capabilities.max_power;
             }
             if (departure_time_duration == 0) {
                 departure_time_duration = SA_SCHEDULE_DURATION; // one day, per spec


### PR DESCRIPTION
## Describe your changes
This PR addresses the issue that inside an ISO15118-2 ChargeParameterDiscoveryRes DC session, EVerest reports the power that is available at that point in time. This can apparently cause EVs to use this as a maximum limit for the whole session. In order to improve real world compatibility, we set this value to the capabilities of the DC power supply. This is in line with the behavior in AC.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

