### PR TITLE
fix(message_queue): protect BootNotification from being dropped during queue overflow

### DIFF
--- a/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
@@ -408,7 +408,11 @@ private:
         while (this->transaction_message_queue.size() + this->normal_message_queue.size() >
                    this->config.queues_total_size_threshold &&
                !this->normal_message_queue.empty()) {
+            auto size_before = this->normal_message_queue.size();
             this->drop_messages_from_normal_message_queue();
+            if (this->normal_message_queue.size() == size_before) {
+                break; // Nothing was droppable (only protected messages like BootNotification remain)
+            }
         }
 
         while (this->transaction_message_queue.size() + this->normal_message_queue.size() >
@@ -417,25 +421,35 @@ private:
         }
     }
 
+    /// \brief Drops messages from the normal message queue to reduce queue size.
+    /// BootNotification messages are never dropped, as they are required for
+    /// the charger to register with the CSMS — dropping them would deadlock
+    /// the queue when transaction messages have stall_until_accepted=true.
     void drop_messages_from_normal_message_queue() {
         // try to drop approx 10% of the allowed size (at least 1)
         const int number_of_dropped_messages = std::min((int)this->normal_message_queue.size(),
                                                         std::max(this->config.queues_total_size_threshold / 10, 1));
 
-        EVLOG_warning << "Dropping " << number_of_dropped_messages << " messages from normal message queue.";
+        EVLOG_warning << "Dropping up to " << number_of_dropped_messages << " messages from normal message queue.";
 
-        for (int i = 0; i < number_of_dropped_messages; i++) {
+        int dropped = 0;
+        auto it = this->normal_message_queue.begin();
+        while (dropped < number_of_dropped_messages && it != this->normal_message_queue.end()) {
+            if (is_boot_notification_message((*it)->messageType)) {
+                ++it; // Never drop BootNotification
+                continue;
+            }
             if (this->config.queue_all_messages) {
                 try {
-                    database_handler->remove_message_queue_message(
-                        this->normal_message_queue.front()->initial_unique_id, QueueType::Normal);
+                    database_handler->remove_message_queue_message((*it)->initial_unique_id, QueueType::Normal);
                 } catch (const everest::db::QueryExecutionException& e) {
-                    EVLOG_warning << "Could not delete message from transaction queue: " << e.what();
+                    EVLOG_warning << "Could not delete message from normal message queue: " << e.what();
                 } catch (const std::exception& e) {
-                    EVLOG_warning << "Could not delete message from transaction queue: " << e.what();
+                    EVLOG_warning << "Could not delete message from normal message queue: " << e.what();
                 }
             }
-            this->normal_message_queue.pop_front();
+            it = this->normal_message_queue.erase(it);
+            dropped++;
         }
     }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
@@ -21,7 +21,8 @@ enum class TestMessageType {
     NON_TRANSACTIONAL,
     NON_TRANSACTIONAL_RESPONSE,
     InternalError,
-    BootNotification
+    BootNotification,
+    BootNotificationResponse
 };
 
 static std::string to_string(TestMessageType m) {
@@ -42,6 +43,8 @@ static std::string to_string(TestMessageType m) {
         return "internal_error";
     case TestMessageType::BootNotification:
         return "boot_notification";
+    case TestMessageType::BootNotificationResponse:
+        return "boot_notificationResponse";
     }
     throw std::out_of_range("unknown TestMessageType");
 };
@@ -70,6 +73,9 @@ static TestMessageType to_test_message_type(const std::string& s) {
     }
     if (s == "boot_notification") {
         return TestMessageType::BootNotification;
+    }
+    if (s == "boot_notificationResponse") {
+        return TestMessageType::BootNotificationResponse;
     }
     throw std::out_of_range("unknown string for TestMessageType");
 };
