### PR TITLE
Implement shutdown handling for modules

### DIFF
--- a/applications/utils/ev-dev-tools/src/ev_cli/__init__.py
+++ b/applications/utils/ev-dev-tools/src/ev_cli/__init__.py
@@ -1,2 +1,2 @@
 """EVerest command line utility."""
-__version__ = '0.7.3'
+__version__ = '0.8.0'

--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/interface-Impl.cpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/interface-Impl.cpp.j2
@@ -13,6 +13,10 @@ void {{ info.class_name }}::init() {
 void {{ info.class_name }}::ready() {
 
 }
+
+void {{ info.class_name }}::shutdown() {
+
+}
 {% for cmd in cmds %}
 
 {{ handle_cmd_signature(cmd, info.class_name, '::'+info.interface) }}{

--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/interface-Impl.hpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/interface-Impl.hpp.j2
@@ -3,7 +3,7 @@
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('3', 'marked regions will be kept') }}
+{{ print_template_info('4', 'marked regions will be kept') }}
 
 #include <{{ info.base_class_header }}>
 
@@ -49,6 +49,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     {{ insert_block(info.blocks.private_defs, indent=4) }}
 };

--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/interface-Impl.hpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/interface-Impl.hpp.j2
@@ -49,6 +49,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown() override;
 
     {{ insert_block(info.blocks.private_defs, indent=4) }}
 };

--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/ld-ev.cpp.j2
@@ -90,6 +90,11 @@ void LdEverest::ready() {
     mod_ptr->ready();
 }
 
+void LdEverest::shutdown() {
+    EVLOG_debug << "shutdown() called on module {{ info.name }}";
+    mod_ptr->shutdown();
+}
+
 void register_module_adapter(Everest::ModuleAdapter module_adapter) {
     adapter = std::move(module_adapter);
 }
@@ -165,7 +170,7 @@ int main(int argc, char* argv[]) {
 
     auto module_loader = Everest::ModuleLoader(argc, argv, Everest::ModuleCallbacks(
         module::register_module_adapter, module::everest_register,
-        module::LdEverest::init, module::LdEverest::ready),
+        module::LdEverest::init, module::LdEverest::ready, module::LdEverest::shutdown),
         {PROJECT_NAME, PROJECT_VERSION, GIT_VERSION});
 
     return module_loader.initialize();

--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/ld-ev.hpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/ld-ev.hpp.j2
@@ -16,6 +16,7 @@ namespace module {
 struct LdEverest {
     static void init(ModuleConfigs module_configs, const ModuleInfo& info);
     static void ready();
+    static void shutdown();
 };
 
 void register_module_adapter(Everest::ModuleAdapter module_adapter);

--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/ld-ev.hpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/ld-ev.hpp.j2
@@ -3,7 +3,7 @@
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('3') }}
+{{ print_template_info('4') }}
 
 #include <framework/ModuleAdapter.hpp>
 #include <framework/everest.hpp>
@@ -16,6 +16,7 @@ namespace module {
 struct LdEverest {
     static void init(ModuleConfigs module_configs, const ModuleInfo& info);
     static void ready();
+    static void shutdown();
 };
 
 void register_module_adapter(Everest::ModuleAdapter module_adapter);

--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/module.cpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/module.cpp.j2
@@ -16,4 +16,10 @@ void {{ info.class_name }}::ready() {
     {% endfor %}
 }
 
+void {{ info.class_name }}::shutdown() {
+    {% for impl in provides %}
+    invoke_shutdown(*p_{{ impl.id }});
+    {% endfor %}
+}
+
 } // namespace module

--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/module.hpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/module.hpp.j2
@@ -97,6 +97,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     {{ insert_block(info.blocks.private_defs, indent=4) }}
 

--- a/applications/utils/ev-dev-tools/src/ev_cli/templates/module.hpp.j2
+++ b/applications/utils/ev-dev-tools/src/ev_cli/templates/module.hpp.j2
@@ -3,7 +3,7 @@
 #ifndef {{ info.hpp_guard }}
 #define {{ info.hpp_guard }}
 
-{{ print_template_info('2', 'marked regions will be kept') }}
+{{ print_template_info('3', 'marked regions will be kept') }}
 
 #include "{{ info.ld_ev_header }}"
 
@@ -97,6 +97,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     {{ insert_block(info.blocks.private_defs, indent=4) }}
 

--- a/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_environment_setup.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_environment_setup.py
@@ -108,6 +108,7 @@ class EverestTestEnvironmentSetup:
                  evse_security_config: Optional[EverestEnvironmentEvseSecurityConfiguration] = None,
                  persistent_store_config: Optional[EverestEnvironmentPersistentStoreConfiguration] = None,
                  standalone_module: Optional[Union[str, List[str]]] = None,
+                 manager_extra_args: Optional[List[str]] = None,
                  everest_config_strategies: Optional[List[EverestConfigAdjustmentStrategy]] = None
                  ) -> None:
         self._core_config = core_config
@@ -116,6 +117,7 @@ class EverestTestEnvironmentSetup:
         self._evse_security_config = evse_security_config
         self._persistent_store_config = persistent_store_config
         self._standalone_module = standalone_module
+        self._manager_extra_args = manager_extra_args or []
         if not self._standalone_module and self._probe_config:
             self._standalone_module = self._probe_config.module_id
         self._additional_everest_config_strategies = everest_config_strategies if everest_config_strategies else []
@@ -134,6 +136,7 @@ class EverestTestEnvironmentSetup:
                                          everest_configuration_adjustment_strategies=configuration_strategies +
                                          self._additional_everest_config_strategies,
                                          standalone_module=self._standalone_module,
+                                         manager_extra_args=self._manager_extra_args,
                                          tmp_path=tmp_path)
 
         if self._ocpp_config:

--- a/applications/utils/everest-testing/src/everest/testing/core_utils/everest_core.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/everest_core.py
@@ -13,7 +13,6 @@ import tempfile
 from typing import List, Optional, Union, Dict
 import uuid
 import yaml
-import selectors
 from signal import SIGINT
 
 from everest.framework import RuntimeSession
@@ -27,7 +26,32 @@ from ._configuration.everest_configuration_strategies.probe_module_configuration
 
 STARTUP_TIMEOUT = 30
 
-Connections = dict[str, List[Requirement]]
+
+class ManagerStatusFifo:
+    """Status-fifo line constants written by the EVerest manager (without trailing newline)."""
+
+    ALL_MODULES_STARTED = "ALL_MODULES_STARTED"
+    WAITING_FOR_STANDALONE_MODULES = "WAITING_FOR_STANDALONE_MODULES"
+
+    MANAGER_INITIALIZING = "MANAGER_INITIALIZING"
+    MANAGER_STARTING_MODULES = "MANAGER_STARTING_MODULES"
+    MANAGER_RUNNING = "MANAGER_RUNNING"
+    MANAGER_RESTART_REQUESTED = "MANAGER_RESTART_REQUESTED"
+    MANAGER_CRASH_SHUTDOWN_IN_PROGRESS = "MANAGER_CRASH_SHUTDOWN_IN_PROGRESS"
+    MANAGER_SHUTDOWN_REQUESTED = "MANAGER_SHUTDOWN_REQUESTED"
+    MANAGER_FORCE_TERMINATING = "MANAGER_FORCE_TERMINATING"
+    MANAGER_SHUTDOWN_FINALIZING = "MANAGER_SHUTDOWN_FINALIZING"
+    MANAGER_IDLE = "MANAGER_IDLE"
+    MANAGER_EXITING = "MANAGER_EXITING"
+
+    SIGINT_RECEIVED = "SIGINT_RECEIVED"
+    ALL_MODULES_STOPPED_CLEAN = "ALL_MODULES_STOPPED_CLEAN"
+    FORCE_SHUTDOWN_TIMEOUT = "FORCE_SHUTDOWN_TIMEOUT"
+    CRASH_RECOVERY_EXHAUSTED = "CRASH_RECOVERY_EXHAUSTED"
+
+    @staticmethod
+    def crash_recovery_attempt(attempt: int, max_attempts: int) -> str:
+        return f"CRASH_RECOVERY_ATTEMPT:{attempt}/{max_attempts}"
 
 
 class StatusFifoListener:
@@ -35,42 +59,107 @@ class StatusFifoListener:
         if not status_fifo_path.exists():
             os.mkfifo(status_fifo_path)
 
-        # note: open doesn't support non-blocking, so we use os.open to get the fd
-        fd = os.open(status_fifo_path, flags=(os.O_RDONLY | os.O_NONBLOCK))
-        self._file_obj = open(fd)
+        # Open RDWR|NONBLOCK (Linux) so we never see a spurious EOF from
+        # read() before the manager opens its write end. With O_RDONLY|
+        # O_NONBLOCK, a read with no writers returns 0 immediately, which
+        # made start() abort and then hang in a blocking stderr readline.
+        self._fd = os.open(status_fifo_path, flags=(os.O_RDWR | os.O_NONBLOCK))
+        self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
+        self._pending_lines: list[str] = []
+        self._read_buffer = b""
 
-        selector = selectors.DefaultSelector()
-        selector.register(self._file_obj, selectors.EVENT_READ)
-        self._selector = selector
+    def _append_lines(self, data: bytes) -> None:
+        if not data:
+            return
+        self._read_buffer += data
+        while b"\n" in self._read_buffer:
+            line, self._read_buffer = self._read_buffer.split(b"\n", 1)
+            if line:
+                self._pending_lines.append(line.decode())
+        self._condition.notify_all()
+
+    def _read_available(self) -> Optional[bool]:
+        """Read available fifo bytes.
+
+        Caller must hold ``self._condition``.
+
+        Returns:
+            True when data was read,
+            None when no bytes were available (or a spurious empty read).
+        """
+        read_any = False
+        while True:
+            try:
+                chunk = os.read(self._fd, 4096)
+            except BlockingIOError:
+                break
+            if chunk == b"":
+                # Should not happen with our RDWR keep-alive; treat as no data
+                # rather than "writer closed" so start() does not abort early.
+                break
+            read_any = True
+            self._append_lines(chunk)
+        return True if read_any else None
+
+    def _drain_pending(self, match_status: list[str]) -> list[str]:
+        matched_status = [status for status in match_status if status in self._pending_lines]
+        if matched_status:
+            self._pending_lines = [line for line in self._pending_lines if line not in matched_status]
+        return matched_status
+
+    def _take_pending_matches(self, match_status: list[str]) -> list[str]:
+        matched_status = self._drain_pending(match_status)
+        if matched_status:
+            return matched_status
+        if not match_status and self._pending_lines:
+            received_status = self._pending_lines
+            self._pending_lines = []
+            return received_status
+        return []
+
+    def discard_pending(self) -> None:
+        """Drop buffered fifo lines so subsequent waits/assertions only see new events."""
+        with self._condition:
+            self._pending_lines.clear()
+            self._read_buffer = b""
+
+    def close(self) -> None:
+        """Release the fifo read end."""
+        with self._condition:
+            try:
+                os.close(self._fd)
+            except OSError:
+                pass
+            self._condition.notify_all()
 
     def wait_for_status(self, timeout: float, match_status: list[str]) -> Optional[list[str]]:
         if match_status is None:
             match_status = []
 
-        end_time = time.time() + timeout
+        end_time = time.monotonic() + timeout
+        poll_interval = 0.05
 
-        while True:
-            for _key, _mask in self._selector.select(timeout):
-                data = self._file_obj.read()
-                if len(data) == 0:
-                    return None
-
-                # plural!
-                received_status = data.splitlines()
-
-                if len(match_status) == 0:
-                    # we're not trying to match any messages
-                    return received_status
-
-                # return the filtered matched messages
-                matched_status = [status for status in match_status if status in received_status]
-                if len(matched_status) > 0:
+        with self._condition:
+            while True:
+                matched_status = self._take_pending_matches(match_status)
+                if matched_status:
                     return matched_status
 
-            timeout = end_time - time.time()
+                timeout_remaining = end_time - time.monotonic()
+                if timeout_remaining <= 0:
+                    return []
 
-            if timeout < 0:
-                return []
+                self._read_available()
+                matched_status = self._take_pending_matches(match_status)
+                if matched_status:
+                    return matched_status
+
+                # Wake when another waiter reads new lines, or poll the fifo periodically.
+                self._condition.wait(timeout=min(timeout_remaining, poll_interval))
+
+
+Connections = dict[str, List[Requirement]]
 
 
 class EverestCore:
@@ -81,6 +170,7 @@ class EverestCore:
                  prefix_path: Path,
                  config_path: Path = None,
                  standalone_module: Optional[Union[str, List[str]]] = None,
+                 manager_extra_args: Optional[List[str]] = None,
                  everest_configuration_adjustment_strategies: Optional[
                      List[EverestConfigAdjustmentStrategy]] = None,
                  tmp_path: Optional[Path] = None) -> None:
@@ -131,6 +221,22 @@ class EverestCore:
         self.all_modules_started_event = threading.Event()
 
         self._standalone_module = standalone_module
+        self._manager_extra_args = manager_extra_args or []
+
+        # Open the fifo read end before manager startup so tests can observe early
+        # lifecycle messages while start() is running in a background thread.
+        self.status_listener = StatusFifoListener(self._status_fifo_path)
+
+    def _reset_status_listener(self) -> None:
+        """Reopen the status fifo read end for a new manager process.
+
+        After a manager exits the write end is closed and readers observe EOF.
+        Reopening before the next start avoids treating that stale EOF as the end
+        of the new run and ensures select() wakes when the new writer connects.
+        """
+        if self.status_listener is not None:
+            self.status_listener.close()
+        self.status_listener = StatusFifoListener(self._status_fifo_path)
 
     @property
     def everest_config(self) -> Dict:
@@ -167,7 +273,6 @@ class EverestCore:
         self.test_connections = test_connections if test_connections != None else {}
         self._create_testing_user_config()
 
