### PR TITLE
Bazel: comply with the 10Gb github cache limit

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,3 +3,10 @@
 # explicit load() statements for rules_cc, rules_python, and rules_shell.
 # This flag can be removed once all dependencies are updated for Bazel 9.
 build --incompatible_autoload_externally=+cc_library,+cc_binary,+cc_test,+cc_shared_library,+cc_import,+cc_toolchain,+py_binary,+py_library,+py_test,+sh_binary,+sh_library,+sh_test
+
+# CI config: smaller binaries, shared repo cache, disk cache for artifacts.
+build:ci -c opt
+build:ci --strip=always
+build:ci --copt=-g0
+build:ci --repository_cache=~/.cache/bazel-repo-cache
+build:ci --disk_cache=~/.cache/bazel-disk-cache

--- a/.github/workflows/job_bazel-build-test.yaml
+++ b/.github/workflows/job_bazel-build-test.yaml
@@ -14,14 +14,14 @@ jobs:
     steps:
       - run: echo branch name is ${{ github.ref }}
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v6
       - name: Mount bazel cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: "~/.cache/bazel"
-          key: ${{ runner.os }}-bazel-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'third-party/bazel/*') }}
+          key: ${{ runner.os }}-bazel-native-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'third-party/bazel/*') }}
           restore-keys: |
-            ${{ runner.os }}-bazel-
+            ${{ runner.os }}-bazel-native-
       - name: Install and start mosquitto
         run: |
           sudo apt-get update

--- a/.github/workflows/job_bazel-build-test.yaml
+++ b/.github/workflows/job_bazel-build-test.yaml
@@ -15,13 +15,20 @@ jobs:
       - run: echo branch name is ${{ github.ref }}
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Mount bazel cache
+      - name: Mount bazel repo cache
         uses: actions/cache@v5
         with:
-          path: "~/.cache/bazel"
-          key: ${{ runner.os }}-bazel-native-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'third-party/bazel/*') }}
+          path: "~/.cache/bazel-repo-cache"
+          key: ${{ runner.os }}-bazel-repo-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'third-party/bazel/*') }}
           restore-keys: |
-            ${{ runner.os }}-bazel-native-
+            ${{ runner.os }}-bazel-repo-
+      - name: Mount bazel disk cache
+        uses: actions/cache@v5
+        with:
+          path: "~/.cache/bazel-disk-cache"
+          key: ${{ runner.os }}-bazel-disk-native-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'third-party/bazel/*') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-disk-native-
       - name: Install and start mosquitto
         run: |
           sudo apt-get update
@@ -29,6 +36,6 @@ jobs:
           sudo systemctl start mosquitto
       - name: Build all
         run: >
-          bazelisk build //...
+          bazelisk build --config=ci //...
       - name: Test all
-        run: bazelisk test //... --test_output=errors
+        run: bazelisk test --config=ci //... --test_output=errors

--- a/.github/workflows/job_bazel-cross-build.yaml
+++ b/.github/workflows/job_bazel-cross-build.yaml
@@ -18,15 +18,14 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v6
       - name: Mount bazel cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: "~/.cache/bazel"
           key: ${{ runner.os }}-bazel-cross-${{ inputs.platform }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'third-party/bazel/*') }}
           restore-keys: |
             ${{ runner.os }}-bazel-cross-${{ inputs.platform }}-
-            ${{ runner.os }}-bazel-
       - name: Build all
         run: >
           bazelisk build //...

--- a/.github/workflows/job_bazel-cross-build.yaml
+++ b/.github/workflows/job_bazel-cross-build.yaml
@@ -19,15 +19,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Mount bazel cache
+      - name: Mount bazel repo cache
         uses: actions/cache@v5
         with:
-          path: "~/.cache/bazel"
-          key: ${{ runner.os }}-bazel-cross-${{ inputs.platform }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'third-party/bazel/*') }}
+          path: "~/.cache/bazel-repo-cache"
+          key: ${{ runner.os }}-bazel-repo-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'third-party/bazel/*') }}
           restore-keys: |
-            ${{ runner.os }}-bazel-cross-${{ inputs.platform }}-
+            ${{ runner.os }}-bazel-repo-
+      - name: Mount bazel disk cache
+        uses: actions/cache@v5
+        with:
+          path: "~/.cache/bazel-disk-cache"
+          key: ${{ runner.os }}-bazel-disk-${{ inputs.platform }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'third-party/bazel/*') }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-disk-${{ inputs.platform }}-
       - name: Build all
         run: >
-          bazelisk build //...
+          bazelisk build --config=ci //...
           --platforms=//third-party/bazel/toolchains:${{ inputs.platform }}
           --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=false


### PR DESCRIPTION
## Describe your changes

The addition of the cross compilation runners overloaded the github cache size. Every build added ~3Gb of cache and the limit in github is 10Gb. 

This pr 
1. removes the fallback key from the cross compilation runners to the common cache
2. avoids in native builds to falling back to cross compilation cache
3. adds a ci config to more aggressively strip symbols from our artifacts (libocpp.a went from 350M to 60M)

This alone does still not suffice to actually comply with the 10Gb cache size limit and we still see cache evictions from valid caches.

The majority of the cache comes from the repo cache (~1.7Gb) - which is shared across all architectures. Splitting the cache into a shared repo cache and a dedicated disk-cache should help us to respect the 10Gb cache limit