@@ -714,6 +720,118 @@ TEST_F(MessageQueueTest, test_non_transactional_retried_with_queue_all_messages)
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     EXPECT_EQ(3, get_call_count());
+}
+
+// \brief Test that BootNotification is not dropped when the normal message queue overflows.
+// Pushes a BootNotification plus enough messages to exceed the threshold, then verifies
+// BootNotification survives the drop and is still sent.
+TEST_F(MessageQueueTest, test_boot_notification_not_dropped_on_queue_overflow) {
+
+    config.queues_total_size_threshold = 10;
+    config.queue_all_messages = true;
+    restart_message_queue();
+
+    EXPECT_CALL(*db, insert_message_queue_message(testing::_, testing::_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*db, remove_message_queue_message(testing::_, testing::_))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly(testing::Return());
+
+    // go offline
+    message_queue->pause();
+
+    // Push BootNotification first (goes to front of normal queue)
+    auto boot_id = push_message_call(TestMessageType::BootNotification);
+
+    // Push enough non-transactional messages to fill normal queue
+    const int non_transactional_count = 8;
+    for (int i = 0; i < non_transactional_count; i++) {
+        push_message_call(TestMessageType::NON_TRANSACTIONAL);
+    }
+
+    // Push transactional messages to exceed threshold and trigger drops
+    const int transactional_count = 5;
+    for (int i = 0; i < transactional_count; i++) {
+        push_message_call(TestMessageType::TRANSACTIONAL);
+    }
+
+    // Set up expectations: BootNotification must be sent
+    std::atomic<bool> boot_sent{false};
+    EXPECT_CALL(send_callback_mock, Call(testing::_))
+        .WillRepeatedly(testing::Invoke([&, this](const json::array_t& msg) -> bool {
+            std::string data = msg.at(3).at("data").get<std::string>();
+            if (data == boot_id) {
+                boot_sent = true;
+            }
+            this->mark_call_sent();
+            reception_timer.timeout(
+                [this, msg]() {
+                    this->message_queue->receive(json{3, msg[1], ""}.dump());
+                },
+                std::chrono::milliseconds(0));
+            return true;
+        }));
+
+    // go online again
+    message_queue->resume(std::chrono::seconds(0));
+
+    // Wait for messages to be processed (BootNotification + surviving non-transactional + transactional)
+    // Some non-transactional messages will have been dropped, but BootNotification must survive
+    wait_for_calls(5, std::chrono::seconds(5));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    EXPECT_TRUE(boot_sent) << "BootNotification was dropped from the queue!";
+}
+
+// \brief Test that when BootNotification is the only message in the normal queue,
+// check_queue_sizes() doesn't loop infinitely trying to drop it.
+TEST_F(MessageQueueTest, test_boot_notification_survives_when_only_message_in_normal_queue) {
+
+    config.queues_total_size_threshold = 10;
+    config.queue_all_messages = true;
+    restart_message_queue();
+
+    EXPECT_CALL(*db, insert_message_queue_message(testing::_, testing::_)).Times(testing::AnyNumber());
+    EXPECT_CALL(*db, remove_message_queue_message(testing::_, testing::_))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly(testing::Return());
+
+    // go offline
+    message_queue->pause();
+
+    // Push BootNotification as the only normal message
+    auto boot_id = push_message_call(TestMessageType::BootNotification);
+
+    // Fill transaction queue past threshold
+    const int transactional_count = 15;
+    for (int i = 0; i < transactional_count; i++) {
+        push_message_call(TestMessageType::TRANSACTIONAL);
+    }
+
+    // Set up expectations: BootNotification must be sent
+    std::atomic<bool> boot_sent{false};
+    EXPECT_CALL(send_callback_mock, Call(testing::_))
+        .WillRepeatedly(testing::Invoke([&, this](const json::array_t& msg) -> bool {
+            std::string data = msg.at(3).at("data").get<std::string>();
+            if (data == boot_id) {
+                boot_sent = true;
+            }
+            this->mark_call_sent();
+            reception_timer.timeout(
+                [this, msg]() {
+                    this->message_queue->receive(json{3, msg[1], ""}.dump());
+                },
+                std::chrono::milliseconds(0));
+            return true;
+        }));
+
+    // go online - this must not hang (the break guard prevents infinite loop)
+    message_queue->resume(std::chrono::seconds(0));
+
+    // Wait for messages to be processed
+    wait_for_calls(5, std::chrono::seconds(5));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    EXPECT_TRUE(boot_sent) << "BootNotification was dropped from the queue!";
 }
 
 } // namespace ocpp


### PR DESCRIPTION
When the websocket connection is delayed, transaction messages accumulate and trigger drop_messages_from_normal_message_queue(). Since BootNotification sits at the front of the normal queue (push_front'd at startup), it gets dropped first — deadlocking the queue because transaction messages with stall_until_accepted=true wait for registration that never completes.

Skip BootNotification in the drop loop using is_boot_notification_message(), and add a break guard in check_queue_sizes() to prevent infinite looping when only protected messages remain in the normal queue.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

