### PR TITLE
fix(ocpp): respect CertSigningWaitMinimum in cert signing retry

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/security.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/security.cpp
@@ -19,7 +19,7 @@
 #include <ocpp/v2/messages/SecurityEventNotification.hpp>
 #include <ocpp/v2/messages/SignCertificate.hpp>
 
-constexpr std::int32_t minimum_cert_signing_wait_time_seconds = 250;
+constexpr std::int32_t minimum_cert_signing_wait_time_seconds = 10;
 
 namespace ocpp::v2 {
 
@@ -322,7 +322,7 @@ void Security::handle_sign_certificate_response(CallResult<SignCertificateRespon
         }
         const int retry_backoff_seconds = clamp_to<int>(
             static_cast<double>(std::max(minimum_cert_signing_wait_time_seconds, cert_signing_wait_minimum.value())) *
-            std::pow(2, this->csr_attempt)); // prevent immediate repetition in case of value 0
+            std::pow(2, std::max(0, this->csr_attempt - 1))); // first wait = CertSigningWaitMinimum * 2^0
         this->certificate_signed_timer.timeout(
             [this]() {
                 EVLOG_info << "Did not receive CertificateSigned.req in time. Will retry with SignCertificate.req";

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_security.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_security.cpp
@@ -873,3 +873,114 @@ TEST_F(SecurityTest, handle_sign_certificate_response_no_response) {
     // Timeout is over, callback is called.
     timer_stub_get_callback()();
 }
+
+TEST_F(SecurityTest, handle_sign_certificate_response_backoff_values) {
+    // Verify the exponential backoff sequence: with CertSigningWaitMinimum=30 and CertSigningRepeatTimes=2,
+    // first wait should be 30s, second wait 60s, then stop.
+    timer_stub_reset_timeout_called_count();
+    timer_stub_reset_callback();
+    timer_stub_reset_timeout_interval();
+    set_update_certificate_symlinks_enabled(this->device_model, true);
+    set_security_profile(this->device_model, 1);
+    this->device_model->set_value(ControllerComponentVariables::ChargeBoxSerialNumber.component,
+                                  ControllerComponentVariables::ChargeBoxSerialNumber.variable.value(),
+                                  AttributeEnum::Actual, "testserialnumber", "test", true);
+    this->device_model->set_value(ControllerComponentVariables::OrganizationName.component,
+                                  ControllerComponentVariables::OrganizationName.variable.value(),
+                                  AttributeEnum::Actual, "testOrganization", "test", true);
+    this->device_model->set_value(ControllerComponentVariables::ISO15118CtrlrCountryName.component,
+                                  ControllerComponentVariables::ISO15118CtrlrCountryName.variable.value(),
+                                  AttributeEnum::Actual, "testCountry", "test", true);
+    this->device_model->set_value(ControllerComponentVariables::UseTPM.component,
+                                  ControllerComponentVariables::UseTPM.variable.value(), AttributeEnum::Actual, "false",
+                                  "test", true);
+    this->device_model->set_value(ControllerComponentVariables::CertSigningWaitMinimum.component,
+                                  ControllerComponentVariables::CertSigningWaitMinimum.variable.value(),
+                                  AttributeEnum::Actual, "30", "test", true);
+    this->device_model->set_value(ControllerComponentVariables::CertSigningRepeatTimes.component,
+                                  ControllerComponentVariables::CertSigningRepeatTimes.variable.value(),
+                                  AttributeEnum::Actual, "2", "test", true);
+
+    ocpp::GetCertificateSignRequestResult sign_request_result;
+    sign_request_result.status = GetCertificateSignRequestStatus::Accepted;
+    sign_request_result.csr = "csr";
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)).WillRepeatedly(Invoke([](const json& call, bool triggered) {
+        // Accept all SignCertificate.req dispatches
+    }));
+    EXPECT_CALL(this->evse_security,
+                generate_certificate_signing_request(ocpp::CertificateSigningUseEnum::ChargingStationCertificate,
+                                                     "testCountry", "testOrganization", "testserialnumber", false))
+        .WillRepeatedly(Return(sign_request_result));
+
+    // Initial sign_certificate_req + Accepted response
+    security.sign_certificate_req(ocpp::CertificateSigningUseEnum::ChargingStationCertificate, false);
+    security.handle_message(create_example_sign_certificate_response(GenericStatusEnum::Accepted));
+
+    // First timeout should be 30s (CertSigningWaitMinimum * 2^0)
+    EXPECT_EQ(timer_stub_get_timeout_interval_ms(), 30000);
+
+    // Fire timeout callback → triggers retry → feed new Accepted response → new timer
+    timer_stub_reset_timeout_interval();
+    timer_stub_get_callback()(); // increments csr_attempt to 2
+    security.handle_message(create_example_sign_certificate_response(GenericStatusEnum::Accepted));
+
+    // Second timeout should be 60s (CertSigningWaitMinimum * 2^1)
+    EXPECT_EQ(timer_stub_get_timeout_interval_ms(), 60000);
+
+    // Fire timeout callback again → csr_attempt becomes 3 > RepeatTimes(2) → should stop
+    timer_stub_reset_timeout_called_count();
+    timer_stub_reset_timeout_interval();
+    timer_stub_get_callback()(); // increments csr_attempt to 3
+    security.handle_message(create_example_sign_certificate_response(GenericStatusEnum::Accepted));
+
+    // Timer should not have been restarted (csr_attempt > CertSigningRepeatTimes)
+    EXPECT_EQ(timer_stub_get_timeout_called_count(), 0);
+    EXPECT_EQ(timer_stub_get_timeout_interval_ms(), 0);
+}
+
+TEST_F(SecurityTest, handle_sign_certificate_response_backoff_floor) {
+    // Verify the 10s safety floor: with CertSigningWaitMinimum=0, the floor of 10s should apply.
+    timer_stub_reset_timeout_called_count();
+    timer_stub_reset_callback();
+    timer_stub_reset_timeout_interval();
+    set_update_certificate_symlinks_enabled(this->device_model, true);
+    set_security_profile(this->device_model, 1);
+    this->device_model->set_value(ControllerComponentVariables::ChargeBoxSerialNumber.component,
+                                  ControllerComponentVariables::ChargeBoxSerialNumber.variable.value(),
+                                  AttributeEnum::Actual, "testserialnumber", "test", true);
+    this->device_model->set_value(ControllerComponentVariables::OrganizationName.component,
+                                  ControllerComponentVariables::OrganizationName.variable.value(),
+                                  AttributeEnum::Actual, "testOrganization", "test", true);
+    this->device_model->set_value(ControllerComponentVariables::ISO15118CtrlrCountryName.component,
+                                  ControllerComponentVariables::ISO15118CtrlrCountryName.variable.value(),
+                                  AttributeEnum::Actual, "testCountry", "test", true);
+    this->device_model->set_value(ControllerComponentVariables::UseTPM.component,
+                                  ControllerComponentVariables::UseTPM.variable.value(), AttributeEnum::Actual, "false",
+                                  "test", true);
+    this->device_model->set_value(ControllerComponentVariables::CertSigningWaitMinimum.component,
+                                  ControllerComponentVariables::CertSigningWaitMinimum.variable.value(),
+                                  AttributeEnum::Actual, "0", "test", true);
+    this->device_model->set_value(ControllerComponentVariables::CertSigningRepeatTimes.component,
+                                  ControllerComponentVariables::CertSigningRepeatTimes.variable.value(),
+                                  AttributeEnum::Actual, "1", "test", true);
+
+    ocpp::GetCertificateSignRequestResult sign_request_result;
+    sign_request_result.status = GetCertificateSignRequestStatus::Accepted;
+    sign_request_result.csr = "csr";
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)).WillRepeatedly(Invoke([](const json& call, bool triggered) {
+        // Accept all SignCertificate.req dispatches
+    }));
+    EXPECT_CALL(this->evse_security,
+                generate_certificate_signing_request(ocpp::CertificateSigningUseEnum::ChargingStationCertificate,
+                                                     "testCountry", "testOrganization", "testserialnumber", false))
+        .WillRepeatedly(Return(sign_request_result));
+
+    // Initial sign_certificate_req + Accepted response
+    security.sign_certificate_req(ocpp::CertificateSigningUseEnum::ChargingStationCertificate, false);
+    security.handle_message(create_example_sign_certificate_response(GenericStatusEnum::Accepted));
+
+    // First timeout should be 10s (max(10, 0) * 2^0 = 10s floor)
+    EXPECT_EQ(timer_stub_get_timeout_interval_ms(), 10000);
+}

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/stubs/timer/everest/timer.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/stubs/timer/everest/timer.hpp
@@ -70,11 +70,13 @@ public:
 
     template <class Rep, class Period>
     void timeout(const std::function<void()>& callback, const std::chrono::duration<Rep, Period>& interval) {
+        timer_stub_set_timeout_interval_ms(std::chrono::duration_cast<std::chrono::milliseconds>(interval).count());
         timer_stub_set_callback(callback);
         timer_stub_timeout_called(1);
     }
 
     template <class Rep, class Period> void timeout(const std::chrono::duration<Rep, Period>& interval) {
+        timer_stub_set_timeout_interval_ms(std::chrono::duration_cast<std::chrono::milliseconds>(interval).count());
         timer_stub_timeout_called(1);
     }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/stubs/timer/timer_stub.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/stubs/timer/timer_stub.cpp
