### PR TITLE
Bazel: Extend the everest_env.bzl to handle arbitrary test binaries

### DIFF
--- a/lib/everest/framework/bazel/everest_env.bzl
+++ b/lib/everest/framework/bazel/everest_env.bzl
@@ -26,15 +26,18 @@ def _everest_env(ctx):
 
     symlinks = {}
     files = []
+    py_toolchain = ctx.toolchains["@bazel_tools//tools/python:toolchain_type"]
+    py_interpreter = py_toolchain.py3_runtime.interpreter.dirname.removeprefix("external/")
     py_imports = []
     py_transitive_sources = []
-    modules = ctx.attr.modules + ctx.attr.test_modules
-    for mod in modules:
-        # Python modules get a special handling.
+
+    # Python modules get a special handling.
+    for mod in ctx.attr.modules + ctx.attr.test_modules:
         if PyInfo in mod:
             py_imports.extend(mod[PyInfo].imports.to_list())
             py_transitive_sources.extend(mod[PyInfo].transitive_sources.to_list())
 
+    for mod in ctx.attr.modules + ctx.attr.test_modules:
         # Find the manifest in the data_runfiles and use its path as prefix.
         manifest = [
             file
@@ -59,10 +62,12 @@ def _everest_env(ctx):
             if not file.path.startswith(prefix)
         ]
 
