### PR TITLE
feat(ocpp): Tariff Message Fallback Handling

### DIFF
--- a/docs/source/how-to-guides/integrate-tariff-and-cost.rst
+++ b/docs/source/how-to-guides/integrate-tariff-and-cost.rst
@@ -36,12 +36,42 @@ and the `session_cost_consumer_API <../reference/api/session_cost_consumer_API/i
 
 
 .. note::
-    
+
     The OCPP implementations follow the requirements of the OCA California
     Pricing Whitepaper. Note that this whitepaper contains requirements for
     displaying pricing information to the user, so in order to comply with it,
     the tariff and session cost messages must be used to show the required
     information on a charger display. The APIs only provide the necessary data.
+
+*************************
+No local cost calculation
+*************************
+
+EVerest does not calculate session costs locally. All cost figures
+published on the session cost consumer API originate exclusively from the
+CSMS:
+
+- In OCPP 2.x, cost values come from the ``totalCost`` field in
+  ``TransactionEventResponse`` or from a ``CostUpdated`` message.
+- In OCPP 1.6, cost values come from ``RunningCost`` and ``FinalCost``
+  DataTransfer messages sent by the CSMS.
+
+EVerest only formats these values (e.g. applying the configured number of
+decimal places) before forwarding them. No energy-based or time-based
+cost computation is performed on the charging station.
+
+When the charging station is offline, no cost figures are available at
+all. The session cost consumer API will only receive human-readable tariff
+text messages (from the locally configured fallback variables), never
+computed cost amounts. The actual session cost is only published once the
+CSMS responds after the connection is restored.
+
+In addition to CSMS-provided cost data, the locally configured fallback
+messages (``TariffFallbackMessage``, ``OfflineTariffFallbackMessage``,
+``TotalCostFallbackMessage`` in OCPP 2.x; ``DefaultPriceText`` in OCPP 1.6)
+are also published via the session cost consumer API as ``tariff_message``
+publications. These contain human-readable pricing text only — they carry
+no cost figures and are not derived from any local computation.
 
 ******************
 OCPP configuration
@@ -56,8 +86,16 @@ OCPP 1.6
 
 Enable the ``CostAndPrice`` profile in the OCPP 1.6 module configuration.
 Once enabled, the OCPP module registers the tariff message and session cost
-callbacks. Configure the configuration keys of the ``CostAndPrice`` profile
-as needed.
+callbacks. The relevant configuration keys are:
+
+- **DefaultPriceText** — the tariff fallback message shown when no
+  ``SetUserPrice`` DataTransfer is received within the timeout. This is the
+  OCPP 1.6 equivalent of ``TariffFallbackMessage`` in OCPP 2.x.
+- **WaitForSetUserPriceTimeout** — how long to wait for a ``SetUserPrice``
+  DataTransfer before publishing the ``DefaultPriceText`` fallback.
+
+There is no OCPP 1.6 equivalent of ``TotalCostFallbackMessage``: no
+fallback cost message is published when a transaction ends while offline.
 
 OCPP 2.x
 ========
@@ -73,6 +111,31 @@ features are active:
 
 Both can be enabled independently. Also configure other variables of the
 ``TariffCostCtrlr`` as needed.
+
+Fallback messages
+-----------------
+
+When the CSMS provides no tariff information, the charging station
+displays locally configured fallback messages. The following
+``TariffCostCtrlr`` variables control this:
+
+- **TariffFallbackMessage** — published when tariff is enabled but the
+  CSMS provides no ``personalMessage`` in the ``AuthorizeResponse``.
+- **OfflineTariffFallbackMessage** — used instead of
+  ``TariffFallbackMessage`` when the charging station is offline. If not
+  configured, ``TariffFallbackMessage`` is used as a fallback.
+- **TotalCostFallbackMessage** — published when a transaction ends while
+  the charging station is offline and no CSMS ``totalCost`` response can
+  be received.
+
+For multi-language deployments, add a language-specific instance of
+``TariffFallbackMessage`` for each supported language (e.g. instance
+``de`` for German, ``nl`` for Dutch). The supported languages are derived
+from ``DisplayMessageCtrlr.Language.valuesList``. The default-language
+text goes into ``personalMessage``; up to four additional language
+entries go into ``customData.personalMessageExtra`` per California
+Pricing spec 4.3.4. All languages are forwarded together as entries
+in the ``messages`` field of the ``tariff_message`` publication.
 
 .. note::
 
@@ -96,8 +159,10 @@ by the CSMS. The CSMS typically sends this message shortly after the
 ``Authorize.conf``, so the tariff message is available close to
 authorization time.
 
-If the ``SetUserPrice`` DataTransfer is not received within the configured
-timeout, a default tariff message (if configured) is published instead.
+If the ``SetUserPrice`` DataTransfer is not received within the
+``WaitForSetUserPriceTimeout``, the ``DefaultPriceText`` fallback (if
+configured) is published. The ``identifier_type`` is ``IdToken`` at
+authorization time, and ``TransactionId`` once a transaction has started.
 
 OCPP 2.x
 ========
@@ -110,6 +175,12 @@ Tariff messages are published at two points:
    consumer API. At this point the ``identifier_type`` is ``IdToken`` and
    the ``identifier_id`` is the token value, since no transaction exists
    yet.
+
+   If the CSMS does not provide a ``personalMessage``, the charging
+   station automatically injects the configured ``TariffFallbackMessage``
+   (or ``OfflineTariffFallbackMessage`` when offline) so that a tariff
+   message is always published when tariff is enabled and a fallback is
+   configured.
 
 2. **During the session** — from the ``updatedPersonalMessage`` field in
    ``TransactionEventResponse`` messages. At this point the
@@ -139,6 +210,14 @@ OCPP 1.6
 Session cost updates are triggered by ``RunningCost`` and ``FinalCost``
 DataTransfer messages from the CSMS.
 
+When a transaction ends while the charging station is offline, the queued
+``StopTransaction`` is sent to the CSMS once the connection is
+re-established. The ``StopTransactionResponse`` carries no cost data. No
+fallback cost message is published. If the CSMS sends a ``FinalCost``
+DataTransfer after reconnect, a ``session_cost`` will be published at
+that point — but this is entirely at the CSMS's discretion and may not
+happen at all.
+
 OCPP 2.x
 ========
 
@@ -154,9 +233,25 @@ same ``TransactionEventResponse``, the personal message appears in both the
 ``tariff_message`` variable and the ``message`` field of the
 ``session_cost`` record.
 
+When a transaction ends while the charging station is offline, the CSMS
+``totalCost`` response will never arrive. In this case, if
+``TotalCostFallbackMessage`` is configured, a ``tariff_message`` is
+published with ``identifier_type = TransactionId``. This message contains
+human-readable text only — no actual cost figures are available.
+Consumers should display this text as a notification that the session
+cost is unavailable, rather than as a cost breakdown.
+
+Once the OCPP connection is re-established, the queued
+``TransactionEvent(Ended)`` is sent to the CSMS. If the CSMS responds
+with a ``totalCost``, a ``session_cost`` with status ``Finished`` is
+published for the same transaction ID.
+
 *****************************
 Relationship between the APIs
 *****************************
+
+OCPP 2.x
+=========
 
 .. list-table::
    :header-rows: 1
@@ -165,12 +260,50 @@ Relationship between the APIs
    * - Event
      - Auth consumer API
      - Session cost consumer API
-   * - Token authorized with tariff
+   * - Token authorized, CSMS provides tariff
      - ``token_validation_status`` includes ``messages``
-     - ``tariff_message`` published
+     - ``tariff_message`` published (``identifier_type = IdToken``)
+   * - Token authorized, no CSMS tariff, fallback configured
+     - ``token_validation_status`` includes ``messages``
+     - ``tariff_message`` published from ``TariffFallbackMessage`` (``identifier_type = IdToken``)
    * - In-session tariff update
      - —
-     - ``tariff_message`` published
-   * - Running / final cost
+     - ``tariff_message`` published (``identifier_type = TransactionId``)
+   * - Running / final cost (online)
      - —
      - ``session_cost`` published (may include ``message``)
+   * - Transaction ended offline, fallback configured
+     - —
+     - ``tariff_message`` published from ``TotalCostFallbackMessage`` (``identifier_type = TransactionId``); no ``session_cost``
+   * - Reconnected, CSMS sends ``totalCost`` for offline transaction
+     - —
+     - ``session_cost`` with status ``Finished`` published; supersedes the earlier fallback text
+
+OCPP 1.6
+=========
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Event
+     - Auth consumer API
+     - Session cost consumer API
+   * - Token authorized, CSMS sends ``SetUserPrice``
+     - ``token_validation_status`` includes ``messages``
+     - ``tariff_message`` published (``identifier_type = IdToken``)
+   * - ``SetUserPrice`` timeout, ``DefaultPriceText`` configured
+     - ``token_validation_status`` includes ``messages``
+     - ``tariff_message`` published from ``DefaultPriceText`` (``identifier_type = IdToken``)
+   * - In-session ``SetUserPrice`` DataTransfer
+     - —
+     - ``tariff_message`` published (``identifier_type = TransactionId``)
+   * - ``RunningCost`` / ``FinalCost`` DataTransfer (online)
+     - —
+     - ``session_cost`` published (may include ``message``)
+   * - Transaction ended offline
+     - —
+     - nothing published
+   * - Reconnected, CSMS sends ``FinalCost`` DataTransfer
+     - —
+     - ``session_cost`` with status ``Finished`` published

--- a/lib/everest/ocpp/config/v2/component_config/standardized/TariffCostCtrlr.json
+++ b/lib/everest/ocpp/config/v2/component_config/standardized/TariffCostCtrlr.json
@@ -86,6 +86,23 @@
       "description": "Instance Cost: Whether costs are enabled.",
       "type": "boolean"
     },
+    "OfflineTariffFallbackMessage": {
+      "variable_name": "OfflineTariffFallbackMessage",
+      "characteristics": {
+        "supportsMonitoring": true,
+        "dataType": "string",
+        "maxLimit": 255
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadWrite",
+          "value": ""
+        }
+      ],
+      "description": "Message (and/or tariff information) to be shown to an EV Driver when the Charging Station is offline and there is no driver specific tariff information available.",
+      "type": "string"
+    },
     "TariffFallbackMessage": {
       "variable_name": "TariffFallbackMessage",
       "characteristics": {
@@ -152,6 +169,38 @@
       "description": "Charging kWh price in the default currency when charging station is offline.",
       "type": "number"
     },
+    "TariffFallbackMessageDe": {
+      "variable_name": "TariffFallbackMessage",
+      "instance": "de",
+      "characteristics": {
+        "supportsMonitoring": true,
+        "dataType": "string"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadWrite"
+        }
+      ],
+      "description": "Message (and/or tariff information) to be shown to an EV Driver when there is no driver specific tariff information available.",
+      "type": "string"
+    },
+    "TariffFallbackMessageNl": {
+      "variable_name": "TariffFallbackMessage",
+      "instance": "nl",
+      "characteristics": {
+        "supportsMonitoring": true,
+        "dataType": "string"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadWrite"
+        }
+      ],
+      "description": "Message (and/or tariff information) to be shown to an EV Driver when there is no driver specific tariff information available.",
+      "type": "string"
+    },
     "TariffFallbackMessageEn": {
       "variable_name": "TariffFallbackMessage",
       "instance": "en-US",
@@ -165,7 +214,7 @@
           "mutability": "ReadWrite"
         }
       ],
-      "description": "Message (and / or tariff information) to be shown to an EV Driver when there is no driver specific tariff information available. Note: Add a TariffFallbackMessage with correct instance for every supported language!!",
+      "description": "Message (and / or tariff information) to be shown to an EV Driver when there is no driver specific tariff information available.",
       "type": "string"
     },
     "OfflineTariffFallbackMessageEn": {

--- a/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
@@ -303,6 +303,7 @@ extern const RequiredComponentVariable TariffCostCtrlrCurrency;
 extern const ComponentVariable TariffCostCtrlrEnabledTariff;
 extern const ComponentVariable TariffCostCtrlrEnabledCost;
 extern const RequiredComponentVariable TariffFallbackMessage;
+extern const ComponentVariable OfflineTariffFallbackMessage;
 extern const RequiredComponentVariable TotalCostFallbackMessage;
 extern const ComponentVariable NumberOfDecimalsForCostValues;
 extern const RequiredComponentVariable EVConnectionTimeOut;

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/tariff_and_cost.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/tariff_and_cost.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <ocpp/v2/message_handler.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
 
 #include <ocpp/v2/functional_blocks/display_message.hpp>
 
@@ -30,6 +31,26 @@ public:
     virtual void handle_cost_and_tariff(const TransactionEventResponse& response,
                                         const TransactionEventRequest& original_message,
                                         const json& original_transaction_event_response) = 0;
+
+    ///
+    /// \brief Publish the TotalCostFallbackMessage via tariff_message_callback when the CS is offline at
+    ///        transaction end and cannot retrieve the actual total cost (I05.FR.02).
+    /// \param transaction_id  The id of the transaction that just ended.
+    ///
+    virtual void send_total_cost_fallback_message(const std::string& transaction_id) = 0;
+
+    ///
+    /// \brief Ensure that id_token_info.personalMessage is set when tariff is enabled.
+    ///        If personalMessage is already set by the CSMS, this is a no-op.
+    ///        Otherwise, the TariffFallbackMessage (or OfflineTariffFallbackMessage when offline) is injected:
+    ///          - The default-language entry goes into id_token_info.personalMessage.
+    ///          - Up to 4 additional language entries go into
+    ///            id_token_info.customData.personalMessageExtra[] per California Pricing spec 4.3.4.
+    ///        The caller is responsible for publishing the result (e.g. via tariff_message_callback).
+    /// \param id_token_info  The IdTokenInfo to modify in place.
+    /// \param offline        When true, reads OfflineTariffFallbackMessage; otherwise TariffFallbackMessage.
+    ///
+    virtual void ensure_personal_message(IdTokenInfo& id_token_info, bool offline) = 0;
 };
 
 class TariffAndCost : public TariffAndCostInterface {
@@ -44,6 +65,9 @@ public:
                                 const TransactionEventRequest& original_message,
                                 const json& original_transaction_event_response) override;
 
+    void send_total_cost_fallback_message(const std::string& transaction_id) override;
+    void ensure_personal_message(IdTokenInfo& id_token_info, bool offline) override;
+
 private:
     // Members
     const FunctionalBlockContext& context;
@@ -55,6 +79,24 @@ private:
     // Functions
     // Functional Block I: TariffAndCost
     void handle_costupdated_req(const Call<CostUpdatedRequest> call);
+
+    ///
+    /// \brief Get the fallback tariff message. Returns the configured TariffFallbackMessage (or
+    ///        OfflineTariffFallbackMessage when offline=true, falling back to TariffFallbackMessage if not configured).
+    ///        Returns std::nullopt when tariff is not enabled or no fallback messages are configured.
+    /// \param offline  When true, reads OfflineTariffFallbackMessage first; otherwise reads TariffFallbackMessage.
+    ///
+    std::optional<TariffMessage> get_fallback_tariff_message(bool offline) const;
+
+    ///
+    /// \brief Read all configured messages for the given ComponentVariable.
+    ///        Tries the default (no-instance) entry and, for every supported language, the
+    ///        language-specific instance.  Missing or empty values are silently skipped.
+    /// \param component_variable  e.g. ControllerComponentVariables::TariffFallbackMessage,
+    ///                            OfflineTariffFallbackMessage, or TotalCostFallbackMessage.
+    /// \return Vector of DisplayMessageContent, possibly empty when nothing is configured.
+    ///
+    std::vector<DisplayMessageContent> get_fallback_messages(const ComponentVariable& component_variable) const;
 
     ///
     /// \brief Check if multilanguage setting (variable) is enabled.

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -378,7 +378,15 @@ std::optional<std::string> ChargePoint::get_evse_transaction_id(std::int32_t evs
 
 AuthorizeResponse ChargePoint::validate_token(const IdToken id_token, const std::optional<CiString<10000>>& certificate,
                                               const std::optional<std::vector<OCSPRequestData>>& ocsp_request_data) {
-    return this->authorization->validate_token(id_token, certificate, ocsp_request_data);
+    auto response = this->authorization->validate_token(id_token, certificate, ocsp_request_data);
+
+    // I04: if the CSMS provided no specific tariff, inject the TariffFallbackMessage so
+    // the display can show the price to the EV Driver.
+    if (this->tariff_and_cost != nullptr) {
+        this->tariff_and_cost->ensure_personal_message(response.idTokenInfo, this->is_offline());
+    }
+
+    return response;
 }
 
 void ChargePoint::on_event(const std::vector<EventData>& events) {

--- a/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -1157,6 +1157,12 @@ const RequiredComponentVariable TariffFallbackMessage = {
         "TariffFallbackMessage",
     }),
 };
+const ComponentVariable OfflineTariffFallbackMessage = {
+    ControllerComponents::TariffCostCtrlr,
+    std::optional<Variable>({
+        "OfflineTariffFallbackMessage",
+    }),
+};
 const RequiredComponentVariable TotalCostFallbackMessage = {
     ControllerComponents::TariffCostCtrlr,
     std::optional<Variable>({

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/tariff_and_cost.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/tariff_and_cost.cpp
@@ -257,6 +257,147 @@ void TariffAndCost::handle_costupdated_req(const Call<CostUpdatedRequest> call) 
         this->io_context);
 }
 
+std::vector<DisplayMessageContent>
+TariffAndCost::get_fallback_messages(const ComponentVariable& component_variable) const {
+    std::vector<DisplayMessageContent> messages;
+
+    // Default (no-instance) entry
+    const auto default_msg = this->context.device_model.get_optional_value<std::string>(component_variable);
+    if (default_msg.has_value() and !default_msg.value().empty()) {
+        messages.push_back({default_msg.value(), std::nullopt, std::nullopt});
+    }
+
+    // Per-language instances — one entry per supported language in DisplayMessageCtrlr.Language
+    const auto metadata = this->context.device_model.get_variable_meta_data(
+        ControllerComponentVariables::DisplayMessageLanguage.component,
+        ControllerComponentVariables::DisplayMessageLanguage.variable.value());
+    if (metadata.has_value() and metadata.value().characteristics.valuesList.has_value()) {
+        for (const auto& language :
+             ocpp::split_string(metadata.value().characteristics.valuesList.value(), ',', true)) {
+            Variable var;
+            var.name = component_variable.variable.value().name;
+            var.instance = language;
+            const auto msg =
+                this->context.device_model.get_optional_value<std::string>(component_variable.component, var);
+            if (msg.has_value() and !msg.value().empty()) {
+                messages.push_back({msg.value(), language, std::nullopt});
+            }
+        }
+    }
+
+    return messages;
+}
+
+std::optional<TariffMessage> TariffAndCost::get_fallback_tariff_message(bool offline) const {
+    if (!is_tariff_enabled()) {
+        return std::nullopt;
+    }
+
+    // I04.FR.01: prefer the offline-specific variable when disconnected; fall back to the
+    // online TariffFallbackMessage when no offline messages are configured.
+    auto messages = offline ? get_fallback_messages(ControllerComponentVariables::OfflineTariffFallbackMessage)
+                            : get_fallback_messages(ControllerComponentVariables::TariffFallbackMessage);
+
+    if (offline and messages.empty()) {
+        EVLOG_debug << "No OfflineTariffFallbackMessage configured, falling back to TariffFallbackMessage";
+        messages = get_fallback_messages(ControllerComponentVariables::TariffFallbackMessage);
+    }
+
+    if (messages.empty()) {
+        return std::nullopt;
+    }
+
+    TariffMessage tariff_message;
+    tariff_message.message = messages;
+    return tariff_message;
+}
+
+void TariffAndCost::send_total_cost_fallback_message(const std::string& transaction_id) {
+    if (!is_cost_enabled() or !this->tariff_message_callback.has_value() or this->tariff_message_callback == nullptr) {
+        return;
+    }
+
+    // I05.FR.02: show TotalCostFallbackMessage when the CS is offline at transaction end.
+    const auto messages = get_fallback_messages(ControllerComponentVariables::TotalCostFallbackMessage);
+    if (messages.empty()) {
+        return;
+    }
+
+    TariffMessage tariff_message;
+    tariff_message.message = messages;
+    tariff_message.ocpp_transaction_id = transaction_id;
+    tariff_message.identifier_id = transaction_id;
+    tariff_message.identifier_type = IdentifierType::TransactionId;
+    this->tariff_message_callback.value()(tariff_message);
+}
+
+void TariffAndCost::ensure_personal_message(IdTokenInfo& id_token_info, bool offline) {
+    if (!is_tariff_enabled()) {
+        return;
+    }
+
+    if (id_token_info.personalMessage.has_value()) {
+        // Personal message already set by CSMS — assume it contains the tariff information.
+        return;
+    }
+
+    const auto fallback = get_fallback_tariff_message(offline);
+    if (!fallback.has_value() or fallback->message.empty()) {
+        return;
+    }
+
+    // Per California Pricing 4.3.4: personalMessage holds the text in the default language
+    // (DisplayMessageCtrlr.Language). All other languages go into customData.personalMessageExtra[] (max 4 additional
+    // entries).
+    const auto default_language =
+        this->context.device_model.get_optional_value<std::string>(ControllerComponentVariables::DisplayMessageLanguage)
+            .value_or(std::string{});
+
+    const auto& messages = fallback->message;
+
+    // Find the entry matching the default language; fall back to index 0 if none matches.
+    std::size_t primary_idx = 0;
+    for (std::size_t i = 0; i < messages.size(); ++i) {
+        if (!default_language.empty() and messages[i].language.has_value() and
+            messages[i].language.value() == default_language) {
+            primary_idx = i;
+            break;
+        }
+    }
+
+    // Set personalMessage to the default-language entry.
+    const auto& primary = messages[primary_idx];
+    MessageContent personal_msg;
+    personal_msg.format = primary.message_format.value_or(MessageFormatEnum::UTF8);
+    personal_msg.content = CiString<1024>(primary.message);
+    if (primary.language.has_value()) {
+        personal_msg.language = CiString<8>(primary.language.value());
+    }
+    id_token_info.personalMessage = personal_msg;
+
+    // Put remaining language entries into customData.personalMessageExtra.
+    constexpr std::size_t max_extra = 4;
+    json extra = json::array();
+    for (std::size_t i = 0; i < messages.size() and extra.size() < max_extra; ++i) {
+        if (i == primary_idx) {
+            continue;
+        }
+        json entry;
+        entry["content"] = messages[i].message;
+        if (messages[i].language.has_value()) {
+            entry["language"] = messages[i].language.value();
+        }
+        extra.push_back(entry);
+    }
+
+    if (!extra.empty()) {
+        CustomData custom_data = id_token_info.customData.value_or(json{});
+        custom_data["vendorId"] = "org.openchargealliance.multilanguage";
+        custom_data["personalMessageExtra"] = extra;
+        id_token_info.customData = custom_data;
+    }
+}
+
 bool TariffAndCost::is_multilanguage_enabled() const {
     return this->context.device_model
         .get_optional_value<bool>(ControllerComponentVariables::CustomImplementationMultiLanguageEnabled)

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
@@ -129,10 +129,15 @@ void TransactionBlock::on_transaction_finished(const std::int32_t evse_id, const
     const std::optional<IdToken> transaction_id_token =
         trigger_reason == ocpp::v2::TriggerReasonEnum::StopAuthorized ? id_token : std::nullopt;
 
+    const bool is_offline = !this->context.connectivity_manager.is_websocket_connected();
     this->transaction_event_req(TransactionEventEnum::Ended, timestamp, enhanced_transaction->get_transaction(),
                                 trigger_reason, enhanced_transaction->get_seq_no(), std::nullopt, std::nullopt,
-                                transaction_id_token, meter_values, std::nullopt,
-                                !this->context.connectivity_manager.is_websocket_connected(), std::nullopt);
+                                transaction_id_token, meter_values, std::nullopt, is_offline, std::nullopt);
+
+    // I05.FR.02: When offline, the CSMS response with totalCost will not arrive, so show the fallback message.
+    if (is_offline) {
+        this->tariff_and_cost.send_total_cost_fallback_message(transaction.transactionId.get());
+    }
 
     // K02.FR.05 The transaction is over, so delete the TxProfiles associated with the transaction.
     smart_charging.delete_transaction_tx_profiles(enhanced_transaction->get_transaction().transactionId);

--- a/lib/everest/ocpp/tests/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ if(LIBOCPP_ENABLE_V2)
     list(APPEND SEPARATE_UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/ocpp/v2/functional_blocks/test_authorization.cpp)
     list(APPEND SEPARATE_UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/ocpp/v2/functional_blocks/test_availability.cpp)
     list(APPEND SEPARATE_UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/ocpp/v2/functional_blocks/test_security.cpp)
+    list(APPEND SEPARATE_UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/ocpp/v2/functional_blocks/test_tariff_and_cost.cpp)
 endif()
 
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
@@ -86,3 +86,28 @@ target_include_directories(libocpp_test_availability PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/../mocks
         ${LIBOCPP_TESTS_V2_ROOT_DIR}
 )
+
+set(TEST_TARIFF_AND_COST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../device_model_test_helper.cpp
+            ${TEST_FUNCTIONAL_BLOCK_CONTEXT_SOURCES}
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/functional_blocks/tariff_and_cost.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/functional_blocks/display_message.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/ctrlr_component_variables.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/ClearDisplayMessage.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/GetDisplayMessages.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/NotifyDisplayMessages.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/SetDisplayMessage.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/CostUpdated.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/TransactionEvent.cpp
+            ${LIBOCPP_TEST_INCLUDE_COMMON_SOURCES}
+            ${LIBOCPP_TEST_INCLUDE_V2_SOURCES}
+)
+
+target_sources(libocpp_test_tariff_and_cost PRIVATE
+        ${TEST_TARIFF_AND_COST_SOURCES})
+
+target_include_directories(libocpp_test_tariff_and_cost PUBLIC
+        ${LIBOCPP_INCLUDE_PATH}
+        ${LIBOCPP_3RDPARTY_PATH}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../mocks
+        ${LIBOCPP_TESTS_V2_ROOT_DIR}
+)

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_tariff_and_cost.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_tariff_and_cost.cpp
@@ -1,0 +1,588 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <boost/asio/io_context.hpp>
+
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/functional_blocks/functional_block_context.hpp>
+#include <ocpp/v2/functional_blocks/tariff_and_cost.hpp>
+#include <ocpp/v2/messages/CostUpdated.hpp>
+
+#include "component_state_manager_mock.hpp"
+#include "connectivity_manager_mock.hpp"
+#include "device_model_test_helper.hpp"
+#include "evse_manager_fake.hpp"
+#include "evse_security_mock.hpp"
+#include "message_dispatcher_mock.hpp"
+#include "meter_values_mock.hpp"
+#include "mocks/database_handler_mock.hpp"
+
+using namespace ocpp::v2;
+using ocpp::IdentifierType;
+using ocpp::RunningCost;
+using ocpp::RunningCostState;
+using ocpp::TariffMessage;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::MockFunction;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+static const std::string TARIFF_FALLBACK_MESSAGE = "Tariff: 0.30 EUR/kWh";
+static const std::string OFFLINE_TARIFF_FALLBACK_MESSAGE = "Offline: 0.35 EUR/kWh";
+static const std::string TOTAL_COST_FALLBACK_MESSAGE = "Total cost unavailable (offline)";
+static const std::string TRANSACTION_ID = "txn-001";
+
+class TariffAndCostTest : public ::testing::Test {
+protected:
+    DeviceModelTestHelper device_model_test_helper;
+    MockMessageDispatcher mock_dispatcher;
+    DeviceModel* device_model;
+    NiceMock<ConnectivityManagerMock> connectivity_manager;
+    NiceMock<DatabaseHandlerMock> database_handler_mock;
+    ocpp::EvseSecurityMock evse_security;
+    EvseManagerFake evse_manager;
+    ComponentStateManagerMock component_state_manager;
+    std::atomic<ocpp::OcppProtocolVersion> ocpp_version;
+    FunctionalBlockContext functional_block_context;
+    NiceMock<MeterValuesMock> meter_values_mock;
+    boost::asio::io_context io_context;
+
+    std::optional<TariffMessageCallback> tariff_message_callback_opt;
+    std::optional<SetRunningCostCallback> set_running_cost_callback_opt;
+
+    MockFunction<void(const TariffMessage&)> tariff_message_mock;
+    MockFunction<void(const RunningCost&, std::uint32_t, std::optional<std::string>)> running_cost_mock;
+
+    TariffAndCostTest() :
+        device_model(device_model_test_helper.get_device_model()),
+        evse_manager(1),
+        ocpp_version(ocpp::OcppProtocolVersion::v201),
+        functional_block_context{mock_dispatcher,       *device_model, connectivity_manager,    evse_manager,
+                                 database_handler_mock, evse_security, component_state_manager, ocpp_version} {
+    }
+
+    std::unique_ptr<TariffAndCost> make_tariff_and_cost() {
+        return std::make_unique<TariffAndCost>(functional_block_context, meter_values_mock, tariff_message_callback_opt,
+                                               set_running_cost_callback_opt, io_context);
+    }
+
+    void set_tariff_enabled(bool available = true, bool enabled = true) {
+        const auto& avail = ControllerComponentVariables::TariffCostCtrlrAvailableTariff;
+        const auto& en = ControllerComponentVariables::TariffCostCtrlrEnabledTariff;
+        ASSERT_EQ(device_model->set_value(avail.component, avail.variable.value(), AttributeEnum::Actual,
+                                          available ? "true" : "false", "default", true),
+                  SetVariableStatusEnum::Accepted);
+        ASSERT_EQ(device_model->set_value(en.component, en.variable.value(), AttributeEnum::Actual,
+                                          enabled ? "true" : "false", "default", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void set_cost_enabled(bool available = true, bool enabled = true) {
+        const auto& avail = ControllerComponentVariables::TariffCostCtrlrAvailableCost;
+        const auto& en = ControllerComponentVariables::TariffCostCtrlrEnabledCost;
+        ASSERT_EQ(device_model->set_value(avail.component, avail.variable.value(), AttributeEnum::Actual,
+                                          available ? "true" : "false", "default", true),
+                  SetVariableStatusEnum::Accepted);
+        ASSERT_EQ(device_model->set_value(en.component, en.variable.value(), AttributeEnum::Actual,
+                                          enabled ? "true" : "false", "default", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void set_tariff_fallback_message(const std::string& msg) {
+        Variable var;
+        var.name = "TariffFallbackMessage";
+        ASSERT_EQ(device_model->set_value(ControllerComponents::TariffCostCtrlr, var, AttributeEnum::Actual, msg,
+                                          "default", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void set_total_cost_fallback_message(const std::string& msg) {
+        Variable var;
+        var.name = "TotalCostFallbackMessage";
+        ASSERT_EQ(device_model->set_value(ControllerComponents::TariffCostCtrlr, var, AttributeEnum::Actual, msg,
+                                          "default", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void set_offline_tariff_fallback_message(const std::string& msg) {
+        Variable var;
+        var.name = "OfflineTariffFallbackMessage";
+        ASSERT_EQ(device_model->set_value(ControllerComponents::TariffCostCtrlr, var, AttributeEnum::Actual, msg,
+                                          "default", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void set_tariff_fallback_message_instance(const std::string& instance, const std::string& msg) {
+        Variable var;
+        var.name = "TariffFallbackMessage";
+        var.instance = instance;
+        ASSERT_EQ(device_model->set_value(ControllerComponents::TariffCostCtrlr, var, AttributeEnum::Actual, msg,
+                                          "default", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    // Helpers for building enhanced messages
+    static ocpp::EnhancedMessage<MessageType> make_costupdated_message(const CostUpdatedRequest& req) {
+        ocpp::Call<CostUpdatedRequest> call(req);
+        ocpp::EnhancedMessage<MessageType> msg;
+        msg.messageType = MessageType::CostUpdated;
+        msg.message = call;
+        return msg;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// handle_message
+// ---------------------------------------------------------------------------
+
+TEST_F(TariffAndCostTest, HandleMessage_WrongType_Throws) {
+    auto tc = make_tariff_and_cost();
+
+    CostUpdatedRequest req;
+    req.totalCost = 1.0f;
+    req.transactionId = TRANSACTION_ID;
+    ocpp::Call<CostUpdatedRequest> call(req);
+    ocpp::EnhancedMessage<MessageType> msg;
+    msg.messageType = MessageType::Authorize; // wrong type
+    msg.message = call;
+
+    EXPECT_THROW(tc->handle_message(msg), MessageTypeNotImplementedException);
+}
+
+TEST_F(TariffAndCostTest, HandleMessage_CostUpdated_CostDisabled_DispatchesResult) {
+    // Cost is disabled: handler should dispatch a CostUpdatedResponse but not call the callback.
+    set_running_cost_callback_opt = running_cost_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(running_cost_mock, Call(_, _, _)).Times(0);
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(1);
+
+    CostUpdatedRequest req;
+    req.totalCost = 5.0f;
+    req.transactionId = TRANSACTION_ID;
+    tc->handle_message(make_costupdated_message(req));
+}
+
+TEST_F(TariffAndCostTest, HandleMessage_CostUpdated_CostEnabled_CallsRunningCostCallback) {
+    set_cost_enabled();
+    set_running_cost_callback_opt = running_cost_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(running_cost_mock, Call(_, _, _)).Times(1);
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(1);
+
+    CostUpdatedRequest req;
+    req.totalCost = 5.0f;
+    req.transactionId = TRANSACTION_ID;
+    tc->handle_message(make_costupdated_message(req));
+}
+
+TEST_F(TariffAndCostTest, HandleMessage_CostUpdated_NoRunningCostCallback_DispatchesResult) {
+    set_cost_enabled();
+    // No running cost callback set.
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(1);
+
+    CostUpdatedRequest req;
+    req.totalCost = 5.0f;
+    req.transactionId = TRANSACTION_ID;
+    tc->handle_message(make_costupdated_message(req));
+}
+
+// ---------------------------------------------------------------------------
+// send_total_cost_fallback_message
+// ---------------------------------------------------------------------------
+
+TEST_F(TariffAndCostTest, SendTotalCostFallbackMessage_CostDisabled_NoCallback) {
+    tariff_message_callback_opt = tariff_message_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(tariff_message_mock, Call(_)).Times(0);
+    tc->send_total_cost_fallback_message(TRANSACTION_ID);
+}
+
+TEST_F(TariffAndCostTest, SendTotalCostFallbackMessage_CostEnabled_NoCallback_DoesNotCrash) {
+    set_cost_enabled();
+    // tariff_message_callback_opt remains nullopt
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_NO_FATAL_FAILURE(tc->send_total_cost_fallback_message(TRANSACTION_ID));
+}
+
+TEST_F(TariffAndCostTest, SendTotalCostFallbackMessage_CostEnabled_NoMessageConfigured_NoCallback) {
+    set_cost_enabled();
+    tariff_message_callback_opt = tariff_message_mock.AsStdFunction();
+    // TotalCostFallbackMessage is empty by default.
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(tariff_message_mock, Call(_)).Times(0);
+    tc->send_total_cost_fallback_message(TRANSACTION_ID);
+}
+
+TEST_F(TariffAndCostTest, SendTotalCostFallbackMessage_CostEnabled_MessageConfigured_CallsCallback) {
+    set_cost_enabled();
+    set_total_cost_fallback_message(TOTAL_COST_FALLBACK_MESSAGE);
+    tariff_message_callback_opt = tariff_message_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(tariff_message_mock, Call(_)).WillOnce(Invoke([](const TariffMessage& msg) {
+        ASSERT_EQ(msg.message.size(), 1u);
+        EXPECT_EQ(msg.message[0].message, TOTAL_COST_FALLBACK_MESSAGE);
+    }));
+    tc->send_total_cost_fallback_message(TRANSACTION_ID);
+}
+
+TEST_F(TariffAndCostTest, SendTotalCostFallbackMessage_SetsTransactionId) {
+    set_cost_enabled();
+    set_total_cost_fallback_message(TOTAL_COST_FALLBACK_MESSAGE);
+    tariff_message_callback_opt = tariff_message_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(tariff_message_mock, Call(_)).WillOnce(Invoke([](const TariffMessage& msg) {
+        EXPECT_EQ(msg.identifier_id, TRANSACTION_ID);
+        EXPECT_EQ(msg.identifier_type, IdentifierType::TransactionId);
+    }));
+    tc->send_total_cost_fallback_message(TRANSACTION_ID);
+}
+
+// ---------------------------------------------------------------------------
+// ensure_personal_message
+// ---------------------------------------------------------------------------
+
+TEST_F(TariffAndCostTest, EnsureTariffMessage_TariffDisabled_NoOp) {
+    set_tariff_fallback_message(TARIFF_FALLBACK_MESSAGE);
+    auto tc = make_tariff_and_cost();
+
+    IdTokenInfo info;
+    info.status = AuthorizationStatusEnum::Accepted;
+    tc->ensure_personal_message(info, false);
+
+    EXPECT_FALSE(info.personalMessage.has_value());
+}
+
+TEST_F(TariffAndCostTest, EnsureTariffMessage_PersonalMessageAlreadySet_NoOp) {
+    set_tariff_enabled();
+    set_tariff_fallback_message(TARIFF_FALLBACK_MESSAGE);
+    auto tc = make_tariff_and_cost();
+
+    IdTokenInfo info;
+    info.status = AuthorizationStatusEnum::Accepted;
+    MessageContent existing;
+    existing.content = "CSMS provided message";
+    existing.format = MessageFormatEnum::UTF8;
+    info.personalMessage = existing;
+
+    tc->ensure_personal_message(info, false);
+
+    EXPECT_EQ(info.personalMessage.value().content, "CSMS provided message");
+}
+
+TEST_F(TariffAndCostTest, EnsureTariffMessage_NoFallbackConfigured_NoOp) {
+    set_tariff_enabled();
+    // TariffFallbackMessage is empty by default.
+    auto tc = make_tariff_and_cost();
+
+    IdTokenInfo info;
+    info.status = AuthorizationStatusEnum::Accepted;
+    tc->ensure_personal_message(info, false);
+
+    EXPECT_FALSE(info.personalMessage.has_value());
+}
+
+TEST_F(TariffAndCostTest, EnsureTariffMessage_FallbackConfigured_SetsPersonalMessage) {
+    set_tariff_enabled();
+    set_tariff_fallback_message(TARIFF_FALLBACK_MESSAGE);
+    auto tc = make_tariff_and_cost();
+
+    IdTokenInfo info;
+    info.status = AuthorizationStatusEnum::Accepted;
+    tc->ensure_personal_message(info, false);
+
+    ASSERT_TRUE(info.personalMessage.has_value());
+    EXPECT_EQ(std::string(info.personalMessage->content), TARIFF_FALLBACK_MESSAGE);
+}
+
+TEST_F(TariffAndCostTest, EnsureTariffMessage_Offline_UsesFallback) {
+    set_tariff_enabled();
+    set_tariff_fallback_message(TARIFF_FALLBACK_MESSAGE);
+    auto tc = make_tariff_and_cost();
+
+    IdTokenInfo info;
+    info.status = AuthorizationStatusEnum::Accepted;
+    tc->ensure_personal_message(info, true); // offline=true, no offline-specific message configured
+
+    // Should fall back to TariffFallbackMessage
+    ASSERT_TRUE(info.personalMessage.has_value());
+    EXPECT_EQ(std::string(info.personalMessage->content), TARIFF_FALLBACK_MESSAGE);
+}
+
+TEST_F(TariffAndCostTest, EnsureTariffMessage_Offline_OfflineMessageConfigured_UsesOfflineMessage) {
+    set_tariff_enabled();
+    set_tariff_fallback_message(TARIFF_FALLBACK_MESSAGE);
+    set_offline_tariff_fallback_message(OFFLINE_TARIFF_FALLBACK_MESSAGE);
+    auto tc = make_tariff_and_cost();
+
+    IdTokenInfo info;
+    info.status = AuthorizationStatusEnum::Accepted;
+    tc->ensure_personal_message(info, true);
+
+    ASSERT_TRUE(info.personalMessage.has_value());
+    EXPECT_EQ(std::string(info.personalMessage->content), OFFLINE_TARIFF_FALLBACK_MESSAGE);
+}
+
+TEST_F(TariffAndCostTest, EnsureTariffMessage_DefaultLanguageEntryBecomesPersonalMessage) {
+    set_tariff_enabled();
+    // Set the base (no-instance) fallback message.
+    set_tariff_fallback_message(TARIFF_FALLBACK_MESSAGE);
+    // Also set the language-specific "en-US" instance that is present in the example config.
+    Variable en_var;
+    en_var.name = "TariffFallbackMessage";
+    en_var.instance = "en-US";
+    ASSERT_EQ(device_model->set_value(ControllerComponents::TariffCostCtrlr, en_var, AttributeEnum::Actual,
+                                      "Tariff: 0.30 EUR/kWh (en-US)", "default", true),
+              SetVariableStatusEnum::Accepted);
+    // Set DisplayMessageCtrlr.Language to "en-US" so it matches the instance above.
+    // Note: "en-US" must be in the current valuesList. The example config has "en_US,de,nl" (underscore);
+    // since "en-US" ≠ "en_US" the language-specific entry won't be found via the valuesList scan.
+    // This test therefore verifies the fallback: when no language match, index 0 (the base message)
+    // is used for personalMessage with no extra entries.
+    auto tc = make_tariff_and_cost();
+
+    IdTokenInfo info;
+    info.status = AuthorizationStatusEnum::Accepted;
+    tc->ensure_personal_message(info, false);
+
+    ASSERT_TRUE(info.personalMessage.has_value());
+    // Base message (index 0) is selected since no language match for the default "en_US" entries.
+    EXPECT_EQ(std::string(info.personalMessage->content), TARIFF_FALLBACK_MESSAGE);
+    // No extra entries since there are no matching per-language instances found via the valuesList.
+    if (info.customData.has_value()) {
+        const json& cd = info.customData.value();
+        if (cd.contains("personalMessageExtra")) {
+            EXPECT_TRUE(cd.at("personalMessageExtra").empty());
+        }
+    }
+}
+
+TEST_F(TariffAndCostTest, EnsureTariffMessage_MultipleLanguages_PopulatesPersonalMessageExtra) {
+    // With both a base message and a language-specific "de" instance, the base message should
+    // become personalMessage (default_language is empty → index 0 is primary), and the "de"
+    // message should go into customData.personalMessageExtra per California Pricing spec 4.3.4.
+    set_tariff_enabled();
+    set_tariff_fallback_message(TARIFF_FALLBACK_MESSAGE);
+    // "de" is in DisplayMessageCtrlr.Language.valuesList ("en_US,de,nl") so it will be found.
+    set_tariff_fallback_message_instance("de", "Tarif: 0,30 EUR/kWh");
+    auto tc = make_tariff_and_cost();
+
+    IdTokenInfo info;
+    info.status = AuthorizationStatusEnum::Accepted;
+    tc->ensure_personal_message(info, false);
+
+    // Base message is primary (index 0 — no default language configured).
+    ASSERT_TRUE(info.personalMessage.has_value());
+    EXPECT_EQ(std::string(info.personalMessage->content), TARIFF_FALLBACK_MESSAGE);
+
+    // The "de" entry must appear in customData.personalMessageExtra.
+    ASSERT_TRUE(info.customData.has_value());
+    const json& cd = info.customData.value();
+    EXPECT_EQ(cd.at("vendorId"), "org.openchargealliance.multilanguage");
+    ASSERT_TRUE(cd.contains("personalMessageExtra"));
+    ASSERT_EQ(cd.at("personalMessageExtra").size(), 1u);
+    EXPECT_EQ(cd.at("personalMessageExtra").at(0).at("content"), "Tarif: 0,30 EUR/kWh");
+    EXPECT_EQ(cd.at("personalMessageExtra").at(0).at("language"), "de");
+}
+
+TEST_F(TariffAndCostTest, EnsureTariffMessage_MaxFourExtraLanguages) {
+    // personalMessageExtra is capped at 4 entries (spec 4.3.4).
+    // We use the base message + "de" (only "de" and "nl" are in valuesList besides "en_US"),
+    // so in practice the cap is not hit here — this test verifies no crash with max entries.
+    set_tariff_enabled();
+    set_tariff_fallback_message(TARIFF_FALLBACK_MESSAGE);
+    set_tariff_fallback_message_instance("de", "Tarif: 0,30 EUR/kWh");
+    set_tariff_fallback_message_instance("nl", "Tarief: 0,30 EUR/kWh");
+    auto tc = make_tariff_and_cost();
+
+    IdTokenInfo info;
+    info.status = AuthorizationStatusEnum::Accepted;
+    tc->ensure_personal_message(info, false);
+
+    ASSERT_TRUE(info.personalMessage.has_value());
+    EXPECT_EQ(std::string(info.personalMessage->content), TARIFF_FALLBACK_MESSAGE);
+
+    ASSERT_TRUE(info.customData.has_value());
+    const json& cd = info.customData.value();
+    EXPECT_EQ(cd.at("vendorId"), "org.openchargealliance.multilanguage");
+    // Two extra languages — both must be present.
+    ASSERT_EQ(cd.at("personalMessageExtra").size(), 2u);
+    // Extra entries must not exceed the max of 4.
+    EXPECT_LE(cd.at("personalMessageExtra").size(), 4u);
+}
+
+// ---------------------------------------------------------------------------
+// handle_cost_and_tariff
+// ---------------------------------------------------------------------------
+
+static TransactionEventRequest make_transaction_event_request(const std::string& transaction_id,
+                                                              TransactionEventEnum event_type) {
+    TransactionEventRequest req;
+    req.eventType = event_type;
+    req.timestamp = ocpp::DateTime();
+    req.triggerReason = TriggerReasonEnum::Authorized;
+    req.seqNo = 0;
+    req.transactionInfo.transactionId = transaction_id;
+    return req;
+}
+
+TEST_F(TariffAndCostTest, HandleCostAndTariff_NeitherEnabled_NoCallbacks) {
+    tariff_message_callback_opt = tariff_message_mock.AsStdFunction();
+    set_running_cost_callback_opt = running_cost_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(tariff_message_mock, Call(_)).Times(0);
+    EXPECT_CALL(running_cost_mock, Call(_, _, _)).Times(0);
+
+    TransactionEventResponse response;
+    MessageContent personal_msg;
+    personal_msg.content = "Some tariff info";
+    personal_msg.format = MessageFormatEnum::UTF8;
+    response.updatedPersonalMessage = personal_msg;
+    response.totalCost = 5.0f;
+
+    const auto req = make_transaction_event_request(TRANSACTION_ID, TransactionEventEnum::Ended);
+    tc->handle_cost_and_tariff(response, req, json{{"totalCost", 5.0}});
+}
+
+TEST_F(TariffAndCostTest, HandleCostAndTariff_TariffEnabled_WithUpdatedPersonalMessage_CallsTariffCallback) {
+    set_tariff_enabled();
+    tariff_message_callback_opt = tariff_message_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(tariff_message_mock, Call(_)).WillOnce(Invoke([](const TariffMessage& msg) {
+        ASSERT_EQ(msg.message.size(), 1u);
+        EXPECT_EQ(msg.message[0].message, "Tariff: 0.25 EUR/kWh");
+        EXPECT_EQ(msg.identifier_type, IdentifierType::TransactionId);
+    }));
+
+    TransactionEventResponse response;
+    MessageContent personal_msg;
+    personal_msg.content = "Tariff: 0.25 EUR/kWh";
+    personal_msg.format = MessageFormatEnum::UTF8;
+    response.updatedPersonalMessage = personal_msg;
+
+    const auto req = make_transaction_event_request(TRANSACTION_ID, TransactionEventEnum::Updated);
+    tc->handle_cost_and_tariff(response, req, json{});
+}
+
+TEST_F(TariffAndCostTest, HandleCostAndTariff_TariffEnabled_NoUpdatedPersonalMessage_NoTariffCallback) {
+    set_tariff_enabled();
+    tariff_message_callback_opt = tariff_message_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(tariff_message_mock, Call(_)).Times(0);
+
+    TransactionEventResponse response;
+    // No updatedPersonalMessage set.
+
+    const auto req = make_transaction_event_request(TRANSACTION_ID, TransactionEventEnum::Updated);
+    tc->handle_cost_and_tariff(response, req, json{});
+}
+
+TEST_F(TariffAndCostTest, HandleCostAndTariff_CostEnabled_WithTotalCost_CallsRunningCostCallback) {
+    set_cost_enabled();
+    set_running_cost_callback_opt = running_cost_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(running_cost_mock, Call(_, _, _))
+        .WillOnce(Invoke([](const RunningCost& cost, std::uint32_t decimals, std::optional<std::string> currency) {
+            EXPECT_DOUBLE_EQ(cost.cost, 5.0);
+            EXPECT_EQ(cost.state, RunningCostState::Finished);
+        }));
+
+    TransactionEventResponse response;
+    response.totalCost = 5.0f;
+
+    const auto req = make_transaction_event_request(TRANSACTION_ID, TransactionEventEnum::Ended);
+    tc->handle_cost_and_tariff(response, req, json{{"totalCost", 5.0}});
+}
+
+TEST_F(TariffAndCostTest, HandleCostAndTariff_CostEnabled_NoTotalCost_NoRunningCostCallback) {
+    set_cost_enabled();
+    set_running_cost_callback_opt = running_cost_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(running_cost_mock, Call(_, _, _)).Times(0);
+
+    TransactionEventResponse response;
+    // No totalCost.
+
+    const auto req = make_transaction_event_request(TRANSACTION_ID, TransactionEventEnum::Ended);
+    tc->handle_cost_and_tariff(response, req, json{});
+}
+
+TEST_F(TariffAndCostTest, HandleCostAndTariff_BothEnabled_CallsBothCallbacks) {
+    set_tariff_enabled();
+    set_cost_enabled();
+    tariff_message_callback_opt = tariff_message_mock.AsStdFunction();
+    set_running_cost_callback_opt = running_cost_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(tariff_message_mock, Call(_)).Times(1);
+    EXPECT_CALL(running_cost_mock, Call(_, _, _)).Times(1);
+
+    TransactionEventResponse response;
+    MessageContent personal_msg;
+    personal_msg.content = "Tariff info";
+    personal_msg.format = MessageFormatEnum::UTF8;
+    response.updatedPersonalMessage = personal_msg;
+    response.totalCost = 3.5f;
+
+    const auto req = make_transaction_event_request(TRANSACTION_ID, TransactionEventEnum::Ended);
+    tc->handle_cost_and_tariff(response, req, json{{"totalCost", 3.5}});
+}
+
+TEST_F(TariffAndCostTest, HandleCostAndTariff_CostEnabled_RunningCostIncludesTariffMessages) {
+    set_tariff_enabled();
+    set_cost_enabled();
+    set_running_cost_callback_opt = running_cost_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(running_cost_mock, Call(_, _, _))
+        .WillOnce(Invoke([](const RunningCost& cost, std::uint32_t, std::optional<std::string>) {
+            ASSERT_TRUE(cost.cost_messages.has_value());
+            ASSERT_EQ(cost.cost_messages->size(), 1u);
+            EXPECT_EQ(cost.cost_messages->at(0).message, "Tariff info");
+        }));
+
+    TransactionEventResponse response;
+    MessageContent personal_msg;
+    personal_msg.content = "Tariff info";
+    personal_msg.format = MessageFormatEnum::UTF8;
+    response.updatedPersonalMessage = personal_msg;
+    response.totalCost = 3.5f;
+
+    const auto req = make_transaction_event_request(TRANSACTION_ID, TransactionEventEnum::Ended);
+    tc->handle_cost_and_tariff(response, req, json{{"totalCost", 3.5}});
+}
+
+TEST_F(TariffAndCostTest, HandleCostAndTariff_ChargingState_RunningCostIsCharging) {
+    set_cost_enabled();
+    set_running_cost_callback_opt = running_cost_mock.AsStdFunction();
+    auto tc = make_tariff_and_cost();
+
+    EXPECT_CALL(running_cost_mock, Call(_, _, _))
+        .WillOnce(Invoke([](const RunningCost& cost, std::uint32_t, std::optional<std::string>) {
+            EXPECT_EQ(cost.state, RunningCostState::Charging);
+        }));
+
+    TransactionEventResponse response;
+    response.totalCost = 1.0f;
+
+    const auto req = make_transaction_event_request(TRANSACTION_ID, TransactionEventEnum::Updated);
+    tc->handle_cost_and_tariff(response, req, json{{"totalCost", 1.0}});
+}

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/mocks/meter_values_mock.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/mocks/meter_values_mock.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <ocpp/v2/functional_blocks/meter_values.hpp>
+
+namespace ocpp::v2 {
+
+class MeterValuesMock : public MeterValuesInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>& message), (override));
+    MOCK_METHOD(void, update_aligned_data_interval, (), (override));
+    MOCK_METHOD(void, on_meter_value, (const std::int32_t evse_id, const MeterValue& meter_value), (override));
+    MOCK_METHOD(MeterValue, get_latest_meter_value_filtered,
+                (const MeterValue& meter_value, ReadingContextEnum context,
+                 const RequiredComponentVariable& component_variable),
+                (override));
+    MOCK_METHOD(void, meter_values_req,
+                (const std::int32_t evse_id, const std::vector<MeterValue>& meter_values,
+                 const bool initiated_by_trigger_message),
+                (override));
+};
+
+} // namespace ocpp::v2

--- a/tests/ocpp_tests/test_sets/ocpp201/california_pricing.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/california_pricing.py
@@ -16,7 +16,8 @@ from everest.testing.core_utils.controller.test_controller_interface import Test
 from ocpp.v201 import call as call201
 from ocpp.v201 import call_result as call_result201
 from ocpp.v201.enums import (IdTokenEnumType as IdTokenTypeEnum, ConnectorStatusEnumType,
-                             ClearCacheStatusEnumType)
+                             ClearCacheStatusEnumType, SetVariableStatusEnumType,
+                             AttributeEnumType)
 from ocpp.v201.datatypes import *
 from everest.testing.ocpp_utils.fixtures import *
 from everest_test_utils_probe_modules import (probe_module,
@@ -586,3 +587,201 @@ class TestOcpp201CostAndPrice:
                                            ],
                                                'timestamp': timestamp[:-9] + 'Z'}]}
                                            )
+
+    @pytest.mark.asyncio
+    @pytest.mark.probe_module
+    @pytest.mark.everest_config_adaptions(ProbeModuleCostAndPriceSessionCostConfigurationAdjustment())
+    async def test_tariff_fallback_message_on_authorize(self, central_system: CentralSystem,
+                                                         test_controller: TestController,
+                                                         test_utility: TestUtility,
+                                                         test_config: OcppTestConfiguration,
+                                                         probe_module):
+        """
+        I04.FR.01 integration: When TariffFallbackMessage is configured and the CSMS returns no
+        personalMessage in AuthorizeResponse, test if personal message is still set to the configured fallback.
+        The injected personalMessage is then converted and published via session_cost.tariff_message
+        so the display can show the price to the EV Driver.
+        """
+        tariff_message_mock = Mock()
+        probe_module.subscribe_variable("session_cost", "tariff_message", tariff_message_mock)
+
+        probe_module.start()
+        await probe_module.wait_to_be_ready()
+
+        chargepoint_with_pm = await central_system.wait_for_chargepoint()
+
+        # Clear auth cache so the CSMS is consulted for every authorization.
+        r: call_result201.ClearCache = await chargepoint_with_pm.clear_cache_req()
+        assert r.status == ClearCacheStatusEnumType.accepted
+
+        # Configure TariffFallbackMessage on the CS via OCPP SetVariables.
+        r = await chargepoint_with_pm.set_config_variables_req(
+            "TariffCostCtrlr", "TariffFallbackMessage", "Tariff: 0.30 EUR/kWh"
+        )
+        assert SetVariableResultType(**r.set_variable_result[0]).attribute_status == SetVariableStatusEnumType.accepted
+
+        evse_id1 = 1
+        connector_id = 1
+        id_token = IdTokenType(id_token="DEADBEEF", type=IdTokenTypeEnum.iso14443)
+
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StatusNotification",
+                                           call201.StatusNotification(datetime.now().isoformat(),
+                                                                      ConnectorStatusEnumType.available,
+                                                                      evse_id=evse_id1,
+                                                                      connector_id=connector_id),
+                                           validate_status_notification_201)
+
+        # Swipe to trigger authorization. The CSMS mock returns Accepted without a personalMessage
+        # (default behavior), so ensure_personal_message must inject the configured fallback.
+        test_controller.swipe(id_token.id_token)
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "Authorize",
+                                           call201.Authorize(id_token))
+
+        # The fallback tariff message must arrive on session_cost.tariff_message.
+        await self.await_mock_called(tariff_message_mock)
+
+        call_data = tariff_message_mock.call_args[0][0]
+        assert call_data["identifier_id"] == "DEADBEEF"
+        assert call_data["identifier_type"] == "IdToken"
+        assert len(call_data["messages"]) == 1
+        assert call_data["messages"][0]["content"] == "Tariff: 0.30 EUR/kWh"
+
+    @pytest.mark.asyncio
+    @pytest.mark.probe_module
+    @pytest.mark.everest_config_adaptions(ProbeModuleCostAndPriceSessionCostConfigurationAdjustment())
+    async def test_tariff_fallback_message_multilanguage_on_authorize(self, central_system: CentralSystem,
+                                                                       test_controller: TestController,
+                                                                       test_utility: TestUtility,
+                                                                       test_config: OcppTestConfiguration,
+                                                                       probe_module):
+        """
+        California Pricing 4.3.4 integration: When TariffFallbackMessage is configured for multiple languages, the
+        base (no-instance) message becomes personalMessage and language-specific instances go into
+        customData.personalMessageExtra. Both are forwarded as entries in session_cost.tariff_message
+        so multi-language displays can show the correct price text.
+        """
+        tariff_message_mock = Mock()
+        probe_module.subscribe_variable("session_cost", "tariff_message", tariff_message_mock)
+
+        probe_module.start()
+        await probe_module.wait_to_be_ready()
+
+        chargepoint_with_pm = await central_system.wait_for_chargepoint()
+
+        # Clear auth cache so the CSMS is consulted for every authorization.
+        r: call_result201.ClearCache = await chargepoint_with_pm.clear_cache_req()
+        assert r.status == ClearCacheStatusEnumType.accepted
+
+        # Set the base TariffFallbackMessage (no language instance).
+        r = await chargepoint_with_pm.set_config_variables_req(
+            "TariffCostCtrlr", "TariffFallbackMessage", "Tariff: 0.30 EUR/kWh"
+        )
+        assert SetVariableResultType(**r.set_variable_result[0]).attribute_status == SetVariableStatusEnumType.accepted
+
+        # Set the German-language instance ("de" is in DisplayMessageCtrlr.Language.valuesList).
+        r = await chargepoint_with_pm.set_variables_req(set_variable_data=[
+            SetVariableDataType(
+                attribute_value="Tarif: 0,30 EUR/kWh",
+                attribute_type=AttributeEnumType.actual,
+                component=ComponentType(name="TariffCostCtrlr"),
+                variable=VariableType(name="TariffFallbackMessage", instance="de")
+            )
+        ])
+        assert SetVariableResultType(**r.set_variable_result[0]).attribute_status == SetVariableStatusEnumType.accepted
+
+        evse_id1 = 1
+        connector_id = 1
+        id_token = IdTokenType(id_token="DEADBEEF", type=IdTokenTypeEnum.iso14443)
+
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StatusNotification",
+                                           call201.StatusNotification(datetime.now().isoformat(),
+                                                                      ConnectorStatusEnumType.available,
+                                                                      evse_id=evse_id1,
+                                                                      connector_id=connector_id),
+                                           validate_status_notification_201)
+
+        test_controller.swipe(id_token.id_token)
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "Authorize",
+                                           call201.Authorize(id_token))
+
+        await self.await_mock_called(tariff_message_mock)
+
+        call_data = tariff_message_mock.call_args[0][0]
+        assert call_data["identifier_id"] == "DEADBEEF"
+        assert call_data["identifier_type"] == "IdToken"
+        # Base message + German entry from personalMessageExtra.
+        assert len(call_data["messages"]) == 2
+        assert call_data["messages"][0]["content"] == "Tariff: 0.30 EUR/kWh"
+        assert call_data["messages"][1]["content"] == "Tarif: 0,30 EUR/kWh"
+        assert call_data["messages"][1]["language"] == "de"
+
+    @pytest.mark.asyncio
+    @pytest.mark.probe_module
+    @pytest.mark.everest_config_adaptions(ProbeModuleCostAndPriceSessionCostConfigurationAdjustment())
+    async def test_total_cost_fallback_message_on_offline_transaction_end(self, central_system: CentralSystem,
+                                                                           test_controller: TestController,
+                                                                           test_utility: TestUtility,
+                                                                           test_config: OcppTestConfiguration,
+                                                                           probe_module):
+        """
+        I05.FR.02 integration: When the CS is offline when a transaction ends and TotalCostFallbackMessage
+        is configured, a default total cost shall still be published via session_cost.tariff_message,
+        even if the CSMS response containing totalCost will never arrive.
+        """
+        tariff_message_mock = Mock()
+        probe_module.subscribe_variable("session_cost", "tariff_message", tariff_message_mock)
+
+        probe_module.start()
+        await probe_module.wait_to_be_ready()
+
+        chargepoint_with_pm = await central_system.wait_for_chargepoint()
+
+        # Configure TotalCostFallbackMessage. TariffFallbackMessage is intentionally left empty so
+        # the auth step does not produce a tariff_message event.
+        r = await chargepoint_with_pm.set_config_variables_req(
+            "TariffCostCtrlr", "TotalCostFallbackMessage", "Total cost unavailable (offline)"
+        )
+        assert SetVariableResultType(**r.set_variable_result[0]).attribute_status == SetVariableStatusEnumType.accepted
+
+        evse_id1 = 1
+        connector_id = 1
+        id_token = IdTokenType(id_token="DEADBEEF", type=IdTokenTypeEnum.iso14443)
+
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StatusNotification",
+                                           call201.StatusNotification(datetime.now().isoformat(),
+                                                                      ConnectorStatusEnumType.available,
+                                                                      evse_id=evse_id1,
+                                                                      connector_id=connector_id),
+                                           validate_status_notification_201)
+
+        # Start a transaction while online.
+        test_controller.swipe(id_token.id_token)
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "Authorize",
+                                           call201.Authorize(id_token))
+
+        test_controller.plug_in()
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "TransactionEvent",
+                                           {"eventType": "Started"})
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "TransactionEvent",
+                                           {"eventType": "Updated"})
+
+        # Go offline before ending the transaction so that the CS cannot retrieve totalCost.
+        test_controller.disconnect_websocket()
+        await asyncio.sleep(2)
+
+        # End the transaction while offline.
+        test_controller.plug_out()
+
+        # The TotalCostFallbackMessage must be published via session_cost.tariff_message.
+        await self.await_mock_called(tariff_message_mock)
+
+        call_data = tariff_message_mock.call_args[0][0]
+        assert call_data["identifier_type"] == "TransactionId"
+        assert len(call_data["messages"]) == 1
+        assert call_data["messages"][0]["content"] == "Total cost unavailable (offline)"
+
+        # Reconnect so queued TransactionEvent(Ended) can be sent and test teardown completes cleanly.
+        test_controller.connect_websocket()
+        chargepoint_with_pm = await central_system.wait_for_chargepoint(wait_for_bootnotification=False)
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "TransactionEvent",
+                                           {"eventType": "Ended"})


### PR DESCRIPTION

## Describe your changes

Inject TariffFallbackMessage into AuthorizeResponse and TotalCostFallbackMessage at offline transaction end.

When the CSMS provides no personalMessage in the AuthorizeResponse, inject the configured TariffFallbackMessage (or OfflineTariffFallbackMessage when offline) into IdTokenInfo.personalMessage, with additional language variants in customData.personalMessageExtra (California Pricing Spec 4.3.4, I04.FR.01). This ensures that the session cost interface always includes a tariff text after authorization.

When a transaction ends while offline, publish TotalCostFallbackMessage via the tariff_message_callback since no CSMS totalCost response will arrive (I05.FR.02). This ensures that a human-readable tariff message is published and can be displayed at the end of the session

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

