### PR TITLE
Add comparison operations to lib util

### DIFF
--- a/lib/everest/util/include/everest/util/math/comparison.hpp
+++ b/lib/everest/util/include/everest/util/math/comparison.hpp
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <type_traits>
+
+/**
+ * @file util.hpp
+ * @brief Mathematical and Optional utility functions for the EVerest framework.
+ */
+
+namespace everest::lib::util {
+
+// --- Floating Point Utilities ---
+
+/**
+ * @brief Calculates a decimal precision threshold (10^-n).
+ * * This function is used to generate an epsilon value based on a human-readable
+ * number of decimal digits. For example, a precision of 3 returns 0.001.
+ * * @tparam T The floating point type (float, double, long double).
+ * @param digits_of_precision The number of decimal places to consider.
+ * @return constexpr T The calculated threshold value.
+ */
+template <class T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
+constexpr T range_limit(int digits_of_precision) {
+    T result = static_cast<T>(1.0);
+    for (int i = 0; i < digits_of_precision; ++i) {
+        result /= static_cast<T>(10.0);
+    }
+    return result;
+}
+
+/**
+ * @brief Compares two floating point numbers for equality within a decimal precision.
+ * * Uses a fixed epsilon (absolute difference) approach. This is ideal for
+ * physical values (like Amps or Volts) where the scale of the numbers is
+ * relatively consistent and known.
+ * @detail std::abs is not guarantted to be constexpr in C++17, using the tenery operate instead.
+ * * @tparam Prec The number of decimal digits of precision to use for comparison.
+ * @tparam T1, T2 Floating point types of the input values.
+ * @param lhs Left hand side value.
+ * @param rhs Right hand side value.
+ * @return true if the absolute difference is less than 10^-Prec.
+ */
+template <int Prec, class T1, class T2,
+          std::enable_if_t<std::is_floating_point_v<T1> && std::is_floating_point_v<T2>>* = nullptr>
+constexpr bool almost_eq(T1 lhs, T2 rhs) {
+    using Common = std::common_type_t<T1, T2>;
+    const auto val_lhs = static_cast<Common>(lhs);
+    const auto val_rhs = static_cast<Common>(rhs);
+    const auto diff = (val_lhs > val_rhs) ? (val_lhs - val_rhs) : (val_rhs - val_lhs);
+    return diff < range_limit<Common>(Prec);
+}
+/**
+ * @brief Compares two std::optional floating point values for equality.
+ * * Logic follows these rules:
+ * 1. If both contain values, performs almost_eq on the underlying values.
+ * 2. If both are empty, they are considered equal (true).
+ * 3. If only one is empty, they are not equal (false).
+ * * @tparam Prec Decimal digits of precision.
+ * @param lhs Optional value A.
+ * @param rhs Optional value B.
+ */
+template <int Prec, class T> constexpr bool almost_eq(std::optional<T> const& lhs, std::optional<T> const& rhs) {
+    if (lhs.has_value() and rhs.has_value()) {
+        return almost_eq<Prec>(lhs.value(), rhs.value());
+    }
+    return lhs.has_value() == rhs.has_value();
+}
+
+/**
+ * @brief Determines if the difference between two values is within a specific noise level.
+ * * Useful for filtering out jitter in sensor readings or small fluctuations
+ * that should not trigger logic changes.
+ * * @param val_a First value.
+ * @param val_b Second value.
+ * @param noise_level The maximum allowed difference to be considered "noise".
+ * @return true if |val_a - val_b| <= noise_level.
+ */
+template <class T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
+bool in_noise_range(T val_a, T val_b, T noise_level) {
+    return std::abs(val_a - val_b) <= noise_level;
+}
+
+// --- Optional Math Utilities (Minimum) ---
+
+/**
+ * @brief Finds the minimum between two std::optional values.
+ * * In this context, an empty std::optional is treated as "no limit" or "infinity".
+ * * @param a First optional value.
+ * @param b Second optional value.
+ * @return The smaller of the two if both exist, otherwise the existing value.
+ */
+template <class T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
+std::optional<T> min_optional(std::optional<T> const& a, std::optional<T> const& b) {
+    if (not a.has_value()) {
+        return b;
+    }
+    if (not b.has_value()) {
+        return a;
+    }
+    return std::min(a.value(), b.value());
+}
+
+template <class T> T min_optional(T a, std::optional<T> const& b) {
+    if (b.has_value() and b.value() < a) {
+        return b.value();
+    }
+    return a;
+}
+
+template <class T> T min_optional(std::optional<T> const& a, T b) {
+    if (a.has_value() and a.value() < b) {
+        return a.value();
+    }
+    return b;
+}
+
+// --- Optional Math Utilities (Maximum) ---
+
+/**
+ * @brief Finds the maximum between two std::optional values.
+ * * In this context, an empty std::optional is treated as "negative infinity".
+ * * @param a First optional value.
+ * @param b Second optional value.
+ * @return The larger of the two if both exist, otherwise the existing value.
+ */
+template <class T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
+std::optional<T> max_optional(std::optional<T> const& a, std::optional<T> const& b) {
+    if (not a.has_value()) {
+        return b;
+    }
+    if (not b.has_value()) {
+        return a;
+    }
+    return std::max(a.value(), b.value());
+}
+
+template <class T> T max_optional(T a, std::optional<T> const& b) {
+    if (b.has_value() and b.value() > a) {
+        return b.value();
+    }
+    return a;
+}
+
+template <class T> T max_optional(std::optional<T> const& a, T b) {
+    if (a.has_value() and a.value() > b) {
+        return a.value();
+    }
+    return b;
+}
+
+// --- Optional Math Utilities (Clamping) ---
+
+/**
+ * @brief Clamps a value between an optional minimum and an optional maximum.
+ * * If a bound is empty, it is ignored (e.g., if min is empty, only the max is applied).
+ * * @param v The value to clamp.
+ * @param min The lower bound constraint.
+ * @param max The upper bound constraint.
+ * @return The clamped value.
+ */
+template <class T> T clamp_optional(T v, std::optional<T> const& min, std::optional<T> const& max) {
+    T result = v;
+    if (min.has_value() and result < min.value()) {
+        result = min.value();
+    }
+    if (max.has_value() and result > max.value()) {
+        result = max.value();
+    }
+    return result;
+}
+
+} // namespace everest::lib::util