-    symlinks.update({"bin/manager": ctx.attr.manager[DefaultInfo].files.to_list()[0]})
+    config_file = ctx.attr.config_file[DefaultInfo].files.to_list()[0]
+    config_path = "etc/everest/{0}".format(config_file.basename)
+    symlinks.update({"bin/manager_impl": ctx.attr.manager[DefaultInfo].files.to_list()[0]})
     symlinks.update(
         {
-            "etc/everest/config-sil.yaml": ctx.attr.config_file[DefaultInfo].files.to_list()[0],
+            config_path: config_file,
         },
     )
     symlinks.update(
@@ -109,42 +114,30 @@ def _everest_env(ctx):
     # For the executable we need to export the python specific variables by
     # hand.
     script = ctx.actions.declare_file("manager_wrapper.{}".format(ctx.label.name))
-    script_content = """
+    script_content = """\
 #!/bin/sh
-set -ex
-export PATH=$(realpath $(PYTHON3)):$PATH
-declare -a PYTHON_ROOTS=({})
-for i in "${{PYTHON_ROOTS[@]}}"
-do
-    export PYTHONPATH=$(realpath ../$i):$PYTHONPATH
-done
-    """.format(" ".join(py_imports))
+set -eu
+SCRIPT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+export PATH="$SCRIPT_DIR/{py_interpreter}:$PATH"
+{pythonpath_lines}
+""".format(
+        py_interpreter = py_interpreter.removeprefix("external/"),
+        pythonpath_lines = "\n".join([
+            'export PYTHONPATH="$SCRIPT_DIR/{0}:$PYTHONPATH"'.format(imp)
+            for imp in py_imports
+        ]),
+    )
+
     if ctx.attr._is_test:
         script_content += """
-bin/manager --prefix . --config etc/everest/config-sil.yaml --check
-        """
-
-        if ctx.attr.test_script and ctx.attr.test_script[DefaultInfo].files.to_list():
-            script_content += """
-bin/manager --prefix . --config etc/everest/config-sil.yaml &
-PID_MANAGER=$!
-{}
-
-if ps -p $PID_MANAGER > /dev/null
-then
-    kill $PID_MANAGER
-else
-    echo "manager died"
-    exit -1
-fi
-
-            """.format(ctx.attr.test_script[DefaultInfo].files.to_list()[0].path)
-            files.append(ctx.attr.test_script[DefaultInfo].files.to_list()[0])
+exec bin/manager_impl --prefix . --config {0} --check
+        """.format(config_path)
     else:
         script_content += """
-bin/manager --prefix . --config etc/everest/config-sil.yaml
-        """
+exec bin/manager_impl "$@"
+""".format(config_path)
     ctx.actions.write(script, script_content, is_executable = True)
+    symlinks.update({"bin/manager": script})
 
     runfiles = ctx.runfiles(
         symlinks = symlinks,
@@ -167,9 +160,9 @@ ATTRS = {
     "config_file": attr.label(
         doc = """
 The EVerest configuration file. It will be linked to
-`/etc/everest/config-sil.yaml`""",
-            allow_single_file = True,
-        ),
+`/etc/everest/<basename>`""",
+        allow_single_file = True,
+    ),
     "manager": attr.label(
         doc = "The EVerest manager.",
         default = Label("//lib/everest/framework:manager"),
@@ -210,10 +203,10 @@ The list of targets with the EVerest modules under test.
 
 The rule validates that the set of provided modules matches the set of modules
 defined in the given `config_file`.""",
-            allow_files = False,
-        ),
+        allow_files = False,
+    ),
     "test_modules": attr.label_list(
-            doc = """
+        doc = """
 The list of targets with EVerest modules which are only enabled by the
 `everest.testing` framework.
 
@@ -222,10 +215,6 @@ The rule will not enforce that these modules are defined in the given
         """,
         allow_files = False,
     ),
-    "test_script": attr.label(
-        allow_single_file = True,
-        doc = "A test script which will run after the manager starts.",
-    ),
     "_validation_tool": attr.label(
         default = Label("//lib/everest/framework/bazel/validate"),
         executable = True,
@@ -233,7 +222,7 @@ The rule will not enforce that these modules are defined in the given
     ),
     "_is_test": attr.bool(
         default = False,
-        doc = "Indicates if target is test target to validate config"
+        doc = "Indicates if target is test target to validate config",
     ),
 }
 
@@ -246,7 +235,8 @@ everest_impl_env = rule(
 
 _everest_impl_test = rule(
     implementation = _everest_env,
-    attrs = dict(ATTRS, _is_test=attr.bool(default=True)),
+    attrs = dict(ATTRS, _is_test = attr.bool(default = True)),
+    toolchains = ["@bazel_tools//tools/python:toolchain_type"],
     doc = """
 Creates an EVerest Test.
 
@@ -263,7 +253,6 @@ everest_test(
     name = "my_everest_env",
     modules = [":ModuleFoo", ":ModuleBar"],
     config_file = ":my_config.yaml",
-    toolchains = ["@rules_python//python:current_py_toolchain"],
     test_script=":my_test_script",
 )
 
@@ -280,7 +269,7 @@ def everest_test(name, target_compatible_with = [], **kwargs):
     _everest_impl_test(
         name = name,
         target_compatible_with = CROSS_PYTHON_INCOMPATIBLE + target_compatible_with,
-        **kwargs,
+        **kwargs
     )
 
 def everest_env(name, target_compatible_with = [], **kwargs):
@@ -299,7 +288,6 @@ def everest_env(name, target_compatible_with = [], **kwargs):
         name = "my_everest_env",
         modules = [":ModuleFoo", ":ModuleBar"],
         config_file = ":my_config.yaml",
-        toolchains = ["@rules_python//python:current_py_toolchain"],
     )
 
     ```
@@ -310,6 +298,6 @@ def everest_env(name, target_compatible_with = [], **kwargs):
     everest_impl_env(
         name = name,
         target_compatible_with = CROSS_PYTHON_INCOMPATIBLE + target_compatible_with,
-        **kwargs,
+        **kwargs
     )
     everest_test(name = name + "__manager_test", tags = ["exclusive"], target_compatible_with = target_compatible_with, **kwargs)

--- a/lib/everest/framework/bazel/validate/src/main.rs
+++ b/lib/everest/framework/bazel/validate/src/main.rs
@@ -38,7 +38,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config_modules: std::collections::HashSet<_> = config
         .active_modules
         .into_values()
-        .map(|m| m.module)
+        .filter_map(|m| {
+            if &m.module == "ProbeModule" {
+                None
+            } else {
+                Some(m.module)
+            }
+        })
         .collect();
 
     let given_modules: std::collections::HashSet<_> = args.modules.into_iter().collect();

--- a/lib/everest/framework/everestrs/tests/modules/BUILD.bazel
+++ b/lib/everest/framework/everestrs/tests/modules/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["smoke_test.sh"])

--- a/lib/everest/framework/everestrs/tests/modules/RsCmdErrors/BUILD.bazel
+++ b/lib/everest/framework/everestrs/tests/modules/RsCmdErrors/BUILD.bazel
@@ -1,48 +1,52 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("//lib/everest/framework/bazel:everest_env.bzl", "everest_test", "everest_env")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//lib/everest/framework/bazel:everest_env.bzl", "everest_env", "everest_test")
 load("//lib/everest/framework/bazel:modules_def.bzl", "rs_everest_module")
 
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
-    edition="2021",
     build_script_env = {
         "EVEREST_CORE_ROOT": "../..",
     },
+    data = [
+        "manifest.yaml",
+        "//lib/everest/framework/everestrs/tests/errors",
+        "//lib/everest/framework/everestrs/tests/interfaces",
+        "//lib/everest/framework/everestrs/tests/types",
+    ],
+    edition = "2021",
     deps = [
         "//lib/everest/framework/everestrs/everestrs-build",
-    ],
-    data= [
-        "//lib/everest/framework/everestrs/tests/types",
-        "//lib/everest/framework/everestrs/tests/interfaces",
-        "//lib/everest/framework/everestrs/tests/errors",
-        "manifest.yaml",
     ],
 )
 
 rust_binary(
     name = "RsCmdErrorsBinary",
     srcs = glob(["src/**/*.rs"]),
-    visibility = ["//visibility:public"],
     edition = "2021",
+    visibility = ["//visibility:public"],
     deps = [
-        "@everest_framework_crate_index//:log",
-        "//lib/everest/framework/everestrs/everestrs",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
         ":build_script",
+        "//lib/everest/framework/everestrs/everestrs",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
+        "@everest_framework_crate_index//:log",
     ],
 )
 
 rust_test(
     name = "RsCmdErrorsTest",
-    edition="2021",
-    deps = ["@everest_framework_crate_index//:mockall",],
-    proc_macro_deps = ["@everest_framework_crate_index//:mockall_double",],
     srcs = [],
-    crate_features = ["mockall", "mockall_double"],
     crate = ":RsCmdErrorsBinary",
+    crate_features = [
+        "mockall",
+        "mockall_double",
+    ],
+    edition = "2021",
+    proc_macro_deps = ["@everest_framework_crate_index//:mockall_double"],
+    deps = ["@everest_framework_crate_index//:mockall"],
 )
 
 rs_everest_module(
@@ -53,20 +57,15 @@ rs_everest_module(
 
 everest_env(
     name = "integration_env",
+    config_file = "config.yaml",
     modules = [
         ":RsCmdErrors",
     ],
-    config_file = "config.yaml",
-    toolchains = ["@rules_python//python:current_py_toolchain"],
 )
 
-everest_test(
+sh_test(
     name = "integration_test",
-    modules = [
-        ":RsCmdErrors",
-    ],
-    config_file = "config.yaml",
-    test_script = "test.sh",
+    srcs = ["//lib/everest/framework/everestrs/tests/modules:smoke_test.sh"],
+    data = [":integration_env"],
     tags = ["exclusive"],
-    toolchains = ["@rules_python//python:current_py_toolchain"],
 )

--- a/lib/everest/framework/everestrs/tests/modules/RsCmdErrors/test.sh
+++ b/lib/everest/framework/everestrs/tests/modules/RsCmdErrors/test.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-echo "This is a test script"
-sleep 5
-echo "Exit"

--- a/lib/everest/framework/everestrs/tests/modules/RsErrors/BUILD.bazel
+++ b/lib/everest/framework/everestrs/tests/modules/RsErrors/BUILD.bazel
@@ -1,46 +1,47 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("//lib/everest/framework/bazel:everest_env.bzl", "everest_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//lib/everest/framework/bazel:everest_env.bzl", "everest_env")
 load("//lib/everest/framework/bazel:modules_def.bzl", "rs_everest_module")
 
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
-    edition="2021",
     build_script_env = {
         "EVEREST_CORE_ROOT": "../..",
     },
+    data = [
+        "manifest.yaml",
+        "//lib/everest/framework/everestrs/tests/errors",
+        "//lib/everest/framework/everestrs/tests/interfaces",
+        "//lib/everest/framework/everestrs/tests/types",
+    ],
+    edition = "2021",
     deps = [
         "//lib/everest/framework/everestrs/everestrs-build",
-    ],
-    data= [
-        "//lib/everest/framework/everestrs/tests/types",
-        "//lib/everest/framework/everestrs/tests/interfaces",
-        "//lib/everest/framework/everestrs/tests/errors",
-        "manifest.yaml",
     ],
 )
 
 rust_binary(
     name = "RsErrors",
     srcs = glob(["src/**/*.rs"]),
-    visibility = ["//visibility:public"],
     edition = "2021",
+    visibility = ["//visibility:public"],
     deps = [
-        "@everest_framework_crate_index//:log",
-        "//lib/everest/framework/everestrs/everestrs",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
         ":build_script",
+        "//lib/everest/framework/everestrs/everestrs",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
+        "@everest_framework_crate_index//:log",
     ],
 )
 
 rust_test(
     name = "RsErrorsTest",
-    deps = ["@everest_framework_crate_index//:serde_yaml"],
-    edition="2021",
     srcs = [],
     crate = ":RsErrors",
+    edition = "2021",
+    deps = ["@everest_framework_crate_index//:serde_yaml"],
 )
 
 rs_everest_module(
@@ -49,13 +50,17 @@ rs_everest_module(
     manifest = "manifest.yaml",
 )
 
-everest_test(
-    name = "integration_test",
+everest_env(
+    name = "integration_env",
+    config_file = "config.yaml",
     modules = [
         ":RsErrorsModule",
     ],
-    config_file = "config.yaml",
-    toolchains = ["@rules_python//python:current_py_toolchain"],
-    test_script = "test.sh",
-    tags = ["exclusive"]
+)
+
+sh_test(
+    name = "integration_test",
+    srcs = ["//lib/everest/framework/everestrs/tests/modules:smoke_test.sh"],
+    data = [":integration_env"],
+    tags = ["exclusive"],
 )

--- a/lib/everest/framework/everestrs/tests/modules/RsErrors/test.sh
+++ b/lib/everest/framework/everestrs/tests/modules/RsErrors/test.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-echo "This is a test script"
-sleep 5
-echo "Exit"

--- a/lib/everest/framework/everestrs/tests/modules/RsErrorsCompilationChecks/BUILD.bazel
+++ b/lib/everest/framework/everestrs/tests/modules/RsErrorsCompilationChecks/BUILD.bazel
@@ -1,42 +1,42 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
-    edition="2021",
     build_script_env = {
         "EVEREST_CORE_ROOT": "../..",
     },
+    data = [
+        "manifest.yaml",
+        "//lib/everest/framework/everestrs/tests/errors",
+        "//lib/everest/framework/everestrs/tests/interfaces",
+        "//lib/everest/framework/everestrs/tests/types",
+    ],
+    edition = "2021",
     deps = [
         "//lib/everest/framework/everestrs/everestrs-build",
-    ],
-    data= [
-        "//lib/everest/framework/everestrs/tests/types",
-        "//lib/everest/framework/everestrs/tests/interfaces",
-        "//lib/everest/framework/everestrs/tests/errors",
-        "manifest.yaml",
     ],
 )
 
 rust_binary(
     name = "RsErrorsCompilation",
     srcs = glob(["src/**/*.rs"]),
-    visibility = ["//visibility:public"],
     edition = "2021",
+    visibility = ["//visibility:public"],
     deps = [
-        "@everest_framework_crate_index//:log",
-        "//lib/everest/framework/everestrs/everestrs",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
         ":build_script",
+        "//lib/everest/framework/everestrs/everestrs",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
+        "@everest_framework_crate_index//:log",
     ],
 )
 
 rust_test(
     name = "RsErrorsCompilationTest",
-    deps = ["@everest_framework_crate_index//:serde_yaml"],
-    edition="2021",
     srcs = [],
     crate = ":RsErrorsCompilation",
+    edition = "2021",
+    deps = ["@everest_framework_crate_index//:serde_yaml"],
 )

--- a/lib/everest/framework/everestrs/tests/modules/RsExample/BUILD.bazel
+++ b/lib/everest/framework/everestrs/tests/modules/RsExample/BUILD.bazel
@@ -1,48 +1,54 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_python//python:defs.bzl", "py_test")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("//lib/everest/framework/bazel:everest_env.bzl", "everest_test", "everest_env")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("//applications/utils:requirements.bzl", "requirement")
+load("//lib/everest/framework/bazel:everest_env.bzl", "everest_env", "everest_test")
 load("//lib/everest/framework/bazel:modules_def.bzl", "rs_everest_module")
+load("//third-party/bazel/toolchains:defs.bzl", "CROSS_PYTHON_INCOMPATIBLE")
 
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
-    edition="2021",
     build_script_env = {
         "EVEREST_CORE_ROOT": "../..",
     },
+    data = [
+        "manifest.yaml",
+        "//lib/everest/framework/everestrs/tests/errors",
+        "//lib/everest/framework/everestrs/tests/interfaces",
+        "//lib/everest/framework/everestrs/tests/types",
+    ],
+    edition = "2021",
     deps = [
         "//lib/everest/framework/everestrs/everestrs-build",
-    ],
-    data= [
-        "//lib/everest/framework/everestrs/tests/types",
-        "//lib/everest/framework/everestrs/tests/interfaces",
-        "//lib/everest/framework/everestrs/tests/errors",
-        "manifest.yaml",
     ],
 )
 
 rust_binary(
     name = "RsExampleBinary",
     srcs = glob(["src/**/*.rs"]),
-    visibility = ["//visibility:public"],
     edition = "2021",
+    visibility = ["//visibility:public"],
     deps = [
-        "@everest_framework_crate_index//:log",
-        "//lib/everest/framework/everestrs/everestrs",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
         ":build_script",
+        "//lib/everest/framework/everestrs/everestrs",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
+        "@everest_framework_crate_index//:log",
     ],
 )
 
 rust_test(
     name = "RsExampleTest",
-    edition="2021",
-    deps = ["@everest_framework_crate_index//:mockall",],
-    proc_macro_deps = ["@everest_framework_crate_index//:mockall_double",],
     srcs = [],
-    crate_features = ["mockall", "mockall_double"],
     crate = ":RsExampleBinary",
+    crate_features = [
+        "mockall",
+        "mockall_double",
+    ],
+    edition = "2021",
+    proc_macro_deps = ["@everest_framework_crate_index//:mockall_double"],
+    deps = ["@everest_framework_crate_index//:mockall"],
 )
 
 rs_everest_module(
@@ -52,21 +58,34 @@ rs_everest_module(
 )
 
 everest_env(
-    name = "integration_env",
+    name = "config_env",
+    config_file = "config.yaml",
     modules = [
         ":RsExample",
     ],
-    config_file = "config.yaml",
-    toolchains = ["@rules_python//python:current_py_toolchain"],
 )
 
-everest_test(
-    name = "integration_test",
+# Integration tests for RsExample using Python's everest.testing framework.
+# Uses ProbeModule to verify RsExample publishes variables and handles commands.
+py_test(
+    name = "py_mocked_test",
+    srcs = glob(["py_tests/**/*.py"]),
+    data = ["config_probe_env"],
+    legacy_create_init = False,
+    main = "py_tests/mocked_test.py",
+    target_compatible_with = CROSS_PYTHON_INCOMPATIBLE,
+    deps = [
+        "//applications/utils/everest-testing",
+        "//lib/everest/framework/everestpy/src:framework",
+        requirement("pytest"),
+        requirement("pytest-asyncio"),
+    ],
+)
+
+everest_env(
+    name = "config_probe_env",
+    config_file = "config_probe.yaml",
     modules = [
         ":RsExample",
     ],
-    config_file = "config.yaml",
-    test_script = "test.sh",
-    tags = ["exclusive"],
-    toolchains = ["@rules_python//python:current_py_toolchain"],
 )

--- a/lib/everest/framework/everestrs/tests/modules/RsExample/config_probe.yaml
+++ b/lib/everest/framework/everestrs/tests/modules/RsExample/config_probe.yaml
@@ -1,0 +1,14 @@
+# Test config for regression tests for the framework.
+active_modules:
+  example_0:
+    module: RsExample
+    connections:
+      a_friend:
+        - module_id: example_1
+          implementation_id: foobar
+  example_1:
+    module: ProbeModule
+    connections:
+      a_friend:
+        - module_id: example_0
+          implementation_id: foobar

--- a/lib/everest/framework/everestrs/tests/modules/RsExample/py_tests/conftest.py
+++ b/lib/everest/framework/everestrs/tests/modules/RsExample/py_tests/conftest.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--everest-prefix",
+        action="store",
+        default=".",
+        help="everest prefix path; default = '.' (for bazel runfiles)",
+    )

--- a/lib/everest/framework/everestrs/tests/modules/RsExample/py_tests/mocked_test.py
+++ b/lib/everest/framework/everestrs/tests/modules/RsExample/py_tests/mocked_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+"""
+Smoke test for RsExample using the Python testing framework.
+
+Launches EVerest with RsExample (example_0) and a ProbeModule (example_1),
+then verifies that RsExample publishes max_current(123.0) on ready and
+responds to the uses_something command.
+"""
+
+import asyncio
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from everest.testing.core_utils.common import Requirement
+from everest.testing.core_utils.fixtures import *
+from everest.testing.core_utils.everest_core import EverestCore
+from everest.testing.core_utils.probe_module import ProbeModule
+
+
+async def wait_for_mock(mock, timeout=10):
+    """Poll until mock has been called or timeout."""
+    for _ in range(int(timeout * 10)):
+        if mock.called:
+            return
+        await asyncio.sleep(0.1)
+    raise TimeoutError(f"Mock not called within {timeout}s")
+
+
+@pytest.mark.asyncio
+@pytest.mark.probe_module(
+    connections={"a_friend": [Requirement("example_0", "foobar")]},
+    module_id="example_1",
+)
+@pytest.mark.everest_core_config("config_probe.yaml")
+async def test_rs_example_publishes_max_current(everest_core: EverestCore):
+    """Verify that RsExample publishes max_current(123.0) on ready."""
+    everest_core.start()
+
+    probe = ProbeModule(everest_core.get_runtime_session(), module_id="example_1")
+
+    max_current_mock = Mock()
+    probe.subscribe_variable("a_friend", "max_current", max_current_mock)
+
+    probe.implement_command("foobar", "uses_something", lambda args: True)
+
+    probe.start()
+    await probe.wait_to_be_ready(timeout=10)
+
+    await wait_for_mock(max_current_mock, timeout=10)
+    value = max_current_mock.call_args[0][0]
+    assert value == 123.0, f"Expected max_current=123.0, got {value}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.probe_module(
+    connections={"a_friend": [Requirement("example_0", "foobar")]},
+    module_id="example_1",
+)
+@pytest.mark.everest_core_config("config_probe.yaml")
+async def test_rs_example_uses_something(everest_core: EverestCore):
+    """Verify that we can call uses_something on RsExample."""
+    everest_core.start()
+
+    probe = ProbeModule(everest_core.get_runtime_session(), module_id="example_1")
+
+    probe.implement_command("foobar", "uses_something", lambda args: True)
+
+    probe.start()
+    await probe.wait_to_be_ready(timeout=10)
+
+    result = await probe.call_command("a_friend", "uses_something", {"key": "hello"})
+    # The C++ binding may return None for boolean results; verify at least no exception.
+    assert result is None or result == True, f"Unexpected result: {result!r}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"] + sys.argv[1:]))

--- a/lib/everest/framework/everestrs/tests/modules/RsExample/test.sh
+++ b/lib/everest/framework/everestrs/tests/modules/RsExample/test.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-echo "This is a test script"
-sleep 5
-echo "Exit"

--- a/lib/everest/framework/everestrs/tests/modules/RsIgnore/BUILD.bazel
+++ b/lib/everest/framework/everestrs/tests/modules/RsIgnore/BUILD.bazel
@@ -1,37 +1,38 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("//lib/everest/framework/bazel:everest_env.bzl", "everest_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//lib/everest/framework/bazel:everest_env.bzl", "everest_env")
 load("//lib/everest/framework/bazel:modules_def.bzl", "rs_everest_module")
 
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
-    edition="2021",
     build_script_env = {
         "EVEREST_CORE_ROOT": "../..",
     },
+    data = [
+        "manifest.yaml",
+        "//lib/everest/framework/everestrs/tests/errors",
+        "//lib/everest/framework/everestrs/tests/interfaces",
+        "//lib/everest/framework/everestrs/tests/types",
+    ],
+    edition = "2021",
     deps = [
         "//lib/everest/framework/everestrs/everestrs-build",
-    ],
-    data= [
-        "//lib/everest/framework/everestrs/tests/types",
-        "//lib/everest/framework/everestrs/tests/interfaces",
-        "//lib/everest/framework/everestrs/tests/errors",
-        "manifest.yaml",
     ],
 )
 
 rust_binary(
     name = "RsIgnoreBinary",
     srcs = glob(["src/**/*.rs"]),
-    visibility = ["//visibility:public"],
     edition = "2021",
+    visibility = ["//visibility:public"],
     deps = [
-        "@everest_framework_crate_index//:log",
-        "//lib/everest/framework/everestrs/everestrs",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
         ":build_script",
+        "//lib/everest/framework/everestrs/everestrs",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
+        "@everest_framework_crate_index//:log",
     ],
 )
 
@@ -41,13 +42,17 @@ rs_everest_module(
     manifest = "manifest.yaml",
 )
 
-everest_test(
-    name = "integration_test",
+everest_env(
+    name = "integration_env",
+    config_file = "config.yaml",
     modules = [
         ":RsIgnore",
     ],
-    config_file = "config.yaml",
-    toolchains = ["@rules_python//python:current_py_toolchain"],
-    test_script = "test.sh",
-    tags = ["exclusive"]
+)
+
+sh_test(
+    name = "integration_test",
+    srcs = ["//lib/everest/framework/everestrs/tests/modules:smoke_test.sh"],
+    data = [":integration_env"],
+    tags = ["exclusive"],
 )

--- a/lib/everest/framework/everestrs/tests/modules/RsIgnore/test.sh
+++ b/lib/everest/framework/everestrs/tests/modules/RsIgnore/test.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-echo "This is a test script"
-sleep 5
-echo "Exit"

--- a/lib/everest/framework/everestrs/tests/modules/RsOnReadyRaceCondition/BUILD.bazel
+++ b/lib/everest/framework/everestrs/tests/modules/RsOnReadyRaceCondition/BUILD.bazel
@@ -1,37 +1,38 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("//lib/everest/framework/bazel:everest_env.bzl", "everest_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//lib/everest/framework/bazel:everest_env.bzl", "everest_env")
 load("//lib/everest/framework/bazel:modules_def.bzl", "rs_everest_module")
 
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
-    edition="2021",
     build_script_env = {
         "EVEREST_CORE_ROOT": "../..",
     },
+    data = [
+        "manifest.yaml",
+        "//lib/everest/framework/everestrs/tests/errors",
+        "//lib/everest/framework/everestrs/tests/interfaces",
+        "//lib/everest/framework/everestrs/tests/types",
+    ],
+    edition = "2021",
     deps = [
         "//lib/everest/framework/everestrs/everestrs-build",
-    ],
-    data= [
-        "//lib/everest/framework/everestrs/tests/types",
-        "//lib/everest/framework/everestrs/tests/interfaces",
-        "//lib/everest/framework/everestrs/tests/errors",
-        "manifest.yaml",
     ],
 )
 
 rust_binary(
     name = "RsOnReadyRaceConditionBinary",
     srcs = glob(["src/**/*.rs"]),
-    visibility = ["//visibility:public"],
     edition = "2021",
+    visibility = ["//visibility:public"],
     deps = [
-        "@everest_framework_crate_index//:log",
-        "//lib/everest/framework/everestrs/everestrs",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
         ":build_script",
+        "//lib/everest/framework/everestrs/everestrs",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
+        "@everest_framework_crate_index//:log",
     ],
 )
 
@@ -41,13 +42,17 @@ rs_everest_module(
     manifest = "manifest.yaml",
 )
 
-everest_test(
-    name = "integration_test",
+everest_env(
+    name = "integration_env",
+    config_file = "config.yaml",
     modules = [
         ":RsOnReadyRaceCondition",
     ],
-    config_file = "config.yaml",
-    toolchains = ["@rules_python//python:current_py_toolchain"],
-    test_script = "test.sh",
-    tags = ["exclusive"]
+)
+
+sh_test(
+    name = "integration_test",
+    srcs = ["//lib/everest/framework/everestrs/tests/modules:smoke_test.sh"],
+    data = [":integration_env"],
+    tags = ["exclusive"],
 )

--- a/lib/everest/framework/everestrs/tests/modules/RsOnReadyRaceCondition/test.sh
+++ b/lib/everest/framework/everestrs/tests/modules/RsOnReadyRaceCondition/test.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-echo "This is a test script"
-sleep 5
-echo "Exit"

--- a/lib/everest/framework/everestrs/tests/modules/RsOptionalConnection/BUILD.bazel
+++ b/lib/everest/framework/everestrs/tests/modules/RsOptionalConnection/BUILD.bazel
@@ -1,21 +1,21 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
 cargo_build_script(
     name = "build_script",
     srcs = ["build.rs"],
-    edition="2021",
     build_script_env = {
         "EVEREST_CORE_ROOT": "../..",
     },
+    data = [
+        "manifest.yaml",
+        "//lib/everest/framework/everestrs/tests/errors",
+        "//lib/everest/framework/everestrs/tests/interfaces",
+        "//lib/everest/framework/everestrs/tests/types",
+    ],
+    edition = "2021",
     deps = [
         "//lib/everest/framework/everestrs/everestrs-build",
-    ],
-    data= [
-        "//lib/everest/framework/everestrs/tests/types",
-        "//lib/everest/framework/everestrs/tests/interfaces",
-        "//lib/everest/framework/everestrs/tests/errors",
-        "manifest.yaml",
     ],
 )
 
@@ -23,13 +23,13 @@ cargo_build_script(
 rust_binary(
     name = "RsOptionalConnection",
     srcs = glob(["src/**/*.rs"]),
-    visibility = ["//visibility:public"],
     edition = "2021",
+    visibility = ["//visibility:public"],
     deps = [
-        "@everest_framework_crate_index//:log",
-        "//lib/everest/framework/everestrs/everestrs",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
-        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
         ":build_script",
+        "//lib/everest/framework/everestrs/everestrs",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_bridge",
+        "//lib/everest/framework/everestrs/everestrs:everestrs_sys",
+        "@everest_framework_crate_index//:log",
     ],
 )

--- a/lib/everest/framework/everestrs/tests/modules/smoke_test.sh
+++ b/lib/everest/framework/everestrs/tests/modules/smoke_test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -ex
+
+echo "Starting the manager"
+
+bin/manager --prefix . --config etc/everest/config.yaml &
+PID_MANAGER=$!
+
+sleep 5
+echo "Exit"
+
+if ps -p $PID_MANAGER > /dev/null
+then
+    kill $PID_MANAGER
+else
+    echo "manager died"
+    exit 1
+fi


### PR DESCRIPTION
## Describe your changes

In the preparation for https://github.com/EVerest/EVerest/pull/1948 we want to extend the Bazel's eversest_env to handle arbitrary binaries. The everest_env setup up an environment which can be passed as data to a `py_test` (demonstrated in the pr), to a `sh_test` (also demonstrated in the pr) or to a `rs_test`  - this will be part of the linked pr. It should of course also work with `cc_test` - if we ever build support for that