-        self.status_listener = StatusFifoListener(self._status_fifo_path)
         logging.info(self._status_fifo_path)
 
         args = [str(manager_path.resolve()), '--config', str(self.everest_config_path),
@@ -180,10 +285,19 @@ class EverestCore:
             for s in standalone_module:
                 args.extend(['--standalone', s])
 
+        if self._manager_extra_args:
+            args.extend(self._manager_extra_args)
+
         logging.info(" ".join(args))
 
         logging.info('Starting EVerest...')
         logging.info('  '.join(args))
+
+        # Reopen the fifo only when restarting after a previous manager run.
+        # Resetting on every start() breaks lifecycle tests that call start() in a
+        # background thread while the main thread waits on the same listener.
+        if self.process is not None:
+            self._reset_status_listener()
 
         self.process = subprocess.Popen(
             args, cwd=self.prefix_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -191,16 +305,52 @@ class EverestCore:
         self.log_reader_thread = Thread(target=self.read_everest_log)
         self.log_reader_thread.start()
 
-        expected_status = 'ALL_MODULES_STARTED' if standalone_module == None else 'WAITING_FOR_STANDALONE_MODULES'
+        expected_status = ManagerStatusFifo.ALL_MODULES_STARTED if standalone_module == None else ManagerStatusFifo.WAITING_FOR_STANDALONE_MODULES
 
         status = self.status_listener.wait_for_status(STARTUP_TIMEOUT, [expected_status])
-        if status == None or len(status) == 0:
-            self.read_everest_log()
-            raise TimeoutError("Timeout while waiting for EVerest to start")
+        if not status:
+            # Do not call read_everest_log() here: the log-reader thread already
+            # owns stderr, and a blocking readline on a live process hangs forever.
+            raise TimeoutError(
+                f"Timeout while waiting for EVerest to start "
+                f"(expected status-fifo message(s): {expected_status})"
+            )
 
         logging.info("EVerest has started")
-        if expected_status == 'ALL_MODULES_STARTED':
+        if expected_status == ManagerStatusFifo.ALL_MODULES_STARTED:
             self.all_modules_started_event.set()
+
+    def wait_for_manager_status(
+        self,
+        status: Union[str, List[str]],
+        timeout_s: float = 60.0,
+    ) -> None:
+        if isinstance(status, str):
+            status = [status]
+        result = self.status_listener.wait_for_status(timeout_s, status)
+        if not result:
+            raise TimeoutError(f"Timeout waiting for manager status fifo message(s): {status}")
+
+    def discard_manager_status_pending(self) -> None:
+        """Drop buffered status-fifo lines (see StatusFifoListener.discard_pending)."""
+        self.status_listener.discard_pending()
+
+    def assert_no_manager_status(
+        self,
+        status: Union[str, List[str]],
+        timeout_s: float = 5.0,
+        *,
+        ignore_pending: bool = False,
+    ) -> None:
+        if isinstance(status, str):
+            status = [status]
+        if ignore_pending:
+            self.status_listener.discard_pending()
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            result = self.status_listener.wait_for_status(0.05, status)
+            if result:
+                raise AssertionError(f"Unexpected manager status fifo message(s): {result}")
 
     def read_everest_log(self):
         while self.process.poll() == None:

--- a/applications/utils/everest-testing/src/everest/testing/core_utils/fixtures.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/fixtures.py
@@ -37,13 +37,42 @@ def probe_module_config(request) -> Optional[EverestEnvironmentProbeModuleConfig
 @pytest.fixture
 def core_config(request) -> EverestEnvironmentCoreConfiguration:
     everest_prefix = Path(request.config.getoption("--everest-prefix"))
+    if not everest_prefix.is_absolute():
+        # Accept both invocation styles:
+        # - from repo root: --everest-prefix build/dist
+        # - from tests dir: --everest-prefix ../build/dist
+        candidates = [
+            (Path.cwd() / everest_prefix).resolve(),
+            (request.config.rootpath / everest_prefix).resolve(),
+            (request.config.rootpath.parent / everest_prefix).resolve(),
+        ]
+        everest_prefix = next((path for path in candidates if path.exists()), candidates[0])
 
     marker = request.node.get_closest_marker("everest_core_config")
     if marker is None:
         everest_config_path = None  # config auto-detected by everest core
     else:
-        path = Path('/etc/everest') if everest_prefix == '/usr' else everest_prefix / 'etc/everest'
-        everest_config_path = path / marker.args[0]
+        config_name = marker.args[0]
+        installed_config_dir = Path('/etc/everest') if everest_prefix == '/usr' else everest_prefix / 'etc/everest'
+        installed_config_path = installed_config_dir / config_name
+        if installed_config_path.exists():
+            everest_config_path = installed_config_path
+        else:
+            # Local dev runs can point at a prefix that is not freshly installed.
+            # In that case, fall back to repository config directories.
+            repo_config_candidates = [
+                request.config.rootpath / "config" / config_name,
+                request.config.rootpath.parent / "config" / config_name,
+            ]
+            matching_repo_path = next((path for path in repo_config_candidates if path.exists()), None)
+            if matching_repo_path is not None:
+                everest_config_path = matching_repo_path
+            else:
+                searched_paths = "', '".join(str(path.parent) for path in [installed_config_path] + repo_config_candidates)
+                raise FileNotFoundError(
+                    f"EVerest config '{config_name}' not found in '{searched_paths}'. "
+                    "Install/update the build output or provide a valid config marker."
+                )
 
     return EverestEnvironmentCoreConfiguration(
         everest_core_path=everest_prefix,
@@ -100,6 +129,7 @@ def everest_environment(request,
                  everest_config_strategies
                  ):
     standalone_module_marker = request.node.get_closest_marker('standalone_module')
+    manager_args_marker = request.node.get_closest_marker('everest_manager_args')
 
     environment_setup = EverestTestEnvironmentSetup(
         core_config=core_config,
@@ -108,6 +138,7 @@ def everest_environment(request,
         evse_security_config=evse_security_config,
         persistent_store_config=persistent_store_config,
         standalone_module=list(standalone_module_marker.args) if standalone_module_marker else None,
+        manager_extra_args=list(manager_args_marker.args) if manager_args_marker else None,
         everest_config_strategies=everest_config_strategies
     )
 

--- a/applications/utils/everest-testing/src/everest/testing/core_utils/probe_module.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/probe_module.py
@@ -28,6 +28,13 @@ class ProbeModule:
         self._mod = m
         self._ready_event = threading.Event()
         self._started = False
+        self._mod.shutdown_handler(self._shutdown)
+
+    def _shutdown(self):
+        """
+        The probe module should not need a shutdown method
+        """
+        pass
 
     def start(self):
         """

--- a/lib/everest/framework/docs/ManagerLifecycle.md
+++ b/lib/everest/framework/docs/ManagerLifecycle.md
@@ -1,0 +1,151 @@
+# Manager lifecycle state machine
+
+State machine diagram: [`ManagerLifecycleStateMachine.mmd`](ManagerLifecycleStateMachine.mmd)
+
+`ManagerState` (defined in `src/manager.hpp`) is the **phase** of the main-loop (what the manager
+is doing right now). `ShutdownCause` records **why** a shutdown or drain was started; it is kept
+across transient states (for example through `ForceTerminating` / `ShutdownFinalizing`) so the next
+step can distinguish normal stop, admin-driven restart, and crash recovery.
+
+Timeouts and limits that drive transitions are defined in `src/manager.cpp` (for example graceful
+shutdown duration before `ForceTerminating`, and the cap on automatic crash restarts).
+
+## Graceful shutdown is opt-in (`--graceful-shutdown`)
+
+By default the manager **does not** publish the MQTT shutdown signal and does not wait for modules
+to exit on their own: whenever the shutdown flow starts (SIGINT/SIGTERM, unexpected module exit,
+admin restart), remaining module processes are terminated immediately via `ForceTerminating`
+(SIGTERM, escalating to SIGKILL after a grace period). This matches the pre-lifecycle manager
+behavior and keeps teardown fast while most modules do not yet shut down cleanly.
+
+With `--graceful-shutdown`, the manager first publishes the MQTT shutdown signal so modules can run
+their registered shutdown handlers and exit by themselves, and only escalates to `ForceTerminating`
+after the graceful shutdown timeout (`SHUTDOWN_TIMEOUT_MS`). The state machine is identical in both
+modes; without the flag the drain deadline is simply zero and the `FORCE_SHUTDOWN_TIMEOUT` status
+event is not emitted (immediate termination is expected, not a timeout).
+
+The sections below describe the graceful (`--graceful-shutdown`) flow; in default mode the
+MQTT shutdown publish is skipped and the force-terminate escalation happens immediately.
+
+## Startup (happy path)
+
+- `Idle` (initial C++ object state) → `Initializing` when `run()` begins.
+- `Initializing` → `StartingModules` when module processes are spawned and ready-handlers are
+  registered (`handle_start_modules()`).
+- `StartingModules` → `Running` when every non-ignored module has published **ready** on MQTT
+  (and standalone handling rules are satisfied). If SIGINT/shutdown is already in progress when
+  the last ready arrives, the transition to `Running` is **skipped** on purpose.
+
+## Normal shutdown (SIGINT / SIGTERM)
+
+- First signal (no modules): cleanup and → `Exiting` with success.
+- First signal (modules running): `shutdown_cause` = `Normal`, → `ShutdownRequested`, MQTT
+  shutdown is published; modules run their shutdown handlers and return so the process can exit;
+  child exits are collected while draining (see **Module process exit** below).
+- When **all** module children have exited while still in a shutdown-flow state, the manager
+  → `ShutdownFinalizing`, then typically `handle_finish_normal_shutdown()`:
+  - If this shutdown was due to the first SIGINT/SIGTERM (`sigint_received_`): → `Exiting` with
+    success after cleanup.
+  - Otherwise the manager can return to **`Idle`** (modules down, manager loop still running;
+    another SIGINT/SIGTERM is required to exit the process in that mode).
+- **Second** SIGINT/SIGTERM after the first was already handled: treated as "terminate now" →
+  `Exiting` with failure (user abort).
+
+## Unexpected module exit ("crash" path)
+
+- While in `StartingModules` or `Running`, if a **module** child exits unexpectedly:
+  `shutdown_cause` = `Crash`; graceful shutdown is initiated (MQTT shutdown publish) → first
+  `ShutdownRequested`, then immediately → `CrashShutdownInProgress` for that path.
+- The same drain / timeout / force-terminate machinery as normal shutdown applies while children
+  remain.
+- When all children are gone: → `ShutdownFinalizing`. If `--recover-module-crashes` was passed
+  on the command line and crash recovery is still allowed (see `MAX_UNEXPECTED_MODULE_RESTARTS`
+  in `src/manager.cpp`), the manager reloads config and goes back to **`StartingModules`** via
+  `handle_restart_modules_after_shutdown()`. If the restart cap is exceeded with recovery enabled,
+  it finishes crash cleanup and → **`Idle`**. Without `--recover-module-crashes` (default), the
+  manager shuts down remaining modules gracefully and then **exits** the process.
+
+## Admin "restart modules"
+
+- Controller IPC can request restart while modules are still running. The manager then →
+  `RestartRequested` and sets `shutdown_cause` = `Restart`. MQTT shutdown is used to drain
+  modules; when all module children have exited, either `advance_lifecycle_state_if_ready()` or the
+  `ShutdownFinalizing` path reloads config and returns to **`StartingModules`**.
+
+## Shutdown timeout and forced kill
+
+- From `ShutdownRequested`, `CrashShutdownInProgress`, or `RestartRequested`, if shutdown lasts
+  longer than the configured graceful timeout, the manager → `ForceTerminating` and sends
+  SIGTERM to remaining module children, then after a further grace period SIGKILL if needed.
+- When all tracked children are gone (including after `ECHILD` bookkeeping recovery), the flow
+  continues to `ShutdownFinalizing` and the same `ShutdownCause`-driven finalization as above.
+
+## `ForceTerminating` and `ShutdownFinalizing`
+
+- `ForceTerminating`: in-flight forced teardown of stubborn module processes.
+- `ShutdownFinalizing`: all module PIDs are gone; the manager decides exit vs idle vs restart
+  based on `ShutdownCause` and `sigint_received_` as described above.
+
+## Expected vs exceptional transitions
+
+**Expected:** linear startup; clean idle shutdown after SIGINT; controlled restart after admin
+request; optional bounded crash recovery restart loop when `--recover-module-crashes` is set;
+manager exit after unexpected module exit when that flag is omitted; timeout escalation only
+when modules miss their shutdown deadline.
+
+**Worth noting:** transitions are applied from the main loop (`waitpid`, lifecycle advance,
+controller IPC, signal polling, shutdown timer). Re-entrancy is avoided by keeping shared state
+on `Manager` and using explicit gates (for example "do not go to `Running` if shutdown already
+started").
+
+## Module process exit
+
+When the manager publishes the global MQTT shutdown signal, each module's `Everest::handle_shutdown()`
+runs the registered shutdown callback (generated `LdEverest::shutdown()` for C++ modules), then
+disconnects MQTT. That stops the module's main loop; `main()` returns and the child process exits
+normally. Module authors should tear down threads and resources in `shutdown()` and **return**
+promptly — the framework does not call `exit()` from module base classes.
+
+If a module does not implement `shutdown()` on an interface implementation, the default logs a
+warning and returns; the process still exits once MQTT disconnect completes.
+
+Legacy module headers that predate the shutdown template may omit a module-level `shutdown()`
+entirely; in that case `ModuleBase::shutdown()` logs a warning and returns (no impl hooks run
+until the module is regenerated).
+
+If a module blocks in `shutdown()` or keeps other threads running, the manager escalates after the
+graceful shutdown timeout (`SHUTDOWN_TIMEOUT_MS`) to SIGTERM and, if needed, SIGKILL (see
+**Shutdown timeout and forced kill** above).
+
+## Status fifo (`--status-fifo`)
+
+When a path is passed to `--status-fifo`, the manager writes single-line messages (each terminated
+with `\n`) for lifecycle state transitions and selected semantic events. Tests and tooling can
+wait on these lines instead of parsing manager logs.
+
+**State notifications** (one per `ManagerState` transition, constants in `utils/status_fifo.hpp`):
+
+- `MANAGER_INITIALIZING`, `MANAGER_STARTING_MODULES`, `MANAGER_RUNNING`, `MANAGER_RESTART_REQUESTED`,
+  `MANAGER_CRASH_SHUTDOWN_IN_PROGRESS`, `MANAGER_SHUTDOWN_REQUESTED`, `MANAGER_FORCE_TERMINATING`,
+  `MANAGER_SHUTDOWN_FINALIZING`, `MANAGER_IDLE`, `MANAGER_EXITING`
+
+**Startup / readiness** (unchanged):
+
+- `ALL_MODULES_STARTED` — all non-ignored modules reported ready (also implies `MANAGER_RUNNING`
+  when the transition was not skipped).
+- `WAITING_FOR_STANDALONE_MODULES` — manager-spawned modules are ready; standalone modules still
+  pending.
+
+**Semantic events** (not always paired 1:1 with a state name):
+
+- `SIGINT_RECEIVED` — first SIGINT/SIGTERM handled by the manager.
+- `ALL_MODULES_STOPPED_CLEAN` — normal shutdown after SIGINT with no unclean module exits
+  (in practice only reachable with `--graceful-shutdown`; force-terminated modules exit by signal).
+- `FORCE_SHUTDOWN_TIMEOUT` — graceful shutdown deadline exceeded; force-terminate path started.
+  Only emitted with `--graceful-shutdown`; in default mode immediate termination is expected and
+  not reported as a timeout.
+- `CRASH_RECOVERY_ATTEMPT:n/max` — crash recovery reload/restart (`--recover-module-crashes`).
+- `CRASH_RECOVERY_EXHAUSTED` — recovery cap exceeded; manager will stay idle after shutdown.
+
+Python helpers live in `everest.testing.core_utils.everest_core` (`ManagerStatusFifo`,
+`EverestCore.wait_for_manager_status`, `EverestCore.assert_no_manager_status`).

--- a/lib/everest/framework/docs/ManagerLifecycleStateMachine.mmd
+++ b/lib/everest/framework/docs/ManagerLifecycleStateMachine.mmd
@@ -1,0 +1,81 @@
+%% EVerest manager — ManagerState lifecycle state machine
+%% Narrative: lib/everest/framework/docs/ManagerLifecycle.md
+%% Transitions / timeouts: lib/everest/framework/src/manager.cpp
+
+stateDiagram-v2
+    direction TB
+
+    state "Startup" as G_BOOT {
+        [*] --> Idle : construct
+        Idle --> Initializing : run()
+        Initializing --> StartingModules : handle_start_modules(), spawn,\nMQTT ready handlers
+        StartingModules --> Running : all non-ignored modules ready\n(skip if shutdown already started)
+    }
+
+    state "Shutdown / drain" as G_DRAIN {
+        ShutdownRequested --> ForceTerminating : drain deadline exceeded\n(SHUTDOWN_TIMEOUT_MS with --graceful-shutdown,\nimmediate otherwise)
+        CrashShutdownInProgress --> ForceTerminating : drain deadline exceeded\n(SHUTDOWN_TIMEOUT_MS with --graceful-shutdown,\nimmediate otherwise)
+        RestartRequested --> ForceTerminating : drain deadline exceeded\n(SHUTDOWN_TIMEOUT_MS with --graceful-shutdown,\nimmediate otherwise)
+        ShutdownRequested --> CrashShutdownInProgress : crash path\n(immediate after MQTT shutdown)
+    }
+
+    state "Finalize" as G_END {
+        ShutdownFinalizing --> Exiting : SIGINT shutdown finish\n(cleanup, EXIT_SUCCESS)
+        Exiting --> [*] : process exit
+    }
+
+    %% Cross-region: signals and IPC while starting or running
+    Running --> ShutdownRequested : first SIGINT/SIGTERM,\nShutdownCause Normal,\nMQTT shutdown published\n(--graceful-shutdown only)
+    StartingModules --> ShutdownRequested : first SIGINT/SIGTERM,\nShutdownCause Normal
+
+    Running --> CrashShutdownInProgress : unexpected module exit,\nShutdownCause Crash
+    StartingModules --> CrashShutdownInProgress : unexpected module exit,\nShutdownCause Crash
+
+    Running --> RestartRequested : IPC restart_modules,\nShutdownCause Restart
+    StartingModules --> RestartRequested : IPC restart_modules,\nShutdownCause Restart
+
+    Running --> Exiting : second SIGINT/SIGTERM\n(sigint_received_ already true)
+
+    %% Drain complete → finalize (when module_handles_ is empty)
+    ShutdownRequested --> ShutdownFinalizing : all module PIDs gone
+    CrashShutdownInProgress --> ShutdownFinalizing : all module PIDs gone
+    RestartRequested --> ShutdownFinalizing : all module PIDs gone
+    ForceTerminating --> ShutdownFinalizing : all module PIDs gone
+
+    %% Finalize outcomes
+    ShutdownFinalizing --> StartingModules : reload config\n(--recover-module-crashes, under max restarts)
+    ShutdownFinalizing --> Idle : crash cap exceeded\n(--recover-module-crashes)
+    ShutdownFinalizing --> Exiting : unexpected module exit\n(default, no flag)
+
+    %% First SIGINT with no module children: Idle/Initializing shortcut to Exiting (see manager.cpp)
+    note right of Running
+        Last MQTT ready while shutdown in progress: skip Running.
+        First SIGINT with no module PIDs: cleanup → Exiting (no drain).
+    end note
+
+    note right of ForceTerminating
+        SIGTERM then SIGKILL after FORCE_KILL_GRACE_TIMEOUT_MS.
+        ShutdownCause at finalize: Normal exit, Restart, or Crash recovery.
+    end note
+
+    classDef idle fill:#64748b,color:#f8fafc
+    classDef init fill:#818cf8,color:#f8fafc
+    classDef starting fill:#4f46e5,color:#f8fafc
+    classDef running fill:#3730a3,color:#f8fafc
+    classDef shutdownReq fill:#ca8a04,color:#f8fafc
+    classDef crash fill:#ea580c,color:#f8fafc
+    classDef restart fill:#c2410c,color:#f8fafc
+    classDef force fill:#9a3412,color:#f8fafc
+    classDef finalize fill:#047857,color:#f8fafc
+    classDef exiting fill:#dc2626,color:#f8fafc
+
+    class Idle idle
+    class Initializing init
+    class StartingModules starting
+    class Running running
+    class ShutdownRequested shutdownReq
+    class CrashShutdownInProgress crash
+    class RestartRequested restart
+    class ForceTerminating force
+    class ShutdownFinalizing finalize
+    class Exiting exiting

--- a/lib/everest/framework/everestjs/everestjs.cpp
+++ b/lib/everest/framework/everestjs/everestjs.cpp
@@ -63,6 +63,8 @@ struct EvModCtx {
     std::map<std::pair<std::string, std::string>, Napi::FunctionReference> cmd_handlers;
 
     std::map<std::string, Napi::FunctionReference> mqtt_subscriptions;
+
+    Napi::FunctionReference js_shutdown_handler_ref;
 };
 
 // FIXME (aw): this could go into a class with singleton pattern
@@ -197,6 +199,54 @@ void framework_ready_handler() {
             return args;
         },
         nullptr);
+}
+
+static Napi::Value register_shutdown_callback(const Napi::CallbackInfo& info) {
+    BOOST_LOG_FUNCTION();
+
+    const auto& env = info.Env();
+
+    try {
+        if (!info[0].IsFunction()) {
+            EVTHROW(EVEXCEPTION(Everest::EverestApiError, "on_shutdown expects a function argument"));
+        }
+        ctx->js_shutdown_handler_ref = Napi::Persistent(info[0].As<Napi::Function>());
+    } catch (std::exception& e) {
+        EVLOG_AND_RETHROW(env);
+    }
+
+    return env.Undefined();
+}
+
+void framework_shutdown_handler() {
+    BOOST_LOG_FUNCTION();
+    // the module's shutdown handler must run inside the main js context; exec() blocks until the
+    // returned value (or promise, for async handlers) has settled, so module communication stays
+    // up while the handler runs and is cut by the framework only afterwards
+    auto handle_shutdown_js = [](const Napi::CallbackInfo& info) -> Napi::Value {
+        auto env = info.Env();
+        Napi::Value result = env.Undefined();
+        if (!ctx->js_shutdown_handler_ref.IsEmpty()) {
+            result = ctx->js_shutdown_handler_ref.Value().Call({ctx->js_module_ref.Value()});
+        } else {
+            EVLOG_warning << "No shutdown handler registered! Please register one via on_shutdown() in your module!";
+        }
+        // stop keeping the node event loop alive: once the module's own handles (timers,
+        // sockets, ...) are cleaned up by its shutdown handler, the process exits on its own
+        ctx->js_cb->unref(env);
+        return result;
+    };
+
+    ctx->js_cb->exec(
+        [handle_shutdown_js](Napi::Env& env) {
+            std::vector<napi_value> args{Napi::Function::New(env, handle_shutdown_js)};
+            return args;
+        },
+        [](const Napi::CallbackInfo&, bool is_rejected) {
+            if (is_rejected) {
+                EVLOG_error << "Module shutdown handler rejected/threw; continuing shutdown";
+            }
+        });
 }
 
 static Napi::Value mqtt_publish(const Napi::CallbackInfo& info) {
@@ -942,6 +992,7 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
         ctx->js_module_ref = Napi::Persistent(module_this);
         ctx->js_cb = std::make_unique<JsExecCtx>(env, callback_wrapper);
         ctx->everest->register_on_ready_handler(framework_ready_handler);
+        ctx->everest->register_on_shutdown_handler(framework_shutdown_handler);
 
         const auto end_time = std::chrono::steady_clock::now();
         EVLOG_info << "Module " << fmt::format(Everest::TERMINAL_STYLE_BLUE, "{}", module_id) << " initialized ["
@@ -997,6 +1048,9 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
 
     exports.DefineProperty(
         Napi::PropertyDescriptor::Value("signal_ready", Napi::Function::New(env, signal_ready), napi_enumerable));
+
+    exports.DefineProperty(Napi::PropertyDescriptor::Value(
+        "register_shutdown_callback", Napi::Function::New(env, register_shutdown_callback), napi_enumerable));
 
     exports.DefineProperty(
         Napi::PropertyDescriptor::Value("boot_module", Napi::Function::New(env, boot_module), napi_enumerable));

--- a/lib/everest/framework/everestjs/index.js
+++ b/lib/everest/framework/everestjs/index.js
@@ -68,6 +68,9 @@ const EverestModule = function EverestModule(handler_setup, user_settings) {
     config: this.config,
     mqtt: this.mqtt,
     telemetry: this.telemetry,
+    // register a handler (may be async) that is called when the global shutdown signal is
+    // received; module communication stays up until the handler has settled
+    on_shutdown: (handler) => addon.register_shutdown_callback.call(this, handler),
   };
 
   if (this.mqtt === undefined) {

--- a/lib/everest/framework/everestjs/js_exec_ctx.hpp
+++ b/lib/everest/framework/everestjs/js_exec_ctx.hpp
@@ -41,6 +41,13 @@ public:
 
     void exec(const ArgFuncType& arg_func, const ResFuncType& res_func);
 
+    /// \brief Stop this thread-safe function from keeping the node event loop alive. Must be
+    /// called from the main js thread. Used during shutdown so the process can exit once the
+    /// module's own work has drained.
+    void unref(const Napi::Env& env) {
+        tsfn.Unref(env);
+    }
+
 private:
     ArgFuncType arg_func;
     ResFuncType res_func;

--- a/lib/everest/framework/everestpy/src/everest/everestpy.cpp
+++ b/lib/everest/framework/everestpy/src/everest/everestpy.cpp
@@ -131,6 +131,7 @@ PYBIND11_MODULE(everestpy, m) {
         .def("say_hello", &Module::say_hello)
         .def("init_done", py::overload_cast<>(&Module::init_done))
         .def("init_done", py::overload_cast<const std::function<void()>&>(&Module::init_done))
+        .def("shutdown_handler", py::overload_cast<const std::function<void()>&>(&Module::shutdown_handler))
         .def("call_command", &Module::call_command)
         .def("publish_variable", &Module::publish_variable)
         .def("implement_command", &Module::implement_command)

--- a/lib/everest/framework/everestpy/src/everest/module.hpp
+++ b/lib/everest/framework/everestpy/src/everest/module.hpp
@@ -4,6 +4,7 @@
 #define EVERESTPY_MODULE_HPP
 
 #include <chrono>
+#include <cstdlib>
 #include <deque>
 #include <functional>
 #include <map>
@@ -39,6 +40,18 @@ public:
 
     void init_done() {
         init_done(nullptr);
+    }
+
+    void shutdown_handler(const std::function<void()>& on_shutdown_handler) {
+        // if (on_shutdown_handler) {
+        //     handle->register_on_shutdown_handler([on_shutdown_handler, module_id = this->module_id]() {
+        //         on_shutdown_handler();
+        //         if (module_id != "probe") {
+        //             _exit(EXIT_SUCCESS); // this does otherwise not play well with pytest, where the probe module is
+        //                                  // mostly used
+        //         }
+        //     });
+        // }
     }
 
     Everest::Config& get_config() {

--- a/lib/everest/framework/everestpy/src/everest/module.hpp
+++ b/lib/everest/framework/everestpy/src/everest/module.hpp
@@ -41,6 +41,12 @@ public:
         init_done(nullptr);
     }
 
+    void shutdown_handler(const std::function<void()>& on_shutdown_handler) {
+        if (on_shutdown_handler) {
+            handle->register_on_shutdown_handler(on_shutdown_handler);
+        }
+    }
+
     Everest::Config& get_config() {
         return *config_;
     }

--- a/lib/everest/framework/everestrs/everestrs/src/everestrs_sys.cpp
+++ b/lib/everest/framework/everestrs/everestrs/src/everestrs_sys.cpp
@@ -123,6 +123,8 @@ JsonBlob Module::get_manifest() const {
 
 void Module::signal_ready(const Runtime& rt) const {
     handle_->register_on_ready_handler([&rt]() { rt.on_ready(); });
+    // like the ready handler, the shutdown handler relies on the Runtime outliving the module
+    handle_->register_on_shutdown_handler([&rt]() { rt.on_shutdown(); });
     handle_->signal_ready();
 }
 

--- a/lib/everest/framework/everestrs/everestrs/src/lib.rs
+++ b/lib/everest/framework/everestrs/everestrs/src/lib.rs
@@ -80,6 +80,7 @@ mod ffi {
         );
 
         fn on_ready(&self);
+        fn on_shutdown(&self);
     }
 
     struct JsonBlob {
@@ -443,6 +444,12 @@ pub trait Subscriber: Sync + Send {
     );
 
     fn on_ready(&self) {}
+
+    /// Called when the global shutdown signal is received. Module communication stays up until
+    /// this handler returns; afterwards the MQTT connection is disconnected. The module is
+    /// responsible for ending its own work (threads, loops) so the process can exit before the
+    /// manager's shutdown timeout escalates to SIGTERM.
+    fn on_shutdown(&self) {}
 }
 
 enum PanicStrategy {
@@ -505,6 +512,16 @@ impl Runtime {
     fn on_ready(&self) {
         if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             self.sub_impl.get().unwrap().on_ready();
+        })) {
+            self.handle_panic(payload);
+        }
+    }
+
+    fn on_shutdown(&self) {
+        if let Err(payload) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if let Some(sub_impl) = self.sub_impl.get() {
+                sub_impl.on_shutdown();
+            }
         })) {
             self.handle_panic(payload);
         }

--- a/lib/everest/framework/include/framework/ModuleAdapter.hpp
+++ b/lib/everest/framework/include/framework/ModuleAdapter.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #ifndef MODULE_ADAPTER_HPP
 #define MODULE_ADAPTER_HPP
 
@@ -44,13 +44,16 @@ struct ModuleBase;
 class ImplementationBase {
 public:
     friend class ModuleAdapter; // for accessing gather_cmds
-    friend class ModuleBase;    // for accessing init & ready
+    friend class ModuleBase;    // for accessing init. ready & shutdown
     virtual ~ImplementationBase() = default;
 
 private:
     virtual void _gather_cmds(std::vector<cmd>&) = 0;
     virtual void init() = 0;
     virtual void ready() = 0;
+    virtual void shutdown() {
+        EVLOG_warning << "No shutdown handler installed! Please implement shutdown() in your implementation!";
+    }
 };
 
 class ModuleBase {
@@ -64,6 +67,16 @@ protected:
     void invoke_init(ImplementationBase& impl);
 
     void invoke_ready(ImplementationBase& impl);
+
+    void invoke_shutdown(ImplementationBase& impl) {
+        impl.shutdown();
+    }
+
+    void shutdown() {
+        EVLOG_warning << "No shutdown handler installed! Please implement shutdown() in your module! (" << info.name
+                      << ")";
+        exit(EXIT_SUCCESS);
+    }
 };
 
 namespace error {

--- a/lib/everest/framework/include/framework/ModuleAdapter.hpp
+++ b/lib/everest/framework/include/framework/ModuleAdapter.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #ifndef MODULE_ADAPTER_HPP
 #define MODULE_ADAPTER_HPP
 
@@ -44,13 +44,16 @@ struct ModuleBase;
 class ImplementationBase {
 public:
     friend class ModuleAdapter; // for accessing gather_cmds
-    friend class ModuleBase;    // for accessing init & ready
+    friend class ModuleBase;    // for accessing init, ready & shutdown
     virtual ~ImplementationBase() = default;
 
 private:
     virtual void _gather_cmds(std::vector<cmd>&) = 0;
     virtual void init() = 0;
     virtual void ready() = 0;
+    virtual void shutdown() {
+        EVLOG_debug << "No shutdown handler installed! Please implement shutdown() in your implementation!";
+    }
 };
 
 class ModuleBase {
@@ -64,6 +67,17 @@ protected:
     void invoke_init(ImplementationBase& impl);
 
     void invoke_ready(ImplementationBase& impl);
+
+    void invoke_shutdown(ImplementationBase& impl) {
+        impl.shutdown();
+    }
+
+    /// Default when a module has not yet declared its own \c shutdown() (legacy generated headers).
+    /// Generated modules define a private \c shutdown() that calls \c invoke_shutdown() on each impl.
+    void shutdown() {
+        EVLOG_debug << "No shutdown handler installed! Please implement shutdown() in your module! (" << info.name
+                    << ")";
+    }
 };
 
 namespace error {

--- a/lib/everest/framework/include/framework/everest.hpp
+++ b/lib/everest/framework/include/framework/everest.hpp
@@ -195,9 +195,19 @@ public:
     void signal_ready();
 
     ///
+    /// \brief Signal that the module wants to shutdown
+    ///
+    void signal_shutdown();
+
+    ///
     /// \brief registers a callback \p handler that is called when the global ready signal is received via mqtt
     ///
     void register_on_ready_handler(const std::function<void()>& handler);
+
+    ///
+    /// \brief registers a callback \p handler that is called when the global shutdown signal is received via mqtt
+    ///
+    void register_on_shutdown_handler(const std::function<void()>& handler);
 
     ///
     /// \brief  Blocks until ready is processed;
@@ -220,9 +230,11 @@ private:
     std::map<std::string, std::set<std::string>> registered_cmds;
     std::atomic<bool> ready_received;
     std::atomic<bool> ready_processed;
+    std::atomic<bool> shutdown_received;
     std::chrono::seconds remote_cmd_res_timeout;
     bool validate_data_with_schema;
     std::unique_ptr<std::function<void()>> on_ready;
+    std::unique_ptr<std::function<void()>> on_shutdown;
     std::thread heartbeat_thread;
     std::string module_name;
     std::shared_future<void> main_loop_end{};
@@ -237,6 +249,8 @@ private:
     bool forward_exceptions;
 
     void handle_ready(const nlohmann::json& data);
+
+    void handle_shutdown(const nlohmann::json& data);
 
     void heartbeat();
 

--- a/lib/everest/framework/include/framework/everest.hpp
+++ b/lib/everest/framework/include/framework/everest.hpp
@@ -60,6 +60,8 @@ public:
             std::shared_ptr<MQTTAbstraction> mqtt_abstraction, const std::string& telemetry_prefix,
             bool telemetry_enabled, bool forward_exceptions = false);
 
+    ~Everest();
+
     // forbid copy assignment and copy construction
     // NOTE (aw): move assignment and construction are also not supported because we're creating explicit references to
     // our instance due to callback registration
@@ -201,6 +203,17 @@ public:
     void register_on_ready_handler(const std::function<void()>& handler);
 
     ///
+    /// \brief registers a callback \p handler that is called when the global shutdown signal is received via mqtt
+    ///
+    /// Receiving the shutdown signal stops all module communication: after the registered handler
+    /// has returned, the MQTT connection is disconnected, so no further variable publications or
+    /// command calls are sent or received. Commands still waiting for their result at that point
+    /// fail with a Shutdown exception. Commands invoked from within the handler itself are still
+    /// processed normally. An empty \p handler is ignored.
+    ///
+    void register_on_shutdown_handler(const std::function<void()>& handler);
+
+    ///
     /// \brief  Blocks until ready is processed;
     ///
     void ensure_ready() const;
@@ -221,9 +234,12 @@ private:
     std::map<std::string, std::set<std::string>> registered_cmds;
     std::atomic<bool> ready_received;
     std::atomic<bool> ready_processed;
+    std::atomic<bool> shutdown_received;
+    std::atomic<bool> shutdown_processed;
     std::chrono::seconds remote_cmd_res_timeout;
     bool validate_data_with_schema;
     std::unique_ptr<std::function<void()>> on_ready;
+    std::unique_ptr<std::function<void()>> on_shutdown;
     std::thread heartbeat_thread;
     std::string module_name;
     std::shared_future<void> main_loop_end{};
@@ -238,6 +254,8 @@ private:
     bool forward_exceptions;
 
     void handle_ready(const nlohmann::json& data);
+
+    void handle_shutdown(const nlohmann::json& data);
 
     void heartbeat();
 

--- a/lib/everest/framework/include/framework/runtime.hpp
+++ b/lib/everest/framework/include/framework/runtime.hpp
@@ -116,6 +116,7 @@ struct ModuleCallbacks {
     std::function<std::vector<cmd>(const RequirementInitialization& requirement_init)> everest_register;
     std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)> init;
     std::function<void()> ready;
+    std::function<void()> shutdown;
 
     ModuleCallbacks() = default;
 
@@ -123,7 +124,7 @@ struct ModuleCallbacks {
         const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
         const std::function<std::vector<cmd>(const RequirementInitialization& requirement_init)>& everest_register,
         const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
-        const std::function<void()>& ready);
+        const std::function<void()>& ready, const std::function<void()>& shutdown = nullptr);
 };
 
 ///\brief Version information

--- a/lib/everest/framework/include/utils/mqtt_abstraction.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction.hpp
@@ -87,6 +87,17 @@ public:
     /// \brief unsubscribes a handler identified by its \p token from the given \p topic
     virtual void unregister_handler(const std::string& topic, const Token& token) = 0;
 
+    /// \brief stops and joins all message-handler worker threads
+    ///
+    /// After this returns no registered handler will be invoked anymore. This must be called
+    /// before any object whose lifetime is captured by a registered handler (e.g. the owning
+    /// Everest instance) is destroyed, otherwise a still-running handler thread could call into
+    /// freed memory (use-after-free / std::bad_function_call). Idempotent.
+    ///
+    /// NOTE: declared last on purpose to keep the vtable layout of all pre-existing methods
+    /// unchanged (append-only), preserving ABI compatibility for already-compiled consumers.
+    virtual void stop_message_handling() = 0;
+
 protected:
     MQTTAbstraction() = default;
 };

--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -49,6 +49,7 @@ public:
 
     bool connect() override;
     void disconnect() override;
+    void stop_message_handling() override;
     void publish(const std::string& topic, const nlohmann::json& json) override;
     void publish(const std::string& topic, const nlohmann::json& json, QOS qos, bool retain = false) override;
     void publish(const std::string& topic, const std::string& data) override;
@@ -109,7 +110,7 @@ private:
     void on_mqtt_connect();
     void handle_mqtt_message(const Message& message);
 
-    static void on_mqtt_disconnect();
+    void on_mqtt_disconnect();
     nlohmann::json get_internal(const MQTTRequest& request);
 };
 } // namespace Everest

--- a/lib/everest/framework/include/utils/status_fifo.hpp
+++ b/lib/everest/framework/include/utils/status_fifo.hpp
@@ -13,6 +13,24 @@ public:
     static constexpr auto ALL_MODULES_STARTED = "ALL_MODULES_STARTED\n";
     static constexpr auto WAITING_FOR_STANDALONE_MODULES = "WAITING_FOR_STANDALONE_MODULES\n";
 
+    // manager lifecycle state notifications (written on ManagerState transitions)
+    static constexpr auto MANAGER_INITIALIZING = "MANAGER_INITIALIZING\n";
+    static constexpr auto MANAGER_STARTING_MODULES = "MANAGER_STARTING_MODULES\n";
+    static constexpr auto MANAGER_RUNNING = "MANAGER_RUNNING\n";
+    static constexpr auto MANAGER_RESTART_REQUESTED = "MANAGER_RESTART_REQUESTED\n";
+    static constexpr auto MANAGER_CRASH_SHUTDOWN_IN_PROGRESS = "MANAGER_CRASH_SHUTDOWN_IN_PROGRESS\n";
+    static constexpr auto MANAGER_SHUTDOWN_REQUESTED = "MANAGER_SHUTDOWN_REQUESTED\n";
+    static constexpr auto MANAGER_FORCE_TERMINATING = "MANAGER_FORCE_TERMINATING\n";
+    static constexpr auto MANAGER_SHUTDOWN_FINALIZING = "MANAGER_SHUTDOWN_FINALIZING\n";
+    static constexpr auto MANAGER_IDLE = "MANAGER_IDLE\n";
+    static constexpr auto MANAGER_EXITING = "MANAGER_EXITING\n";
+
+    // semantic lifecycle events (not 1:1 with ManagerState)
+    static constexpr auto SIGINT_RECEIVED = "SIGINT_RECEIVED\n";
+    static constexpr auto ALL_MODULES_STOPPED_CLEAN = "ALL_MODULES_STOPPED_CLEAN\n";
+    static constexpr auto FORCE_SHUTDOWN_TIMEOUT = "FORCE_SHUTDOWN_TIMEOUT\n";
+    static constexpr auto CRASH_RECOVERY_EXHAUSTED = "CRASH_RECOVERY_EXHAUSTED\n";
+
     static StatusFifo create_from_path(const std::string&);
     void update(const std::string&);
 

--- a/lib/everest/framework/lib/everest.cpp
+++ b/lib/everest/framework/lib/everest.cpp
@@ -36,6 +36,7 @@ using json_uri = nlohmann::json_uri;
 using json_validator = nlohmann::json_schema::json_validator;
 
 const auto remote_cmd_res_timeout_seconds = 300;
+const auto remote_cmd_res_timeout_step = std::chrono::seconds(1);
 const std::array<std::string_view, 3> TELEMETRY_RESERVED_KEYS = {{"connector_id"}};
 constexpr auto ensure_ready_timeout_ms = 100;
 
@@ -47,6 +48,7 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     module_id(std::move(module_id_)),
     ready_received(false),
     ready_processed(false),
+    shutdown_received(false),
     remote_cmd_res_timeout(remote_cmd_res_timeout_seconds),
     validate_data_with_schema(validate_data_with_schema),
     mqtt_everest_prefix(mqtt_abstraction->get_everest_prefix()),
@@ -67,6 +69,7 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     this->telemetry_config = this->config.get_telemetry_config();
 
     this->on_ready = nullptr;
+    this->on_shutdown = nullptr;
 
     // setup error_manager_req_global if enabled + error_database + error_state_monitor
     if (this->module_manifest.contains("enable_global_errors") &&
@@ -202,6 +205,13 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
         std::make_shared<TypedHandler>(HandlerType::GlobalReady, std::make_shared<Handler>(handle_ready_wrapper));
     this->mqtt_abstraction->register_handler(fmt::format("{}ready", mqtt_everest_prefix), everest_ready, QOS::QOS2);
 
+    // register handler for global shutdown signal
+    Handler handle_shutdown_wrapper = [this](const std::string&, const json& data) { this->handle_shutdown(data); };
+    std::shared_ptr<TypedHandler> everest_shutdown =
+        std::make_shared<TypedHandler>(HandlerType::ExternalMQTT, std::make_shared<Handler>(handle_shutdown_wrapper));
+    this->mqtt_abstraction->register_handler(fmt::format("{}shutdown", mqtt_everest_prefix), everest_shutdown,
+                                             QOS::QOS2);
+
     this->publish_metadata();
 }
 
@@ -265,6 +275,13 @@ void Everest::register_on_ready_handler(const std::function<void()>& handler) {
     BOOST_LOG_FUNCTION();
 
     this->on_ready = std::make_unique<std::function<void()>>(handler);
+}
+
+void Everest::register_on_shutdown_handler(const std::function<void()>& handler) {
+    BOOST_LOG_FUNCTION();
+    if (handler != nullptr) {
+        this->on_shutdown = std::make_unique<std::function<void()>>(handler);
+    }
 }
 
 std::optional<ModuleTierMappings> Everest::get_3_tier_model_mapping() {
@@ -413,8 +430,16 @@ json Everest::call_cmd(const Requirement& req, const std::string& cmd_name, cons
         std::chrono::steady_clock::now() + this->remote_cmd_res_timeout;
     std::future_status res_future_status = std::future_status::deferred;
     do {
-        res_future_status = res_future.wait_until(res_wait);
-    } while (res_future_status == std::future_status::deferred);
+        res_future_status = res_future.wait_for(remote_cmd_res_timeout_step);
+    } while (!this->shutdown_received &&
+             (res_future_status == std::future_status::deferred ||
+              (res_future_status == std::future_status::timeout && std::chrono::steady_clock::now() < res_wait)));
+
+    if (this->shutdown_received) {
+        EVLOG_AND_THROW(Shutdown(fmt::format(
+            "Shutting down while waiting for result of {}->{}()",
+            this->config.printable_identifier(connection.module_id, connection.implementation_id), cmd_name)));
+    }
 
     CmdResult result;
     if (res_future_status == std::future_status::timeout) {
@@ -818,6 +843,15 @@ void Everest::ensure_ready() const {
     }
 }
 
+void Everest::signal_shutdown() {
+    BOOST_LOG_FUNCTION();
+
+    EVLOG_info << "Module " << this->module_id << " requested shutdown of EVerest.";
+
+    // FIXME: maybe make this a publish tied to the module like with ready?
+    this->mqtt_abstraction->publish(fmt::format("{}shutdown", mqtt_everest_prefix), json(true));
+}
+
 ///
 /// \brief Ready handler for global readyness (e.g. all modules are ready now).
 /// This will called when receiving the global ready signal from manager.
@@ -857,6 +891,39 @@ void Everest::handle_ready(const json& data) {
 
     // TODO(kai): make heartbeat interval configurable, disable it completely until then
     // this->heartbeat_thread = std::thread(&Everest::heartbeat, this);
+}
+
+/// \brief Shutdown handler for shutting down the module
+void Everest::handle_shutdown(const json& data) {
+    BOOST_LOG_FUNCTION();
+
+    EVLOG_debug << fmt::format("handle_shutdown: {}", data.dump());
+
+    bool shutdown = false;
+
+    if (data.is_boolean()) {
+        shutdown = data.get<bool>();
+    }
+
+    // ignore non-truish shutdown signals
+    if (!shutdown) {
+        return;
+    }
+
+    if (this->shutdown_received) {
+        EVLOG_warning << "Ignoring repeated everest shutdown signal!";
+        return;
+    }
+    this->shutdown_received = true;
+
+    if (this->on_shutdown != nullptr) {
+        auto on_shutdown_handler = *on_shutdown;
+        on_shutdown_handler();
+    } else {
+        EVLOG_warning << "No shutdown handler registered for module " << this->module_id;
+    }
+
+    this->mqtt_abstraction->disconnect();
 }
 
 void Everest::provide_cmd(const std::string& impl_id, const std::string& cmd_name, const JsonCommand& handler) {

--- a/lib/everest/framework/lib/everest.cpp
+++ b/lib/everest/framework/lib/everest.cpp
@@ -36,6 +36,7 @@ using json_uri = nlohmann::json_uri;
 using json_validator = nlohmann::json_schema::json_validator;
 
 const auto remote_cmd_res_timeout_seconds = 300;
+const auto remote_cmd_res_timeout_step = std::chrono::seconds(1);
 const std::array<std::string_view, 3> TELEMETRY_RESERVED_KEYS = {{"connector_id"}};
 constexpr auto ensure_ready_timeout_ms = 100;
 
@@ -47,6 +48,8 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     module_id(std::move(module_id_)),
     ready_received(false),
     ready_processed(false),
+    shutdown_received(false),
+    shutdown_processed(false),
     remote_cmd_res_timeout(remote_cmd_res_timeout_seconds),
     validate_data_with_schema(validate_data_with_schema),
     mqtt_everest_prefix(mqtt_abstraction->get_everest_prefix()),
@@ -67,6 +70,7 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
     this->telemetry_config = this->config.get_telemetry_config();
 
     this->on_ready = nullptr;
+    this->on_shutdown = nullptr;
 
     // setup error_manager_req_global if enabled + error_database + error_state_monitor
     if (this->module_manifest.contains("enable_global_errors") &&
@@ -202,7 +206,33 @@ Everest::Everest(std::string module_id_, const Config& config_, bool validate_da
         std::make_shared<TypedHandler>(HandlerType::GlobalReady, std::make_shared<Handler>(handle_ready_wrapper));
     this->mqtt_abstraction->register_handler(fmt::format("{}ready", mqtt_everest_prefix), everest_ready, QOS::QOS2);
 
+    // register handler for global shutdown signal
+    Handler handle_shutdown_wrapper = [this](const std::string&, const json& data) { this->handle_shutdown(data); };
+    std::shared_ptr<TypedHandler> everest_shutdown =
+        std::make_shared<TypedHandler>(HandlerType::ExternalMQTT, std::make_shared<Handler>(handle_shutdown_wrapper));
+    this->mqtt_abstraction->register_handler(fmt::format("{}shutdown", mqtt_everest_prefix), everest_shutdown,
+                                             QOS::QOS2);
+
     this->publish_metadata();
+}
+
+Everest::~Everest() {
+    BOOST_LOG_FUNCTION();
+
+    // The MQTT message-handler threads (owned by mqtt_abstraction, which is a shared_ptr and
+    // may outlive this object) invoke handlers that were registered by this instance and
+    // capture `this` (e.g. handle_ready(), handle_shutdown(), cmd/var/error handlers). Those
+    // threads must be stopped and joined before any member of this Everest instance
+    // (on_ready, on_shutdown, the registered handler lambdas, error managers, ...) is
+    // destroyed; otherwise a still-running handler thread could call into freed memory,
+    // causing use-after-free / std::bad_function_call crashes during shutdown.
+    //
+    // This destructor body runs before any member is destroyed, so it is the correct place
+    // to tear the threads down while everything they may touch is still alive.
+    if (this->mqtt_abstraction) {
+        this->mqtt_abstraction->disconnect();            // signal the MQTT main loop to stop
+        this->mqtt_abstraction->stop_message_handling(); // join all handler threads
+    }
 }
 
 void Everest::spawn_main_loop_thread() {
@@ -265,6 +295,17 @@ void Everest::register_on_ready_handler(const std::function<void()>& handler) {
     BOOST_LOG_FUNCTION();
 
     this->on_ready = std::make_unique<std::function<void()>>(handler);
+}
+
+void Everest::register_on_shutdown_handler(const std::function<void()>& handler) {
+    BOOST_LOG_FUNCTION();
+
+    if (!handler) {
+        // an empty handler would throw std::bad_function_call when invoked on shutdown;
+        // leave on_shutdown unset so the "no shutdown handler registered" warning path is taken
+        return;
+    }
+    this->on_shutdown = std::make_unique<std::function<void()>>(handler);
 }
 
 std::optional<ModuleTierMappings> Everest::get_3_tier_model_mapping() {
@@ -413,8 +454,21 @@ json Everest::call_cmd(const Requirement& req, const std::string& cmd_name, cons
         std::chrono::steady_clock::now() + this->remote_cmd_res_timeout;
     std::future_status res_future_status = std::future_status::deferred;
     do {
-        res_future_status = res_future.wait_until(res_wait);
-    } while (res_future_status == std::future_status::deferred);
+        res_future_status = res_future.wait_for(remote_cmd_res_timeout_step);
+    } while (!this->shutdown_processed &&
+             (res_future_status == std::future_status::deferred ||
+              (res_future_status == std::future_status::timeout && std::chrono::steady_clock::now() < res_wait)));
+
+    if (res_future_status != std::future_status::ready && this->shutdown_processed) {
+        // Once the shutdown handler has returned, module communication is stopped (MQTT is
+        // disconnected), so a still-pending command result can never arrive. Throw to unwind the
+        // caller blocked on this command instead of letting it run into the command timeout.
+        // A result that already arrived is used normally, and commands called from within the
+        // shutdown handler itself (before shutdown_processed is set) are still processed.
+        EVLOG_AND_THROW(Shutdown(fmt::format(
+            "Shutting down while waiting for result of {}->{}()",
+            this->config.printable_identifier(connection.module_id, connection.implementation_id), cmd_name)));
+    }
 
     CmdResult result;
     if (res_future_status == std::future_status::timeout) {
@@ -867,6 +921,33 @@ void Everest::handle_ready(const json& data) {
 
     // TODO(kai): make heartbeat interval configurable, disable it completely until then
     // this->heartbeat_thread = std::thread(&Everest::heartbeat, this);
+}
+
+/// \brief Shutdown handler for shutting down the module. Any message on the shutdown topic triggers
+/// the shutdown; the payload is only logged (it may carry the shutdown cause in the future).
+void Everest::handle_shutdown(const json& data) {
+    BOOST_LOG_FUNCTION();
+
+    EVLOG_debug << fmt::format("handle_shutdown: {}", data.dump());
+
+    if (this->shutdown_received) {
+        EVLOG_warning << "Ignoring repeated everest shutdown signal!";
+        return;
+    }
+    this->shutdown_received = true;
+
+    if (this->on_shutdown != nullptr) {
+        auto on_shutdown_handler = *on_shutdown;
+        on_shutdown_handler();
+    } else {
+        EVLOG_warning << "No shutdown handler registered for module " << this->module_id;
+    }
+
+    // Only after the shutdown handler has returned is communication cut; commands issued from
+    // within the handler are processed normally, pending commands fail with Shutdown from here on.
+    // Disconnect MQTT so the module main loop ends and the process exits via normal main() return.
+    this->shutdown_processed = true;
+    this->mqtt_abstraction->disconnect();
 }
 
 void Everest::provide_cmd(const std::string& impl_id, const std::string& cmd_name, const JsonCommand& handler) {

--- a/lib/everest/framework/lib/message_handler.cpp
+++ b/lib/everest/framework/lib/message_handler.cpp
@@ -116,6 +116,13 @@ MessageHandler::~MessageHandler() {
 }
 
 void MessageHandler::add(const ParsedMessage& message) {
+    // Once stopped (during teardown) no further messages must be dispatched: doing so could
+    // enqueue work or spawn the ready thread after the worker threads have been joined and
+    // while the objects the handlers reference are being destroyed.
+    if (!this->running) {
+        return;
+    }
+
     EVLOG_verbose << "Adding message to queue: " << message.topic << " with data: " << message.data;
 
     MqttMessageType msg_type = MqttMessageType::ExternalMQTT; // Default to ExternalMQTT if msg_type is not present

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -87,10 +87,16 @@ MQTTAbstractionImpl::MQTTAbstractionImpl(const MQTTSettings& mqtt_settings) :
 }
 
 MQTTAbstractionImpl::~MQTTAbstractionImpl() {
-    if (this->running.load()) {
-        this->disconnect();
-    }
-    // this->mqtt_mainloop_thread.join();
+    // Signal the main loop to stop (if it is still running). The actual
+    // mqtt_client->disconnect() runs on the main loop thread itself, which is joined when
+    // the mqtt_mainloop_thread member is destroyed.
+    this->disconnect();
+
+    // Stop and join all MessageHandler worker threads before the remaining members are
+    // destroyed. A worker thread may still be executing a handler; joining here guarantees
+    // no handler runs against a partially-destroyed object. stop() is idempotent, so calling
+    // it again (here and in ~MessageHandler()) is safe.
+    this->message_handler.stop();
 }
 
 bool MQTTAbstractionImpl::connect() {
@@ -122,10 +128,19 @@ bool MQTTAbstractionImpl::connect() {
 void MQTTAbstractionImpl::disconnect() {
     BOOST_LOG_FUNCTION();
 
+    // Only signal the main loop to stop; do NOT call mqtt_client->disconnect() here.
+    // disconnect() can be invoked from arbitrary threads (e.g. the external MQTT worker
+    // thread via Everest::handle_shutdown(), or the main thread during teardown). The
+    // actual mqtt_client->disconnect() is performed by the main loop thread after
+    // ev_handler.run() returns (see spawn_main_loop_thread()), keeping all mqtt_client
+    // access on a single thread and avoiding a concurrent-access / use-after-free crash.
+    this->running = false;
     this->disconnect_event.notify();
+}
 
-    // FIXME(kai): always set connected to false for the moment
-    this->mqtt_is_connected = false;
+void MQTTAbstractionImpl::stop_message_handling() {
+    BOOST_LOG_FUNCTION();
+    this->message_handler.stop();
 }
 
 void MQTTAbstractionImpl::publish(const std::string& topic, const json& json) {
@@ -323,6 +338,15 @@ std::shared_future<void> MQTTAbstractionImpl::spawn_main_loop_thread() {
                                                     [this](const auto&) { on_mqtt_message(); });
 
             this->ev_handler.run(this->running);
+
+            // The loop has been asked to stop (running == false). Perform the actual MQTT
+            // disconnect here, on the loop-owning thread, so that mqtt_client is never
+            // accessed concurrently from another thread (disconnect() only signals; see
+            // disconnect()).
+            if (this->mqtt_client) {
+                this->mqtt_client->disconnect();
+            }
+            this->mqtt_is_connected = false;
         } catch (boost::exception& e) {
             EVLOG_critical << fmt::format("Caught MQTT mainloop boost::exception:\n{}",
                                           boost::diagnostic_information(e, true));
@@ -411,6 +435,15 @@ void MQTTAbstractionImpl::on_mqtt_connect() {
 
 void MQTTAbstractionImpl::on_mqtt_disconnect() {
     BOOST_LOG_FUNCTION();
+
+    // On intentional shutdown running is set to false (by disconnect()) before the main loop
+    // thread performs mqtt_client->disconnect(), so the resulting disconnect callback must be
+    // ignored instead of being treated as a broker crash.
+    if (!this->running.load()) {
+        EVLOG_info << "MQTT disconnect ignored (intentional shutdown)";
+        this->mqtt_is_connected = false;
+        return;
+    }
 
     EVLOG_AND_THROW(EverestInternalError("Lost connection to MQTT broker"));
 }

--- a/lib/everest/framework/lib/runtime.cpp
+++ b/lib/everest/framework/lib/runtime.cpp
@@ -425,8 +425,12 @@ ModuleCallbacks::ModuleCallbacks(
     const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
     const std::function<std::vector<cmd>(const RequirementInitialization& requirement_init)>& everest_register,
     const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
-    const std::function<void()>& ready) :
-    register_module_adapter(register_module_adapter), everest_register(everest_register), init(init), ready(ready) {
+    const std::function<void()>& ready, const std::function<void()>& shutdown) :
+    register_module_adapter(register_module_adapter),
+    everest_register(everest_register),
+    init(init),
+    ready(ready),
+    shutdown(shutdown) {
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays): pass-through of argc and argv from main()
@@ -613,6 +617,10 @@ int ModuleLoader::initialize() {
         // this handler gets called when the global ready signal is received
         everest.register_on_ready_handler(this->callbacks.ready);
 
+        // register the modules shutdown handler with the framework
+        // this handler gets called when the global shutdown signal is received
+        everest.register_on_shutdown_handler(this->callbacks.shutdown);
+
         // the module should now be ready
         everest.signal_ready();
 
@@ -621,8 +629,6 @@ int ModuleLoader::initialize() {
                    << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms]";
 
         everest.wait_for_main_loop_end();
-
-        EVLOG_info << "Exiting...";
     } catch (boost::exception& e) {
         EVLOG_critical << fmt::format("Caught top level boost::exception:\n{}", boost::diagnostic_information(e, true));
         shutdown_mqtt();

--- a/lib/everest/framework/lib/runtime.cpp
+++ b/lib/everest/framework/lib/runtime.cpp
@@ -426,8 +426,12 @@ ModuleCallbacks::ModuleCallbacks(
     const std::function<void(ModuleAdapter module_adapter)>& register_module_adapter,
     const std::function<std::vector<cmd>(const RequirementInitialization& requirement_init)>& everest_register,
     const std::function<void(ModuleConfigs module_configs, const ModuleInfo& info)>& init,
-    const std::function<void()>& ready) :
-    register_module_adapter(register_module_adapter), everest_register(everest_register), init(init), ready(ready) {
+    const std::function<void()>& ready, const std::function<void()>& shutdown) :
+    register_module_adapter(register_module_adapter),
+    everest_register(everest_register),
+    init(init),
+    ready(ready),
+    shutdown(shutdown) {
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays): pass-through of argc and argv from main()
@@ -613,9 +617,13 @@ int ModuleLoader::initialize() {
 
         everest.spawn_main_loop_thread();
 
-        // register the modules ready handler with the framework
-        // this handler gets called when the global ready signal is received
+        // register the modules ready handler with the framework.
+        // this handler gets called when the global ready signal is received.
         everest.register_on_ready_handler(this->callbacks.ready);
+
+        // Register the module shutdown handler with the framework.
+        // This handler is called when the global shutdown signal is received.
+        everest.register_on_shutdown_handler(this->callbacks.shutdown);
 
         // the module should now be ready
         everest.signal_ready();
@@ -625,8 +633,6 @@ int ModuleLoader::initialize() {
                    << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms]";
 
         everest.wait_for_main_loop_end();
-
-        EVLOG_info << "Exiting...";
     } catch (boost::exception& e) {
         EVLOG_critical << fmt::format("Caught top level boost::exception:\n{}", boost::diagnostic_information(e, true));
         shutdown_mqtt();

--- a/lib/everest/framework/src/CMakeLists.txt
+++ b/lib/everest/framework/src/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(manager)
 target_sources(manager
     PRIVATE
         system_unix.cpp
+        manager_admin_panel.cpp
         manager.cpp
 )
 # generate version information header

--- a/lib/everest/framework/src/controller/CMakeLists.txt
+++ b/lib/everest/framework/src/controller/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(controller
         websockets_shared
         fmt::fmt
         ryml::ryml
-        
+
         everest::log
         everest::yaml
         date::date-tz

--- a/lib/everest/framework/src/manager.cpp
+++ b/lib/everest/framework/src/manager.cpp
@@ -42,6 +42,7 @@ using namespace Everest;
 
 const auto PARENT_DIED_SIGNAL = SIGTERM;
 const int CONTROLLER_IPC_READ_TIMEOUT_MS = 50;
+const auto SHUTDOWN_TIMEOUT_MS = 5000;
 const auto complete_start_time = std::chrono::system_clock::now();
 
 #ifdef ENABLE_ADMIN_PANEL
@@ -93,6 +94,14 @@ struct ModuleStartInfo {
 
     // required capabilities of this module
     std::vector<std::string> capabilities;
+};
+
+struct ModuleShutdownInfo {
+    std::string id;
+    int wstatus;
+
+    ModuleShutdownInfo(const std::string& id_, int wstatus_) : id(id_), wstatus(wstatus_) {
+    }
 };
 
 namespace {
@@ -604,8 +613,61 @@ ConfigBootMode parse_config_boot_mode(const std::string& config_opt, const std::
     throw std::logic_error("Could not parse config boot source, this should never happen.");
 }
 
+void cleanup(Everest::MQTTAbstraction& mqtt_abstraction) {
+    mqtt_abstraction.disconnect();
+}
+
+void print_start_message(const std::string& version_information) {
+    EVLOG_info << "  \033[0;1;35;95m_\033[0;1;31;91m__\033[0;1;33;93m__\033[0;1;32;92m__\033[0;1;36;96m_\033[0m      "
+                  "\033[0;1;31;91m_\033[0;1;33;93m_\033[0m                \033[0;1;36;96m_\033[0m   ";
+    EVLOG_info << " \033[0;1;31;91m|\033[0m  \033[0;1;33;93m_\033[0;1;32;92m__\033[0;1;36;96m_\\\033[0m "
+                  "\033[0;1;34;94m\\\033[0m    \033[0;1;33;93m/\033[0m \033[0;1;32;92m/\033[0m               "
+                  "\033[0;1;34;94m|\033[0m \033[0;1;35;95m|\033[0m";
+    EVLOG_info
+        << " \033[0;1;33;93m|\033[0m \033[0;1;32;92m|_\033[0;1;36;96m_\033[0m   \033[0;1;35;95m\\\033[0m "
+           "\033[0;1;31;91m\\\033[0m  \033[0;1;33;93m/\033[0m \033[0;1;32;92m/\033[0;1;36;96m__\033[0m "
+           "\033[0;1;34;94m_\033[0m \033[0;1;35;95m_\033[0;1;31;91m_\033[0m \033[0;1;33;93m__\033[0;1;32;92m_\033[0m  "
+           "\033[0;1;36;96m_\033[0;1;34;94m__\033[0;1;35;95m|\033[0m \033[0;1;31;91m|_\033[0m";
+    EVLOG_info << " \033[0;1;32;92m|\033[0m  \033[0;1;36;96m_\033[0;1;34;94m_|\033[0m   \033[0;1;31;91m\\\033[0m "
+                  "\033[0;1;33;93m\\\033[0;1;32;92m/\033[0m \033[0;1;36;96m/\033[0m \033[0;1;34;94m_\033[0m "
+                  "\033[0;1;35;95m\\\033[0m \033[0;1;31;91m'_\033[0;1;33;93m_/\033[0m \033[0;1;32;92m_\033[0m "
+                  "\033[0;1;36;96m\\\033[0;1;34;94m/\033[0m \033[0;1;35;95m__\033[0;1;31;91m|\033[0m "
+                  "\033[0;1;33;93m__\033[0;1;32;92m|\033[0m";
+    EVLOG_info << " \033[0;1;36;96m|\033[0m \033[0;1;34;94m|_\033[0;1;35;95m__\033[0;1;31;91m_\033[0m   "
+                  "\033[0;1;32;92m\\\033[0m  \033[0;1;36;96m/\033[0m  \033[0;1;35;95m__\033[0;1;31;91m/\033[0m "
+                  "\033[0;1;33;93m|\033[0m \033[0;1;32;92m|\033[0m  "
+                  "\033[0;1;36;96m_\033[0;1;34;94m_/\033[0;1;35;95m\\_\033[0;1;31;91m_\033[0m \033[0;1;33;93m\\\033[0m "
+                  "\033[0;1;32;92m|_\033[0m";
+    EVLOG_info << " \033[0;1;34;94m|_\033[0;1;35;95m__\033[0;1;31;91m__\033[0;1;33;93m_|\033[0m   "
+                  "\033[0;1;36;96m\\\033[0;1;34;94m/\033[0m "
+                  "\033[0;1;35;95m\\_\033[0;1;31;91m__\033[0;1;33;93m|_\033[0;1;32;92m|\033[0m  "
+                  "\033[0;1;36;96m\\\033[0;1;34;94m__\033[0;1;35;95m_|\033[0;1;31;91m|_\033[0;1;33;93m__\033[0;1;32;"
+                  "92m/\\\033[0;1;36;96m__\033[0;1;34;94m|\033[0m";
+    EVLOG_info << "";
+    EVLOG_info << PROJECT_NAME << " " << PROJECT_VERSION << " " << GIT_VERSION;
+    EVLOG_info << version_information;
+    EVLOG_info << "";
+}
+
+void print_shutdown_message(const std::optional<std::chrono::system_clock::time_point> shutdown_start_time,
+                            const std::string& message_prefix = "") {
+    auto shutdown_duration = 0;
+    if (shutdown_start_time.has_value()) {
+        shutdown_duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() -
+                                                                                  shutdown_start_time.value())
+                                .count();
+    } else {
+        EVLOG_info << "shutdown start time is not set?";
+    }
+    EVLOG_info << fmt::format(
+        TERMINAL_STYLE_ERROR, "👋👋👋 {}{}", message_prefix,
+        fmt::format(TERMINAL_STYLE_ERROR, "EVerest manager is exiting [{}ms] 👋👋👋", shutdown_duration));
+}
+
 int boot(const po::variables_map& vm) {
     const bool check = (vm.count("check") != 0);
+    bool sigint_received = false;
+    auto signal_polling = Everest::system::SignalPolling();
 
     const auto prefix_opt = parse_string_option(vm, "prefix");
     const auto config_opt = parse_string_option(vm, "config");
@@ -640,35 +702,7 @@ int boot(const po::variables_map& vm) {
 
     Logging::init(ms.runtime_settings.logging_config_file.string());
 
-    EVLOG_info << "  \033[0;1;35;95m_\033[0;1;31;91m__\033[0;1;33;93m__\033[0;1;32;92m__\033[0;1;36;96m_\033[0m      "
-                  "\033[0;1;31;91m_\033[0;1;33;93m_\033[0m                \033[0;1;36;96m_\033[0m   ";
-    EVLOG_info << " \033[0;1;31;91m|\033[0m  \033[0;1;33;93m_\033[0;1;32;92m__\033[0;1;36;96m_\\\033[0m "
-                  "\033[0;1;34;94m\\\033[0m    \033[0;1;33;93m/\033[0m \033[0;1;32;92m/\033[0m               "
-                  "\033[0;1;34;94m|\033[0m \033[0;1;35;95m|\033[0m";
-    EVLOG_info
-        << " \033[0;1;33;93m|\033[0m \033[0;1;32;92m|_\033[0;1;36;96m_\033[0m   \033[0;1;35;95m\\\033[0m "
-           "\033[0;1;31;91m\\\033[0m  \033[0;1;33;93m/\033[0m \033[0;1;32;92m/\033[0;1;36;96m__\033[0m "
-           "\033[0;1;34;94m_\033[0m \033[0;1;35;95m_\033[0;1;31;91m_\033[0m \033[0;1;33;93m__\033[0;1;32;92m_\033[0m  "
-           "\033[0;1;36;96m_\033[0;1;34;94m__\033[0;1;35;95m|\033[0m \033[0;1;31;91m|_\033[0m";
-    EVLOG_info << " \033[0;1;32;92m|\033[0m  \033[0;1;36;96m_\033[0;1;34;94m_|\033[0m   \033[0;1;31;91m\\\033[0m "
-                  "\033[0;1;33;93m\\\033[0;1;32;92m/\033[0m \033[0;1;36;96m/\033[0m \033[0;1;34;94m_\033[0m "
-                  "\033[0;1;35;95m\\\033[0m \033[0;1;31;91m'_\033[0;1;33;93m_/\033[0m \033[0;1;32;92m_\033[0m "
-                  "\033[0;1;36;96m\\\033[0;1;34;94m/\033[0m \033[0;1;35;95m__\033[0;1;31;91m|\033[0m "
-                  "\033[0;1;33;93m__\033[0;1;32;92m|\033[0m";
-    EVLOG_info << " \033[0;1;36;96m|\033[0m \033[0;1;34;94m|_\033[0;1;35;95m__\033[0;1;31;91m_\033[0m   "
-                  "\033[0;1;32;92m\\\033[0m  \033[0;1;36;96m/\033[0m  \033[0;1;35;95m__\033[0;1;31;91m/\033[0m "
-                  "\033[0;1;33;93m|\033[0m \033[0;1;32;92m|\033[0m  "
-                  "\033[0;1;36;96m_\033[0;1;34;94m_/\033[0;1;35;95m\\_\033[0;1;31;91m_\033[0m \033[0;1;33;93m\\\033[0m "
-                  "\033[0;1;32;92m|_\033[0m";
-    EVLOG_info << " \033[0;1;34;94m|_\033[0;1;35;95m__\033[0;1;31;91m__\033[0;1;33;93m_|\033[0m   "
-                  "\033[0;1;36;96m\\\033[0;1;34;94m/\033[0m "
-                  "\033[0;1;35;95m\\_\033[0;1;31;91m__\033[0;1;33;93m|_\033[0;1;32;92m|\033[0m  "
-                  "\033[0;1;36;96m\\\033[0;1;34;94m__\033[0;1;35;95m_|\033[0;1;31;91m|_\033[0;1;33;93m__\033[0;1;32;"
-                  "92m/\\\033[0;1;36;96m__\033[0;1;34;94m|\033[0m";
-    EVLOG_info << "";
-    EVLOG_info << PROJECT_NAME << " " << PROJECT_VERSION << " " << GIT_VERSION;
-    EVLOG_info << ms.version_information;
-    EVLOG_info << "";
+    print_start_message(ms.version_information);
 
     if (not ms.mqtt_settings.uses_socket()) {
         EVLOG_info << "Using MQTT broker " << ms.mqtt_settings.broker_host << ":" << ms.mqtt_settings.broker_port;
@@ -822,23 +856,23 @@ int boot(const po::variables_map& vm) {
 #endif
 
     int wstatus; // NOLINT(cppcoreguidelines-init-variables): this is always initialized in the following waitpid call
+    std::vector<ModuleShutdownInfo> shutdown_info;
+    bool shutdown_initiated = false;
+    bool shutdown_complete = false;
+    bool completing_shutdown = false;
+    std::optional<std::chrono::system_clock::time_point> shutdown_start_time;
 
     while (true) {
-// check if anyone died
-#ifdef ENABLE_ADMIN_PANEL
-        // non-blocking if admin panel is enabled, as this main loop also processes controller RPC
+        // check if anyone died
+        // non-blocking as this main loop also processes controller RPC and the signal fd
         auto pid = waitpid(-1, &wstatus, WNOHANG);
-#else
-        // block if admin panel is disabled, no controller RPC is handled by main loop
-        auto pid = waitpid(-1, &wstatus, 0);
-#endif
 
         if (pid == 0) {
             // nothing new from our child process
         } else if (pid == -1) {
             throw std::runtime_error(fmt::format("Syscall to waitpid() failed ({})", strerror(errno)));
         } else {
-
+            auto module_exited_time = std::chrono::system_clock::now();
 #ifdef ENABLE_ADMIN_PANEL
             // one of our children exited (first check controller, then modules)
             if (pid == controller_handle.pid) {
@@ -856,6 +890,58 @@ int boot(const po::variables_map& vm) {
             module_handles.erase(module_iter);
             // one of our modules died -> kill 'em all
             if (modules_started) {
+                if (wstatus == 0) {
+                    if (not shutdown_initiated) {
+                        shutdown_initiated = true;
+                        if (not shutdown_start_time.has_value()) {
+                            shutdown_start_time = module_exited_time;
+                        }
+                    }
+                    EVLOG_info << "Module " << fmt::format(TERMINAL_STYLE_BLUE, "{}", module_name) << " shutdown ["
+                               << std::chrono::duration_cast<std::chrono::milliseconds>(
+                                      module_exited_time - shutdown_start_time.value_or(module_exited_time))
+                                      .count()
+                               << "ms]";
+
+                    EVLOG_debug << fmt::format("Module {} (pid: {}) exited with status: {}.", module_name, pid,
+                                               wstatus);
+                    shutdown_info.push_back({module_name, wstatus});
+                    if (module_handles.size() > 0) {
+                        continue;
+                    } else {
+                        // TODO: check the shutdown_info here for non-zero exit codes
+                        for (const auto& shutdown_info_entry : shutdown_info) {
+                            EVLOG_info << fmt::format("Module {} exited with status: {}.", shutdown_info_entry.id,
+                                                      shutdown_info_entry.wstatus);
+                        }
+                        print_shutdown_message(shutdown_start_time,
+                                               fmt::format(TERMINAL_STYLE_OK, "All modules shut down properly. "));
+                        shutdown_complete = true;
+                        cleanup(*mqtt_abstraction);
+                        return EXIT_SUCCESS;
+                    }
+                } else if (shutdown_info.size() > 0) {
+                    EVLOG_error << fmt::format("Module {} (pid: {}) exited with status: {} during a shutdown. This is "
+                                               "probably a bug in your shutdown handler implementation.",
+                                               module_name, pid, wstatus);
+                    shutdown_info.push_back({module_name, wstatus});
+                    if (module_handles.size() > 0) {
+                        continue;
+                    } else {
+                        std::string remaining_modules;
+                        for (auto& info : shutdown_info) {
+                            if (info.wstatus != 0) {
+                                remaining_modules += fmt::format(" {} (status: {})", info.id, info.wstatus);
+                            }
+                        }
+
+                        EVLOG_info << "Modules that did not shut down correctly:" << remaining_modules;
+                        print_shutdown_message(shutdown_start_time);
+
+                        cleanup(*mqtt_abstraction);
+                        return EXIT_SUCCESS;
+                    }
+                }
                 EVLOG_critical << fmt::format("Module {} (pid: {}) exited with status: {}. Terminating all modules.",
                                               module_name, pid, wstatus);
                 shutdown_modules(module_handles, *config, *mqtt_abstraction);
@@ -864,7 +950,10 @@ int boot(const po::variables_map& vm) {
                 mqtt_abstraction->disconnect();
 
                 // Exit if a module died, this gives systemd a change to restart manager
-                EVLOG_critical << "Exiting manager.";
+                print_shutdown_message(shutdown_start_time,
+                                       fmt::format(fmt::format(TERMINAL_STYLE_ERROR, "Abnormal shutdown caused by {}{}",
+                                                               fmt::format(TERMINAL_STYLE_BLUE, module_name),
+                                                               fmt::format(TERMINAL_STYLE_ERROR, " module. "))));
                 return EXIT_FAILURE;
             } else {
                 EVLOG_info << fmt::format("Module {} (pid: {}) exited with status: {}.", module_name, pid, wstatus);
@@ -911,6 +1000,34 @@ int boot(const po::variables_map& vm) {
             // TIMEOUT fall-through
         }
 #endif
+        // check signals
+        auto signal_received = signal_polling.poll_signal();
+        if (signal_received.has_value()) {
+            if (signal_received.value() == SIGINT) {
+                if (not sigint_received) {
+                    sigint_received = true;
+                    shutdown_start_time = std::chrono::system_clock::now();
+                    EVLOG_info << "Shutting down modules...";
+                    mqtt_abstraction->publish(fmt::format("{}shutdown", ms.mqtt_settings.everest_prefix),
+                                              std::string("true"), QOS::QOS2, false);
+                } else {
+                    EVLOG_info << "Terminating manager";
+                    exit(EXIT_FAILURE);
+                }
+            }
+        }
+
+        if (shutdown_initiated and not completing_shutdown and shutdown_start_time.has_value()) {
+            if (std::chrono::system_clock::now() >=
+                shutdown_start_time.value() + std::chrono::milliseconds(SHUTDOWN_TIMEOUT_MS)) {
+                completing_shutdown = true;
+                if (not shutdown_complete) {
+                    EVLOG_error << "Could not shut down in time. Terminating all remaining modules.";
+                    shutdown_complete = true;
+                    shutdown_modules(module_handles, *config, *mqtt_abstraction);
+                }
+            }
+        }
     }
 
     return EXIT_SUCCESS;

--- a/lib/everest/framework/src/manager.cpp
+++ b/lib/everest/framework/src/manager.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
-#include <unordered_map>
+#include <optional>
 
 #include <cstdlib>
 #include <errno.h>
@@ -28,11 +28,11 @@
 #include <framework/everest.hpp>
 #include <framework/runtime.hpp>
 #include <utils/config.hpp>
-#include <utils/date.hpp>
 #include <utils/mqtt_abstraction.hpp>
 #include <utils/status_fifo.hpp>
 
-#include "controller/ipc.hpp"
+#include "manager.hpp"
+#include "manager_admin_panel.hpp"
 #include "system_unix.hpp"
 #include <generated/version_information.hpp>
 
@@ -41,36 +41,17 @@ namespace fs = std::filesystem;
 
 using namespace Everest;
 
-const auto PARENT_DIED_SIGNAL = SIGTERM;
-const int CONTROLLER_IPC_READ_TIMEOUT_MS = 50;
-const auto complete_start_time = std::chrono::steady_clock::now();
-
-#ifdef ENABLE_ADMIN_PANEL
-class ControllerHandle {
-public:
-    ControllerHandle(pid_t pid, int socket_fd) : pid(pid), socket_fd(socket_fd) {
-        // we do "non-blocking" read
-        controller_ipc::set_read_timeout(socket_fd, CONTROLLER_IPC_READ_TIMEOUT_MS);
-    }
-
-    void send_message(const nlohmann::json& msg) {
-        controller_ipc::send_message(socket_fd, msg);
-    }
-
-    controller_ipc::Message receive_message() {
-        return controller_ipc::receive_message(socket_fd);
-    }
-
-    void shutdown() {
-        // FIXME (aw): tbd
-    }
-
-    const pid_t pid;
-
-private:
-    const int socket_fd;
-};
-#endif
+// While no shutdown/force-kill deadline is running the main loop only has to react to signals
+// (SIGINT/SIGTERM/SIGCHLD wake the signal fd poll immediately), so it can block for a long time
+// instead of ticking every SIGNAL_POLL_TIMEOUT_MS.
+const auto IDLE_SIGNAL_POLL_TIMEOUT_MS = 60000;
+const auto SIGNAL_POLL_TIMEOUT_MS = 50;
+// Graceful-shutdown deadline before force-terminating modules; only applies with
+// --graceful-shutdown. Without the flag the deadline is zero and modules are terminated
+// immediately when the shutdown flow starts.
+const auto SHUTDOWN_TIMEOUT_MS = 5000;
+const auto FORCE_KILL_GRACE_TIMEOUT_MS = 5000;
+const std::uint8_t MAX_UNEXPECTED_MODULE_RESTARTS = 3;
 
 // Helper struct keeping information on how to start module
 struct ModuleStartInfo {
@@ -97,6 +78,25 @@ struct ModuleStartInfo {
 };
 
 namespace {
+
+// Anonymous-namespace helpers used by Manager::run() and module spawn paths.
+
+/// \brief Convert a wait status code to a compact readable string.
+std::string format_wait_status(int status) {
+    if (WIFEXITED(status)) {
+        return fmt::format("exit_code={}", WEXITSTATUS(status));
+    }
+    if (WIFSIGNALED(status)) {
+        return fmt::format("signal={}", WTERMSIG(status));
+    }
+    return fmt::format("raw={}", status);
+}
+
+/// \brief Return true if process exited normally with code 0.
+bool is_clean_exit(int status) {
+    return WIFEXITED(status) && (WEXITSTATUS(status) == 0);
+}
+
 /// \brief Setup common environment variables for everestjs and everestpy
 void setup_environment(const ModuleStartInfo& module_info, const RuntimeSettings& rs,
                        const MQTTSettings& mqtt_settings) {
@@ -117,7 +117,9 @@ void setup_environment(const ModuleStartInfo& module_info, const RuntimeSettings
     }
 }
 
-static void exec_module(const std::string& bin, std::vector<std::string>& arguments, system::SubProcess& proc_handle) {
+/// \brief Execute a module process and report exec failures to parent.
+static void exec_module_binary(const std::string& bin, std::vector<std::string>& arguments,
+                               system::SubProcess& proc_handle) {
     // Convert the argument list to the format required by `execv*()`.
     std::vector<char*> argv_list(arguments.size() + 1);
     std::transform(arguments.begin(), arguments.end(), argv_list.begin(), [](auto& value) { return value.data(); });
@@ -132,6 +134,7 @@ static void exec_module(const std::string& bin, std::vector<std::string>& argume
     proc_handle.send_error_and_exit(msg);
 }
 
+/// \brief Build argv and execute a C++ module binary.
 void exec_cpp_module(system::SubProcess& proc_handle, const ModuleStartInfo& module_info, const RuntimeSettings& rs,
                      const MQTTSettings& mqtt_settings) {
     std::vector<std::string> arguments = {
@@ -154,13 +157,12 @@ void exec_cpp_module(system::SubProcess& proc_handle, const ModuleStartInfo& mod
                                            std::to_string(mqtt_settings.broker_port)});
     }
 
-    exec_module(module_info.path.string(), arguments, proc_handle);
+    exec_module_binary(module_info.path.string(), arguments, proc_handle);
 }
 
+/// \brief Prepare environment and execute a JavaScript module via node.
 void exec_javascript_module(system::SubProcess& proc_handle, const ModuleStartInfo& module_info,
                             const RuntimeSettings& rs, const MQTTSettings& mqtt_settings) {
-    // instead of using setenv, using execvpe might be a better way for a controlled environment!
-
     // FIXME (aw): everest directory layout
     const auto node_modules_path = rs.prefix / defaults::LIB_DIR / defaults::NAMESPACE / "node_modules";
     setenv("NODE_PATH", node_modules_path.c_str(), 0);
@@ -172,13 +174,12 @@ void exec_javascript_module(system::SubProcess& proc_handle, const ModuleStartIn
         module_info.path.string(),
     };
 
-    exec_module("node", arguments, proc_handle);
+    exec_module_binary("node", arguments, proc_handle);
 }
 
+/// \brief Prepare environment and execute a Python module.
 void exec_python_module(system::SubProcess& proc_handle, const ModuleStartInfo& module_info, const RuntimeSettings& rs,
                         const MQTTSettings& mqtt_settings) {
-    // instead of using setenv, using execvpe might be a better way for a controlled environment!
-
     setup_environment(module_info, rs, mqtt_settings);
 
     // Prepend the everestpy path to $PYTHONPATH. This ensures modules can always find everestpy.
@@ -214,9 +215,10 @@ void exec_python_module(system::SubProcess& proc_handle, const ModuleStartInfo& 
     }
 
     std::vector<std::string> arguments = {python_binary, module_info.path.c_str()};
-    exec_module(python_binary, arguments, proc_handle);
+    exec_module_binary(python_binary, arguments, proc_handle);
 }
 
+/// \brief Dispatch module execution to the language-specific executor.
 void exec_module(const RuntimeSettings& rs, const MQTTSettings& mqtt_settings, const ModuleStartInfo& module,
                  system::SubProcess& proc_handle) {
     switch (module.language) {
@@ -235,6 +237,7 @@ void exec_module(const RuntimeSettings& rs, const MQTTSettings& mqtt_settings, c
     }
 }
 
+/// \brief Spawn configured module processes and return pid-to-module mapping.
 std::map<pid_t, std::string> spawn_modules(const std::vector<ModuleStartInfo>& modules, const ManagerSettings& ms) {
     std::map<pid_t, std::string> started_modules;
 
@@ -263,37 +266,15 @@ std::map<pid_t, std::string> spawn_modules(const std::vector<ModuleStartInfo>& m
 
     return started_modules;
 }
+
 } // namespace
 
-struct ModuleReadyInfo {
-    bool ready;
-    std::shared_ptr<TypedHandler> ready_token;
-    std::shared_ptr<TypedHandler> get_config_token;
-};
+/// \brief Publish startup metadata, register handlers, and spawn module processes.
+void Manager::publish_startup_metadata(const RuntimeContext& ctx) const {
+    const auto& config = *ctx.config;
+    auto& mqtt_abstraction = ctx.mqtt_abstraction;
+    const auto& ms = ctx.ms;
 
-// FIXME (aw): these are globals here, because they are used in the ready callback handlers
-using ModulesReadyType = std::unordered_map<std::string, ModuleReadyInfo>;
-namespace {
-ModulesReadyType modules_ready; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-// Don't hold the mutex and use any function of the `mqtt_abstraction` since the
-// mutex is also held inside the `ready` handler which can deadlock.
-std::mutex modules_ready_mutex; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstraction& mqtt_abstraction,
-                                           const std::vector<std::string>& ignored_modules,
-                                           const std::vector<std::string>& standalone_modules,
-                                           const ManagerSettings& ms, StatusFifo& status_fifo, bool retain_topics) {
-    BOOST_LOG_FUNCTION();
-
-    std::vector<ModuleStartInfo> modules_to_spawn;
-
-    const auto& module_configurations = config.get_module_configurations();
-    const auto& module_names = config.get_module_names();
-    modules_to_spawn.reserve(module_configurations.size());
-    const auto number_of_modules = module_configurations.size();
-    EVLOG_info << "Starting " << number_of_modules << " modules";
-
-    // TODO: move this into its own functions / class? ConfigService?
     const auto interface_definitions = config.get_interface_definitions();
     std::vector<std::string> interface_names;
     for (auto& interface_definition : interface_definitions.items()) {
@@ -301,14 +282,11 @@ std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstractio
     }
 
     MqttMessagePayload payload{MqttMessageType::GetConfigResponse, interface_names};
-
     mqtt_abstraction.publish(fmt::format("{}interfaces", ms.mqtt_settings.everest_prefix), payload, QOS::QOS2, true);
 
     for (const auto& interface_definition : interface_definitions.items()) {
-
         MqttMessagePayload interface_definition_payload{MqttMessageType::GetConfigResponse,
                                                         interface_definition.value()};
-
         mqtt_abstraction.publish(
             fmt::format("{}interface_definitions/{}", ms.mqtt_settings.everest_prefix, interface_definition.key()),
             interface_definition_payload, QOS::QOS2, true);
@@ -321,13 +299,10 @@ std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstractio
     }
 
     MqttMessagePayload type_names_payload{MqttMessageType::GetConfigResponse, type_names};
-
     mqtt_abstraction.publish(fmt::format("{}types", ms.mqtt_settings.everest_prefix), type_names_payload, QOS::QOS2,
                              true);
     for (const auto& type_definition : type_definitions.items()) {
-
         MqttMessagePayload type_definition_payload{MqttMessageType::GetConfigResponse, type_definition.value()};
-
         // type_definition keys already start with a / so omit it in the topic name
         mqtt_abstraction.publish(
             fmt::format("{}type_definitions{}", ms.mqtt_settings.everest_prefix, type_definition.key()),
@@ -335,36 +310,708 @@ std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstractio
     }
 
     const auto settings = config.get_settings();
-
     MqttMessagePayload settings_payload{MqttMessageType::GetConfigResponse, settings};
-
     mqtt_abstraction.publish(fmt::format("{}settings", ms.mqtt_settings.everest_prefix), settings_payload, QOS::QOS2,
                              true);
 
     if (ms.runtime_settings.validate_schema) {
         const auto schemas = config.get_schemas();
-
         MqttMessagePayload schemas_payload{MqttMessageType::GetConfigResponse, schemas};
-
         mqtt_abstraction.publish(fmt::format("{}schemas", ms.mqtt_settings.everest_prefix), schemas_payload, QOS::QOS2,
                                  true);
     }
-    const auto manifests = config.get_manifests();
 
+    const auto manifests = config.get_manifests();
     for (const auto& manifest : manifests.items()) {
         auto manifest_copy = manifest.value();
         manifest_copy.erase("config");
-
         MqttMessagePayload manifest_payload{MqttMessageType::GetConfigResponse, manifest_copy};
-
         mqtt_abstraction.publish(fmt::format("{}manifests/{}", ms.mqtt_settings.everest_prefix, manifest.key()),
                                  manifest_payload, QOS::QOS2, true);
     }
 
+    const auto module_names = config.get_module_names();
     MqttMessagePayload module_names_payload{MqttMessageType::GetConfigResponse, module_names};
-
     mqtt_abstraction.publish(fmt::format("{}module_names", ms.mqtt_settings.everest_prefix), module_names_payload,
                              QOS::QOS2, true);
+}
+
+/// \brief Unregister all module ready handlers and clear tracked ready state.
+void Manager::unregister_module_ready_handlers(ManagerConfig& config, MQTTAbstraction& mqtt_abstraction) {
+    ModulesReadyType modules_ready_moved;
+    {
+        const std::lock_guard<std::mutex> lck(modules_ready_mutex_);
+        modules_ready_moved = std::move(modules_ready_);
+        // Probably not needed after our move but lets be explicit.
+        modules_ready_.clear();
+    }
+
+    for (const auto& module : modules_ready_moved) {
+        const auto& ready_info = module.second;
+        if (!ready_info.ready_token) {
+            // Skip entries from a partial startup that never got a token assigned.
+            continue;
+        }
+        const auto& module_name = module.first;
+        const std::string topic = fmt::format("{}/ready", config.mqtt_module_prefix(module_name));
+        mqtt_abstraction.unregister_handler(topic, ready_info.ready_token);
+    }
+}
+
+void Manager::cleanup_modules_state(ManagerConfig& config, MQTTAbstraction& mqtt_abstraction) {
+    unregister_module_ready_handlers(config, mqtt_abstraction);
+    mqtt_abstraction.clear_retained_topics();
+}
+
+/// \brief Stop all remaining module processes, escalating SIGTERM to SIGKILL.
+void Manager::shutdown_modules(const std::map<pid_t, std::string>& modules, ManagerConfig& config,
+                               MQTTAbstraction& mqtt_abstraction) {
+
+    unregister_module_ready_handlers(config, mqtt_abstraction);
+
+    for (const auto& child : modules) {
+        auto retval = kill(child.first, SIGTERM);
+        // FIXME (aw): supply errno strings
+        if (retval != 0) {
+            EVLOG_critical << fmt::format("SIGTERM of child: {} (pid: {}) {}: {}. Escalating to SIGKILL", child.second,
+                                          child.first, fmt::format(TERMINAL_STYLE_ERROR, "failed"), retval);
+            retval = kill(child.first, SIGKILL);
+            if (retval != 0) {
+                EVLOG_critical << fmt::format("SIGKILL of child: {} (pid: {}) {}: {}.", child.second, child.first,
+                                              fmt::format(TERMINAL_STYLE_ERROR, "failed"), retval);
+            } else {
+                EVLOG_info << fmt::format("SIGKILL of child: {} (pid: {}) {}.", child.second, child.first,
+                                          fmt::format(TERMINAL_STYLE_OK, "succeeded"));
+            }
+        } else {
+            EVLOG_info << fmt::format("SIGTERM of child: {} (pid: {}) {}.", child.second, child.first,
+                                      fmt::format(TERMINAL_STYLE_OK, "succeeded"));
+        }
+    }
+}
+
+namespace {
+
+/// \brief Select configuration boot mode from CLI options.
+ConfigBootMode parse_config_boot_mode(const std::string& config_opt, const std::string& db_opt, const bool db_init) {
+    if (config_opt.empty() and db_opt.empty()) {
+        // no config or db option given, use default
+        return ConfigBootMode::YamlFile;
+    }
+    if (!config_opt.empty() && !db_opt.empty()) {
+        if (db_init == false) {
+            throw BootException("Both --config and --db options are set, but no --db-init option is given. "
+                                "This is not allowed.");
+        }
+        return ConfigBootMode::DatabaseInit;
+    }
+    if (!config_opt.empty()) {
+        // only config option given, use yaml file
+        return ConfigBootMode::YamlFile;
+    }
+    if (!db_opt.empty()) {
+        // only db option given, use database
+        return ConfigBootMode::Database;
+    }
+    throw std::logic_error("Could not parse config boot source, this should never happen.");
+}
+
+/// \brief Disconnect MQTT before the manager process exits (after controller shutdown).
+void disconnect_mqtt(MQTTAbstraction& mqtt_abstraction) {
+    mqtt_abstraction.disconnect();
+}
+
+/// \brief Print startup banner and version information.
+void print_start_message(const std::string& version_information) {
+    EVLOG_info << "  \033[0;1;35;95m_\033[0;1;31;91m__\033[0;1;33;93m__\033[0;1;32;92m__\033[0;1;36;96m_\033[0m      "
+                  "\033[0;1;31;91m_\033[0;1;33;93m_\033[0m                \033[0;1;36;96m_\033[0m   ";
+    EVLOG_info << " \033[0;1;31;91m|\033[0m  \033[0;1;33;93m_\033[0;1;32;92m__\033[0;1;36;96m_\\\033[0m "
+                  "\033[0;1;34;94m\\\033[0m    \033[0;1;33;93m/\033[0m \033[0;1;32;92m/\033[0m               "
+                  "\033[0;1;34;94m|\033[0m \033[0;1;35;95m|\033[0m";
+    EVLOG_info
+        << " \033[0;1;33;93m|\033[0m \033[0;1;32;92m|_\033[0;1;36;96m_\033[0m   \033[0;1;35;95m\\\033[0m "
+           "\033[0;1;31;91m\\\033[0m  \033[0;1;33;93m/\033[0m \033[0;1;32;92m/\033[0;1;36;96m__\033[0m "
+           "\033[0;1;34;94m_\033[0m \033[0;1;35;95m_\033[0;1;31;91m_\033[0m \033[0;1;33;93m__\033[0;1;32;92m_\033[0m  "
+           "\033[0;1;36;96m_\033[0;1;34;94m__\033[0;1;35;95m|\033[0m \033[0;1;31;91m|_\033[0m";
+    EVLOG_info << " \033[0;1;32;92m|\033[0m  \033[0;1;36;96m_\033[0;1;34;94m_|\033[0m   \033[0;1;31;91m\\\033[0m "
+                  "\033[0;1;33;93m\\\033[0;1;32;92m/\033[0m \033[0;1;36;96m/\033[0m \033[0;1;34;94m_\033[0m "
+                  "\033[0;1;35;95m\\\033[0m \033[0;1;31;91m'_\033[0;1;33;93m_/\033[0m \033[0;1;32;92m_\033[0m "
+                  "\033[0;1;36;96m\\\033[0;1;34;94m/\033[0m \033[0;1;35;95m__\033[0;1;31;91m|\033[0m "
+                  "\033[0;1;33;93m__\033[0;1;32;92m|\033[0m";
+    EVLOG_info << " \033[0;1;36;96m|\033[0m \033[0;1;34;94m|_\033[0;1;35;95m__\033[0;1;31;91m_\033[0m   "
+                  "\033[0;1;32;92m\\\033[0m  \033[0;1;36;96m/\033[0m  \033[0;1;35;95m__\033[0;1;31;91m/\033[0m "
+                  "\033[0;1;33;93m|\033[0m \033[0;1;32;92m|\033[0m  "
+                  "\033[0;1;36;96m_\033[0;1;34;94m_/\033[0;1;35;95m\\_\033[0;1;31;91m_\033[0m \033[0;1;33;93m\\\033[0m "
+                  "\033[0;1;32;92m|_\033[0m";
+    EVLOG_info << " \033[0;1;34;94m|_\033[0;1;35;95m__\033[0;1;31;91m__\033[0;1;33;93m_|\033[0m   "
+                  "\033[0;1;36;96m\\\033[0;1;34;94m/\033[0m "
+                  "\033[0;1;35;95m\\_\033[0;1;31;91m__\033[0;1;33;93m|_\033[0;1;32;92m|\033[0m  "
+                  "\033[0;1;36;96m\\\033[0;1;34;94m__\033[0;1;35;95m_|\033[0;1;31;91m|_\033[0;1;33;93m__\033[0;1;32;"
+                  "92m/\\\033[0;1;36;96m__\033[0;1;34;94m|\033[0m";
+    EVLOG_info << "";
+    EVLOG_info << PROJECT_NAME << " " << PROJECT_VERSION << " " << GIT_VERSION;
+    EVLOG_info << version_information;
+    EVLOG_info << "";
+}
+
+/// \brief Print final shutdown message including elapsed shutdown duration.
+void print_shutdown_message(const std::optional<std::chrono::steady_clock::time_point> shutdown_start_time,
+                            const std::string& message_prefix = "") {
+    auto shutdown_duration = 0LL;
+    if (shutdown_start_time.has_value()) {
+        shutdown_duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                                                  shutdown_start_time.value())
+                                .count();
+    } else {
+        EVLOG_info << "shutdown start time is not set?";
+    }
+    EVLOG_info << fmt::format(
+        TERMINAL_STYLE_ERROR, "👋👋👋 {}{}", message_prefix,
+        fmt::format(TERMINAL_STYLE_ERROR, "EVerest manager is exiting [{}ms] 👋👋👋", shutdown_duration));
+}
+
+} // namespace
+
+// ---- State/event handlers ---------------------------------------------------
+
+std::string Manager::format_unclean_exits() const {
+    std::string bad_modules;
+    for (const auto& info : shutdown_info_) {
+        if (!is_clean_exit(info.wstatus)) {
+            bad_modules += fmt::format(" {} ({})", info.id, format_wait_status(info.wstatus));
+        }
+    }
+    return bad_modules;
+}
+
+void Manager::reset_shutdown_state() {
+    shutdown_info_.clear();
+    shutdown_start_time_ = std::nullopt;
+    shutdown_cause_ = ShutdownCause::None;
+    force_terminate_start_time_ = std::nullopt;
+    force_kill_sent_ = false;
+}
+
+std::optional<int> Manager::transition_to_idle_after_shutdown(std::string_view log_message) {
+    transition_to(ManagerState::Idle);
+    EVLOG_info << log_message;
+    return std::nullopt;
+}
+
+int Manager::transition_to_exiting_after_shutdown(RuntimeContext& ctx, ManagerAdminPanel& admin_panel, int exit_code,
+                                                  bool reset_state) {
+    admin_panel.shutdown_controller();
+    disconnect_mqtt(ctx.mqtt_abstraction);
+    if (reset_state) {
+        reset_shutdown_state();
+    }
+    transition_to(ManagerState::Exiting);
+    return exit_code;
+}
+
+void Manager::handle_restart_modules_after_shutdown(RuntimeContext& ctx) {
+    // Cleanup with the OLD config before the reload below. Required because this function is also
+    // called from advance_lifecycle_state_if_ready() (crash-with-restart path) which does not go
+    // through handle_finish_* finalize functions.
+    cleanup_modules_state(*ctx.config, ctx.mqtt_abstraction);
+
+    ctx.config = std::make_shared<ManagerConfig>(ctx.ms);
+    module_handles_ = handle_start_modules(ctx);
+    reset_shutdown_state();
+    EVLOG_info << "Modules restart initiated with reloaded configuration.";
+}
+
+std::optional<int> Manager::handle_finish_normal_shutdown(RuntimeContext& ctx, ManagerAdminPanel& admin_panel) {
+    const std::string bad_modules = format_unclean_exits();
+    // Cleanup module state while MQTT is still connected (must be before disconnect_mqtt() in Exiting path).
+    cleanup_modules_state(*ctx.config, ctx.mqtt_abstraction);
+    if (sigint_received_) {
+        if (bad_modules.empty()) {
+            notify_status_fifo(StatusFifo::ALL_MODULES_STOPPED_CLEAN);
+            print_shutdown_message(shutdown_start_time_,
+                                   fmt::format(TERMINAL_STYLE_OK, "All modules shut down properly. "));
+        } else {
+            EVLOG_warning << "Modules that did not shut down cleanly:" << bad_modules;
+            print_shutdown_message(shutdown_start_time_);
+        }
+        return transition_to_exiting_after_shutdown(ctx, admin_panel, EXIT_SUCCESS, true);
+    }
+
+    if (!bad_modules.empty()) {
+        EVLOG_warning << "Modules that did not shut down cleanly:" << bad_modules;
+    }
+    reset_shutdown_state();
+    return transition_to_idle_after_shutdown("Manager is idle after module shutdown. Send SIGINT/SIGTERM to stop.");
+}
+
+std::optional<int> Manager::handle_finish_crash_recovery(RuntimeContext& ctx, ManagerAdminPanel& admin_panel) {
+    const auto duration_ms = shutdown_start_time_.has_value()
+                                 ? std::chrono::duration_cast<std::chrono::milliseconds>(
+                                       std::chrono::steady_clock::now() - shutdown_start_time_.value())
+                                       .count()
+                                 : 0;
+    const std::string bad_modules = format_unclean_exits();
+    if (bad_modules.empty()) {
+        EVLOG_info << fmt::format("All {} modules shut down gracefully after crash [{}ms].", shutdown_info_.size(),
+                                  duration_ms);
+    } else {
+        EVLOG_warning << fmt::format(
+            "Crash recovery shutdown completed in {} ms. Modules that did not shut down cleanly: {}", duration_ms,
+            bad_modules);
+    }
+
+    cleanup_modules_state(*ctx.config, ctx.mqtt_abstraction);
+    reset_shutdown_state();
+
+    // Stay idle only when the user has not requested a stop via SIGINT/SIGTERM.
+    if (recover_module_crashes_ && !sigint_received_) {
+        return transition_to_idle_after_shutdown(
+            "Crash recovery completed, manager is idle after module shutdown. Send SIGINT/SIGTERM to stop.");
+    }
+
+    EVLOG_critical << "Unexpected module exit; manager is exiting.";
+    return transition_to_exiting_after_shutdown(ctx, admin_panel, EXIT_FAILURE, false);
+}
+
+std::optional<int> Manager::handle_finalize_shutdown_transition(RuntimeContext& ctx, ManagerAdminPanel& admin_panel,
+                                                                bool restart_requested, bool crash_in_progress) {
+    if (crash_in_progress) {
+        return handle_finish_crash_recovery(ctx, admin_panel);
+    }
+    if (restart_requested) {
+        handle_restart_modules_after_shutdown(ctx);
+        return std::nullopt;
+    }
+    return handle_finish_normal_shutdown(ctx, admin_panel);
+}
+
+void Manager::handle_initiate_graceful_shutdown(const std::chrono::steady_clock::time_point& module_exited_time,
+                                                bool publish_when_sigint_received,
+                                                const std::optional<std::string>& info_log,
+                                                MQTTAbstraction& mqtt_abstraction, const ManagerSettings& ms) {
+    if (is_in_shutdown_flow_state() or is_idle()) {
+        return;
+    }
+    transition_to(ManagerState::ShutdownRequested);
+    shutdown_start_time_ = module_exited_time;
+    if (publish_when_sigint_received or not sigint_received_) {
+        if (info_log.has_value()) {
+            EVLOG_critical << info_log.value();
+        }
+        if (graceful_shutdown_enabled_) {
+            mqtt_abstraction.publish(fmt::format("{}shutdown", ms.mqtt_settings.everest_prefix), std::string("true"),
+                                     QOS::QOS2, false);
+        }
+    }
+}
+
+// ---- Core run loop ----------------------------------------------------------
+
+int Manager::run() {
+    const bool check = (vm_.count("check") != 0);
+    auto status_fifo = StatusFifo::create_from_path(vm_["status-fifo"].as<std::string>());
+    status_fifo_ = &status_fifo;
+    sigint_received_ = false;
+    shutdown_cause_ = ShutdownCause::None;
+    transition_to(ManagerState::Initializing);
+    unexpected_module_exit_count_ = 0;
+    shutdown_start_time_ = std::nullopt;
+    force_terminate_start_time_ = std::nullopt;
+    force_kill_sent_ = false;
+    auto signal_polling = system::SignalPolling();
+
+    const auto prefix_opt = parse_string_option(vm_, "prefix");
+    const auto config_opt = parse_string_option(vm_, "config");
+    const auto db_opt = parse_string_option(vm_, "db");
+    const auto db_init = vm_.count("db-init") != 0;
+    ConfigBootMode boot_mode = parse_config_boot_mode(config_opt, db_opt, db_init);
+
+    ManagerSettings ms;
+
+    switch (boot_mode) {
+    case ConfigBootMode::YamlFile:
+        ms = ManagerSettings(prefix_opt, config_opt);
+        break;
+    case ConfigBootMode::Database:
+        ms = ManagerSettings(prefix_opt, db_opt, DatabaseTag{});
+        break;
+    case ConfigBootMode::DatabaseInit:
+        ms = ManagerSettings(prefix_opt, config_opt, db_opt);
+        break;
+    default:
+        throw BootException(fmt::format("Invalid boot source: {}", static_cast<int>(boot_mode)));
+    }
+
+    // CLI override for mqtt_everest_prefix (e.g. for parallel test execution).
+    if (vm_.count("mqtt_everest_prefix") != 0) {
+        auto prefix = vm_["mqtt_everest_prefix"].as<std::string>();
+        if (!prefix.empty() && prefix.back() != '/') {
+            prefix += "/";
+        }
+        ms.mqtt_settings.everest_prefix = prefix;
+    }
+
+    Logging::init(ms.runtime_settings.logging_config_file.string());
+
+    Date::preload_tzdb();
+
+    print_start_message(ms.version_information);
+
+    if (not ms.mqtt_settings.uses_socket()) {
+        EVLOG_info << "Using MQTT broker " << ms.mqtt_settings.broker_host << ":" << ms.mqtt_settings.broker_port;
+    } else {
+        EVLOG_info << "Using MQTT broker unix domain sockets:" << ms.mqtt_settings.broker_socket_path;
+    }
+    if (ms.runtime_settings.telemetry_enabled) {
+        EVLOG_info << "Telemetry enabled";
+    }
+    if (not ms.run_as_user.empty()) {
+        EVLOG_info << "EVerest will run as system user: " << ms.run_as_user;
+    }
+    if (ms.runtime_settings.forward_exceptions) {
+        EVLOG_info << "Catching and forwarding command exceptions to callers";
+    }
+
+    auto admin_panel = ManagerAdminPanel::create(ms);
+
+    EVLOG_verbose << fmt::format("EVerest prefix was set to {}", ms.runtime_settings.prefix.string());
+
+    // dump all manifests if requested and terminate afterwards
+    if (vm_.count("dumpmanifests")) {
+        const auto dumpmanifests_path = fs::path(vm_["dumpmanifests"].as<std::string>());
+        EVLOG_debug << fmt::format("Dumping all known validated manifests into '{}'", dumpmanifests_path.string());
+
+        auto manifests = Config::load_all_manifests(ms.runtime_settings.modules_dir.string(), ms.schemas_dir.string());
+
+        for (const auto& module : manifests.items()) {
+            const std::string filename = module.key() + ".yaml";
+            const auto module_output_path = dumpmanifests_path / filename;
+            // FIXME (aw): should we check if the directory exists?
+            std::ofstream output_stream(module_output_path);
+
+            // FIXME (aw): this should be either YAML prettyfied, or better, directly copied
+            output_stream << module.value().dump(DUMP_INDENT);
+        }
+
+        return EXIT_SUCCESS;
+    }
+
+    const bool retain_topics = (vm_.count("retain-topics") != 0);
+
+    std::shared_ptr<ManagerConfig> config; // TODO: maybe this can stay unique when we re-work start_modules()
+    try {
+        config = load_and_validate_config(ms);
+    } catch (...) {
+        return EXIT_FAILURE;
+    }
+
+    // dump config if requested
+    if (vm_.count("dump")) {
+        const auto dump_path = fs::path(vm_["dump"].as<std::string>());
+        EVLOG_debug << fmt::format("Dumping validated config and manifests into '{}'", dump_path.string());
+
+        const auto config_dump_path = dump_path / "config.json";
+
+        std::ofstream output_config_stream(config_dump_path);
+
+        output_config_stream << json(config->get_module_configurations()).dump(DUMP_INDENT);
+
+        const auto manifests = config->get_manifests();
+
+        for (const auto& module : manifests.items()) {
+            const std::string filename = module.key() + ".json";
+            const auto module_output_path = dump_path / filename;
+            std::ofstream output_stream(module_output_path);
+
+            output_stream << module.value().dump(DUMP_INDENT);
+        }
+    }
+
+    // only config check (and or config dumping) was requested, log check result and exit
+    if (check) {
+        EVLOG_debug << "Config is valid, terminating as requested";
+        return EXIT_SUCCESS;
+    }
+
+    std::vector<std::string> standalone_modules = collect_standalone_modules(*config);
+    std::vector<std::string> ignored_modules = collect_ignored_modules();
+
+    auto mqtt_abstraction = create_and_connect_mqtt(ms);
+    if (!mqtt_abstraction) {
+        return EXIT_FAILURE;
+    }
+
+    auto config_service = std::make_unique<config::ConfigService>(*mqtt_abstraction, config);
+
+    RuntimeContext runtime_ctx{config, *mqtt_abstraction, ignored_modules, standalone_modules,
+                               ms,     status_fifo,       retain_topics};
+    if (vm_.count("into-idle") == 0) {
+        module_handles_ = handle_start_modules(runtime_ctx);
+    } else {
+        transition_to(ManagerState::Idle);
+    }
+
+    if (const auto err_set_user = ManagerAdminPanel::switch_manager_user_if_needed(runtime_ctx.ms)) {
+        EVLOG_error << "Error switching manager to user " << runtime_ctx.ms.run_as_user << ": " << *err_set_user;
+        return EXIT_FAILURE;
+    }
+
+    int wstatus; // NOLINT(cppcoreguidelines-init-variables): this is always initialized in the following waitpid call
+    shutdown_info_.clear();
+
+    while (true) {
+        if (handle_waitpid_event(wstatus, runtime_ctx, admin_panel)) {
+            continue;
+        }
+
+        const auto lifecycle_advance = advance_lifecycle_state_if_ready(runtime_ctx, admin_panel);
+        if (lifecycle_advance.status == LifecycleAdvanceResult::Status::ExitRequested) {
+            return *lifecycle_advance.exit_code;
+        }
+        if (lifecycle_advance.status == LifecycleAdvanceResult::Status::TransitionApplied) {
+            continue;
+        }
+
+        if (const auto exit_from_panel = handle_controller_ipc_poll(runtime_ctx, admin_panel, prefix_opt)) {
+            return *exit_from_panel;
+        }
+        if (const auto exit_from_signal = handle_signal_poll(signal_polling, runtime_ctx, admin_panel)) {
+            return *exit_from_signal;
+        }
+
+        handle_shutdown_timeout(runtime_ctx);
+    }
+
+    return EXIT_SUCCESS;
+}
+
+// ---- Setup/helpers ----------------------------------------------------------
+
+std::string_view Manager::state_to_string(ManagerState state) const {
+    switch (state) {
+    case ManagerState::Initializing:
+        return "Initializing";
+    case ManagerState::StartingModules:
+        return "StartingModules";
+    case ManagerState::Running:
+        return "Running";
+    case ManagerState::RestartRequested:
+        return "RestartRequested";
+    case ManagerState::CrashShutdownInProgress:
+        return "CrashShutdownInProgress";
+    case ManagerState::ShutdownRequested:
+        return "ShutdownRequested";
+    case ManagerState::ForceTerminating:
+        return "ForceTerminating";
+    case ManagerState::ShutdownFinalizing:
+        return "ShutdownFinalizing";
+    case ManagerState::Idle:
+        return "Idle";
+    case ManagerState::Exiting:
+        return "Exiting";
+    default:
+        return "Unknown";
+    }
+}
+
+std::shared_ptr<ManagerConfig> Manager::load_and_validate_config(const ManagerSettings& ms) const {
+    const auto start_time = std::chrono::steady_clock::now();
+    std::shared_ptr<ManagerConfig> config;
+    try {
+        config = std::make_shared<ManagerConfig>(ms);
+    } catch (EverestInternalError& e) {
+        EVLOG_error << fmt::format("Failed to load and validate config!\n{}", boost::diagnostic_information(e, true));
+        throw;
+    } catch (boost::exception& e) {
+        EVLOG_error << "Failed to load and validate config!";
+        EVLOG_critical << fmt::format("Caught top level boost::exception:\n{}", boost::diagnostic_information(e, true));
+        throw;
+    } catch (std::exception& e) {
+        EVLOG_error << "Failed to load and validate config!";
+        EVLOG_critical << fmt::format("Caught top level std::exception:\n{}", boost::diagnostic_information(e, true));
+        throw;
+    }
+    const auto end_time = std::chrono::steady_clock::now();
+    EVLOG_info << "Config loading completed in "
+               << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms";
+    return config;
+}
+
+std::unique_ptr<MQTTAbstraction> Manager::create_and_connect_mqtt(const ManagerSettings& ms) const {
+    auto mqtt_abstraction = make_mqtt_abstraction(ms.mqtt_settings);
+    if (!mqtt_abstraction->connect()) {
+        if (not ms.mqtt_settings.uses_socket()) {
+            EVLOG_error << fmt::format("Cannot connect to MQTT broker at {}:{}", ms.mqtt_settings.broker_host,
+                                       ms.mqtt_settings.broker_port);
+        } else {
+            EVLOG_error << fmt::format("Cannot connect to MQTT broker socket at {}",
+                                       ms.mqtt_settings.broker_socket_path);
+        }
+        return nullptr;
+    }
+
+    mqtt_abstraction->spawn_main_loop_thread();
+    return mqtt_abstraction;
+}
+
+std::vector<std::string> Manager::collect_standalone_modules(const ManagerConfig& config) const {
+    std::vector<std::string> standalone_modules;
+    if (vm_.count("standalone")) {
+        standalone_modules = vm_["standalone"].as<std::vector<std::string>>();
+    }
+
+    const auto& module_configurations = config.get_module_configurations();
+    for (const auto& [module_id, module_config] : module_configurations) {
+        if (!module_config.standalone) {
+            continue;
+        }
+        if (std::find(standalone_modules.begin(), standalone_modules.end(), module_id) == standalone_modules.end()) {
+            EVLOG_info << "Module " << fmt::format(TERMINAL_STYLE_BLUE, "{}", module_id)
+                       << " marked as standalone in config";
+            standalone_modules.push_back(module_id);
+        }
+    }
+
+    return standalone_modules;
+}
+
+std::vector<std::string> Manager::collect_ignored_modules() const {
+    if (vm_.count("ignore")) {
+        return vm_["ignore"].as<std::vector<std::string>>();
+    }
+    return {};
+}
+
+void Manager::notify_status_fifo(const std::string_view message) {
+    if (status_fifo_ != nullptr) {
+        status_fifo_->update(std::string(message));
+    }
+}
+
+void Manager::notify_status_fifo_for_state(ManagerState state) {
+    switch (state) {
+    case ManagerState::Initializing:
+        notify_status_fifo(StatusFifo::MANAGER_INITIALIZING);
+        break;
+    case ManagerState::StartingModules:
+        notify_status_fifo(StatusFifo::MANAGER_STARTING_MODULES);
+        break;
+    case ManagerState::Running:
+        notify_status_fifo(StatusFifo::MANAGER_RUNNING);
+        break;
+    case ManagerState::RestartRequested:
+        notify_status_fifo(StatusFifo::MANAGER_RESTART_REQUESTED);
+        break;
+    case ManagerState::CrashShutdownInProgress:
+        notify_status_fifo(StatusFifo::MANAGER_CRASH_SHUTDOWN_IN_PROGRESS);
+        break;
+    case ManagerState::ShutdownRequested:
+        notify_status_fifo(StatusFifo::MANAGER_SHUTDOWN_REQUESTED);
+        break;
+    case ManagerState::ForceTerminating:
+        notify_status_fifo(StatusFifo::MANAGER_FORCE_TERMINATING);
+        break;
+    case ManagerState::ShutdownFinalizing:
+        notify_status_fifo(StatusFifo::MANAGER_SHUTDOWN_FINALIZING);
+        break;
+    case ManagerState::Idle:
+        notify_status_fifo(StatusFifo::MANAGER_IDLE);
+        break;
+    case ManagerState::Exiting:
+        notify_status_fifo(StatusFifo::MANAGER_EXITING);
+        break;
+    default:
+        break;
+    }
+}
+
+void Manager::notify_crash_recovery_attempt(const std::uint8_t attempt, const std::uint8_t max) {
+    notify_status_fifo(fmt::format("CRASH_RECOVERY_ATTEMPT:{}/{}\n", attempt, max));
+}
+
+void Manager::transition_to_unlocked(ManagerState new_state) {
+    const auto current_state = state_.load();
+    if (current_state == new_state) {
+        return;
+    }
+    EVLOG_info << "Manager state transition: " << state_to_string(current_state) << " -> "
+               << state_to_string(new_state);
+    state_ = new_state;
+    notify_status_fifo_for_state(new_state);
+}
+
+void Manager::transition_to(ManagerState new_state) {
+    const std::lock_guard<std::mutex> lock(state_transition_mutex_);
+    transition_to_unlocked(new_state);
+}
+
+ManagerState Manager::current_state_unlocked() const {
+    return state_.load();
+}
+
+bool Manager::is_in_shutdown_flow_state_unlocked() const {
+    const auto s = current_state_unlocked();
+    return (s == ManagerState::ShutdownRequested) || (s == ManagerState::CrashShutdownInProgress) ||
+           (s == ManagerState::ForceTerminating) || (s == ManagerState::RestartRequested) ||
+           (s == ManagerState::ShutdownFinalizing);
+}
+
+Manager::Manager(const po::variables_map& vm) :
+    vm_(vm),
+    recover_module_crashes_(vm.count("recover-module-crashes") != 0),
+    graceful_shutdown_enabled_(vm.count("graceful-shutdown") != 0) {
+}
+
+// ---- State predicates -------------------------------------------------------
+
+bool Manager::is_in_shutdown_flow_state() const {
+    const std::lock_guard<std::mutex> lock(state_transition_mutex_);
+    return is_in_shutdown_flow_state_unlocked();
+}
+
+bool Manager::is_restart_requested() const {
+    const std::lock_guard<std::mutex> lock(state_transition_mutex_);
+    return current_state_unlocked() == ManagerState::RestartRequested;
+}
+
+bool Manager::are_modules_started() const {
+    const std::lock_guard<std::mutex> lock(state_transition_mutex_);
+    return current_state_unlocked() == ManagerState::Running;
+}
+
+bool Manager::is_idle() const {
+    const std::lock_guard<std::mutex> lock(state_transition_mutex_);
+    return current_state_unlocked() == ManagerState::Idle;
+}
+
+// ---- Event loop dispatch handlers ------------------------------------------
+
+/// \brief Handle module startup by publishing metadata, registering handlers, and spawning module processes.
+std::map<pid_t, std::string> Manager::handle_start_modules(const RuntimeContext& ctx) {
+    BOOST_LOG_FUNCTION();
+    module_startup_start_time_ = std::chrono::steady_clock::now();
+    auto& config = *ctx.config;
+    const auto& module_configurations = config.get_module_configurations();
+    if (module_configurations.size() == 0) {
+        EVLOG_info << "List of modules to start is empty";
+        transition_to(ManagerState::Idle);
+        return {};
+    }
+    transition_to(ManagerState::StartingModules);
+    auto& mqtt_abstraction = ctx.mqtt_abstraction;
+    const auto& ignored_modules = ctx.ignored_modules;
+    const auto& standalone_modules = ctx.standalone_modules;
+    const auto& ms = ctx.ms;
+    auto& status_fifo = ctx.status_fifo;
+    const bool retain_topics = ctx.retain_topics;
+
+    std::vector<ModuleStartInfo> modules_to_spawn;
+
+    modules_to_spawn.reserve(module_configurations.size());
+    const auto number_of_modules = module_configurations.size();
+    EVLOG_info << "Starting " << number_of_modules << " modules";
+
+    publish_startup_metadata(ctx);
 
     for (const auto& [module_id_, module_config] : module_configurations) {
         const auto& module_name = module_config.module_name;
@@ -375,8 +1022,12 @@ std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstractio
             continue;
         }
 
-        // FIXME (aw): implicitly adding ModuleReadyInfo and setting its ready member
-        auto module_it = modules_ready.emplace(module_id, ModuleReadyInfo{false, nullptr, nullptr}).first;
+        // ready handlers registered in earlier loop iterations may already fire on the
+        // message-dispatch thread and iterate modules_ready_, so structural changes need the lock
+        auto module_it = [&] {
+            const std::lock_guard<std::mutex> lock(modules_ready_mutex_);
+            return modules_ready_.emplace(module_id, ModuleReadyInfo{}).first;
+        }();
 
         std::vector<std::string> capabilities =
             module_configurations.at(module_id).capabilities.value_or(std::vector<std::string>{});
@@ -386,53 +1037,75 @@ std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstractio
                                       fmt::join(capabilities.begin(), capabilities.end(), " "));
         }
 
-        const Handler module_ready_handler = [module_id, &mqtt_abstraction, &config, standalone_modules,
+        const Handler module_ready_handler = [this, module_id, &mqtt_abstraction, &config, standalone_modules,
                                               mqtt_everest_prefix = ms.mqtt_settings.everest_prefix, &status_fifo,
                                               retain_topics](const std::string&, const nlohmann::json& json) {
             EVLOG_debug << fmt::format("received module ready signal for module: {}({})", module_id, json.dump());
-            const std::unique_lock<std::mutex> lock(modules_ready_mutex);
-            // FIXME (aw): here are race conditions, if the ready handler gets called while modules are shut down!
-            try {
-                modules_ready.at(module_id).ready = json.get<bool>();
-            } catch (const std::out_of_range& ex) {
-                // This can happen if we're shutting down and a module becomes
-                // ready.
-                EVLOG_error << "The module " << module_id << " is not in `modules_ready`: " << ex.what();
-                return;
-            }
+            bool all_modules_ready = false;
             std::size_t modules_spawned = 0;
-            for (const auto& mod : modules_ready) {
-                const std::string text_ready =
-                    fmt::format((mod.second.ready) ? TERMINAL_STYLE_OK : TERMINAL_STYLE_ERROR, "ready");
-                EVLOG_debug << fmt::format("  {}: {}", mod.first, text_ready);
-                if (mod.second.ready) {
-                    modules_spawned += 1;
+            const std::size_t modules_ready_count = [&] {
+                const std::lock_guard<std::mutex> lock(modules_ready_mutex_);
+                // FIXME (aw): here are race conditions, if the ready handler gets called while modules are shut down!
+                try {
+                    modules_ready_.at(module_id).ready = json.get<bool>();
+                } catch (const std::out_of_range& ex) {
+                    // This can happen if we're shutting down and a module becomes
+                    // ready.
+                    EVLOG_error << "The module " << module_id << " is not in `modules_ready`: " << ex.what();
+                    return std::size_t{0};
                 }
-            }
-            if (!standalone_modules.empty() && std::find(standalone_modules.begin(), standalone_modules.end(),
-                                                         module_id) != standalone_modules.end()) {
-                EVLOG_info << fmt::format("Standalone module {} initialized.", module_id);
-            }
-            if (std::all_of(modules_ready.begin(), modules_ready.end(),
-                            [](const auto& element) { return element.second.ready; })) {
+                for (const auto& mod : modules_ready_) {
+                    const std::string text_ready =
+                        fmt::format((mod.second.ready) ? TERMINAL_STYLE_OK : TERMINAL_STYLE_ERROR, "ready");
+                    EVLOG_debug << fmt::format("  {}: {}", mod.first, text_ready);
+                    if (mod.second.ready) {
+                        modules_spawned += 1;
+                    }
+                }
+                if (!standalone_modules.empty() && std::find(standalone_modules.begin(), standalone_modules.end(),
+                                                             module_id) != standalone_modules.end()) {
+                    EVLOG_info << fmt::format("Standalone module {} initialized.", module_id);
+                }
+                all_modules_ready = std::all_of(modules_ready_.begin(), modules_ready_.end(),
+                                                [](const auto& element) { return element.second.ready; });
+                return modules_ready_.size();
+            }();
+
+            if (all_modules_ready) {
                 const auto complete_end_time = std::chrono::steady_clock::now();
-                status_fifo.update(StatusFifo::ALL_MODULES_STARTED);
                 if (not retain_topics) {
                     EVLOG_info << "Clearing retained topics published by manager during startup";
                     mqtt_abstraction.clear_retained_topics();
                 } else {
                     EVLOG_info << "Keeping retained topics published by manager during startup for inspection";
                 }
-                EVLOG_info << fmt::format(
-                    TERMINAL_STYLE_OK, "🚙🚙🚙 All modules are initialized. EVerest up and running [{}ms] 🚙🚙🚙",
-                    std::chrono::duration_cast<std::chrono::milliseconds>(complete_end_time - complete_start_time)
-                        .count());
+                EVLOG_info << fmt::format(TERMINAL_STYLE_OK,
+                                          "🚙🚙🚙 All modules are initialized. EVerest up and running [{}ms] 🚙🚙🚙",
+                                          std::chrono::duration_cast<std::chrono::milliseconds>(
+                                              complete_end_time - module_startup_start_time_)
+                                              .count());
 
+                bool skip_running_transition = false;
+                {
+                    const std::lock_guard<std::mutex> state_lock(state_transition_mutex_);
+                    if (sigint_received_ || is_in_shutdown_flow_state_unlocked()) {
+                        EVLOG_info << "All modules reported ready while shutdown is already in progress. "
+                                      "Skipping transition to Running.";
+                        skip_running_transition = true;
+                    } else {
+                        transition_to_unlocked(ManagerState::Running);
+                    }
+                }
+                if (skip_running_transition) {
+                    return;
+                }
+
+                status_fifo.update(StatusFifo::ALL_MODULES_STARTED);
                 MqttMessagePayload payload{MqttMessageType::GlobalReady, nlohmann::json(true)};
 
                 mqtt_abstraction.publish(fmt::format("{}ready", mqtt_everest_prefix), payload);
             } else if (!standalone_modules.empty()) {
-                if (modules_spawned == modules_ready.size() - standalone_modules.size()) {
+                if (modules_spawned == modules_ready_count - standalone_modules.size()) {
                     EVLOG_info << fmt::format(fg(fmt::terminal_color::green),
                                               "Modules started by manager are ready, waiting for standalone modules.");
                     status_fifo.update(StatusFifo::WAITING_FOR_STANDALONE_MODULES);
@@ -441,9 +1114,13 @@ std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstractio
         };
 
         const std::string ready_topic = fmt::format("{}/ready", config.mqtt_module_prefix(module_id));
-        module_it->second.ready_token =
+        auto ready_token =
             std::make_shared<TypedHandler>(HandlerType::ModuleReady, std::make_shared<Handler>(module_ready_handler));
-        mqtt_abstraction.register_handler(ready_topic, module_it->second.ready_token, QOS::QOS2);
+        {
+            const std::lock_guard<std::mutex> lock(modules_ready_mutex_);
+            module_it->second.ready_token = ready_token;
+        }
+        mqtt_abstraction.register_handler(ready_topic, ready_token, QOS::QOS2);
 
         if (std::any_of(standalone_modules.begin(), standalone_modules.end(),
                         [module_id](const auto& element) { return element == module_id; })) {
@@ -492,433 +1169,275 @@ std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstractio
     return spawn_modules(modules_to_spawn, ms);
 }
 
-void shutdown_modules(const std::map<pid_t, std::string>& modules, ManagerConfig& config,
-                      MQTTAbstraction& mqtt_abstraction) {
+Manager::LifecycleAdvanceResult Manager::advance_lifecycle_state_if_ready(RuntimeContext& ctx,
+                                                                          ManagerAdminPanel& admin_panel) {
+    const bool in_shutdown_flow = is_in_shutdown_flow_state();
+    const bool crash_in_progress = (shutdown_cause_ == ShutdownCause::Crash);
+    const bool restart_requested = (shutdown_cause_ == ShutdownCause::Restart);
 
-    ModulesReadyType modules_ready_moved;
-    {
-        const std::lock_guard<std::mutex> lck(modules_ready_mutex);
-        modules_ready_moved = std::move(modules_ready);
-        // Probably not needed after our move but lets be explicit.
-        modules_ready.clear();
-    }
-
-    for (const auto& module : modules_ready_moved) {
-        const auto& ready_info = module.second;
-        const auto& module_name = module.first;
-        const std::string topic = fmt::format("{}/ready", config.mqtt_module_prefix(module_name));
-        mqtt_abstraction.unregister_handler(topic, ready_info.ready_token);
-    }
-
-    for (const auto& child : modules) {
-        auto retval = kill(child.first, SIGTERM);
-        // FIXME (aw): supply errno strings
-        if (retval != 0) {
-            EVLOG_critical << fmt::format("SIGTERM of child: {} (pid: {}) {}: {}. Escalating to SIGKILL", child.second,
-                                          child.first, fmt::format(TERMINAL_STYLE_ERROR, "failed"), retval);
-            retval = kill(child.first, SIGKILL);
-            if (retval != 0) {
-                EVLOG_critical << fmt::format("SIGKILL of child: {} (pid: {}) {}: {}.", child.second, child.first,
-                                              fmt::format(TERMINAL_STYLE_ERROR, "failed"), retval);
-            } else {
-                EVLOG_info << fmt::format("SIGKILL of child: {} (pid: {}) {}.", child.second, child.first,
-                                          fmt::format(TERMINAL_STYLE_OK, "succeeded"));
+    // Finalize shutdown as soon as all module processes are gone, even if we got here through ECHILD
+    // after a timeout-triggered force shutdown.
+    if (in_shutdown_flow && module_handles_.empty()) {
+        {
+            const std::lock_guard<std::mutex> lock(state_transition_mutex_);
+            if (current_state_unlocked() != ManagerState::ShutdownFinalizing) {
+                transition_to_unlocked(ManagerState::ShutdownFinalizing);
             }
+        }
+        // A SIGINT/SIGTERM during a crash drain means the user wants to stop; do not auto-restart.
+        if (crash_in_progress && recover_module_crashes_ && !sigint_received_ &&
+            unexpected_module_exit_count_ <= MAX_UNEXPECTED_MODULE_RESTARTS) {
+            EVLOG_warning << fmt::format(
+                "Unexpected module exit recovery attempt {}/{}. Reloading config and restarting "
+                "modules.",
+                unexpected_module_exit_count_, MAX_UNEXPECTED_MODULE_RESTARTS);
+            notify_crash_recovery_attempt(unexpected_module_exit_count_, MAX_UNEXPECTED_MODULE_RESTARTS);
+            handle_restart_modules_after_shutdown(ctx);
+            return {LifecycleAdvanceResult::Status::TransitionApplied, std::nullopt};
+        }
+        if (crash_in_progress && unexpected_module_exit_count_ > MAX_UNEXPECTED_MODULE_RESTARTS) {
+            EVLOG_error << fmt::format("Reached maximum unexpected module exit recovery attempts ({}/{}). "
+                                       "Manager will stay idle after shutdown.",
+                                       unexpected_module_exit_count_, MAX_UNEXPECTED_MODULE_RESTARTS);
+            notify_status_fifo(StatusFifo::CRASH_RECOVERY_EXHAUSTED);
+        }
+        if (const auto exit_code =
+                handle_finalize_shutdown_transition(ctx, admin_panel, restart_requested, crash_in_progress)) {
+            return {LifecycleAdvanceResult::Status::ExitRequested, *exit_code};
+        }
+        return {LifecycleAdvanceResult::Status::TransitionApplied, std::nullopt};
+    }
+
+    // Admin restart can mark restart_modules while modules are still draining.
+    // If all children are gone, restart immediately with reloaded config.
+    if (restart_requested && module_handles_.empty()) {
+        handle_restart_modules_after_shutdown(ctx);
+        return {LifecycleAdvanceResult::Status::TransitionApplied, std::nullopt};
+    }
+
+    return {LifecycleAdvanceResult::Status::NoTransition, std::nullopt};
+}
+
+bool Manager::handle_child_exit(pid_t pid, int wstatus, RuntimeContext& ctx, ManagerAdminPanel& admin_panel) {
+    auto module_exited_time = std::chrono::steady_clock::now();
+    if (admin_panel.is_controller_process(pid)) {
+        // During intentional manager shutdown/restart, controller exit is expected.
+        if (is_in_shutdown_flow_state() || state_ == ManagerState::Exiting || sigint_received_ ||
+            is_restart_requested()) {
+            EVLOG_info << "Controller process exited during manager shutdown/restart.";
+            return true;
+        }
+        admin_panel.throw_if_controller_exited(pid);
+    }
+    const std::string wait_status = format_wait_status(wstatus);
+
+    const auto module_iter = module_handles_.find(pid);
+    if (module_iter == module_handles_.end()) {
+        throw std::runtime_error(fmt::format("Unknown child with pid ({}) died.", pid));
+    }
+
+    const auto module_name = module_iter->second;
+    module_handles_.erase(module_iter);
+
+    const bool unexpected_exit_during_start_or_run = [&] {
+        const std::lock_guard<std::mutex> lock(state_transition_mutex_);
+        const auto s = current_state_unlocked();
+        return s == ManagerState::StartingModules || s == ManagerState::Running;
+    }();
+    if (unexpected_exit_during_start_or_run) {
+        // During startup/running, an exiting module is unexpected: trigger graceful shutdown.
+        shutdown_cause_ = ShutdownCause::Crash;
+        ++unexpected_module_exit_count_;
+        const auto shutdown_info_log =
+            "Module " + fmt::format(TERMINAL_STYLE_BLUE, "{}", module_name) +
+            (graceful_shutdown_enabled_ ? " exited unexpectedly, signaling remaining modules to shut down gracefully..."
+                                        : " exited unexpectedly, terminating remaining modules...");
+        handle_initiate_graceful_shutdown(module_exited_time, true, shutdown_info_log, ctx.mqtt_abstraction, ctx.ms);
+        transition_to(ManagerState::CrashShutdownInProgress);
+        shutdown_info_.push_back({module_name, wstatus});
+        return true;
+    }
+
+    if (is_in_shutdown_flow_state() || sigint_received_) {
+        // During shutdown drain, keep collecting statuses for final shutdown summary.
+        EVLOG_info << "Module " << fmt::format(TERMINAL_STYLE_BLUE, "{}", module_name) << " (pid " << pid
+                   << ") shutdown ["
+                   << std::chrono::duration_cast<std::chrono::milliseconds>(
+                          module_exited_time - shutdown_start_time_.value_or(module_exited_time))
+                          .count()
+                   << "ms] with status: " << wait_status;
+        shutdown_info_.push_back({module_name, wstatus});
+        return true;
+    }
+
+    EVLOG_info << fmt::format("Module {} (pid: {}) exited with status: {}.", module_name, pid, wait_status);
+    return false;
+}
+
+std::optional<int> Manager::handle_signal(int signo, RuntimeContext& ctx, ManagerAdminPanel& admin_panel) {
+    if (signo != SIGINT && signo != SIGTERM) {
+        return std::nullopt;
+    }
+    if (!sigint_received_) {
+        EVLOG_info << "SIGINT/SIGTERM received";
+        sigint_received_ = true;
+        notify_status_fifo(StatusFifo::SIGINT_RECEIVED);
+        // Do not downgrade an in-progress crash drain to a normal shutdown: finalization keys the
+        // exit code off shutdown_cause_, and a crash must stay visible as EXIT_FAILURE.
+        if (shutdown_cause_ != ShutdownCause::Crash) {
+            shutdown_cause_ = ShutdownCause::Normal;
+        }
+        shutdown_start_time_ = std::chrono::steady_clock::now();
+        force_terminate_start_time_ = std::nullopt;
+        force_kill_sent_ = false;
+        if (module_handles_.empty()) {
+            print_shutdown_message(shutdown_start_time_);
+            admin_panel.shutdown_controller();
+            disconnect_mqtt(ctx.mqtt_abstraction);
+            transition_to(ManagerState::Exiting);
+            return EXIT_SUCCESS;
+        }
+        transition_to(ManagerState::ShutdownRequested);
+        EVLOG_info << "Shutting down modules...";
+        if (graceful_shutdown_enabled_) {
+            ctx.mqtt_abstraction.publish(fmt::format("{}shutdown", ctx.ms.mqtt_settings.everest_prefix),
+                                         std::string("true"), QOS::QOS2, false);
+        }
+        return std::nullopt;
+    }
+
+    EVLOG_info << "Terminating manager";
+    admin_panel.shutdown_controller();
+    transition_to(ManagerState::Exiting);
+    return EXIT_FAILURE;
+}
+
+void Manager::handle_shutdown_timeout(RuntimeContext& ctx) {
+    if (state_ == ManagerState::ShutdownFinalizing) {
+        return;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    const bool should_check_shutdown_timeout =
+        (state_ == ManagerState::ShutdownRequested || state_ == ManagerState::CrashShutdownInProgress ||
+         state_ == ManagerState::RestartRequested) &&
+        shutdown_start_time_.has_value();
+
+    // Without --graceful-shutdown there is no drain phase: force-terminate as soon as the
+    // shutdown flow starts (legacy behavior, no FORCE_SHUTDOWN_TIMEOUT event).
+    const auto shutdown_timeout_ms = graceful_shutdown_enabled_ ? SHUTDOWN_TIMEOUT_MS : 0;
+    if (should_check_shutdown_timeout &&
+        now >= shutdown_start_time_.value() + std::chrono::milliseconds(shutdown_timeout_ms)) {
+        transition_to(ManagerState::ForceTerminating);
+        if (graceful_shutdown_enabled_) {
+            notify_status_fifo(StatusFifo::FORCE_SHUTDOWN_TIMEOUT);
+            EVLOG_warning << "Not all modules shut down within the timeout. Forcefully terminating remaining modules.";
         } else {
-            EVLOG_info << fmt::format("SIGTERM of child: {} (pid: {}) {}.", child.second, child.first,
+            EVLOG_info << "Terminating modules (graceful shutdown not enabled)...";
+        }
+        shutdown_modules(module_handles_, *ctx.config, ctx.mqtt_abstraction);
+        force_terminate_start_time_ = now;
+        force_kill_sent_ = false;
+        return;
+    }
+
+    if (state_ != ManagerState::ForceTerminating || force_kill_sent_ || !force_terminate_start_time_.has_value() ||
+        module_handles_.empty()) {
+        return;
+    }
+
+    if (now < force_terminate_start_time_.value() + std::chrono::milliseconds(FORCE_KILL_GRACE_TIMEOUT_MS)) {
+        return;
+    }
+
+    EVLOG_warning << fmt::format(
+        "Modules still alive {}ms after SIGTERM in ForceTerminating. Escalating to SIGKILL for remaining {} modules.",
+        FORCE_KILL_GRACE_TIMEOUT_MS, module_handles_.size());
+    for (const auto& child : module_handles_) {
+        const auto retval = kill(child.first, SIGKILL);
+        if (retval != 0) {
+            EVLOG_critical << fmt::format("SIGKILL of child: {} (pid: {}) {}: {}.", child.second, child.first,
+                                          fmt::format(TERMINAL_STYLE_ERROR, "failed"), retval);
+        } else {
+            EVLOG_info << fmt::format("SIGKILL of child: {} (pid: {}) {}.", child.second, child.first,
                                       fmt::format(TERMINAL_STYLE_OK, "succeeded"));
         }
     }
+    force_kill_sent_ = true;
 }
 
-#ifdef ENABLE_ADMIN_PANEL
-ControllerHandle start_controller(const ManagerSettings& ms) {
-    std::array<int, 2> socket_pair; // NOLINT(cppcoreguidelines-pro-type-member-init): this is always initialized in the
-                                    // following socketpair call
-
-    // FIXME (aw): destroy this socketpair somewhere
-    socketpair(AF_UNIX, SOCK_DGRAM, 0, socket_pair.data());
-    const int manager_socket = socket_pair[0];
-    const int controller_socket = socket_pair[1];
-
-    auto proc_handle = system::SubProcess::create(ms.run_as_user);
-
-    if (proc_handle.is_child()) {
-        // FIXME (aw): hack to get the correct directory of the controller
-        const auto bin_dir = fs::canonical("/proc/self/exe").parent_path();
-
-        const auto controller_binary = bin_dir / "controller";
-
-        close(manager_socket);
-        dup2(controller_socket, STDIN_FILENO);
-        close(controller_socket);
-
-        execl(controller_binary.c_str(), MAGIC_CONTROLLER_ARG0, NULL);
-
-        // exec failed
-        proc_handle.send_error_and_exit(
-            fmt::format("Syscall to execl() with \"{} {}\" failed ({})", controller_binary.string(), strerror(errno)));
+bool Manager::handle_waitpid_event(int& wstatus, RuntimeContext& ctx, ManagerAdminPanel& admin_panel) {
+    // non-blocking as this main loop also processes controller RPC and the signal fd
+    const auto pid = waitpid(-1, &wstatus, WNOHANG);
+    if (pid == 0) {
+        return false;
     }
-
-    close(controller_socket);
-
-    // send initial config to controller
-    controller_ipc::send_message(manager_socket,
-                                 {
-                                     {"method", "boot"},
-                                     {"params",
-                                      {
-                                          {"module_dir", ms.runtime_settings.modules_dir.string()},
-                                          {"interface_dir", ms.interfaces_dir.string()},
-                                          {"www_dir", ms.www_dir.string()},
-                                          {"configs_dir", ms.configs_dir.string()},
-                                          {"logging_config_file", ms.runtime_settings.logging_config_file.string()},
-                                          {"controller_port", ms.controller_port},
-                                          {"controller_rpc_timeout_ms", ms.controller_rpc_timeout_ms},
-                                      }},
-                                 });
-
-    return {proc_handle.check_child_executed(), manager_socket};
-}
-#endif
-
-ConfigBootMode parse_config_boot_mode(const std::string& config_opt, const std::string& db_opt, const bool db_init) {
-    if (config_opt.empty() and db_opt.empty()) {
-        // no config or db option given, use default
-        return ConfigBootMode::YamlFile;
-    }
-    if (!config_opt.empty() && !db_opt.empty()) {
-        if (db_init == false) {
-            throw BootException("Both --config and --db options are set, but no --db-init option is given. "
-                                "This is not allowed.");
-        }
-        return ConfigBootMode::DatabaseInit;
-    }
-    if (!config_opt.empty()) {
-        // only config option given, use yaml file
-        return ConfigBootMode::YamlFile;
-    }
-    if (!db_opt.empty()) {
-        // only db option given, use database
-        return ConfigBootMode::Database;
-    }
-    throw std::logic_error("Could not parse config boot source, this should never happen.");
-}
-
-int boot(const po::variables_map& vm) {
-    const bool check = (vm.count("check") != 0);
-
-    const auto prefix_opt = parse_string_option(vm, "prefix");
-    const auto config_opt = parse_string_option(vm, "config");
-    const auto db_opt = parse_string_option(vm, "db");
-    const auto db_init = vm.count("db-init") != 0;
-    ConfigBootMode boot_mode = parse_config_boot_mode(config_opt, db_opt, db_init);
-
-    ManagerSettings ms;
-
-    switch (boot_mode) {
-    case ConfigBootMode::YamlFile:
-        ms = ManagerSettings(prefix_opt, config_opt);
-        break;
-    case ConfigBootMode::Database:
-        ms = ManagerSettings(prefix_opt, db_opt, DatabaseTag{});
-        break;
-    case ConfigBootMode::DatabaseInit:
-        ms = ManagerSettings(prefix_opt, config_opt, db_opt);
-        break;
-    default:
-        throw BootException(fmt::format("Invalid boot source: {}", static_cast<int>(boot_mode)));
-    }
-
-    // CLI override for mqtt_everest_prefix (e.g. for parallel test execution).
-    if (vm.count("mqtt_everest_prefix") != 0) {
-        auto prefix = vm["mqtt_everest_prefix"].as<std::string>();
-        if (!prefix.empty() && prefix.back() != '/') {
-            prefix += "/";
-        }
-        ms.mqtt_settings.everest_prefix = prefix;
-    }
-
-    Logging::init(ms.runtime_settings.logging_config_file.string());
-
-    Date::preload_tzdb();
-
-    EVLOG_info << "  \033[0;1;35;95m_\033[0;1;31;91m__\033[0;1;33;93m__\033[0;1;32;92m__\033[0;1;36;96m_\033[0m      "
-                  "\033[0;1;31;91m_\033[0;1;33;93m_\033[0m                \033[0;1;36;96m_\033[0m   ";
-    EVLOG_info << " \033[0;1;31;91m|\033[0m  \033[0;1;33;93m_\033[0;1;32;92m__\033[0;1;36;96m_\\\033[0m "
-                  "\033[0;1;34;94m\\\033[0m    \033[0;1;33;93m/\033[0m \033[0;1;32;92m/\033[0m               "
-                  "\033[0;1;34;94m|\033[0m \033[0;1;35;95m|\033[0m";
-    EVLOG_info
-        << " \033[0;1;33;93m|\033[0m \033[0;1;32;92m|_\033[0;1;36;96m_\033[0m   \033[0;1;35;95m\\\033[0m "
-           "\033[0;1;31;91m\\\033[0m  \033[0;1;33;93m/\033[0m \033[0;1;32;92m/\033[0;1;36;96m__\033[0m "
-           "\033[0;1;34;94m_\033[0m \033[0;1;35;95m_\033[0;1;31;91m_\033[0m \033[0;1;33;93m__\033[0;1;32;92m_\033[0m  "
-           "\033[0;1;36;96m_\033[0;1;34;94m__\033[0;1;35;95m|\033[0m \033[0;1;31;91m|_\033[0m";
-    EVLOG_info << " \033[0;1;32;92m|\033[0m  \033[0;1;36;96m_\033[0;1;34;94m_|\033[0m   \033[0;1;31;91m\\\033[0m "
-                  "\033[0;1;33;93m\\\033[0;1;32;92m/\033[0m \033[0;1;36;96m/\033[0m \033[0;1;34;94m_\033[0m "
-                  "\033[0;1;35;95m\\\033[0m \033[0;1;31;91m'_\033[0;1;33;93m_/\033[0m \033[0;1;32;92m_\033[0m "
-                  "\033[0;1;36;96m\\\033[0;1;34;94m/\033[0m \033[0;1;35;95m__\033[0;1;31;91m|\033[0m "
-                  "\033[0;1;33;93m__\033[0;1;32;92m|\033[0m";
-    EVLOG_info << " \033[0;1;36;96m|\033[0m \033[0;1;34;94m|_\033[0;1;35;95m__\033[0;1;31;91m_\033[0m   "
-                  "\033[0;1;32;92m\\\033[0m  \033[0;1;36;96m/\033[0m  \033[0;1;35;95m__\033[0;1;31;91m/\033[0m "
-                  "\033[0;1;33;93m|\033[0m \033[0;1;32;92m|\033[0m  "
-                  "\033[0;1;36;96m_\033[0;1;34;94m_/\033[0;1;35;95m\\_\033[0;1;31;91m_\033[0m \033[0;1;33;93m\\\033[0m "
-                  "\033[0;1;32;92m|_\033[0m";
-    EVLOG_info << " \033[0;1;34;94m|_\033[0;1;35;95m__\033[0;1;31;91m__\033[0;1;33;93m_|\033[0m   "
-                  "\033[0;1;36;96m\\\033[0;1;34;94m/\033[0m "
-                  "\033[0;1;35;95m\\_\033[0;1;31;91m__\033[0;1;33;93m|_\033[0;1;32;92m|\033[0m  "
-                  "\033[0;1;36;96m\\\033[0;1;34;94m__\033[0;1;35;95m_|\033[0;1;31;91m|_\033[0;1;33;93m__\033[0;1;32;"
-                  "92m/\\\033[0;1;36;96m__\033[0;1;34;94m|\033[0m";
-    EVLOG_info << "";
-    EVLOG_info << PROJECT_NAME << " " << PROJECT_VERSION << " " << GIT_VERSION;
-    EVLOG_info << ms.version_information;
-    EVLOG_info << "";
-
-    if (not ms.mqtt_settings.uses_socket()) {
-        EVLOG_info << "Using MQTT broker " << ms.mqtt_settings.broker_host << ":" << ms.mqtt_settings.broker_port;
-    } else {
-        EVLOG_info << "Using MQTT broker unix domain sockets:" << ms.mqtt_settings.broker_socket_path;
-    }
-    if (ms.runtime_settings.telemetry_enabled) {
-        EVLOG_info << "Telemetry enabled";
-    }
-    if (not ms.run_as_user.empty()) {
-        EVLOG_info << "EVerest will run as system user: " << ms.run_as_user;
-    }
-    if (ms.runtime_settings.forward_exceptions) {
-        EVLOG_info << "Catching and forwarding command exceptions to callers";
-    }
-
-#ifdef ENABLE_ADMIN_PANEL
-    auto controller_handle = start_controller(ms);
-#endif
-
-    EVLOG_verbose << fmt::format("EVerest prefix was set to {}", ms.runtime_settings.prefix.string());
-
-    // dump all manifests if requested and terminate afterwards
-    if (vm.count("dumpmanifests")) {
-        const auto dumpmanifests_path = fs::path(vm["dumpmanifests"].as<std::string>());
-        EVLOG_debug << fmt::format("Dumping all known validated manifests into '{}'", dumpmanifests_path.string());
-
-        auto manifests = Config::load_all_manifests(ms.runtime_settings.modules_dir.string(), ms.schemas_dir.string());
-
-        for (const auto& module : manifests.items()) {
-            const std::string filename = module.key() + ".yaml";
-            const auto module_output_path = dumpmanifests_path / filename;
-            // FIXME (aw): should we check if the directory exists?
-            std::ofstream output_stream(module_output_path);
-
-            // FIXME (aw): this should be either YAML prettyfied, or better, directly copied
-            output_stream << module.value().dump(DUMP_INDENT);
-        }
-
-        return EXIT_SUCCESS;
-    }
-
-    const bool retain_topics = (vm.count("retain-topics") != 0);
-
-    const auto start_time = std::chrono::steady_clock::now();
-    std::shared_ptr<ManagerConfig> config; // TODO: maybe this can stay unique when we re-work start_modules()
-    try {
-        config = std::make_shared<ManagerConfig>(ms);
-    } catch (EverestInternalError& e) {
-        EVLOG_error << fmt::format("Failed to load and validate config!\n{}", boost::diagnostic_information(e, true));
-        return EXIT_FAILURE;
-    } catch (boost::exception& e) {
-        EVLOG_error << "Failed to load and validate config!";
-        EVLOG_critical << fmt::format("Caught top level boost::exception:\n{}", boost::diagnostic_information(e, true));
-        return EXIT_FAILURE;
-    } catch (std::exception& e) {
-        EVLOG_error << "Failed to load and validate config!";
-        EVLOG_critical << fmt::format("Caught top level std::exception:\n{}", boost::diagnostic_information(e, true));
-        return EXIT_FAILURE;
-    }
-    const auto end_time = std::chrono::steady_clock::now();
-    EVLOG_info << "Config loading completed in "
-               << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms";
-
-    // dump config if requested
-    if (vm.count("dump")) {
-        const auto dump_path = fs::path(vm["dump"].as<std::string>());
-        EVLOG_debug << fmt::format("Dumping validated config and manifests into '{}'", dump_path.string());
-
-        const auto config_dump_path = dump_path / "config.json";
-
-        std::ofstream output_config_stream(config_dump_path);
-
-        output_config_stream << json(config->get_module_configurations()).dump(DUMP_INDENT);
-
-        const auto manifests = config->get_manifests();
-
-        for (const auto& module : manifests.items()) {
-            const std::string filename = module.key() + ".json";
-            const auto module_output_path = dump_path / filename;
-            std::ofstream output_stream(module_output_path);
-
-            output_stream << module.value().dump(DUMP_INDENT);
-        }
-    }
-
-    // only config check (and or config dumping) was requested, log check result and exit
-    if (check) {
-        EVLOG_debug << "Config is valid, terminating as requested";
-        return EXIT_SUCCESS;
-    }
-
-    std::vector<std::string> standalone_modules;
-    if (vm.count("standalone")) {
-        standalone_modules = vm["standalone"].as<std::vector<std::string>>();
-    }
-
-    const auto& module_configurations = config->get_module_configurations();
-    for (const auto& [module_id, module_config] : module_configurations) {
-        // check if standalone parameter is set
-        if (module_config.standalone) {
-            if (std::find(standalone_modules.begin(), standalone_modules.end(), module_id) ==
-                standalone_modules.end()) {
-                EVLOG_info << "Module " << fmt::format(TERMINAL_STYLE_BLUE, "{}", module_id)
-                           << " marked as standalone in config";
-
-                standalone_modules.push_back(module_id);
-            }
-        }
-    }
-
-    std::vector<std::string> ignored_modules;
-    if (vm.count("ignore")) {
-        ignored_modules = vm["ignore"].as<std::vector<std::string>>();
-    }
-
-    // create StatusFifo object
-    auto status_fifo = StatusFifo::create_from_path(vm["status-fifo"].as<std::string>());
-
-    auto mqtt_abstraction = make_mqtt_abstraction(ms.mqtt_settings);
-
-    if (!mqtt_abstraction->connect()) {
-        if (not ms.mqtt_settings.uses_socket()) {
-            EVLOG_error << fmt::format("Cannot connect to MQTT broker at {}:{}", ms.mqtt_settings.broker_host,
-                                       ms.mqtt_settings.broker_port);
-        } else {
-            EVLOG_error << fmt::format("Cannot connect to MQTT broker socket at {}",
-                                       ms.mqtt_settings.broker_socket_path);
-        }
-        return EXIT_FAILURE;
-    }
-
-    mqtt_abstraction->spawn_main_loop_thread();
-
-    auto config_service = std::make_unique<config::ConfigService>(*mqtt_abstraction, config);
-
-    auto module_handles =
-        start_modules(*config, *mqtt_abstraction, ignored_modules, standalone_modules, ms, status_fifo, retain_topics);
-    bool modules_started = true;
-    bool restart_modules = false;
-
-#ifndef ENABLE_ADMIN_PANEL
-    // switch to low privilege user if configured
-    if (not ms.run_as_user.empty()) {
-        auto err_set_user = system::set_real_user(ms.run_as_user);
-        if (not err_set_user.empty()) {
-            EVLOG_error << "Error switching manager to user " << ms.run_as_user << ": " << err_set_user;
-            return EXIT_FAILURE;
-        }
-    }
-#endif
-
-    int wstatus; // NOLINT(cppcoreguidelines-init-variables): this is always initialized in the following waitpid call
-
-    while (true) {
-// check if anyone died
-#ifdef ENABLE_ADMIN_PANEL
-        // non-blocking if admin panel is enabled, as this main loop also processes controller RPC
-        auto pid = waitpid(-1, &wstatus, WNOHANG);
-#else
-        // block if admin panel is disabled, no controller RPC is handled by main loop
-        auto pid = waitpid(-1, &wstatus, 0);
-#endif
-
-        if (pid == 0) {
-            // nothing new from our child process
-        } else if (pid == -1) {
+    if (pid == -1) {
+        if (errno != ECHILD) {
             throw std::runtime_error(fmt::format("Syscall to waitpid() failed ({})", strerror(errno)));
-        } else {
-
-#ifdef ENABLE_ADMIN_PANEL
-            // one of our children exited (first check controller, then modules)
-            if (pid == controller_handle.pid) {
-                // FIXME (aw): what to do, if the controller exited? Restart it?
-                throw std::runtime_error("The controller process exited.");
-            }
-#endif
-
-            const auto module_iter = module_handles.find(pid);
-            if (module_iter == module_handles.end()) {
-                throw std::runtime_error(fmt::format("Unknown child width pid ({}) died.", pid));
-            }
-
-            const auto module_name = module_iter->second;
-            module_handles.erase(module_iter);
-            // one of our modules died -> kill 'em all
-            if (modules_started) {
-                EVLOG_critical << fmt::format("Module {} (pid: {}) exited with status: {}. Terminating all modules.",
-                                              module_name, pid, wstatus);
-                shutdown_modules(module_handles, *config, *mqtt_abstraction);
-
-                mqtt_abstraction->clear_retained_topics();
-                mqtt_abstraction->disconnect();
-
-                // Exit if a module died, this gives systemd a change to restart manager
-                EVLOG_critical << "Exiting manager.";
-                return EXIT_FAILURE;
-            } else {
-                EVLOG_info << fmt::format("Module {} (pid: {}) exited with status: {}.", module_name, pid, wstatus);
-            }
         }
-
-#ifdef ENABLE_ADMIN_PANEL
-        if (module_handles.size() == 0 && restart_modules) {
-            module_handles = start_modules(*config, *mqtt_abstraction, ignored_modules, standalone_modules, ms,
-                                           status_fifo, retain_topics);
-            restart_modules = false;
-            modules_started = true;
+        // ECHILD: no more OS child processes.
+        // If we still track module pids here, internal bookkeeping diverged from kernel state and
+        // shutdown/restart finalization can stall forever waiting for module_handles_ to drain.
+        if (!module_handles_.empty()) {
+            EVLOG_warning << fmt::format("waitpid() returned ECHILD but manager still tracks {} module pids. "
+                                         "Clearing stale module handles to continue lifecycle finalization.",
+                                         module_handles_.size());
+            module_handles_.clear();
         }
+        return false;
+    }
+    return handle_child_exit(pid, wstatus, ctx, admin_panel);
+}
 
-        // check for news from the controller
-        const auto msg = controller_handle.receive_message();
-        if (msg.status == controller_ipc::MESSAGE_RETURN_STATUS::OK) {
-            // FIXME (aw): implement all possible messages here, for now just log them
-            const auto& payload = msg.json;
-            if (payload.at("method") == "restart_modules") {
-                shutdown_modules(module_handles, *config, *mqtt_abstraction);
-                config = std::make_unique<ManagerConfig>(ms);
-                modules_started = false;
-                restart_modules = true;
-            } else if (payload.at("method") == "check_config") {
-                const std::string check_config_file_path = payload.at("params");
-
-                try {
-                    // check the config
-                    auto cfg = ManagerConfig(ManagerSettings(prefix_opt, check_config_file_path));
-                    controller_handle.send_message({{"id", payload.at("id")}});
-                } catch (const std::exception& e) {
-                    controller_handle.send_message({{"result", e.what()}, {"id", payload.at("id")}});
-                }
-            } else {
-                // unknown payload
-                EVLOG_error << fmt::format("Received unknown command via controller ipc:\n{}\n... ignoring",
-                                           payload.dump(DUMP_INDENT));
-            }
-        } else if (msg.status == controller_ipc::MESSAGE_RETURN_STATUS::ERROR) {
-            fmt::print("Error in IPC communication with controller: {}\nExiting\n", msg.json.at("error").dump(2));
-            return EXIT_FAILURE;
-        } else {
-            // TIMEOUT fall-through
-        }
-#endif
+std::optional<int> Manager::handle_controller_ipc_poll(RuntimeContext& ctx, ManagerAdminPanel& admin_panel,
+                                                       const std::string& prefix_opt) {
+    bool modules_started = are_modules_started();
+    const bool restart_already_requested = is_restart_requested();
+    bool restart_requested = restart_already_requested;
+    if (const auto exit_from_panel = admin_panel.poll_controller_ipc(restart_requested, modules_started, prefix_opt)) {
+        return *exit_from_panel;
     }
 
-    return EXIT_SUCCESS;
+    // Only act on the transition into RestartRequested; the state itself preserves the restart
+    // intent for advance_lifecycle_state_if_ready() once all children have exited.
+    if (restart_requested && !restart_already_requested) {
+        shutdown_cause_ = ShutdownCause::Restart;
+        transition_to(ManagerState::RestartRequested);
+        if (graceful_shutdown_enabled_) {
+            ctx.mqtt_abstraction.publish(fmt::format("{}shutdown", ctx.ms.mqtt_settings.everest_prefix),
+                                         std::string("true"), QOS::QOS2, false);
+        }
+        // Arm the graceful-shutdown deadline once so timeout/fallback handling covers modules
+        // that do not exit after the MQTT shutdown publish. Re-arming on subsequent loop
+        // iterations would push the force-terminate deadline back forever.
+        if (!module_handles_.empty()) {
+            shutdown_start_time_ = std::chrono::steady_clock::now();
+        }
+    }
+
+    return std::nullopt;
 }
-} // namespace
+
+int Manager::signal_poll_timeout_ms() const {
+    if (is_in_shutdown_flow_state()) {
+        // shutdown/force-kill deadlines are checked from the main loop
+        return SIGNAL_POLL_TIMEOUT_MS;
+    }
+    return IDLE_SIGNAL_POLL_TIMEOUT_MS;
+}
+
+std::optional<int> Manager::handle_signal_poll(system::SignalPolling& signal_polling, RuntimeContext& ctx,
+                                               ManagerAdminPanel& admin_panel) {
+    // a readable controller IPC socket also ends the poll, so controller requests are serviced
+    // promptly on the next loop iteration even during a long idle poll
+    const auto signal_received =
+        signal_polling.poll_signal(signal_poll_timeout_ms(), admin_panel.controller_ipc_fd().value_or(-1));
+    if (!signal_received.has_value()) {
+        return std::nullopt;
+    }
+    return handle_signal(signal_received.value(), ctx, admin_panel);
+}
 
 int main(int argc, char* argv[]) {
     po::options_description desc("EVerest manager");
@@ -943,13 +1462,20 @@ int main(int argc, char* argv[]) {
     desc.add_options()("db", po::value<std::string>(), "Full path to the configuration database file");
     desc.add_options()("db-init", "Indicator to initialize the database if it does not contain a valid configuration. "
                                   "Requires --config and --db to be set.");
+    desc.add_options()("into-idle", "Boot into idle state (no modules are started)");
+    desc.add_options()("recover-module-crashes",
+                       "After unexpected module exit, reload config and restart modules (bounded by an internal retry "
+                       "limit). Default: shut down all modules and exit the manager.");
+    desc.add_options()("graceful-shutdown",
+                       "On shutdown/restart, publish the shutdown signal via MQTT so modules can run their shutdown "
+                       "handlers, and force-terminate stragglers only after a timeout. Default: terminate module "
+                       "processes immediately (SIGTERM, escalating to SIGKILL).");
     desc.add_options()("status-fifo", po::value<std::string>()->default_value(""),
                        "Path to a named pipe, that shall be used for status updates from the manager");
     desc.add_options()("retain-topics", "Retain configuration MQTT topics setup by manager for inspection, by default "
                                         "these will be cleared after startup");
     desc.add_options()("mqtt_everest_prefix", po::value<std::string>(),
                        "Override the MQTT everest prefix (useful for running multiple instances in parallel)");
-
     po::variables_map vm;
 
     try {
@@ -976,7 +1502,8 @@ int main(int argc, char* argv[]) {
             return EXIT_SUCCESS;
         }
 
-        return boot(vm);
+        Manager manager(vm);
+        return manager.run();
 
     } catch (const BootException& e) {
         EVLOG_error << "Failed to start up everest:\n" << e.what();

--- a/lib/everest/framework/src/manager.hpp
+++ b/lib/everest/framework/src/manager.hpp
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <atomic>
+#include <boost/program_options/variables_map.hpp>
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+#include <unordered_map>
+#include <vector>
+
+namespace Everest {
+class ManagerConfig;
+class MQTTAbstraction;
+class StatusFifo;
+struct ManagerSettings;
+namespace system {
+class SignalPolling;
+}
+} // namespace Everest
+struct TypedHandler;
+
+class ManagerAdminPanel;
+
+struct ModuleShutdownInfo {
+    std::string id;
+    int wstatus;
+};
+
+/// @file manager.hpp
+///
+/// `ManagerState` is the **phase** of the main-loop (what the manager is doing right now).
+/// `ShutdownCause` records **why** a shutdown or drain was started; it is kept across transient
+/// states (for example through `ForceTerminating` / `ShutdownFinalizing`) so the next step can
+/// distinguish normal stop, admin-driven restart, and crash recovery.
+///
+/// The full lifecycle description lives in `lib/everest/framework/docs/ManagerLifecycle.md`,
+/// the state machine diagram in `lib/everest/framework/docs/ManagerLifecycleStateMachine.mmd`.
+/// Timeouts and limits that drive transitions are defined in `manager.cpp`.
+
+/// \brief Runtime phase of the manager main loop (see file-level state machine description).
+enum class ManagerState {
+    Initializing,
+    StartingModules,
+    Running,
+    RestartRequested,
+    CrashShutdownInProgress,
+    ShutdownRequested,
+    ForceTerminating,
+    ShutdownFinalizing,
+    Idle,
+    Exiting
+};
+
+/// \brief Why the current shutdown / drain was started (persists across some ManagerState values).
+enum class ShutdownCause {
+    None,
+    Normal,
+    Restart,
+    Crash
+};
+
+class Manager {
+public:
+    /// \brief Construct manager with parsed CLI arguments.
+    /// \param vm Parsed command line options used by manager startup/runtime.
+    explicit Manager(const boost::program_options::variables_map& vm);
+
+    /// \brief Start manager lifecycle and main event loop.
+    /// \return Process exit code (EXIT_SUCCESS / EXIT_FAILURE).
+    int run();
+
+private:
+    /// \brief Ready-subscription tracking for a single module.
+    struct ModuleReadyInfo {
+        bool ready{false};
+        std::shared_ptr<TypedHandler> ready_token;
+    };
+    using ModulesReadyType = std::unordered_map<std::string, ModuleReadyInfo>;
+
+    // Per-run dependencies passed through handlers to avoid long parameter lists
+    // while keeping runtime data explicit (instead of hidden mutable members).
+    /// \brief Aggregates runtime dependencies used across handlers for one run.
+    struct RuntimeContext {
+        std::shared_ptr<Everest::ManagerConfig>& config;
+        Everest::MQTTAbstraction& mqtt_abstraction;
+        const std::vector<std::string>& ignored_modules;
+        const std::vector<std::string>& standalone_modules;
+        const Everest::ManagerSettings& ms;
+        Everest::StatusFifo& status_fifo;
+        bool retain_topics;
+    };
+
+    /// \brief Outcome of one lifecycle state-advance evaluation.
+    struct LifecycleAdvanceResult {
+        enum class Status {
+            NoTransition,
+            TransitionApplied,
+            ExitRequested
+        };
+        Status status{Status::NoTransition};
+        std::optional<int> exit_code{};
+    };
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Setup/helpers
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// \brief Load and validate manager configuration from current boot source.
+    /// \param ms Fully resolved manager settings for this run.
+    /// \return Shared validated configuration object.
+    std::shared_ptr<Everest::ManagerConfig> load_and_validate_config(const Everest::ManagerSettings& ms) const;
+
+    /// \brief Create MQTT abstraction, connect, and spawn its main loop thread.
+    /// \param ms Fully resolved manager settings for this run.
+    /// \return Connected MQTT abstraction, or nullptr on connection failure.
+    std::unique_ptr<Everest::MQTTAbstraction> create_and_connect_mqtt(const Everest::ManagerSettings& ms) const;
+
+    /// \brief Collect standalone module ids from config plus CLI overrides.
+    /// \param config Validated manager configuration for this run.
+    /// \return Module ids that manager should not spawn automatically.
+    std::vector<std::string> collect_standalone_modules(const Everest::ManagerConfig& config) const;
+
+    /// \brief Collect ignored module ids from CLI overrides.
+    /// \return Module ids that manager should ignore entirely during startup.
+    std::vector<std::string> collect_ignored_modules() const;
+
+    /// \brief Publish interfaces/types/settings/manifests metadata on MQTT.
+    /// \param ctx Runtime dependencies for the current run.
+    void publish_startup_metadata(const RuntimeContext& ctx) const;
+
+    /// \brief Unregister all module ready handlers and clear ready-tracking state.
+    void unregister_module_ready_handlers(Everest::ManagerConfig& config, Everest::MQTTAbstraction& mqtt_abstraction);
+
+    /// \brief Unregister module ready handlers and clear retained MQTT topics.
+    /// \note Must be called with the config that was used to register handlers (before any reload).
+    /// \note MQTT must still be connected; call before any disconnect.
+    void cleanup_modules_state(Everest::ManagerConfig& config, Everest::MQTTAbstraction& mqtt_abstraction);
+
+    /// \brief Terminate remaining module processes (SIGTERM, then SIGKILL fallback).
+    void shutdown_modules(const std::map<pid_t, std::string>& modules, Everest::ManagerConfig& config,
+                          Everest::MQTTAbstraction& mqtt_abstraction);
+
+    /// \brief Convert ManagerState enum to a readable string for logs.
+    std::string_view state_to_string(ManagerState state) const;
+
+    /// \brief Apply state transition with transition logging.
+    void transition_to(ManagerState new_state);
+
+    /// \brief Like transition_to(); caller must hold state_transition_mutex_.
+    void transition_to_unlocked(ManagerState new_state);
+
+    /// \brief Write a status-fifo message when a fifo path was configured for this run.
+    void notify_status_fifo(std::string_view message);
+
+    /// \brief Write the status-fifo message that corresponds to \p state.
+    void notify_status_fifo_for_state(ManagerState state);
+
+    /// \brief Write CRASH_RECOVERY_ATTEMPT:n/max to the status fifo.
+    void notify_crash_recovery_attempt(std::uint8_t attempt, std::uint8_t max);
+
+    /// \brief Like is_in_shutdown_flow_state(); caller must hold state_transition_mutex_.
+    bool is_in_shutdown_flow_state_unlocked() const;
+
+    /// \brief Load current state; caller must hold state_transition_mutex_.
+    ManagerState current_state_unlocked() const;
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // State predicates
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// \brief True only when manager is fully running.
+    bool are_modules_started() const;
+    /// \brief True when manager is in any shutdown-related state.
+    bool is_in_shutdown_flow_state() const;
+    /// \brief True when restart has been requested.
+    bool is_restart_requested() const;
+    /// \brief True when in idle.
+    bool is_idle() const;
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // State/event handlers
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// \brief Handle module startup: transition to StartingModules, register ready handlers, and spawn modules.
+    /// \param ctx Runtime dependencies for the current run.
+    /// \return Mapping of spawned child pid to module id.
+    std::map<pid_t, std::string> handle_start_modules(const RuntimeContext& ctx);
+
+    /// \brief Advance lifecycle state when current phase is complete.
+    /// \param ctx Runtime dependencies for the current run.
+    /// \param admin_panel Controller IPC/process integration helper.
+    /// \return Result containing transition/exit outcome for this evaluation step.
+    LifecycleAdvanceResult advance_lifecycle_state_if_ready(RuntimeContext& ctx, ManagerAdminPanel& admin_panel);
+
+    /// \brief Complete shutdown finalization according to preserved restart/crash intent.
+    /// \param ctx Runtime dependencies for the current run.
+    /// \param admin_panel Controller IPC/process integration helper.
+    /// \param restart_requested Preserved restart intent for this finalization step.
+    /// \param crash_in_progress Preserved crash-recovery intent for this finalization step.
+    /// \return Exit code when manager should terminate, std::nullopt otherwise.
+    std::optional<int> handle_finalize_shutdown_transition(RuntimeContext& ctx, ManagerAdminPanel& admin_panel,
+                                                           bool restart_requested, bool crash_in_progress);
+
+    /// \brief Reload config and initiate module restart sequence.
+    void handle_restart_modules_after_shutdown(RuntimeContext& ctx);
+
+    /// \brief Format the entries of shutdown_info_ that did not exit cleanly for logging.
+    /// \return Space-separated "id (wait status)" list, empty when all modules exited cleanly.
+    std::string format_unclean_exits() const;
+
+    /// \brief Reset all shutdown/drain bookkeeping state.
+    void reset_shutdown_state();
+
+    /// \brief Transition to Idle after modules have shut down; logs \p log_message.
+    /// \return std::nullopt for callers that return std::optional<int>.
+    std::optional<int> transition_to_idle_after_shutdown(std::string_view log_message);
+
+    /// \brief Disconnect controller and MQTT, optionally reset shutdown state, transition to Exiting.
+    /// \return Process exit code for the caller.
+    int transition_to_exiting_after_shutdown(RuntimeContext& ctx, ManagerAdminPanel& admin_panel, int exit_code,
+                                             bool reset_state);
+
+    /// \brief Finalize normal shutdown and decide exit vs idle outcome.
+    /// \param ctx Runtime dependencies for the current run.
+    /// \param admin_panel Controller IPC/process integration helper.
+    /// \return EXIT_SUCCESS/EXIT_FAILURE when manager exits, std::nullopt for idle mode.
+    std::optional<int> handle_finish_normal_shutdown(RuntimeContext& ctx, ManagerAdminPanel& admin_panel);
+
+    /// \brief Finalize crash-recovery shutdown path.
+    /// \param ctx Runtime dependencies for the current run.
+    /// \param admin_panel Controller IPC/process integration helper.
+    /// \return EXIT_FAILURE when manager exits after crash (default), std::nullopt when staying idle
+    ///         (`--recover-module-crashes` and restart cap exceeded).
+    std::optional<int> handle_finish_crash_recovery(RuntimeContext& ctx, ManagerAdminPanel& admin_panel);
+
+    /// \brief Start the shutdown flow; publishes the shutdown topic when graceful shutdown is
+    ///        enabled (`--graceful-shutdown`), otherwise modules are force-terminated by the
+    ///        zero-deadline path in handle_shutdown_timeout().
+    /// \param module_exited_time Timestamp used as shutdown start reference.
+    /// \param publish_when_sigint_received Whether to publish shutdown topic even after SIGINT.
+    /// \param info_log Optional critical log message emitted before publish.
+    /// \param mqtt_abstraction Active MQTT abstraction instance.
+    /// \param ms Fully resolved manager settings for this run.
+    void handle_initiate_graceful_shutdown(const std::chrono::steady_clock::time_point& module_exited_time,
+                                           bool publish_when_sigint_received,
+                                           const std::optional<std::string>& info_log,
+                                           Everest::MQTTAbstraction& mqtt_abstraction,
+                                           const Everest::ManagerSettings& ms);
+
+    /// \brief Enforce shutdown timeout and force-terminate remaining modules.
+    /// \param ctx Runtime dependencies for the current run.
+    void handle_shutdown_timeout(RuntimeContext& ctx);
+
+    /// \brief Poll waitpid once and dispatch child exit handling.
+    /// \param wstatus waitpid status output parameter.
+    /// \param ctx Runtime dependencies for the current run.
+    /// \param admin_panel Controller IPC/process integration helper.
+    /// \return true when loop should short-circuit/continue after handling.
+    bool handle_waitpid_event(int& wstatus, RuntimeContext& ctx, ManagerAdminPanel& admin_panel);
+
+    /// \brief Handle one child exit and update shutdown/restart state.
+    /// \param pid Exited child process id.
+    /// \param wstatus waitpid status for the exited child.
+    /// \param ctx Runtime dependencies for the current run.
+    /// \param admin_panel Controller IPC/process integration helper.
+    /// \return true when loop should short-circuit/continue after handling.
+    bool handle_child_exit(pid_t pid, int wstatus, RuntimeContext& ctx, ManagerAdminPanel& admin_panel);
+
+    /// \brief Poll controller IPC commands (restart/check-config).
+    /// \param ctx Runtime dependencies for the current run.
+    /// \param admin_panel Controller IPC/process integration helper.
+    /// \param prefix_opt Prefix passed to config-check requests.
+    /// \return Exit code when manager should terminate, std::nullopt otherwise.
+    std::optional<int> handle_controller_ipc_poll(RuntimeContext& ctx, ManagerAdminPanel& admin_panel,
+                                                  const std::string& prefix_opt);
+
+    /// \brief Handle SIGINT/SIGTERM transition and optional immediate exit.
+    /// \param signo Signal number received by polling.
+    /// \param ctx Runtime dependencies for the current run.
+    /// \param admin_panel Controller IPC/process integration helper.
+    /// \return Exit code when manager should terminate, std::nullopt otherwise.
+    std::optional<int> handle_signal(int signo, RuntimeContext& ctx, ManagerAdminPanel& admin_panel);
+
+    /// \brief Poll signal fd and forward handled signals to handle_signal().
+    /// \param signal_polling Signal polling abstraction used by manager loop.
+    /// \param ctx Runtime dependencies for the current run.
+    /// \param admin_panel Controller IPC/process integration helper.
+    /// \return Exit code when manager should terminate, std::nullopt otherwise.
+    std::optional<int> handle_signal_poll(Everest::system::SignalPolling& signal_polling, RuntimeContext& ctx,
+                                          ManagerAdminPanel& admin_panel);
+
+    /// \brief Main-loop signal poll timeout: short while deadlines are running or controller IPC
+    ///        needs polling, long otherwise (SIGINT/SIGTERM/SIGCHLD wake the poll immediately).
+    int signal_poll_timeout_ms() const;
+
+    const boost::program_options::variables_map& vm_;
+    Everest::StatusFifo* status_fifo_{nullptr};
+    bool recover_module_crashes_{false};
+    // Opt-in via --graceful-shutdown: publish the MQTT shutdown signal and give modules
+    // SHUTDOWN_TIMEOUT_MS to exit on their own. Default (false): terminate module processes
+    // immediately (SIGTERM, escalating to SIGKILL after FORCE_KILL_GRACE_TIMEOUT_MS).
+    bool graceful_shutdown_enabled_{false};
+    // state_ is atomic because the module-ready handler runs on the MQTT thread; transitions are
+    // serialized with state_transition_mutex_ (main loop and ready handler).
+    std::atomic<ManagerState> state_{ManagerState::Idle};
+    ShutdownCause shutdown_cause_{ShutdownCause::None};
+    std::atomic<bool> sigint_received_{false};
+    // Unexpected-exit recovery attempts for this manager process lifetime (current config).
+    // Not cleared on transition to Running; resets when run() starts (future: also on config change).
+    std::uint8_t unexpected_module_exit_count_{0};
+    std::chrono::steady_clock::time_point module_startup_start_time_{std::chrono::steady_clock::now()};
+    std::optional<std::chrono::steady_clock::time_point> shutdown_start_time_;
+    std::optional<std::chrono::steady_clock::time_point> force_terminate_start_time_;
+    bool force_kill_sent_{false};
+    std::map<pid_t, std::string> module_handles_;
+    std::vector<ModuleShutdownInfo> shutdown_info_;
+    ModulesReadyType modules_ready_; // guarded by modules_ready_mutex_
+    std::mutex modules_ready_mutex_;
+    mutable std::mutex state_transition_mutex_;
+};

--- a/lib/everest/framework/src/manager_admin_panel.cpp
+++ b/lib/everest/framework/src/manager_admin_panel.cpp
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "manager_admin_panel.hpp"
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+#include <optional>
+#include <signal.h>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <fmt/core.h>
+
+#include <everest/logging.hpp>
+#include <framework/runtime.hpp>
+#include <utils/config.hpp>
+
+#include "controller/ipc.hpp"
+#include "system_unix.hpp"
+
+namespace fs = std::filesystem;
+using namespace Everest;
+
+namespace {
+const int CONTROLLER_IPC_READ_TIMEOUT_MS = 50;
+} // namespace
+
+#ifdef ENABLE_ADMIN_PANEL
+struct ControllerHandle {
+    ControllerHandle(pid_t pid, int socket_fd) : pid(pid), socket_fd(socket_fd) {
+        controller_ipc::set_read_timeout(socket_fd, CONTROLLER_IPC_READ_TIMEOUT_MS);
+    }
+
+    void send_message(const nlohmann::json& msg) {
+        controller_ipc::send_message(socket_fd, msg);
+    }
+
+    controller_ipc::Message receive_message() {
+        return controller_ipc::receive_message(socket_fd);
+    }
+
+    int fd() const {
+        return socket_fd;
+    }
+
+    const pid_t pid;
+
+private:
+    const int socket_fd;
+};
+
+struct ManagerAdminPanel::Impl {
+    explicit Impl(ControllerHandle h) : handle(h) {
+    }
+
+    static ControllerHandle start_controller(const ManagerSettings& ms) {
+        std::array<int, 2> socket_pair{};
+
+        if (socketpair(AF_UNIX, SOCK_DGRAM, 0, socket_pair.data()) != 0) {
+            throw std::runtime_error(
+                fmt::format("Syscall to socketpair() failed while starting controller ({})", strerror(errno)));
+        }
+        const int manager_socket = socket_pair[0];
+        const int controller_socket = socket_pair[1];
+
+        auto proc_handle = system::SubProcess::create(ms.run_as_user);
+
+        if (proc_handle.is_child()) {
+            const auto bin_dir = fs::canonical("/proc/self/exe").parent_path();
+            const auto controller_binary = bin_dir / "controller";
+
+            // The manager may block SIGINT/SIGTERM for signalfd polling.
+            // Unblock them in the controller child so external SIGTERM can stop it.
+            sigset_t unblocked_signals;
+            sigemptyset(&unblocked_signals);
+            sigaddset(&unblocked_signals, SIGINT);
+            sigaddset(&unblocked_signals, SIGTERM);
+            if (sigprocmask(SIG_UNBLOCK, &unblocked_signals, nullptr) != 0) {
+                proc_handle.send_error_and_exit(
+                    fmt::format("Syscall to sigprocmask() failed while preparing controller ({})", strerror(errno)));
+            }
+
+            close(manager_socket);
+            dup2(controller_socket, STDIN_FILENO);
+            close(controller_socket);
+
+            execl(controller_binary.c_str(), MAGIC_CONTROLLER_ARG0, NULL);
+
+            proc_handle.send_error_and_exit(fmt::format("Syscall to execl() with \"{} {}\" failed ({})",
+                                                        MAGIC_CONTROLLER_ARG0, controller_binary.string(),
+                                                        strerror(errno)));
+        }
+
+        close(controller_socket);
+
+        controller_ipc::send_message(manager_socket,
+                                     {{"method", "boot"},
+                                      {"params",
+                                       {{"module_dir", ms.runtime_settings.modules_dir.string()},
+                                        {"interface_dir", ms.interfaces_dir.string()},
+                                        {"www_dir", ms.www_dir.string()},
+                                        {"configs_dir", ms.configs_dir.string()},
+                                        {"logging_config_file", ms.runtime_settings.logging_config_file.string()},
+                                        {"controller_port", ms.controller_port},
+                                        {"controller_rpc_timeout_ms", ms.controller_rpc_timeout_ms}}}});
+
+        return {proc_handle.check_child_executed(), manager_socket};
+    }
+
+    ControllerHandle handle;
+};
+
+ManagerAdminPanel::ManagerAdminPanel(std::unique_ptr<Impl> impl_) : impl(std::move(impl_)) {
+}
+#endif
+
+#ifndef ENABLE_ADMIN_PANEL
+ManagerAdminPanel::ManagerAdminPanel() = default;
+#endif
+ManagerAdminPanel::~ManagerAdminPanel() = default;
+ManagerAdminPanel::ManagerAdminPanel(ManagerAdminPanel&&) noexcept = default;
+ManagerAdminPanel& ManagerAdminPanel::operator=(ManagerAdminPanel&&) noexcept = default;
+
+ManagerAdminPanel ManagerAdminPanel::create(const ManagerSettings& ms) {
+#ifdef ENABLE_ADMIN_PANEL
+    return ManagerAdminPanel(std::make_unique<Impl>(Impl::start_controller(ms)));
+#else
+    static_cast<void>(ms);
+    return ManagerAdminPanel{};
+#endif
+}
+
+void ManagerAdminPanel::throw_if_controller_exited(pid_t pid) const {
+#ifdef ENABLE_ADMIN_PANEL
+    if (not impl) {
+        throw std::runtime_error("ManagerAdminPanel is not initialized.");
+    }
+    if (pid == impl->handle.pid) {
+        throw std::runtime_error("The controller process exited.");
+    }
+#else
+    static_cast<void>(pid);
+#endif
+}
+
+bool ManagerAdminPanel::is_controller_process(pid_t pid) const {
+#ifdef ENABLE_ADMIN_PANEL
+    if (not impl) {
+        return false;
+    }
+    return pid == impl->handle.pid;
+#else
+    static_cast<void>(pid);
+    return false;
+#endif
+}
+
+void ManagerAdminPanel::shutdown_controller() const {
+#ifdef ENABLE_ADMIN_PANEL
+    if (not impl) {
+        return;
+    }
+    if (kill(impl->handle.pid, SIGTERM) != 0 && errno != ESRCH) {
+        EVLOG_warning << fmt::format("Failed to SIGTERM controller process {} ({})", impl->handle.pid, strerror(errno));
+    }
+#endif
+}
+
+std::optional<int> ManagerAdminPanel::poll_controller_ipc(bool& restart_modules, bool& modules_started,
+                                                          const std::string& prefix_opt) {
+#ifdef ENABLE_ADMIN_PANEL
+    if (not impl) {
+        return EXIT_FAILURE;
+    }
+    const auto msg = impl->handle.receive_message();
+    if (msg.status == controller_ipc::MESSAGE_RETURN_STATUS::OK) {
+        const auto& payload = msg.json;
+        if (payload.at("method") == "restart_modules") {
+            // The manager decides how to drain modules (graceful broadcast vs immediate
+            // termination) when it acts on the restart_modules flag.
+            restart_modules = true;
+            modules_started = false;
+            EVLOG_info << "Controller requested module restart (config will be reloaded).";
+        } else if (payload.at("method") == "check_config") {
+            const std::string check_config_file_path = payload.at("params");
+
+            try {
+                auto cfg = ManagerConfig(ManagerSettings(prefix_opt, check_config_file_path));
+                static_cast<void>(cfg);
+                impl->handle.send_message({{"id", payload.at("id")}, {"result", {{"ok", true}}}});
+            } catch (const std::exception& e) {
+                impl->handle.send_message({{"result", e.what()}, {"id", payload.at("id")}});
+            }
+        } else {
+            EVLOG_error << fmt::format("Received unknown command via controller ipc:\n{}\n... ignoring",
+                                       payload.dump(2));
+        }
+    } else if (msg.status == controller_ipc::MESSAGE_RETURN_STATUS::ERROR) {
+        fmt::print("Error in IPC communication with controller: {}\nExiting\n", msg.json.at("error").dump(2));
+        return EXIT_FAILURE;
+    }
+    return std::nullopt;
+#else
+    static_cast<void>(restart_modules);
+    static_cast<void>(modules_started);
+    static_cast<void>(prefix_opt);
+    return std::nullopt;
+#endif
+}
+
+std::optional<int> ManagerAdminPanel::controller_ipc_fd() const {
+#ifdef ENABLE_ADMIN_PANEL
+    if (not impl) {
+        return std::nullopt;
+    }
+    return impl->handle.fd();
+#else
+    return std::nullopt;
+#endif
+}
+
+std::optional<std::string> ManagerAdminPanel::switch_manager_user_if_needed(const ManagerSettings& ms) {
+#ifndef ENABLE_ADMIN_PANEL
+    if (not ms.run_as_user.empty()) {
+        auto err_set_user = system::set_real_user(ms.run_as_user);
+        if (not err_set_user.empty()) {
+            return err_set_user;
+        }
+    }
+#else
+    static_cast<void>(ms);
+#endif
+    return std::nullopt;
+}

--- a/lib/everest/framework/src/manager_admin_panel.hpp
+++ b/lib/everest/framework/src/manager_admin_panel.hpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <sys/types.h>
+
+namespace Everest {
+struct ManagerSettings;
+} // namespace Everest
+
+struct ManagerAdminPanel {
+    ~ManagerAdminPanel();
+    ManagerAdminPanel(ManagerAdminPanel&&) noexcept;
+    ManagerAdminPanel& operator=(ManagerAdminPanel&&) noexcept;
+
+    ManagerAdminPanel(const ManagerAdminPanel&) = delete;
+    ManagerAdminPanel& operator=(const ManagerAdminPanel&) = delete;
+
+    static ManagerAdminPanel create(const Everest::ManagerSettings& ms);
+    static std::optional<std::string> switch_manager_user_if_needed(const Everest::ManagerSettings& ms);
+    void shutdown_controller() const;
+    bool is_controller_process(pid_t pid) const;
+
+    void throw_if_controller_exited(pid_t pid) const;
+
+    /// Process controller IPC for one main-loop iteration.
+    /// Returns an exit code for `boot`, or `nullopt` to continue.
+    std::optional<int> poll_controller_ipc(bool& restart_modules, bool& modules_started, const std::string& prefix_opt);
+
+    /// File descriptor of the controller IPC socket, usable as an extra wakeup fd for the
+    /// manager main-loop poll. nullopt when the admin panel is disabled or not initialized.
+    std::optional<int> controller_ipc_fd() const;
+
+private:
+#ifdef ENABLE_ADMIN_PANEL
+    struct Impl;
+    std::unique_ptr<Impl> impl;
+
+    ManagerAdminPanel() = delete;
+    explicit ManagerAdminPanel(std::unique_ptr<Impl> impl_);
+#else
+    ManagerAdminPanel();
+#endif
+};

--- a/lib/everest/framework/src/system_unix.cpp
+++ b/lib/everest/framework/src/system_unix.cpp
@@ -13,6 +13,7 @@
 #include <signal.h>
 #include <sys/capability.h>
 #include <sys/prctl.h>
+#include <sys/signalfd.h>
 #include <unistd.h>
 
 #include <fmt/core.h>
@@ -22,6 +23,7 @@
 namespace Everest::system {
 
 const auto PARENT_DIED_SIGNAL = SIGTERM;
+const int SIGNAL_POLL_TIMEOUT_MS = 50;
 
 struct GetPasswdEntryResult {
     explicit GetPasswdEntryResult(const std::string& error_) : error(error_) {
@@ -249,6 +251,47 @@ SubProcess SubProcess::create(const std::string& run_as_user, const std::vector<
         close(writing_end_fd);
         return {reading_end_fd, pid};
     }
+}
+
+namespace {
+int setup_signal_fd() {
+    sigset_t mask;
+
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGINT);
+    // sigaddset(&mask, SIGTERM); // TODO: what should SIGTERM lead to, a controlled shutdown of some sorts would be a
+    // good idea but unsure if it should go through a mqtt publish
+    if (sigprocmask(SIG_BLOCK, &mask, NULL) == -1) {
+        return EXIT_FAILURE;
+    }
+
+    return signalfd(-1, &mask, 0);
+}
+} // namespace
+
+SignalPolling::SignalPolling() {
+    signal_fd = setup_signal_fd();
+    if (signal_fd != -1) {
+        pollfds[0] = {signal_fd, POLLIN, 0};
+        available = true;
+    }
+}
+
+std::optional<uint32_t> SignalPolling::poll_signal() {
+    if (not available) {
+        return std::nullopt;
+    }
+    std::optional<uint32_t> received_signal = std::nullopt;
+    auto poll_retval = poll(pollfds, 1, SIGNAL_POLL_TIMEOUT_MS);
+    if (poll_retval > 0) {
+        struct signalfd_siginfo siginfo;
+        auto read_retval = read(signal_fd, &siginfo, sizeof(siginfo));
+        if (read_retval == sizeof(siginfo)) {
+            received_signal.emplace(siginfo.ssi_signo);
+        } // TODO(kai): should we go to not available in this case?
+    }
+
+    return received_signal;
 }
 
 } // namespace Everest::system

--- a/lib/everest/framework/src/system_unix.cpp
+++ b/lib/everest/framework/src/system_unix.cpp
@@ -3,16 +3,22 @@
 
 #include "system_unix.hpp"
 
+#include <algorithm>
+#include <array>
 #include <cassert>
+#include <chrono>
 #include <stdexcept>
+#include <thread>
 
 #include <fcntl.h>
 #include <grp.h>
 #include <linux/securebits.h>
+#include <poll.h>
 #include <pwd.h>
 #include <signal.h>
 #include <sys/capability.h>
 #include <sys/prctl.h>
+#include <sys/signalfd.h>
 #include <unistd.h>
 
 #include <fmt/core.h>
@@ -22,6 +28,7 @@
 namespace Everest::system {
 
 const auto PARENT_DIED_SIGNAL = SIGTERM;
+const int SIGNAL_POLL_TIMEOUT_MS = 50;
 
 struct GetPasswdEntryResult {
     explicit GetPasswdEntryResult(const std::string& error_) : error(error_) {
@@ -257,11 +264,83 @@ SubProcess SubProcess::create(const std::string& run_as_user, const std::vector<
             kill(getpid(), PARENT_DIED_SIGNAL);
         }
 
+        // The manager blocks signals for signalfd polling.
+        // Child module processes must unblock SIGTERM so manager can terminate them directly, and
+        // SIGCHLD so modules that spawn their own subprocesses (e.g. Python asyncio child watchers)
+        // keep working. Keep SIGINT blocked in children so Ctrl+C is coordinated by manager instead
+        // of interrupting module internals (e.g. Python waits), which can produce noisy/asynchronous
+        // failures.
+        sigset_t unblocked_signals;
+        sigemptyset(&unblocked_signals);
+        sigaddset(&unblocked_signals, SIGTERM);
+        sigaddset(&unblocked_signals, SIGCHLD);
+        if (sigprocmask(SIG_UNBLOCK, &unblocked_signals, nullptr) != 0) {
+            handle.send_error_and_exit(fmt::format("Syscall to sigprocmask() failed ({})", strerror(errno)));
+        }
+
         return handle;
     } else {
         close(writing_end_fd);
         return {reading_end_fd, pid};
     }
+}
+
+namespace {
+int setup_signal_fd() {
+    sigset_t mask;
+
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGINT);
+    sigaddset(&mask, SIGTERM);
+    // SIGCHLD is part of the mask so a child exit wakes up a (long) blocking poll on the
+    // signal fd; the manager then reaps the child via waitpid
+    sigaddset(&mask, SIGCHLD);
+    if (sigprocmask(SIG_BLOCK, &mask, NULL) == -1) {
+        return -1;
+    }
+
+    const int fd = signalfd(-1, &mask, 0);
+    if (fd == -1) {
+        // restore default signal delivery, otherwise the blocked signals could neither be polled
+        // nor delivered and the process could not be terminated with SIGINT/SIGTERM anymore
+        sigprocmask(SIG_UNBLOCK, &mask, NULL);
+    }
+    return fd;
+}
+} // namespace
+
+SignalPolling::SignalPolling() {
+    signal_fd = setup_signal_fd();
+    if (signal_fd != -1) {
+        available = true;
+    }
+}
+
+std::optional<uint32_t> SignalPolling::poll_signal(int timeout_ms, int extra_wakeup_fd) {
+    if (not available) {
+        // no signal fd: sleep instead of poll so the caller's loop does not busy-spin; signals
+        // use their default disposition since the mask was restored in setup_signal_fd()
+        std::this_thread::sleep_for(std::chrono::milliseconds(std::min(timeout_ms, SIGNAL_POLL_TIMEOUT_MS)));
+        return std::nullopt;
+    }
+    std::array<struct pollfd, 2> pollfds{};
+    pollfds[0] = {signal_fd, POLLIN, 0};
+    nfds_t nfds = 1;
+    if (extra_wakeup_fd != -1) {
+        pollfds[1] = {extra_wakeup_fd, POLLIN, 0};
+        nfds = 2;
+    }
+    std::optional<uint32_t> received_signal = std::nullopt;
+    auto poll_retval = poll(pollfds.data(), nfds, timeout_ms);
+    if (poll_retval > 0 && (pollfds[0].revents & POLLIN) != 0) {
+        struct signalfd_siginfo siginfo;
+        auto read_retval = read(signal_fd, &siginfo, sizeof(siginfo));
+        if (read_retval == sizeof(siginfo)) {
+            received_signal.emplace(siginfo.ssi_signo);
+        } // TODO(kai): should we go to not available in this case?
+    }
+
+    return received_signal;
 }
 
 } // namespace Everest::system

--- a/lib/everest/framework/src/system_unix.hpp
+++ b/lib/everest/framework/src/system_unix.hpp
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include <cstdint>
+#include <poll.h>
 #include <sys/types.h>
 
 namespace Everest::system {
@@ -37,5 +40,17 @@ std::string set_caps(const std::vector<std::string>& capabilities);
 std::string set_real_user(const std::string& user_name);
 
 std::string set_user_and_capabilities(const std::string& run_as_user, const std::vector<std::string>& capabilities);
+
+class SignalPolling {
+public:
+    SignalPolling();
+
+    std::optional<uint32_t> poll_signal();
+
+private:
+    bool available = false;
+    int signal_fd = -1;
+    struct pollfd pollfds[1];
+};
 
 } // namespace Everest::system

--- a/lib/everest/framework/src/system_unix.hpp
+++ b/lib/everest/framework/src/system_unix.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 
 #pragma once
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include <cstdint>
 #include <sys/types.h>
 
 namespace Everest::system {
@@ -37,5 +39,21 @@ std::string set_caps(const std::vector<std::string>& capabilities);
 std::string set_real_user(const std::string& user_name);
 
 std::string set_user_and_capabilities(const std::string& run_as_user, const std::vector<std::string>& capabilities);
+
+class SignalPolling {
+public:
+    SignalPolling();
+
+    /// \brief Wait up to \p timeout_ms for a blocked signal (SIGINT/SIGTERM/SIGCHLD) to arrive.
+    ///        When \p extra_wakeup_fd is not -1, the poll also returns (with std::nullopt) as soon
+    ///        as that fd becomes readable, so the caller can service it without waiting for the
+    ///        timeout.
+    /// \return The received signal number, or std::nullopt on timeout/extra fd wakeup.
+    std::optional<uint32_t> poll_signal(int timeout_ms, int extra_wakeup_fd = -1);
+
+private:
+    bool available = false;
+    int signal_fd = -1;
+};
 
 } // namespace Everest::system

--- a/lib/everest/framework/tests/include/tests/mock_mqtt_abstraction.hpp
+++ b/lib/everest/framework/tests/include/tests/mock_mqtt_abstraction.hpp
@@ -94,6 +94,8 @@ public:
     }
     void disconnect() override {
     }
+    void stop_message_handling() override {
+    }
     void subscribe(const std::string& /*topic*/) override {
     }
     void subscribe(const std::string& /*topic*/, QOS /*qos*/) override {

--- a/modules/API/API/API.cpp
+++ b/modules/API/API/API.cpp
@@ -760,4 +760,11 @@ void API::ready() {
     });
 }
 
+void API::shutdown() {
+    this->running = false;
+    for (auto& api_thread : this->api_threads) {
+        api_thread.join();
+    }
+}
+
 } // namespace module

--- a/modules/API/API/API.hpp
+++ b/modules/API/API/API.hpp
@@ -193,6 +193,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/API/API/API.hpp
+++ b/modules/API/API/API.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
@@ -20,6 +20,7 @@
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
+#include <atomic>
 #include <condition_variable>
 #include <list>
 #include <memory>
@@ -193,11 +194,13 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
     std::vector<std::thread> api_threads;
-    bool running = true;
+    // written by shutdown() from the framework's shutdown-handler thread while the api_threads read it
+    std::atomic<bool> running{true};
 
     StartupMonitor evse_manager_check;
 

--- a/modules/EV/PyEvJosev/module.py
+++ b/modules/EV/PyEvJosev/module.py
@@ -83,6 +83,7 @@ class PyEVJosevModule():
 
         self._mod = m
         self._mod.init_done(self._ready)
+        self._mod.shutdown_handler(self._shutdown)
 
     def start_evcc_handler(self):
         exi_codec = ExificientEXICodec()
@@ -102,6 +103,9 @@ class PyEVJosevModule():
 
     def _ready(self):
         log.debug("ready!")
+
+    def _shutdown(self):
+        log.debug("shutdown")
 
     # implementation handlers
 

--- a/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
@@ -33,6 +33,8 @@ struct MqttStub : public Everest::MQTTAbstraction {
     }
     void disconnect() override {
     }
+    void stop_message_handling() override {
+    }
     void publish(const std::string& topic, const nlohmann::json& json) override {
     }
     void publish(const std::string& topic, const nlohmann::json& json, QOS qos, bool retain = false) override {

--- a/modules/Examples/CppExamples/Example/Example.cpp
+++ b/modules/Examples/CppExamples/Example/Example.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include "Example.hpp"
 
 namespace module {
@@ -14,6 +14,11 @@ void Example::ready() {
     invoke_ready(*p_store);
 
     mqtt.publish("external/topic", "data");
+}
+
+void Example::shutdown() {
+    invoke_shutdown(*p_example);
+    invoke_shutdown(*p_store);
 }
 
 } // namespace module

--- a/modules/Examples/CppExamples/Example/Example.hpp
+++ b/modules/Examples/CppExamples/Example/Example.hpp
@@ -56,6 +56,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/Examples/CppExamples/Example/Example.hpp
+++ b/modules/Examples/CppExamples/Example/Example.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
@@ -56,6 +56,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/Examples/CppExamples/Example/example/exampleImpl.cpp
+++ b/modules/Examples/CppExamples/Example/example/exampleImpl.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include "exampleImpl.hpp"
 
 // initial cpp template for interface example_child
@@ -16,6 +16,9 @@ void exampleImpl::init() {
 void exampleImpl::ready() {
     publish_max_current(config.current);
     mod->r_kvs->call_store("test", "test");
+}
+
+void exampleImpl::shutdown() {
 }
 
 bool exampleImpl::handle_uses_something(std::string& key) {

--- a/modules/Examples/CppExamples/Example/example/exampleImpl.hpp
+++ b/modules/Examples/CppExamples/Example/example/exampleImpl.hpp
@@ -49,6 +49,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown();
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/Examples/CppExamples/Example/example/exampleImpl.hpp
+++ b/modules/Examples/CppExamples/Example/example/exampleImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/example/Implementation.hpp>
@@ -49,6 +49,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown();
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/Examples/CppExamples/Example/store/kvsImpl.cpp
+++ b/modules/Examples/CppExamples/Example/store/kvsImpl.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include "kvsImpl.hpp"
 
 namespace module {
@@ -9,6 +9,9 @@ void kvsImpl::init() {
 }
 
 void kvsImpl::ready() {
+}
+
+void kvsImpl::shutdown() {
 }
 
 void kvsImpl::handle_store(std::string& key,

--- a/modules/Examples/CppExamples/Example/store/kvsImpl.hpp
+++ b/modules/Examples/CppExamples/Example/store/kvsImpl.hpp
@@ -51,6 +51,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown();
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/Examples/CppExamples/Example/store/kvsImpl.hpp
+++ b/modules/Examples/CppExamples/Example/store/kvsImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/kvs/Implementation.hpp>
@@ -51,6 +51,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown();
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/Examples/CppExamples/ExampleUser/ExampleUser.cpp
+++ b/modules/Examples/CppExamples/ExampleUser/ExampleUser.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include "ExampleUser.hpp"
 
 namespace module {
@@ -10,6 +10,10 @@ void ExampleUser::init() {
 
 void ExampleUser::ready() {
     invoke_ready(*p_example_user);
+}
+
+void ExampleUser::shutdown() {
+    invoke_shutdown(*p_example_user);
 }
 
 } // namespace module

--- a/modules/Examples/CppExamples/ExampleUser/ExampleUser.hpp
+++ b/modules/Examples/CppExamples/ExampleUser/ExampleUser.hpp
@@ -48,6 +48,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/Examples/CppExamples/ExampleUser/example_user/example_userImpl.cpp
+++ b/modules/Examples/CppExamples/ExampleUser/example_user/example_userImpl.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include "example_userImpl.hpp"
 
 namespace module {
@@ -10,6 +10,9 @@ void example_userImpl::init() {
 
 void example_userImpl::ready() {
     mod->r_example->call_uses_something("hello_there");
+}
+
+void example_userImpl::shutdown() {
 }
 
 } // namespace example_user

--- a/modules/Examples/CppExamples/ExampleUser/example_user/example_userImpl.hpp
+++ b/modules/Examples/CppExamples/ExampleUser/example_user/example_userImpl.hpp
@@ -44,6 +44,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown();
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/Examples/CppExamples/ExampleUser/example_user/example_userImpl.hpp
+++ b/modules/Examples/CppExamples/ExampleUser/example_user/example_userImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/example_user/Implementation.hpp>
@@ -44,6 +44,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown();
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here

--- a/modules/Misc/Store/Store.cpp
+++ b/modules/Misc/Store/Store.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include "Store.hpp"
 
 namespace module {
@@ -10,6 +10,10 @@ void Store::init() {
 
 void Store::ready() {
     invoke_ready(*p_main);
+}
+
+void Store::shutdown() {
+    invoke_shutdown(*p_main);
 }
 
 } // namespace module

--- a/modules/Misc/Store/Store.hpp
+++ b/modules/Misc/Store/Store.hpp
@@ -43,6 +43,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/Misc/Store/Store.hpp
+++ b/modules/Misc/Store/Store.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 2
+// template version 3
 //
 
 #include "ld-ev.hpp"
@@ -43,6 +43,7 @@ private:
     friend class LdEverest;
     void init();
     void ready();
+    void shutdown();
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here

--- a/modules/Misc/Store/main/kvsImpl.cpp
+++ b/modules/Misc/Store/main/kvsImpl.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include "kvsImpl.hpp"
 
 namespace module {
@@ -9,6 +9,9 @@ void kvsImpl::init() {
 }
 
 void kvsImpl::ready() {
+}
+
+void kvsImpl::shutdown() {
 }
 
 void kvsImpl::handle_store(std::string& key,

--- a/modules/Misc/Store/main/kvsImpl.hpp
+++ b/modules/Misc/Store/main/kvsImpl.hpp
@@ -51,6 +51,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown();
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     std::map<std::string, std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string>> kvs{};

--- a/modules/Misc/Store/main/kvsImpl.hpp
+++ b/modules/Misc/Store/main/kvsImpl.hpp
@@ -5,7 +5,7 @@
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
-// template version 3
+// template version 4
 //
 
 #include <generated/interfaces/kvs/Implementation.hpp>
@@ -51,6 +51,7 @@ private:
 
     virtual void init() override;
     virtual void ready() override;
+    void shutdown();
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     std::map<std::string, std::variant<std::nullptr_t, Array, Object, bool, double, int, std::string>> kvs{};

--- a/modules/Simulation/CMakeLists.txt
+++ b/modules/Simulation/CMakeLists.txt
@@ -1,4 +1,5 @@
 ev_add_module(DCSupplySimulator)
+ev_add_module(ManagerLifecycleSimulator)
 ev_add_module(IMDSimulator)
 ev_add_module(OVMSimulator)
 ev_add_module(SlacSimulator)

--- a/modules/Simulation/ManagerLifecycleSimulator/CMakeLists.txt
+++ b/modules/Simulation/ManagerLifecycleSimulator/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+# template version 3
+#
+
+# module setup:
+#   - ${MODULE_NAME}: module name
+ev_setup_cpp_module()
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+# insert your custom targets and additional config variables here
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/Simulation/ManagerLifecycleSimulator/ManagerLifecycleSimulator.cpp
+++ b/modules/Simulation/ManagerLifecycleSimulator/ManagerLifecycleSimulator.cpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "ManagerLifecycleSimulator.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+namespace module {
+
+namespace {
+constexpr auto BLOCKED_SHUTDOWN_SLEEP_DURATION = std::chrono::milliseconds(100000);
+} // namespace
+
+void ManagerLifecycleSimulator::init() {
+    const std::string EXIT_TOPIC = "everest_api/" + this->info.id + "/cmd/exit";
+    EVLOG_info << "ManagerLifecycleSimulator: subscribing to exit command on topic: " << EXIT_TOPIC;
+    this->mqtt.subscribe(EXIT_TOPIC, [this](const std::string& payload) {
+        int exit_code = EXIT_SUCCESS;
+        if (!payload.empty()) {
+            try {
+                std::size_t parsed_chars = 0;
+                exit_code = std::stoi(payload, &parsed_chars);
+                if (parsed_chars != payload.size()) {
+                    EVLOG_warning << "ManagerLifecycleSimulator: exit payload contains trailing characters (payload='"
+                                  << payload << "'). Using parsed exit code " << exit_code << ".";
+                }
+            } catch (const std::exception& e) {
+                EVLOG_warning << "ManagerLifecycleSimulator: invalid exit payload '" << payload
+                              << "'. Expected integer, defaulting to exit code 0. Error: " << e.what();
+                exit_code = EXIT_SUCCESS;
+            }
+        }
+
+        EVLOG_info << "ManagerLifecycleSimulator: exit command received via MQTT, exiting process with code "
+                   << exit_code << ".";
+        std::exit(exit_code);
+    });
+
+    const std::string BLOCK_TOPIC = "everest_api/" + this->info.id + "/cmd/block";
+    EVLOG_info << "ManagerLifecycleSimulator: subscribing to block command on topic: " << BLOCK_TOPIC;
+    this->mqtt.subscribe(BLOCK_TOPIC, [this](const std::string& /*payload*/) {
+        EVLOG_info << "ManagerLifecycleSimulator: blocking command received via MQTT, blocking process.";
+        this->blocked = true;
+    });
+}
+
+void ManagerLifecycleSimulator::ready() {
+}
+
+void ManagerLifecycleSimulator::shutdown() {
+    if (this->blocked) {
+        EVLOG_info << "ManagerLifecycleSimulator: shutdown command received via framework, but process is blocked.";
+        std::this_thread::sleep_for(BLOCKED_SHUTDOWN_SLEEP_DURATION);
+    }
+    EVLOG_info << "ManagerLifecycleSimulator: shutdown command received via framework.";
+}
+
+} // namespace module

--- a/modules/Simulation/ManagerLifecycleSimulator/ManagerLifecycleSimulator.hpp
+++ b/modules/Simulation/ManagerLifecycleSimulator/ManagerLifecycleSimulator.hpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
-#ifndef EXAMPLE_USER_HPP
-#define EXAMPLE_USER_HPP
+#ifndef MANAGER_LIFECYCLE_SIMULATOR_HPP
+#define MANAGER_LIFECYCLE_SIMULATOR_HPP
 
 //
 // AUTO GENERATED - MARKED REGIONS WILL BE KEPT
@@ -9,12 +9,6 @@
 //
 
 #include "ld-ev.hpp"
-
-// headers for provided interface implementations
-#include <generated/interfaces/example_user/Implementation.hpp>
-
-// headers for required interface implementations
-#include <generated/interfaces/example/Interface.hpp>
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
@@ -24,15 +18,14 @@ namespace module {
 
 struct Conf {};
 
-class ExampleUser : public Everest::ModuleBase {
+class ManagerLifecycleSimulator : public Everest::ModuleBase {
 public:
-    ExampleUser() = delete;
-    ExampleUser(const ModuleInfo& info, std::unique_ptr<example_userImplBase> p_example_user,
-                std::unique_ptr<exampleIntf> r_example, Conf& config) :
-        ModuleBase(info), p_example_user(std::move(p_example_user)), r_example(std::move(r_example)), config(config){};
+    ManagerLifecycleSimulator() = delete;
+    ManagerLifecycleSimulator(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider, Conf& config) :
+        ModuleBase(info), mqtt(mqtt_provider), config(config) {
+    }
 
-    const std::unique_ptr<example_userImplBase> p_example_user;
-    const std::unique_ptr<exampleIntf> r_example;
+    Everest::MqttProvider& mqtt;
     const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
@@ -52,6 +45,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+    bool blocked = false;
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 
@@ -61,4 +55,4 @@ private:
 
 } // namespace module
 
-#endif // EXAMPLE_USER_HPP
+#endif // MANAGER_LIFECYCLE_SIMULATOR_HPP

--- a/modules/Simulation/ManagerLifecycleSimulator/manifest.yaml
+++ b/modules/Simulation/ManagerLifecycleSimulator/manifest.yaml
@@ -1,0 +1,6 @@
+description: Simulation module for manager lifecycle behavior (exit/block) over MQTT. Used to test manager crash recovery and shutdown handling.
+enable_external_mqtt: true
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Florin Mihut (Pionix GmbH)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ if(IS_PYTHON_VENV_ACTIVE)
 endif()
 
 add_subdirectory(everest-core_tests)
+add_subdirectory(core_tests/config)
 add_subdirectory(async_api_tests)
 
 if (TARGET EEBUS)

--- a/tests/core_tests/config/CMakeLists.txt
+++ b/tests/core_tests/config/CMakeLists.txt
@@ -1,0 +1,5 @@
+install(
+    DIRECTORY "."
+    DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/everest"
+    FILES_MATCHING PATTERN "*.yaml"
+)

--- a/tests/core_tests/config/config-sil-immortal_manager.yaml
+++ b/tests/core_tests/config/config-sil-immortal_manager.yaml
@@ -1,0 +1,5 @@
+active_modules:
+  exit_simulator:
+    module: ManagerLifecycleSimulator
+  block_simulator:
+    module: ManagerLifecycleSimulator

--- a/tests/core_tests/manager_lifecycle_tests.py
+++ b/tests/core_tests/manager_lifecycle_tests.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+import threading
+import time
+from collections import defaultdict
+
+import pytest
+
+from everest.testing.core_utils.everest_core import EverestCore, ManagerStatusFifo
+from everest.testing.core_utils.fixtures import *
+
+
+def topic_count_matching(topic_counts, topic_predicate):
+    return sum(count for topic, count in topic_counts.items() if topic_predicate(topic))
+
+
+def wait_for_matching_topic_count(topic_counts, topic_predicate, expected_count: int, timeout_s: float = 60.0):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        current_count = topic_count_matching(topic_counts, topic_predicate)
+        if current_count >= expected_count:
+            return
+        time.sleep(0.2)
+    raise TimeoutError(
+        f"Timeout waiting for matching topics to reach count {expected_count}. "
+        f"Current count is {topic_count_matching(topic_counts, topic_predicate)}."
+    )
+
+
+def clear_status_fifo_pending(everest_core: EverestCore) -> None:
+    listener = everest_core.status_listener
+    if hasattr(listener, "discard_pending"):
+        listener.discard_pending()
+        return
+    if hasattr(listener, "_pending_lines"):
+        listener._pending_lines.clear()
+    if hasattr(listener, "_read_buffer"):
+        listener._read_buffer = b""
+
+
+@pytest.mark.everest_core_config("config-sil-immortal_manager.yaml")
+def test_manager_stop_during_startup(everest_core: EverestCore):
+    start_exception = []
+    shutdown_errors = []
+
+    def start_core():
+        try:
+            everest_core.start()
+        except Exception as exc:
+            start_exception.append(exc)
+
+    def wait_for_sigint():
+        try:
+            everest_core.wait_for_manager_status(ManagerStatusFifo.SIGINT_RECEIVED, timeout_s=60.0)
+        except Exception as exc:
+            shutdown_errors.append(exc)
+
+    starter_thread = threading.Thread(target=start_core)
+    sigint_thread = threading.Thread(target=wait_for_sigint)
+    starter_thread.start()
+
+    everest_core.wait_for_manager_status(ManagerStatusFifo.MANAGER_STARTING_MODULES, timeout_s=60.0)
+    sigint_thread.start()
+    everest_core.stop()
+    sigint_thread.join(timeout=60.0)
+    starter_thread.join(timeout=60.0)
+
+    assert not shutdown_errors, shutdown_errors
+    assert not starter_thread.is_alive(), "Startup thread did not exit after stop()."
+
+
+@pytest.mark.everest_core_config("config-sil-immortal_manager.yaml")
+@pytest.mark.everest_manager_args("--graceful-shutdown")
+def test_manager_graceful_shutdown_from_running(everest_core: EverestCore):
+    shutdown_errors = []
+
+    def wait_for_shutdown():
+        try:
+            everest_core.wait_for_manager_status(ManagerStatusFifo.SIGINT_RECEIVED, timeout_s=60.0)
+            everest_core.wait_for_manager_status(ManagerStatusFifo.ALL_MODULES_STOPPED_CLEAN, timeout_s=60.0)
+        except Exception as exc:
+            shutdown_errors.append(exc)
+
+    everest_core.start()
+
+    shutdown_thread = threading.Thread(target=wait_for_shutdown)
+    shutdown_thread.start()
+    everest_core.stop()
+    shutdown_thread.join(timeout=60.0)
+
+    assert not shutdown_errors, shutdown_errors
+
+
+@pytest.mark.everest_core_config("config-sil-immortal_manager.yaml")
+@pytest.mark.everest_manager_args("--into-idle")
+def test_manager_into_idle_skips_module_startup(everest_core: EverestCore):
+    start_exception = []
+
+    def start_core():
+        try:
+            everest_core.start()
+        except Exception as exc:
+            start_exception.append(exc)
+
+    starter_thread = threading.Thread(target=start_core)
+    starter_thread.start()
+
+    everest_core.wait_for_manager_status(ManagerStatusFifo.MANAGER_IDLE, timeout_s=60.0)
+    everest_core.assert_no_manager_status(ManagerStatusFifo.ALL_MODULES_STARTED, timeout_s=5.0)
+    everest_core.stop()
+    starter_thread.join(timeout=60.0)
+
+    assert not starter_thread.is_alive(), "Startup thread did not exit after stop()."
+    assert start_exception, "Expected start() to fail because no modules are started with --into-idle."
+    assert all(isinstance(exc, TimeoutError) for exc in start_exception), (
+        f"Unexpected startup exception(s): {start_exception}"
+    )
+
+
+@pytest.mark.everest_core_config("config-sil-immortal_manager.yaml")
+@pytest.mark.everest_manager_args("--recover-module-crashes", "--graceful-shutdown")
+def test_manager_restarts_modules_after_unexpected_exit(
+    everest_core: EverestCore, connected_mqtt_client
+):
+    topic_counts = defaultdict(int)
+    mqtt_everest_prefix = f"everest_{everest_core.everest_uuid}"
+    mqtt_external_prefix = everest_core.mqtt_external_prefix
+    ready_topic_suffix = "/modules/exit_simulator/ready"
+    ready_topic_filter = f"{mqtt_everest_prefix}/modules/+/ready"
+    exit_cmd_topic = f"{mqtt_external_prefix}everest_api/exit_simulator/cmd/exit"
+    ready_topic_predicate = lambda topic: topic.startswith(f"{mqtt_everest_prefix}/") and topic.endswith(ready_topic_suffix)
+
+    def on_message(_client, _userdata, msg):
+        topic_counts[msg.topic] += 1
+
+    connected_mqtt_client.on_message = on_message
+    connected_mqtt_client.subscribe(ready_topic_filter)
+    time.sleep(0.2)
+
+    everest_core.start()
+
+    wait_for_matching_topic_count(topic_counts, ready_topic_predicate, 1, timeout_s=60.0)
+    baseline_ready = topic_count_matching(topic_counts, ready_topic_predicate)
+
+    connected_mqtt_client.publish(exit_cmd_topic, "1")
+
+    everest_core.wait_for_manager_status(ManagerStatusFifo.ALL_MODULES_STARTED, timeout_s=60.0)
+
+    wait_for_matching_topic_count(
+        topic_counts,
+        ready_topic_predicate,
+        baseline_ready + 1,
+        timeout_s=60.0,
+    )
+
+
+@pytest.mark.everest_core_config("config-sil-immortal_manager.yaml")
+@pytest.mark.everest_manager_args("--recover-module-crashes", "--graceful-shutdown")
+def test_manager_restarts_modules_after_unexpected_exit_max_3_times(
+    everest_core: EverestCore, connected_mqtt_client
+):
+    mqtt_external_prefix = everest_core.mqtt_external_prefix
+    exit_cmd_topic = f"{mqtt_external_prefix}everest_api/exit_simulator/cmd/exit"
+
+    everest_core.start()
+
+    expected_status_sets = [
+        [
+            ManagerStatusFifo.MANAGER_CRASH_SHUTDOWN_IN_PROGRESS,
+            ManagerStatusFifo.crash_recovery_attempt(1, 3),
+            ManagerStatusFifo.ALL_MODULES_STARTED,
+        ],
+        [
+            ManagerStatusFifo.crash_recovery_attempt(2, 3),
+            ManagerStatusFifo.ALL_MODULES_STARTED,
+        ],
+        [
+            ManagerStatusFifo.crash_recovery_attempt(3, 3),
+            ManagerStatusFifo.ALL_MODULES_STARTED,
+        ],
+        [
+            ManagerStatusFifo.CRASH_RECOVERY_EXHAUSTED,
+        ],
+    ]
+
+    for status_set in expected_status_sets:
+        connected_mqtt_client.publish(exit_cmd_topic, "1")
+        for status in status_set:
+            everest_core.wait_for_manager_status(status, timeout_s=60.0)
+
+    everest_core.assert_no_manager_status(
+        ManagerStatusFifo.crash_recovery_attempt(1, 3),
+        timeout_s=10.0,
+    )
+    everest_core.assert_no_manager_status(ManagerStatusFifo.ALL_MODULES_STARTED, timeout_s=10.0)
+
+
+@pytest.mark.everest_core_config("config-sil-immortal_manager.yaml")
+def test_manager_does_not_transition_back_to_running_when_stopped_during_startup(
+    everest_core: EverestCore
+):
+    start_exception = []
+
+    def start_core():
+        try:
+            everest_core.start()
+        except Exception as exc:
+            start_exception.append(exc)
+
+    starter_thread = threading.Thread(target=start_core)
+    starter_thread.start()
+
+    everest_core.wait_for_manager_status(ManagerStatusFifo.MANAGER_STARTING_MODULES, timeout_s=60.0)
+    everest_core.stop()
+    everest_core.wait_for_manager_status(ManagerStatusFifo.MANAGER_SHUTDOWN_REQUESTED, timeout_s=60.0)
+    starter_thread.join(timeout=60.0)
+
+    assert not starter_thread.is_alive(), "Startup thread did not exit after stop()."
+    if start_exception:
+        assert all(isinstance(exc, TimeoutError) for exc in start_exception), (
+            f"Unexpected startup exception(s): {start_exception}"
+        )
+
+    # Ignore lifecycle events that may have been emitted before/during the first
+    # shutdown request (modules can become ready in the same window as stop()).
+    # What must not happen is a restart back to Running after shutdown was requested.
+    clear_status_fifo_pending(everest_core)
+    everest_core.assert_no_manager_status(ManagerStatusFifo.ALL_MODULES_STARTED, timeout_s=5.0)
+    everest_core.assert_no_manager_status(ManagerStatusFifo.MANAGER_RUNNING, timeout_s=5.0)
+
+
+@pytest.mark.everest_core_config("config-sil-immortal_manager.yaml")
+@pytest.mark.everest_manager_args("--recover-module-crashes", "--graceful-shutdown")
+def test_manager_recovers_after_crash_with_blocked_module_timeout(
+    everest_core: EverestCore, connected_mqtt_client
+):
+    topic_counts = defaultdict(int)
+    mqtt_everest_prefix = f"everest_{everest_core.everest_uuid}"
+    mqtt_external_prefix = everest_core.mqtt_external_prefix
+    block_ready_topic_suffix = "/modules/block_simulator/ready"
+    block_ready_topic_filter = f"{mqtt_everest_prefix}/modules/+/ready"
+    block_cmd_topic = f"{mqtt_external_prefix}everest_api/block_simulator/cmd/block"
+    exit_cmd_topic = f"{mqtt_external_prefix}everest_api/exit_simulator/cmd/exit"
+    block_ready_topic_predicate = lambda topic: topic.startswith(f"{mqtt_everest_prefix}/") and topic.endswith(
+        block_ready_topic_suffix
+    )
+
+    def on_message(_client, _userdata, msg):
+        topic_counts[msg.topic] += 1
+
+    connected_mqtt_client.on_message = on_message
+    connected_mqtt_client.subscribe(block_ready_topic_filter)
+    time.sleep(0.2)
+
+    everest_core.start()
+
+    wait_for_matching_topic_count(topic_counts, block_ready_topic_predicate, 1, timeout_s=60.0)
+    baseline_ready = topic_count_matching(topic_counts, block_ready_topic_predicate)
+    connected_mqtt_client.publish(block_cmd_topic, "")
+    time.sleep(0.5)
+
+    connected_mqtt_client.publish(exit_cmd_topic, "1")
+
+    everest_core.wait_for_manager_status(ManagerStatusFifo.FORCE_SHUTDOWN_TIMEOUT, timeout_s=60.0)
+    everest_core.wait_for_manager_status(ManagerStatusFifo.ALL_MODULES_STARTED, timeout_s=60.0)
+
+    wait_for_matching_topic_count(
+        topic_counts,
+        block_ready_topic_predicate,
+        baseline_ready + 1,
+        timeout_s=60.0,
+    )
+
+
+@pytest.mark.everest_core_config("config-sil-immortal_manager.yaml")
+def test_manager_default_stop_terminates_modules_immediately(everest_core: EverestCore):
+    """Without --graceful-shutdown, stop() must force-terminate modules right away:
+    no MQTT shutdown drain, no FORCE_SHUTDOWN_TIMEOUT event, no clean-stop event."""
+    everest_core.start()
+    everest_core.stop()
+
+    everest_core.wait_for_manager_status(ManagerStatusFifo.SIGINT_RECEIVED, timeout_s=5.0)
+    everest_core.wait_for_manager_status(ManagerStatusFifo.MANAGER_FORCE_TERMINATING, timeout_s=5.0)
+    everest_core.wait_for_manager_status(ManagerStatusFifo.MANAGER_EXITING, timeout_s=5.0)
+    # Immediate termination is expected behavior, not a graceful-shutdown timeout.
+    everest_core.assert_no_manager_status(ManagerStatusFifo.FORCE_SHUTDOWN_TIMEOUT, timeout_s=1.0)
+    everest_core.assert_no_manager_status(ManagerStatusFifo.ALL_MODULES_STOPPED_CLEAN, timeout_s=1.0)
+
+    assert everest_core.process.returncode == 0
+
+
+@pytest.mark.everest_core_config("config-sil-immortal_manager.yaml")
+def test_manager_default_crash_terminates_remaining_modules_and_exits(
+    everest_core: EverestCore, connected_mqtt_client
+):
+    """Without --recover-module-crashes and --graceful-shutdown, an unexpected module exit must
+    lead to immediate termination of the remaining modules and a manager exit with failure."""
+    mqtt_external_prefix = everest_core.mqtt_external_prefix
+    exit_cmd_topic = f"{mqtt_external_prefix}everest_api/exit_simulator/cmd/exit"
+
+    everest_core.start()
+
+    connected_mqtt_client.publish(exit_cmd_topic, "1")
+
+    everest_core.wait_for_manager_status(ManagerStatusFifo.MANAGER_CRASH_SHUTDOWN_IN_PROGRESS, timeout_s=60.0)
+    everest_core.wait_for_manager_status(ManagerStatusFifo.MANAGER_FORCE_TERMINATING, timeout_s=60.0)
+    everest_core.wait_for_manager_status(ManagerStatusFifo.MANAGER_EXITING, timeout_s=60.0)
+    everest_core.assert_no_manager_status(ManagerStatusFifo.FORCE_SHUTDOWN_TIMEOUT, timeout_s=1.0)
+    everest_core.assert_no_manager_status(
+        ManagerStatusFifo.crash_recovery_attempt(1, 3),
+        timeout_s=1.0,
+    )
+
+    assert everest_core.process.wait(timeout=60.0) != 0

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -18,6 +18,7 @@ markers =
     ocpp_config_adaptions: adaptions to the libocpp configuration
     ocpp_config: select a specific libocpp configuration file
     flaky: mark test as flaky and allow reruns
+    everest_manager_args: extra CLI arguments forwarded to the manager binary
     eebus_certificate_path: certificate used for eebus grpc api
     eebus_private_key_path: private key used for eebus grpc api
     eebus_rpc_port: port used for eebus grpc api


### PR DESCRIPTION
## Describe your changes

Modules (C++, Rust, Python, JS) can implement a shutdown() method that can be used to eg tear-down threads that is triggered from the framework.

A debug log is printed during startup if no shutdown method is implemented for a module

If a shutdown takes longer than a preconfigured amount of time, the module will be terminated.

Implement examples of shutdown handler in some modules

Add manager lifecycle state machine
Add new command line options to manager: --into-idle, and --recover-module-crashes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