--- a/lib/everest/util/include/everest/util/math/comparison.hpp
+++ b/lib/everest/util/include/everest/util/math/comparison.hpp
@@ -19,21 +19,30 @@ namespace everest::lib::util {
 // --- Floating Point Utilities ---
 
 /**
- * @brief Calculates a decimal precision threshold (10^-n).
- * * This function is used to generate an epsilon value based on a human-readable
- * number of decimal digits. For example, a precision of 3 returns 0.001.
- * * @note Zero or negative values for `digits_of_precision` will result in a
- * threshold of 1.0.
+ * @brief Calculates a threshold based on powers of ten (10^-n).
+ * * * Positive `digits_of_precision` generate fractional limits (e.g., 3 yields 0.001).
+ * * Negative `digits_of_precision` generate magnitude limits (e.g., -2 yields 100.0).
+ * * A value of 0 yields 1.0.
  * * @tparam T The floating point type (float, double, long double).
- * @param digits_of_precision The number of decimal places to consider.
+ * @param digits_of_precision The exponent modifier for the threshold.
  * @return constexpr T The calculated threshold value.
  */
 template <class T, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
 constexpr T range_limit(int digits_of_precision) {
     T result = static_cast<T>(1.0);
-    for (int i = 0; i < digits_of_precision; ++i) {
-        result /= static_cast<T>(10.0);
+
+    if (digits_of_precision > 0) {
+        // Handle fractions (10^-n)
+        for (int i = 0; i < digits_of_precision; ++i) {
+            result /= static_cast<T>(10.0);
+        }
+    } else if (digits_of_precision < 0) {
+        // Handle magnitudes (10^+n)
+        for (int i = 0; i > digits_of_precision; --i) {
+            result *= static_cast<T>(10.0);
+        }
     }
+
     return result;
 }
 

--- a/lib/everest/util/include/everest/util/math/comparison.hpp
+++ b/lib/everest/util/include/everest/util/math/comparison.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 - 2026 Pionix GmbH and Contributors to EVerest
 
+#pragma once
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -8,7 +10,7 @@
 #include <type_traits>
 
 /**
- * @file util.hpp
+ * @file comparison.hpp
  * @brief Mathematical and Optional utility functions for the EVerest framework.
  */
 
@@ -20,6 +22,8 @@ namespace everest::lib::util {
  * @brief Calculates a decimal precision threshold (10^-n).
  * * This function is used to generate an epsilon value based on a human-readable
  * number of decimal digits. For example, a precision of 3 returns 0.001.
+ * * @note Zero or negative values for `digits_of_precision` will result in a
+ * threshold of 1.0.
  * * @tparam T The floating point type (float, double, long double).
  * @param digits_of_precision The number of decimal places to consider.
  * @return constexpr T The calculated threshold value.
@@ -38,7 +42,6 @@ constexpr T range_limit(int digits_of_precision) {
  * * Uses a fixed epsilon (absolute difference) approach. This is ideal for
  * physical values (like Amps or Volts) where the scale of the numbers is
  * relatively consistent and known.
- * @detail std::abs is not guarantted to be constexpr in C++17, using the tenery operate instead.
  * * @tparam Prec The number of decimal digits of precision to use for comparison.
  * @tparam T1, T2 Floating point types of the input values.
  * @param lhs Left hand side value.
@@ -51,6 +54,7 @@ constexpr bool almost_eq(T1 lhs, T2 rhs) {
     using Common = std::common_type_t<T1, T2>;
     const auto val_lhs = static_cast<Common>(lhs);
     const auto val_rhs = static_cast<Common>(rhs);
+    // std::abs is not guaranteed to be constexpr in C++17, using the ternary operate instead.
     const auto diff = (val_lhs > val_rhs) ? (val_lhs - val_rhs) : (val_rhs - val_lhs);
     return diff < range_limit<Common>(Prec);
 }

--- a/lib/everest/util/tests/CMakeLists.txt
+++ b/lib/everest/util/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(everest_util_tests
   async/wrapper_tests.cpp
   enum/EnumFlagsTest.cpp
   enum/EnumFlagsTest_B.cpp
+  math/comparison_tests.cpp
   queue/simple_queue_tests.cpp
   queue/thread_safe_queue_tests.cpp
   queue/thread_safe_bounded_queue_tests.cpp

--- a/lib/everest/util/tests/math/comparison_tests.cpp
+++ b/lib/everest/util/tests/math/comparison_tests.cpp
@@ -11,12 +11,25 @@ TEST_F(ComparisonTest, RangeLimit) {
     EXPECT_NEAR(range_limit<double>(1), 0.1, 1e-9);
     EXPECT_NEAR(range_limit<double>(3), 0.001, 1e-9);
     EXPECT_EQ(range_limit<double>(0), 1.0);
+    EXPECT_DOUBLE_EQ(range_limit<double>(-1), 10.0);
+    EXPECT_DOUBLE_EQ(range_limit<double>(-2), 100.0);
+    EXPECT_DOUBLE_EQ(range_limit<double>(-3), 1000.0);
 }
 
 TEST_F(ComparisonTest, AlmostEqBasic) {
     // 3 digits of precision = 0.001 threshold
     EXPECT_TRUE((almost_eq<3>(1.0001, 1.0002)));
     EXPECT_FALSE((almost_eq<3>(1.0, 1.002)));
+}
+
+TEST_F(ComparisonTest, AlmostEqNegativePrecision) {
+    // -2 digits of precision = 100.0 threshold
+    EXPECT_TRUE((almost_eq<-2>(207.0, 250.0)));
+    EXPECT_FALSE((almost_eq<-2>(100.0, 250.0)));
+
+    // -1 digit of precision = 10.0 threshold
+    EXPECT_TRUE((almost_eq<-1>(15.0, 22.0)));  // diff 7 < 10
+    EXPECT_FALSE((almost_eq<-1>(15.0, 28.0))); // diff 13 > 10
 }
 
 TEST_F(ComparisonTest, AlmostEqOptional) {

--- a/lib/everest/util/tests/math/comparison_tests.cpp
+++ b/lib/everest/util/tests/math/comparison_tests.cpp
@@ -1,0 +1,92 @@
+#include <everest/util/math/comparison.hpp>
+#include <gtest/gtest.h>
+
+namespace everest::lib::util {
+
+class ComparisonTest : public ::testing::Test {};
+
+// --- Floating Point & almost_eq Tests ---
+
+TEST_F(ComparisonTest, RangeLimit) {
+    EXPECT_NEAR(range_limit<double>(1), 0.1, 1e-9);
+    EXPECT_NEAR(range_limit<double>(3), 0.001, 1e-9);
+    EXPECT_EQ(range_limit<double>(0), 1.0);
+}
+
+TEST_F(ComparisonTest, AlmostEqBasic) {
+    // 3 digits of precision = 0.001 threshold
+    EXPECT_TRUE((almost_eq<3>(1.0001, 1.0002)));
+    EXPECT_FALSE((almost_eq<3>(1.0, 1.002)));
+}
+
+TEST_F(ComparisonTest, AlmostEqOptional) {
+    std::optional<double> a = 1.0001;
+    std::optional<double> b = 1.0002;
+    std::optional<double> empty;
+
+    EXPECT_TRUE(almost_eq<3>(a, b));
+    EXPECT_TRUE(almost_eq<3>(empty, empty));
+    EXPECT_FALSE(almost_eq<3>(a, empty));
+}
+
+// --- Min/Max Optional Tests ---
+
+TEST_F(ComparisonTest, MinOptional) {
+    std::optional<float> low = 10.0f;
+    std::optional<float> high = 20.0f;
+    std::optional<float> empty;
+
+    // Optional & Optional
+    EXPECT_EQ(min_optional(low, high).value(), 10.0f);
+    EXPECT_EQ(min_optional(low, empty).value(), 10.0f);
+    EXPECT_FALSE(min_optional(empty, empty).has_value());
+
+    // Value & Optional
+    EXPECT_EQ(min_optional(15.0f, high), 15.0f);
+    EXPECT_EQ(min_optional(25.0f, high), 20.0f);
+    EXPECT_EQ(min_optional(25.0f, empty), 25.0f);
+}
+
+TEST_F(ComparisonTest, MaxOptional) {
+    std::optional<float> low = 10.0f;
+    std::optional<float> empty;
+
+    EXPECT_EQ(max_optional(low, 5.0f), 10.0f);
+    EXPECT_EQ(max_optional(low, 15.0f), 15.0f);
+    EXPECT_EQ(max_optional(empty, 15.0f), 15.0f);
+}
+
+// --- Clamping Tests ---
+
+TEST_F(ComparisonTest, ClampOptional) {
+    std::optional<double> min_limit = 10.0;
+    std::optional<double> max_limit = 20.0;
+    std::optional<double> no_limit;
+
+    // Inside range
+    EXPECT_DOUBLE_EQ(clamp_optional(15.0, min_limit, max_limit), 15.0);
+
+    // Underflow
+    EXPECT_DOUBLE_EQ(clamp_optional(5.0, min_limit, max_limit), 10.0);
+
+    // Overflow
+    EXPECT_DOUBLE_EQ(clamp_optional(25.0, min_limit, max_limit), 20.0);
+
+    // One-sided clamping
+    EXPECT_DOUBLE_EQ(clamp_optional(5.0, no_limit, max_limit), 5.0);
+    EXPECT_DOUBLE_EQ(clamp_optional(25.0, min_limit, no_limit), 25.0);
+
+    // No limits
+    EXPECT_DOUBLE_EQ(clamp_optional(100.0, no_limit, no_limit), 100.0);
+}
+
+// --- Noise Range Tests ---
+
+TEST_F(ComparisonTest, InNoiseRange) {
+    EXPECT_TRUE(in_noise_range(10.0, 10.05, 0.1));
+    EXPECT_FALSE(in_noise_range(10.0, 10.11, 0.1));
+    // Exact boundary
+    EXPECT_TRUE(in_noise_range(10.0, 10.1, 0.1));
+}
+
+} // namespace everest::lib::util


### PR DESCRIPTION
## Describe your changes
Adds utils for comparison of floating point and optional floating point values to everest::lib::util
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