@@ -11,6 +11,7 @@ static std::uint32_t timeout_called_count;
 static std::uint32_t interval_called_count;
 static std::uint32_t at_called_count;
 static std::function<void()> callback;
+static std::int64_t timeout_interval_ms;
 
 void timer_stub_stop_called(std::uint32_t called_count) {
     stop_called_count += called_count;
@@ -70,4 +71,16 @@ std::uint32_t timer_stub_get_at_called_count() {
 
 std::function<void()> timer_stub_get_callback() {
     return callback;
+}
+
+void timer_stub_set_timeout_interval_ms(std::int64_t interval_ms) {
+    timeout_interval_ms = interval_ms;
+}
+
+std::int64_t timer_stub_get_timeout_interval_ms() {
+    return timeout_interval_ms;
+}
+
+void timer_stub_reset_timeout_interval() {
+    timeout_interval_ms = 0;
 }

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/stubs/timer/timer_stub.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/stubs/timer/timer_stub.hpp
@@ -23,3 +23,7 @@ std::uint32_t timer_stub_get_timeout_called_count();
 std::uint32_t timer_stub_get_interval_called_count();
 std::uint32_t timer_stub_get_at_called_count();
 std::function<void()> timer_stub_get_callback();
+
+void timer_stub_set_timeout_interval_ms(std::int64_t interval_ms);
+std::int64_t timer_stub_get_timeout_interval_ms();
+void timer_stub_reset_timeout_interval();


### PR DESCRIPTION
The certificate signing retry logic had two spec violations (A02.FR.17, A02.FR.18):

- A hardcoded 250s floor overrode CertSigningWaitMinimum via std::max(), making configured values below 250s ineffective. Reduced to a 10s safety floor to prevent rapid retries from misconfiguration while respecting legitimate values.

- Exponential backoff started at 2^1 instead of 2^0, doubling the first wait. Fixed exponent to csr_attempt-1 so the first wait equals CertSigningWaitMinimum per spec.

Also extends the timer test stub to capture timeout intervals and adds unit tests verifying the backoff sequence and the 10s floor.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

