### PR TITLE
fix(EvseManager): Setting the power values for the powersupply should not jumping anymore + Parameterize ISO smoke tests

### DIFF
--- a/.ci/build-kit/scripts/create_integration_image.sh
+++ b/.ci/build-kit/scripts/create_integration_image.sh
@@ -18,3 +18,11 @@ if [ $retVal -ne 0 ]; then
     echo "Failed to pip-install"
     exit $retVal
 fi
+
+$(cd ./tests/ocpp_tests/test_sets/everest-aux/ && ./install_certs.sh "$EXT_MOUNT/dist")
+retVal=$?
+
+if [ $retVal -ne 0 ]; then
+    echo "Failed to install certs"
+    exit $retVal
+fi

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -833,27 +833,10 @@ void EvseManager::ready() {
                 target_current = (actual_voltage <= 0.0)
                                      ? max_charge_current
                                      : std::min((max_charge_power / actual_voltage), max_charge_current);
-                if (not(almost_eq(target_voltage, latest_target_voltage) and
-                        almost_eq(target_current, latest_target_current))) {
-                    latest_target_current = target_current;
-                    latest_target_voltage = target_voltage;
-                    target_changed = true;
-                }
 
-                if (target_changed or energy_flow_changed) {
-                    apply_new_target_voltage_current();
-                    if (not contactor_open) {
-                        powersupply_DC_on();
-                    }
-
-                    {
-                        Everest::scoped_lock_timeout lock(ev_info_mutex,
-                                                          Everest::MutexDescription::EVSE_publish_ev_info);
-                        ev_info.target_voltage = latest_target_voltage;
-                        ev_info.target_current = latest_target_current;
-                        p_evse->publish_ev_info(ev_info);
-                    }
-                }
+                raw_ev_target_voltage = target_voltage;
+                raw_ev_target_current = target_current;
+                process_dc_ev_target_voltage_current(charger->get_evse_max_hlc_limits());
             });
 
             // Car requests DC contactor open. We don't actually open but switch off DC supply.

--- a/tests/core_tests/smoke_tests.py
+++ b/tests/core_tests/smoke_tests.py
@@ -501,10 +501,24 @@ async def test_iso15118_ac_session_stop_by_evse(
 @pytest.mark.probe_module(
     connections={"evse_manager": [Requirement("evse_manager", "evse")]}
 )
-@pytest.mark.everest_core_config("config-sil-dc.yaml")
-@pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy())
+@pytest.mark.everest_core_config("config-sil-dc-isomux.yaml")
+@pytest.mark.parametrize(
+    "iso15118_version",
+    [
+        pytest.param(
+            "iso15118_dc_d2",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy()),
+            id="iso15118_dc_d2",
+        ),
+        pytest.param(
+            "iso15118_dc_d20",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(ev_d20_only=True)),
+            id="iso15118_dc_d20",
+        ),
+    ],
+)
 async def test_iso15118_dc_session(
-    test_controller: TestController, everest_core: EverestCore
+    iso15118_version,test_controller: TestController, everest_core: EverestCore
 ):
     """Test session events of an ISO 15118 DC charging session."""
     _, session_event_mock, powermeter_mock, _ = await setup_session_mocks(
@@ -517,16 +531,30 @@ async def test_iso15118_dc_session(
 @pytest.mark.probe_module(
     connections={"evse_manager": [Requirement("evse_manager", "evse")]}
 )
-@pytest.mark.everest_core_config("config-sil-dc.yaml")
-@pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy())
+@pytest.mark.everest_core_config("config-sil-dc-isomux.yaml")
+@pytest.mark.parametrize(
+    "iso15118_version",
+    [
+        pytest.param(
+            "iso15118_dc_d2",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy()),
+            id="iso15118_dc_d2",
+        ),
+        pytest.param(
+            "iso15118_dc_d20",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(ev_d20_only=True)),
+            id="iso15118_dc_d20",
+        ),
+    ],
+)
 async def test_iso15118_dc_session_stop_by_evse(
-    test_controller: TestController, everest_core: EverestCore
+    iso15118_version, test_controller: TestController, everest_core: EverestCore
 ):
     """Test session events of an ISO 15118 DC charging session and stop by EVSE."""
     probe_module, session_event_mock, powermeter_mock, _ = await setup_session_mocks(
         test_controller, everest_core
     )
