### PR TITLE
feat(IsoMux): Make proxy device configurable

### DIFF
--- a/modules/EVSE/IsoMux/IsoMux.hpp
+++ b/modules/EVSE/IsoMux/IsoMux.hpp
@@ -34,6 +34,7 @@ struct Conf {
     int tls_timeout;
     int proxy_port_iso2;
     int proxy_port_iso20;
+    std::string proxy_device;
 };
 
 class IsoMux : public Everest::ModuleBase {

--- a/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.cpp
@@ -22,6 +22,7 @@ void ISO15118_chargerImpl::init() {
     /* Configure if_name and auth_mode */
     v2g_ctx->if_name = mod->config.device.data();
     dlog(DLOG_LEVEL_DEBUG, "if_name %s", v2g_ctx->if_name);
+    v2g_ctx->proxy_if_name = mod->config.proxy_device.empty() ? nullptr : mod->config.proxy_device.data();
 
     /* Configure tls_security */
     if (mod->config.tls_security == "force") {

--- a/modules/EVSE/IsoMux/connection/connection.cpp
+++ b/modules/EVSE/IsoMux/connection/connection.cpp
@@ -442,7 +442,7 @@ void* connection_handle(void* data) {
         port = conn->ctx->proxy_port_iso20;
     }
 
-    int proxy_fd = proxy_connect(port);
+    int proxy_fd = proxy_connect(port, conn->ctx->proxy_if_name);
 
     if (proxy_fd > 0) {
         EVLOG_info << "Connected to proxy module for " << (conn->ctx->selected_iso20 ? "ISO-20" : "ISO-2/DIN");

--- a/modules/EVSE/IsoMux/connection/proxy.hpp
+++ b/modules/EVSE/IsoMux/connection/proxy.hpp
@@ -5,18 +5,24 @@
 #ifndef ISOMUX_PROXY_H
 #define ISOMUX_PROXY_H
 
+#include <arpa/inet.h>
 #include <cstddef>
 #include <netinet/in.h>
+#include <unistd.h>
+
+#include "../tools.hpp"
 
 /*!
  * \brief connect to a local V2G server
  * \param port port to connect to
+ * \param proxy_if_name network interface whose IPv6 link-local address is used
+ *        as the connection target.  Pass nullptr (default) to fall back to ::1.
  * \return 0 on failure, otherwise the socket
  */
-inline int proxy_connect(uint16_t port) {
+inline int proxy_connect(uint16_t port, const char* proxy_if_name = nullptr) {
 
     int sock_fd = -1;
-    struct sockaddr_in6 server_addr;
+    struct sockaddr_in6 server_addr {};
 
     /* Create socket for communication with server */
     sock_fd = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
@@ -25,9 +31,20 @@ inline int proxy_connect(uint16_t port) {
         return -1;
     }
 
-    /* Connect to server running on localhost */
     server_addr.sin6_family = AF_INET6;
-    inet_pton(AF_INET6, "::1", &server_addr.sin6_addr);
+
+    if (proxy_if_name != nullptr && proxy_if_name[0] != '\0') {
+        /* Connect to the link-local address of the dedicated proxy interface */
+        if (get_interface_ipv6_address(proxy_if_name, ADDR6_TYPE_LINKLOCAL, &server_addr) != 0) {
+            perror("proxy_connect: get_interface_ipv6_address()");
+            close(sock_fd);
+            return -1;
+        }
+    } else {
+        /* Fall back to loopback */
+        inet_pton(AF_INET6, "::1", &server_addr.sin6_addr);
+    }
+
     server_addr.sin6_port = htons(port);
 
     /* Try to do TCP handshake with server */

--- a/modules/EVSE/IsoMux/manifest.yaml
+++ b/modules/EVSE/IsoMux/manifest.yaml
@@ -39,6 +39,13 @@ config:
       TCP port of the local ISO20 instance
     type: integer
     default: 50000
+  proxy_device:
+    description: >-
+      Network interface used to reach the local ISO2/ISO20 module instances.
+      When set, the proxy connects to the IPv6 link-local address of this
+      interface. Leave empty to use the default loopback (::1).
+    type: string
+    default: ""
 provides:
   charger:
     interface: ISO15118_charger

--- a/modules/EVSE/IsoMux/v2g.hpp
+++ b/modules/EVSE/IsoMux/v2g.hpp
@@ -122,6 +122,7 @@ struct v2g_context {
     uint16_t proxy_port_iso20;
 
     const char* if_name;
+    const char* proxy_if_name;
     struct sockaddr_in6* local_tcp_addr;
     struct sockaddr_in6* local_tls_addr;
 

--- a/modules/EVSE/IsoMux/v2g_ctx.cpp
+++ b/modules/EVSE/IsoMux/v2g_ctx.cpp
@@ -31,6 +31,7 @@ struct v2g_context* v2g_ctx_create(evse_securityIntf* r_security) {
 
     /* interface from config file or options */
     ctx->if_name = "eth1";
+    ctx->proxy_if_name = nullptr;
 
     ctx->network_read_timeout = 1000;
     ctx->network_read_timeout_tls = 5000;


### PR DESCRIPTION

## Describe your changes

* Add a new  config option `proxy_device` to IsoMux. When set, the proxy connects to the IPv6 link-local address of the given interface instead of the hardcoded ::1 loopback; Defaults to empty string to preserve existing behaviour.
* Required for parallel ISO 15118 test execution where multiple IsoMux instances would otherwise conflict on the shared loopback (required by https://github.com/EVerest/EVerest/pull/1940)

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

