### PR TITLE
Add missing module documentation

### DIFF
--- a/modules/API/ocpp_debug_consumer_API/docs/index.rst
+++ b/modules/API/ocpp_debug_consumer_API/docs/index.rst
@@ -1,0 +1,11 @@
+.. _everest_modules_handwritten_ocpp_debug_consumer_API:
+
+.. *******************************************
+.. ocpp_debug_consumer_API
+.. *******************************************
+
+The complete API specification can be found in the
+
+``docs/source/reference/EVerest_API/ocpp_debug_consumer_API.yaml``
+
+file in the source repository, or in the `AsyncAPI HTML documentation <../../../api/ocpp_debug_consumer_API/index.html>`_ automatically generated from it.


### PR DESCRIPTION
## Describe your changes
The handwritten module documentation for the ocpp_debug_consumer_API module, linking to the auto-generated AsyncAPI reference, was missing.

The ocpp_debug_consumer_API had been merged into #1978 earlier.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

