### PR TITLE
fix(v16): use configured OcspRequestInterval instead of hardcoded 12h default

### DIFF
--- a/lib/everest/ocpp/config/v16/config-full.json
+++ b/lib/everest/ocpp/config/v16/config-full.json
@@ -48,7 +48,7 @@
         "UseSslDefaultVerifyPaths": true,
         "VerifyCsmsCommonName": true,
         "VerifyCsmsAllowWildcards": true,
-        "OcspRequestInterval": 604800,
+        "OcspRequestInterval": 43200,
         "SeccLeafSubjectCommonName": "DEPNX100001",
         "SeccLeafSubjectCountry": "DE",
         "SeccLeafSubjectOrganization": "Pionix",

--- a/lib/everest/ocpp/config/v16/profile_schemas/Internal.json
+++ b/lib/everest/ocpp/config/v16/profile_schemas/Internal.json
@@ -284,7 +284,7 @@
             "$comment": "Interval in seconds used to request OCSP revocation status information on the CSO Sub-CA certificates",
             "type": "integer",
             "readOnly": false,
-            "default": 604800,
+            "default": 43200,
             "minimum": 86400
         },
         "SeccLeafSubjectCommonName": {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -29,7 +29,6 @@ const auto ISO15118_PNC_VENDOR_ID = "org.openchargealliance.iso15118pnc";
 const auto CALIFORNIA_PRICING_VENDOR_ID = "org.openchargealliance.costmsg";
 const auto CLIENT_CERTIFICATE_TIMER_INTERVAL = std::chrono::hours(12);
 const auto V2G_CERTIFICATE_TIMER_INTERVAL = std::chrono::hours(12);
-const auto OCSP_REQUEST_TIMER_INTERVAL = std::chrono::hours(12);
 const auto INITIAL_CERTIFICATE_REQUESTS_DELAY = std::chrono::seconds(60);
 const auto WEBSOCKET_INIT_DELAY = std::chrono::seconds(2);
 const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 1000;
@@ -199,7 +198,7 @@ ChargePointImpl::ChargePointImpl(ChargePointConfigurationInterface& cfg, const f
             };
         this->ocsp_request_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() {
             this->update_ocsp_cache();
-            this->ocsp_request_timer->interval(OCSP_REQUEST_TIMER_INTERVAL);
+            this->ocsp_request_timer->interval(std::chrono::seconds(this->configuration.getOcspRequestInterval()));
         });
     }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
@@ -43,7 +43,7 @@ const std::map<std::string, std::string> required_vars_internal = {
     {"VerifyCsmsAllowWildcards", "false"},
     {"MaxMessageSize", "65000"},
     {"MaxCompositeScheduleDuration", "31536000"},
-    {"OcspRequestInterval", "604800"},
+    {"OcspRequestInterval", "43200"},
     {"RetryBackoffRandomRange", "10"},
     {"RetryBackoffRepeatTimes", "3"},
     {"RetryBackoffWaitMinimum", "3"},

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_custom.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_custom.cpp
@@ -27,7 +27,7 @@ const std::map<std::string, std::string> expected_key_value = {
     {"LogMessagesRaw", "false"},
     {"MaxCompositeScheduleDuration", "31536000"},
     {"MaxMessageSize", "65000"},
-    {"OcspRequestInterval", "604800"},
+    {"OcspRequestInterval", "43200"},
     {"RetryBackoffRandomRange", "10"},
     {"RetryBackoffRepeatTimes", "3"},
     {"RetryBackoffWaitMinimum", "3"},

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
@@ -374,10 +374,10 @@ TEST_P(Configuration, MaxMessageSize) {
 TEST_P(Configuration, OcspRequestInterval) {
     ASSERT_NE(get(), nullptr);
     // initial values are from the JSON unit test config files
-    EXPECT_EQ(get()->getOcspRequestInterval(), 604800);
+    EXPECT_EQ(get()->getOcspRequestInterval(), 43200);
     auto kv = get()->getOcspRequestIntervalKeyValue();
     EXPECT_EQ(kv.key, "OcspRequestInterval");
-    EXPECT_EQ(kv.value, "604800");
+    EXPECT_EQ(kv.value, "43200");
     EXPECT_FALSE(kv.readonly);
 
     get()->setOcspRequestInterval(86500);


### PR DESCRIPTION
## Describe your changes

Reopening https://github.com/EVerest/libocpp/pull/1177 in the monorepo as requested by @Pietfried in [this comment](https://github.com/EVerest/libocpp/pull/1177#issuecomment-4112701687).

The OCSP request timer callback in `ChargePointImpl` constructor uses a hardcoded 12-hour interval (`OCSP_REQUEST_TIMER_INTERVAL`) for recurring OCSP cache updates. This means the user-configured `OcspRequestInterval` value (default: 604800s / 7 days, minimum: 86400s / 1 day) is ignored at startup.

When the CSMS later updates the interval via `ChangeConfiguration`, the correct config-based value is used (line ~1973), but the initial timer setup never reads from configuration.

### Changes

- Replace `OCSP_REQUEST_TIMER_INTERVAL` with `std::chrono::seconds(this->configuration.getOcspRequestInterval())` in the timer callback (consistent with the pattern already used in the `ChangeConfiguration` handler)
- Remove the now-unused `OCSP_REQUEST_TIMER_INTERVAL` constant

## Issue ticket number and link

Fixes https://github.com/EVerest/EVerest/issues/1991

## Checklist

- [x] My changes follow the existing code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally with my changes