### PR TITLE
chore(codeowners): add owners for lib/everest/evse_security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,7 @@
 # lib
 /lib/3rd_party/nanopb/ @a-w50 @corneliusclaussen @hikinggrass
 /lib/everest/can_dpm1000/ @a-w50 @corneliusclaussen @hikinggrass
+/lib/everest/evse_security/ @pietfried @hikinggrass @james-ctc
 /lib/everest/gpio/ @corneliusclaussen @hikinggrass @hikinggrass
 /lib/everest/conversions/ @hikinggrass @pietfried @corneliusclaussen @mlitre
 /lib/everest/slac/ @a-w50 @corneliusclaussen @SebaLukas


### PR DESCRIPTION
Lost in the monorepo transition.

## Describe your changes
Bring back the codeowners from the original libevse-security repository. This stops using the catch-all `*` owners.
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