-    
+
     await run_basic_session(test_controller, session_event_mock, powermeter_mock, "plug_in_dc_iso", finish_with_plug_out=False)
 
     await probe_module.call_command(
@@ -547,10 +575,24 @@ async def test_iso15118_dc_session_stop_by_evse(
 @pytest.mark.probe_module(
     connections={"evse_manager": [Requirement("evse_manager", "evse")]}
 )
-@pytest.mark.everest_core_config("config-sil-dc.yaml")
-@pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy())
+@pytest.mark.everest_core_config("config-sil-dc-isomux.yaml")
+@pytest.mark.parametrize(
+    "iso15118_version",
+    [
+        pytest.param(
+            "iso15118_dc_d2",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy()),
+            id="iso15118_dc_d2",
+        ),
+        pytest.param(
+            "iso15118_dc_d20",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(ev_d20_only=True)),
+            id="iso15118_dc_d20",
+        ),
+    ],
+)
 async def test_iso15118_dc_session_error_before_session(
-    test_controller: TestController, everest_core: EverestCore
+    iso15118_version, test_controller: TestController, everest_core: EverestCore
 ):
     """
     Test session events of an ISO 15118 DC charging session with an error before the session.
@@ -572,7 +614,7 @@ async def test_iso15118_dc_session_error_before_session(
 
     test_controller.plug_in_dc_iso()
 
-    assert_no_events(session_event_mock, ["SessionStarted"], wait_time=10)
+    await assert_no_events(session_event_mock, ["SessionStarted"], wait_time=10)
     assert (
         session_event_mock.call_count == 0
     ), "No session events should occur while error is active"
@@ -685,10 +727,24 @@ async def test_iso15118_dc_session_no_energy_before_session(
         "gcp": [Requirement("grid_connection_point", "external_limits")],
     }
 )
-@pytest.mark.everest_core_config("config-sil-dc.yaml")
-@pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(zero_power_ignore_pause=True, hlc_charge_loop_without_energy_timeout_s=30))
+@pytest.mark.everest_core_config("config-sil-dc-isomux.yaml")
+@pytest.mark.parametrize(
+    "iso15118_version",
+    [
+        pytest.param(
+            "iso15118_dc_d2",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(zero_power_ignore_pause=True, hlc_charge_loop_without_energy_timeout_s=30)),
+            id="iso15118_dc_d2",
+        ),
+        pytest.param(
+            "iso15118_dc_d20",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(zero_power_ignore_pause=True, hlc_charge_loop_without_energy_timeout_s=30, ev_d20_only=True)),
+            id="iso15118_dc_d20",
+        ),
+    ],
+)
 async def test_iso15118_dc_session_no_energy_before_session_no_pause(
-    test_controller: TestController, everest_core: EverestCore
+    iso15118_version,test_controller: TestController, everest_core: EverestCore
 ):
     """
     Test ISO 15118 DC charging session with no energy at the start. zero_power_ignore_pause=True
@@ -794,10 +850,24 @@ async def test_iso15118_ac_session_no_energy_during_session_timeout_triggers(
         "gcp": [Requirement("grid_connection_point", "external_limits")],
     }
 )
-@pytest.mark.everest_core_config("config-sil-dc.yaml")
-@pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(hlc_charge_loop_without_energy_timeout_s=30))
+@pytest.mark.everest_core_config("config-sil-dc-isomux.yaml")
+@pytest.mark.parametrize(
+    "iso15118_version",
+    [
+        pytest.param(
+            "iso15118_dc_d2",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(hlc_charge_loop_without_energy_timeout_s=30)),
+            id="iso15118_dc_d2",
+        ),
+        pytest.param(
+            "iso15118_dc_d20",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(hlc_charge_loop_without_energy_timeout_s=30, ev_d20_only=True)),
+            id="iso15118_dc_d20",
+        ),
+    ],
+)
 async def test_iso15118_dc_session_no_energy_during_session(
-    test_controller: TestController, everest_core: EverestCore
+    iso15118_version,test_controller: TestController, everest_core: EverestCore
 ):
     """Test ISO 15118 DC charging session where energy is removed and restored during charging."""
     probe_module, session_event_mock, powermeter_mock, _ = await setup_session_mocks(
@@ -809,7 +879,7 @@ async def test_iso15118_dc_session_no_energy_during_session(
     await set_external_limits(probe_module, "gcp", 0, 0)
     await assert_energy_below(powermeter_mock, energy_threshold_wh=30, timeout=5)
     await set_external_limits(probe_module, "gcp", 10000, 10000)
-    await assert_energy_exceeds(powermeter_mock, energy_threshold_wh=30, timeout=15)
+    await assert_energy_exceeds(powermeter_mock, energy_threshold_wh=40, timeout=15)
     
     await end_session(test_controller, session_event_mock)
 
@@ -820,10 +890,24 @@ async def test_iso15118_dc_session_no_energy_during_session(
         "gcp": [Requirement("grid_connection_point", "external_limits")],
     }
 )
-@pytest.mark.everest_core_config("config-sil-dc.yaml")
-@pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(hlc_charge_loop_without_energy_timeout_s=5))
+@pytest.mark.everest_core_config("config-sil-dc-isomux.yaml")
+@pytest.mark.parametrize(
+    "iso15118_version",
+    [
+        pytest.param(
+            "iso15118_dc_d2",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(hlc_charge_loop_without_energy_timeout_s=5)),
+            id="iso15118_dc_d2",
+        ),
+        pytest.param(
+            "iso15118_dc_d20",
+            marks=pytest.mark.everest_config_adaptions(DcConfigAdjustmentStrategy(hlc_charge_loop_without_energy_timeout_s=5, ev_d20_only=True)),
+            id="iso15118_dc_d20",
+        ),
+    ],
+)
 async def test_iso15118_dc_session_no_energy_during_session_timeout_triggers(
-    test_controller: TestController, everest_core: EverestCore
+    iso15118_version, test_controller: TestController, everest_core: EverestCore
 ):
     """Test ISO 15118 DC charging session where energy is removed and iso charge loop timeout triggers."""
     probe_module, session_event_mock, powermeter_mock, _ = await setup_session_mocks(


### PR DESCRIPTION
## Describe your changes
- Now the new added process_dc_ev_target_voltage_current() is also called n the subscribe_d20_dynamic_mode_values()
- Parameterizing ISO smoke tests so that they run with d2 and d20

## Issue ticket number and link
If running d20 dynamic mode the powersupply is jumping from the target current to zero and back to the target current

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

