### PR TITLE
Fix: RpcApi discharge limit sign

### DIFF
--- a/modules/API/RpcApi/RpcApiRequestHandler.cpp
+++ b/modules/API/RpcApi/RpcApiRequestHandler.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright chargebyte GmbH and Contributors to EVerest
 
+#include <cmath>
 #include <everest/external_energy_limits/external_energy_limits.hpp>
 #include <everest/logging.hpp>
 #include <utils/date.hpp>
@@ -43,13 +44,14 @@ static types::energy::ExternalLimits get_external_limits(float phy_value, bool i
     zero_entry.limits_to_leaves.total_power_W = {0, RPCAPI_MODULE_SOURCE};
 
     if (is_power) {
-        target_entry.limits_to_leaves.total_power_W = {phy_value, RPCAPI_MODULE_SOURCE};
+        target_entry.limits_to_leaves.total_power_W = {std::abs(phy_value), RPCAPI_MODULE_SOURCE};
     } else {
-        target_entry.limits_to_leaves.ac_max_current_A = {phy_value, RPCAPI_MODULE_SOURCE};
+        target_entry.limits_to_leaves.ac_max_current_A = {std::abs(phy_value), RPCAPI_MODULE_SOURCE};
     }
 
     if (phy_value > 0) {
         external_limits.schedule_import = std::vector<types::energy::ScheduleReqEntry>(1, target_entry);
+        external_limits.schedule_export = std::vector<types::energy::ScheduleReqEntry>(1, zero_entry);
     } else {
         external_limits.schedule_export = std::vector<types::energy::ScheduleReqEntry>(1, target_entry);
         external_limits.schedule_import = std::vector<types::energy::ScheduleReqEntry>(1, zero_entry);
@@ -66,19 +68,21 @@ static types::energy::ExternalLimits get_external_limits(float phy_value, bool i
 
     types::energy::ScheduleReqEntry zero_entry;
     zero_entry.timestamp = timestamp;
-    zero_entry.limits_to_leaves.total_power_W = {0, RPCAPI_MODULE_SOURCE};
 
     target_entry.limits_to_leaves.ac_max_phase_count = {phases, RPCAPI_MODULE_SOURCE};
     target_entry.limits_to_leaves.ac_min_phase_count = {phases, RPCAPI_MODULE_SOURCE};
 
     if (is_power) {
-        target_entry.limits_to_leaves.total_power_W = {phy_value, RPCAPI_MODULE_SOURCE};
+        target_entry.limits_to_leaves.total_power_W = {std::abs(phy_value), RPCAPI_MODULE_SOURCE};
+        zero_entry.limits_to_leaves.total_power_W = {0, RPCAPI_MODULE_SOURCE};
     } else {
-        target_entry.limits_to_leaves.ac_max_current_A = {phy_value, RPCAPI_MODULE_SOURCE};
+        target_entry.limits_to_leaves.ac_max_current_A = {std::abs(phy_value), RPCAPI_MODULE_SOURCE};
+        zero_entry.limits_to_leaves.ac_max_current_A = {0, RPCAPI_MODULE_SOURCE};
     }
 
     if (phy_value > 0) {
         external_limits.schedule_import = std::vector<types::energy::ScheduleReqEntry>(1, target_entry);
+        external_limits.schedule_export = std::vector<types::energy::ScheduleReqEntry>(1, zero_entry);
     } else {
         external_limits.schedule_export = std::vector<types::energy::ScheduleReqEntry>(1, target_entry);
         external_limits.schedule_import = std::vector<types::energy::ScheduleReqEntry>(1, zero_entry);


### PR DESCRIPTION
## Describe your changes

This PR aligns RpcApi external limit handling with the API module by normalizing signed current and power limits to absolute values and using the sign only to select import vs. export schedules. Previously, discharge values could not be configured correctly through the RpcApi module.

## Issue ticket number and link
--

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [-] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

