### PR TITLE
fix(EvseManager,DC): Set default current ramp to 25A/s

### DIFF
--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -429,7 +429,7 @@ config:
     description: >-
       Maximum ampere per second limit for up/down ramping of current in charging loop.
     type: integer
-    default: 5
+    default: 25
 provides:
   evse:
     interface: evse_manager


### PR DESCRIPTION
## Describe your changes

IEC61851-23 requires a minimum current ramp speed for DC charging of 20A/s, so the default of 5A/s is too low. Setting to 25A/s as the standard suggests to support higher ramp speeds. Too high ramp speeds may cause issues with some vehicles as well. Probably needs to be adjusted in the application in the end.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

