### PR TITLE
feat(ocpp): implement Q03 Central V2X control with charging schedule

### DIFF
--- a/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
+++ b/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
@@ -2584,6 +2584,11 @@ This document contains the status of which OCPP 2.0.1 and OCPP2.1 numbered funct
 | V2X.03 |        |        |
 | V2X.04 |        |        |
 | V2X.05 |        |        |
+| V2X.06 |        |        |
+| V2X.07 |        |        |
+| V2X.08 |        |        |
+| V2X.09 |        |        |
+| V2X.10 |        |        |
 
 ## Bidirectional Power Transfer - V2X Authorization (New in OCPP 2.1)
 
@@ -2620,13 +2625,19 @@ This document contains the status of which OCPP 2.0.1 and OCPP2.1 numbered funct
 | Q02.FR.06 |   ✅   |        |
 | Q02.FR.07 |   ✅   | The consumer of libocpp shall call `on_ev_charging_needs` when ChargeParameterDiscoveryReq is received via ISO15118       |
 
-## Bidirectional Power Transfer - Charging only (V2X control) before starting V2X (New in OCPP 2.1)
+## Bidirectional Power Transfer - Central V2X control with charging schedule (New in OCPP 2.1)
 
 | ID        | Status                        | Remark |
 | --------- | ----------------------------- | ------ |
 |           | OperationMode CentralSetpoint |        |
-| Q03.FR.01 |                               |        |
-| Q03.FR.02 |                               |        |
+| Q03.FR.01 |   🌐                          |        |
+| Q03.FR.02 |   🌐                          |        |
+| Q03.FR.03 |   🌐                          |        |
+
+## Bidirectional Power Transfer - Central V2X control with dynamic CSMS setpoint (New in OCPP 2.1)
+
+This use case adheres to requirements related to CentralSetpoint from Q03 and Dynamic charging profiles from
+K28 - Dynamic charging profiles from CSMS. There are no specific requirements for this use case.
 
 ## Bidirectional Power Transfer - External V2X setpoint control with a charging profile from CSMS (New in OCPP 2.1)
 

--- a/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
+++ b/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
@@ -2584,6 +2584,11 @@ This document contains the status of which OCPP 2.0.1 and OCPP2.1 numbered funct
 | V2X.03 |        |        |
 | V2X.04 |        |        |
 | V2X.05 |        |        |
+| V2X.06 |        | Not implemented — L2/L3 phase-variant rules                                                          |
+| V2X.07 |        | Not implemented — L2/L3 phase-variant rules                                                          |
+| V2X.08 |   🌐   |                                                                                                       |
+| V2X.09 |   🌐   |                                                                                                       |
+| V2X.10 |        | Partially implemented — V2X.09 branch rejects with `PhaseConflict` reasonCode for non-TxProfile periods carrying `dischargeLimit_L2/_L3` or `setpoint(Reactive)_L2/_L3`. V2X.08 branch deferred (requires per-EVSE cache of EV `v2xChargingParameters`). |
 
 ## Bidirectional Power Transfer - V2X Authorization (New in OCPP 2.1)
 
@@ -2620,13 +2625,19 @@ This document contains the status of which OCPP 2.0.1 and OCPP2.1 numbered funct
 | Q02.FR.06 |   ✅   |        |
 | Q02.FR.07 |   ✅   | The consumer of libocpp shall call `on_ev_charging_needs` when ChargeParameterDiscoveryReq is received via ISO15118       |
 
-## Bidirectional Power Transfer - Charging only (V2X control) before starting V2X (New in OCPP 2.1)
+## Bidirectional Power Transfer - Central V2X control with charging schedule (New in OCPP 2.1)
 
 | ID        | Status                        | Remark |
 | --------- | ----------------------------- | ------ |
 |           | OperationMode CentralSetpoint |        |
-| Q03.FR.01 |                               |        |
-| Q03.FR.02 |                               |        |
+| Q03.FR.01 |   🌐                          |        |
+| Q03.FR.02 |   🌐                          |        |
+| Q03.FR.03 |   🌐                          |        |
+
+## Bidirectional Power Transfer - Central V2X control with dynamic CSMS setpoint (New in OCPP 2.1)
+
+This use case adheres to requirements related to CentralSetpoint from Q03 and Dynamic charging profiles from
+K28 - Dynamic charging profiles from CSMS. There are no specific requirements for this use case.
 
 ## Bidirectional Power Transfer - External V2X setpoint control with a charging profile from CSMS (New in OCPP 2.1)
 

--- a/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
+++ b/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
@@ -2584,11 +2584,11 @@ This document contains the status of which OCPP 2.0.1 and OCPP2.1 numbered funct
 | V2X.03 |        |        |
 | V2X.04 |        |        |
 | V2X.05 |        |        |
-| V2X.06 |        |        |
-| V2X.07 |        |        |
-| V2X.08 |        |        |
-| V2X.09 |        |        |
-| V2X.10 |        |        |
+| V2X.06 |        | Not implemented — L2/L3 phase-variant rules                                                          |
+| V2X.07 |        | Not implemented — L2/L3 phase-variant rules                                                          |
+| V2X.08 |        | Not implemented — L2/L3 phase-variant rules                                                          |
+| V2X.09 |        | Not implemented — L2/L3 phase-variant rules                                                          |
+| V2X.10 |        | Not implemented — L2/L3 phase-variant rules                                                          |
 
 ## Bidirectional Power Transfer - V2X Authorization (New in OCPP 2.1)
 

--- a/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
+++ b/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
@@ -2586,9 +2586,9 @@ This document contains the status of which OCPP 2.0.1 and OCPP2.1 numbered funct
 | V2X.05 |        |        |
 | V2X.06 |        | Not implemented — L2/L3 phase-variant rules                                                          |
 | V2X.07 |        | Not implemented — L2/L3 phase-variant rules                                                          |
-| V2X.08 |        | Not implemented — L2/L3 phase-variant rules                                                          |
-| V2X.09 |        | Not implemented — L2/L3 phase-variant rules                                                          |
-| V2X.10 |        | Not implemented — L2/L3 phase-variant rules                                                          |
+| V2X.08 |   🌐   |                                                                                                       |
+| V2X.09 |   🌐   |                                                                                                       |
+| V2X.10 |        | Partially implemented — V2X.09 branch rejects with `PhaseConflict` reasonCode for non-TxProfile periods carrying `dischargeLimit_L2/_L3` or `setpoint(Reactive)_L2/_L3`. V2X.08 branch deferred (requires per-EVSE cache of EV `v2xChargingParameters`). |
 
 ## Bidirectional Power Transfer - V2X Authorization (New in OCPP 2.1)
 

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
@@ -76,6 +76,7 @@ enum class ProfileValidationResultEnum {
     ChargingSchedulePeriodNoFreqWattCurve,
     ChargingSchedulePeriodSignDifference,
     ChargingSchedulePeriodSetpointOutOfRange,
+    ChargingSchedulePeriodPhaseConflict,
     ChargingStationMaxProfileCannotBeRelative,
     ChargingStationMaxProfileEvseIdGreaterThanZero,
     DuplicateTxDefaultProfileFound,
@@ -246,6 +247,22 @@ protected:
     ///         otherwise ChargingSchedulePeriodSetpointOutOfRange.
     ///
     ProfileValidationResultEnum validate_setpoint_within_limit_range(const ChargingProfile& profile) const;
+
+    ///
+    /// \brief Reject SetChargingProfile requests that violate the V2X.09 branch of V2X.10:
+    ///        a non-TxProfile carrying any \c dischargeLimit_L2 / \c _L3,
+    ///        \c setpoint_L2 / \c _L3, or \c setpointReactive_L2 / \c _L3 in any
+    ///        chargingSchedulePeriod must be rejected with reasonCode `PhaseConflict`.
+    ///
+    /// The V2X.08 branch (EV omitted \c maxDischargePower_L2 / \c _L3 in
+    /// NotifyEVChargingNeedsRequest) requires per-EVSE caching of EV V2X parameters
+    /// and is intentionally deferred.
+    ///
+    /// \param profile  Charging profile to validate.
+    /// \return Valid when the profile is a TxProfile, or when no per-phase fields are
+    ///         present; otherwise ChargingSchedulePeriodPhaseConflict.
+    ///
+    ProfileValidationResultEnum validate_phase_conflict(const ChargingProfile& profile) const;
 
     ///
     /// \brief Checks a given \p profile does not have an id that conflicts with an existing profile

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
@@ -236,6 +236,18 @@ protected:
                                                            std::optional<EvseInterface*> evse_opt = std::nullopt) const;
 
     ///
+    /// \brief V2X.05: Ensure every charging schedule period has setpoint within [dischargeLimit, limit].
+    ///
+    /// Stored profiles keep their clamping behavior in the composite schedule, so this must not
+    /// run from validate_profile_schedules which is reused during composite-schedule calculation.
+    ///
+    /// \param profile  Charging profile to validate.
+    /// \return ProfileValidationResultEnum::Valid when all setpoints lie in range (or not set),
+    ///         otherwise ChargingSchedulePeriodSetpointOutOfRange.
+    ///
+    ProfileValidationResultEnum validate_setpoint_within_limit_range(const ChargingProfile& profile) const;
+
+    ///
     /// \brief Checks a given \p profile does not have an id that conflicts with an existing profile
     /// of type ChargingStationExternalConstraints
     ///

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
@@ -75,6 +75,8 @@ enum class ProfileValidationResultEnum {
     ChargingSchedulePeriodNoPhaseForDC,
     ChargingSchedulePeriodNoFreqWattCurve,
     ChargingSchedulePeriodSignDifference,
+    ChargingSchedulePeriodSetpointOutOfRange,
+    ChargingSchedulePeriodPhaseConflict,
     ChargingStationMaxProfileCannotBeRelative,
     ChargingStationMaxProfileEvseIdGreaterThanZero,
     DuplicateTxDefaultProfileFound,
@@ -233,6 +235,34 @@ protected:
     /// we set it to the default value (3).
     ProfileValidationResultEnum validate_profile_schedules(ChargingProfile& profile,
                                                            std::optional<EvseInterface*> evse_opt = std::nullopt) const;
+
+    ///
+    /// \brief V2X.05: Ensure every charging schedule period has setpoint within [dischargeLimit, limit].
+    ///
+    /// Stored profiles keep their clamping behavior in the composite schedule, so this must not
+    /// run from validate_profile_schedules which is reused during composite-schedule calculation.
+    ///
+    /// \param profile  Charging profile to validate.
+    /// \return ProfileValidationResultEnum::Valid when all setpoints lie in range (or not set),
+    ///         otherwise ChargingSchedulePeriodSetpointOutOfRange.
+    ///
+    ProfileValidationResultEnum validate_setpoint_within_limit_range(const ChargingProfile& profile) const;
+
+    ///
+    /// \brief Reject SetChargingProfile requests that violate the V2X.09 branch of V2X.10:
+    ///        a non-TxProfile carrying any \c dischargeLimit_L2 / \c _L3,
+    ///        \c setpoint_L2 / \c _L3, or \c setpointReactive_L2 / \c _L3 in any
+    ///        chargingSchedulePeriod must be rejected with reasonCode `PhaseConflict`.
+    ///
+    /// The V2X.08 branch (EV omitted \c maxDischargePower_L2 / \c _L3 in
+    /// NotifyEVChargingNeedsRequest) requires per-EVSE caching of EV V2X parameters
+    /// and is intentionally deferred.
+    ///
+    /// \param profile  Charging profile to validate.
+    /// \return Valid when the profile is a TxProfile, or when no per-phase fields are
+    ///         present; otherwise ChargingSchedulePeriodPhaseConflict.
+    ///
+    ProfileValidationResultEnum validate_phase_conflict(const ChargingProfile& profile) const;
 
     ///
     /// \brief Checks a given \p profile does not have an id that conflicts with an existing profile

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
@@ -75,6 +75,7 @@ enum class ProfileValidationResultEnum {
     ChargingSchedulePeriodNoPhaseForDC,
     ChargingSchedulePeriodNoFreqWattCurve,
     ChargingSchedulePeriodSignDifference,
+    ChargingSchedulePeriodSetpointOutOfRange,
     ChargingStationMaxProfileCannotBeRelative,
     ChargingStationMaxProfileEvseIdGreaterThanZero,
     DuplicateTxDefaultProfileFound,

--- a/lib/everest/ocpp/include/ocpp/v2/profile.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/profile.hpp
@@ -54,14 +54,6 @@ struct period_entry_t {
     std::int32_t stack_level;
     ChargingRateUnitEnum charging_rate_unit;
     std::optional<float> min_charging_rate;
-
-    bool equals(const period_entry_t& other) const {
-        return (start == other.start) && (end == other.end) && (limit == other.limit) &&
-               (discharge_limit == other.discharge_limit) && (setpoint == other.setpoint) &&
-               (number_phases == other.number_phases) && (stack_level == other.stack_level) &&
-               (charging_rate_unit == other.charging_rate_unit) && (min_charging_rate == other.min_charging_rate) &&
-               (operationMode == other.operationMode);
-    }
 };
 
 /// \brief Calculate the number of seconds elapsed between \param to and \param from
@@ -69,6 +61,13 @@ std::int32_t elapsed_seconds(const ocpp::DateTime& to, const ocpp::DateTime& fro
 
 /// \brief Rounds down the \param dt to the nearest second
 ocpp::DateTime floor_seconds(const ocpp::DateTime& dt);
+
+/// \brief Map an optional OperationMode to its effective value.
+///
+/// An absent operationMode behaves as ChargingOnly. Use this helper in every
+/// comparator and dedup site so that nullopt and an explicit ChargingOnly are
+/// not treated as different.
+OperationModeEnum effective_mode(const std::optional<OperationModeEnum>& mode);
 
 /// \brief calculate the start times for the profile
 /// \param now the current date and time

--- a/lib/everest/ocpp/include/ocpp/v2/profile.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/profile.hpp
@@ -25,6 +25,7 @@ struct IntermediatePeriod {
     PeriodLimit power_setpoint;
     std::optional<std::int32_t> numberPhases;
     std::optional<std::int32_t> phaseToUse;
+    std::optional<OperationModeEnum> operationMode;
 };
 
 using IntermediateProfile = std::vector<IntermediatePeriod>;
@@ -49,6 +50,7 @@ struct period_entry_t {
     PeriodLimit setpoint;
     std::optional<std::int32_t> number_phases;
     std::optional<std::int32_t> phase_to_use;
+    std::optional<OperationModeEnum> operationMode;
     std::int32_t stack_level;
     ChargingRateUnitEnum charging_rate_unit;
     std::optional<float> min_charging_rate;
@@ -57,7 +59,8 @@ struct period_entry_t {
         return (start == other.start) && (end == other.end) && (limit == other.limit) &&
                (discharge_limit == other.discharge_limit) && (setpoint == other.setpoint) &&
                (number_phases == other.number_phases) && (stack_level == other.stack_level) &&
-               (charging_rate_unit == other.charging_rate_unit) && (min_charging_rate == other.min_charging_rate);
+               (charging_rate_unit == other.charging_rate_unit) && (min_charging_rate == other.min_charging_rate) &&
+               (operationMode == other.operationMode);
     }
 };
 

--- a/lib/everest/ocpp/include/ocpp/v2/profile.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/profile.hpp
@@ -25,6 +25,7 @@ struct IntermediatePeriod {
     PeriodLimit power_setpoint;
     std::optional<std::int32_t> numberPhases;
     std::optional<std::int32_t> phaseToUse;
+    std::optional<OperationModeEnum> operationMode;
 };
 
 using IntermediateProfile = std::vector<IntermediatePeriod>;
@@ -49,16 +50,10 @@ struct period_entry_t {
     PeriodLimit setpoint;
     std::optional<std::int32_t> number_phases;
     std::optional<std::int32_t> phase_to_use;
+    std::optional<OperationModeEnum> operationMode;
     std::int32_t stack_level;
     ChargingRateUnitEnum charging_rate_unit;
     std::optional<float> min_charging_rate;
-
-    bool equals(const period_entry_t& other) const {
-        return (start == other.start) && (end == other.end) && (limit == other.limit) &&
-               (discharge_limit == other.discharge_limit) && (setpoint == other.setpoint) &&
-               (number_phases == other.number_phases) && (stack_level == other.stack_level) &&
-               (charging_rate_unit == other.charging_rate_unit) && (min_charging_rate == other.min_charging_rate);
-    }
 };
 
 /// \brief Calculate the number of seconds elapsed between \param to and \param from
@@ -66,6 +61,13 @@ std::int32_t elapsed_seconds(const ocpp::DateTime& to, const ocpp::DateTime& fro
 
 /// \brief Rounds down the \param dt to the nearest second
 ocpp::DateTime floor_seconds(const ocpp::DateTime& dt);
+
+/// \brief Map an optional OperationMode to its effective value.
+///
+/// An absent operationMode behaves as ChargingOnly. Use this helper in every
+/// comparator and dedup site so that nullopt and an explicit ChargingOnly are
+/// not treated as different.
+OperationModeEnum effective_mode(const std::optional<OperationModeEnum>& mode);
 
 /// \brief calculate the start times for the profile
 /// \param now the current date and time

--- a/lib/everest/ocpp/include/ocpp/v2/profile.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/profile.hpp
@@ -54,14 +54,6 @@ struct period_entry_t {
     std::int32_t stack_level;
     ChargingRateUnitEnum charging_rate_unit;
     std::optional<float> min_charging_rate;
-
-    bool equals(const period_entry_t& other) const {
-        return (start == other.start) && (end == other.end) && (limit == other.limit) &&
-               (discharge_limit == other.discharge_limit) && (setpoint == other.setpoint) &&
-               (number_phases == other.number_phases) && (stack_level == other.stack_level) &&
-               (charging_rate_unit == other.charging_rate_unit) && (min_charging_rate == other.min_charging_rate) &&
-               (operationMode == other.operationMode);
-    }
 };
 
 /// \brief Calculate the number of seconds elapsed between \param to and \param from

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -196,6 +196,10 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingSchedulePeriodNoFreqWattCurve";
     case ocpp::v2::ProfileValidationResultEnum::ChargingSchedulePeriodSignDifference:
         return "ChargingSchedulePeriodSignDifference";
+    case ocpp::v2::ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange:
+        return "ChargingSchedulePeriodSetpointOutOfRange";
+    case ocpp::v2::ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict:
+        return "ChargingSchedulePeriodPhaseConflict";
     case ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative:
         return "ChargingStationMaxProfileCannotBeRelative";
     case ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero:
@@ -262,7 +266,10 @@ std::string profile_validation_result_to_reason_code(ProfileValidationResultEnum
     case ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedLimitSetpoint:
     case ProfileValidationResultEnum::ChargingSchedulePeriodSignDifference:
     case ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue:
+    case ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange:
         return "InvalidSchedule";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict:
+        return "PhaseConflict";
     case ProfileValidationResultEnum::ChargingSchedulePeriodNoPhaseForDC:
         return "NoPhaseForDC";
     case ProfileValidationResultEnum::ChargingSchedulePeriodNoFreqWattCurve:
@@ -397,6 +404,49 @@ ProfileValidationResultEnum SmartCharging::verify_rate_limit(const ChargingProfi
     return result;
 }
 
+ProfileValidationResultEnum SmartCharging::validate_setpoint_within_limit_range(const ChargingProfile& profile) const {
+    // V2X.05: reject setpoints outside [dischargeLimit, limit].
+    // Kept out of validate_profile_schedules so stored profiles retain clamping behavior during
+    // composite-schedule calculation.
+    if (this->context.ocpp_version != OcppProtocolVersion::v21) {
+        return ProfileValidationResultEnum::Valid;
+    }
+    for (const auto& schedule : profile.chargingSchedule) {
+        for (const auto& period : schedule.chargingSchedulePeriod) {
+            if (!period.setpoint.has_value()) {
+                continue;
+            }
+            const float sp = period.setpoint.value();
+            if ((period.limit.has_value() && sp > period.limit.value()) ||
+                (period.dischargeLimit.has_value() && sp < period.dischargeLimit.value())) {
+                return ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange;
+            }
+        }
+    }
+    return ProfileValidationResultEnum::Valid;
+}
+
+ProfileValidationResultEnum SmartCharging::validate_phase_conflict(const ChargingProfile& profile) const {
+    // V2X.10 (V2X.09 branch): non-TxProfile carrying any per-phase dischargeLimit /
+    // setpoint / setpointReactive value must be rejected with reasonCode "PhaseConflict".
+    if (this->context.ocpp_version != OcppProtocolVersion::v21) {
+        return ProfileValidationResultEnum::Valid;
+    }
+    if (profile.chargingProfilePurpose == ChargingProfilePurposeEnum::TxProfile) {
+        return ProfileValidationResultEnum::Valid;
+    }
+    for (const auto& schedule : profile.chargingSchedule) {
+        for (const auto& period : schedule.chargingSchedulePeriod) {
+            if (period.dischargeLimit_L2.has_value() || period.dischargeLimit_L3.has_value() ||
+                period.setpoint_L2.has_value() || period.setpoint_L3.has_value() ||
+                period.setpointReactive_L2.has_value() || period.setpointReactive_L3.has_value()) {
+                return ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict;
+            }
+        }
+    }
+    return ProfileValidationResultEnum::Valid;
+}
+
 std::pair<bool, bool> SmartCharging::validate_profile_with_offline_time(const ChargingProfile& profile) {
     const auto time_disconnected = this->context.connectivity_manager.get_time_disconnected();
     // Being online means the profile is valid
@@ -476,6 +526,14 @@ SetChargingProfileResponse SmartCharging::conform_validate_and_add_profile(Charg
     response.status = ChargingProfileStatusEnum::Rejected;
 
     auto result = this->conform_and_validate_profile(profile, evse_id, source_of_request);
+
+    if (result == ProfileValidationResultEnum::Valid) {
+        result = validate_setpoint_within_limit_range(profile);
+    }
+
+    if (result == ProfileValidationResultEnum::Valid) {
+        result = validate_phase_conflict(profile);
+    }
 
     if (result == ProfileValidationResultEnum::Valid) {
         result = verify_rate_limit(profile);

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -400,6 +400,28 @@ ProfileValidationResultEnum SmartCharging::verify_rate_limit(const ChargingProfi
     return result;
 }
 
+ProfileValidationResultEnum SmartCharging::validate_setpoint_within_limit_range(const ChargingProfile& profile) const {
+    // V2X.05: reject setpoints outside [dischargeLimit, limit].
+    // Kept out of validate_profile_schedules so stored profiles retain clamping behavior during
+    // composite-schedule calculation.
+    if (this->context.ocpp_version != OcppProtocolVersion::v21) {
+        return ProfileValidationResultEnum::Valid;
+    }
+    for (const auto& schedule : profile.chargingSchedule) {
+        for (const auto& period : schedule.chargingSchedulePeriod) {
+            if (!period.setpoint.has_value()) {
+                continue;
+            }
+            const float sp = period.setpoint.value();
+            if ((period.limit.has_value() && sp > period.limit.value()) ||
+                (period.dischargeLimit.has_value() && sp < period.dischargeLimit.value())) {
+                return ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange;
+            }
+        }
+    }
+    return ProfileValidationResultEnum::Valid;
+}
+
 std::pair<bool, bool> SmartCharging::validate_profile_with_offline_time(const ChargingProfile& profile) {
     const auto time_disconnected = this->context.connectivity_manager.get_time_disconnected();
     // Being online means the profile is valid
@@ -479,6 +501,10 @@ SetChargingProfileResponse SmartCharging::conform_validate_and_add_profile(Charg
     response.status = ChargingProfileStatusEnum::Rejected;
 
     auto result = this->conform_and_validate_profile(profile, evse_id, source_of_request);
+
+    if (result == ProfileValidationResultEnum::Valid) {
+        result = validate_setpoint_within_limit_range(profile);
+    }
 
     if (result == ProfileValidationResultEnum::Valid) {
         result = verify_rate_limit(profile);
@@ -1026,18 +1052,6 @@ ProfileValidationResultEnum SmartCharging::validate_profile_schedules(ChargingPr
                 // in the 2.1 spec).
                 if (!check_limits_and_setpoints(charging_schedule_period)) {
                     return ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedLimitSetpoint;
-                }
-
-                // V2X.05: Reject if setpoint lies outside the range [dischargeLimit, limit].
-                if (charging_schedule_period.setpoint.has_value()) {
-                    const float sp = charging_schedule_period.setpoint.value();
-                    if (charging_schedule_period.limit.has_value() && sp > charging_schedule_period.limit.value()) {
-                        return ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange;
-                    }
-                    if (charging_schedule_period.dischargeLimit.has_value() &&
-                        sp < charging_schedule_period.dischargeLimit.value()) {
-                        return ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange;
-                    }
                 }
 
                 // Q08.FR.02: v2xBaseline and v2xFreqWattCurve must be set when operation mode is LocalFrequency.

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -196,6 +196,8 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingSchedulePeriodNoFreqWattCurve";
     case ocpp::v2::ProfileValidationResultEnum::ChargingSchedulePeriodSignDifference:
         return "ChargingSchedulePeriodSignDifference";
+    case ocpp::v2::ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange:
+        return "ChargingSchedulePeriodSetpointOutOfRange";
     case ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative:
         return "ChargingStationMaxProfileCannotBeRelative";
     case ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero:
@@ -262,6 +264,7 @@ std::string profile_validation_result_to_reason_code(ProfileValidationResultEnum
     case ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedLimitSetpoint:
     case ProfileValidationResultEnum::ChargingSchedulePeriodSignDifference:
     case ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue:
+    case ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange:
         return "InvalidSchedule";
     case ProfileValidationResultEnum::ChargingSchedulePeriodNoPhaseForDC:
         return "NoPhaseForDC";
@@ -1023,6 +1026,18 @@ ProfileValidationResultEnum SmartCharging::validate_profile_schedules(ChargingPr
                 // in the 2.1 spec).
                 if (!check_limits_and_setpoints(charging_schedule_period)) {
                     return ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedLimitSetpoint;
+                }
+
+                // V2X.05: Reject if setpoint lies outside the range [dischargeLimit, limit].
+                if (charging_schedule_period.setpoint.has_value()) {
+                    const float sp = charging_schedule_period.setpoint.value();
+                    if (charging_schedule_period.limit.has_value() && sp > charging_schedule_period.limit.value()) {
+                        return ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange;
+                    }
+                    if (charging_schedule_period.dischargeLimit.has_value() &&
+                        sp < charging_schedule_period.dischargeLimit.value()) {
+                        return ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange;
+                    }
                 }
 
                 // Q08.FR.02: v2xBaseline and v2xFreqWattCurve must be set when operation mode is LocalFrequency.

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -198,6 +198,8 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingSchedulePeriodSignDifference";
     case ocpp::v2::ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange:
         return "ChargingSchedulePeriodSetpointOutOfRange";
+    case ocpp::v2::ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict:
+        return "ChargingSchedulePeriodPhaseConflict";
     case ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative:
         return "ChargingStationMaxProfileCannotBeRelative";
     case ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero:
@@ -266,6 +268,8 @@ std::string profile_validation_result_to_reason_code(ProfileValidationResultEnum
     case ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue:
     case ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange:
         return "InvalidSchedule";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict:
+        return "PhaseConflict";
     case ProfileValidationResultEnum::ChargingSchedulePeriodNoPhaseForDC:
         return "NoPhaseForDC";
     case ProfileValidationResultEnum::ChargingSchedulePeriodNoFreqWattCurve:
@@ -422,6 +426,27 @@ ProfileValidationResultEnum SmartCharging::validate_setpoint_within_limit_range(
     return ProfileValidationResultEnum::Valid;
 }
 
+ProfileValidationResultEnum SmartCharging::validate_phase_conflict(const ChargingProfile& profile) const {
+    // V2X.10 (V2X.09 branch): non-TxProfile carrying any per-phase dischargeLimit /
+    // setpoint / setpointReactive value must be rejected with reasonCode "PhaseConflict".
+    if (this->context.ocpp_version != OcppProtocolVersion::v21) {
+        return ProfileValidationResultEnum::Valid;
+    }
+    if (profile.chargingProfilePurpose == ChargingProfilePurposeEnum::TxProfile) {
+        return ProfileValidationResultEnum::Valid;
+    }
+    for (const auto& schedule : profile.chargingSchedule) {
+        for (const auto& period : schedule.chargingSchedulePeriod) {
+            if (period.dischargeLimit_L2.has_value() || period.dischargeLimit_L3.has_value() ||
+                period.setpoint_L2.has_value() || period.setpoint_L3.has_value() ||
+                period.setpointReactive_L2.has_value() || period.setpointReactive_L3.has_value()) {
+                return ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict;
+            }
+        }
+    }
+    return ProfileValidationResultEnum::Valid;
+}
+
 std::pair<bool, bool> SmartCharging::validate_profile_with_offline_time(const ChargingProfile& profile) {
     const auto time_disconnected = this->context.connectivity_manager.get_time_disconnected();
     // Being online means the profile is valid
@@ -504,6 +529,10 @@ SetChargingProfileResponse SmartCharging::conform_validate_and_add_profile(Charg
 
     if (result == ProfileValidationResultEnum::Valid) {
         result = validate_setpoint_within_limit_range(profile);
+    }
+
+    if (result == ProfileValidationResultEnum::Valid) {
+        result = validate_phase_conflict(profile);
     }
 
     if (result == ProfileValidationResultEnum::Valid) {

--- a/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
@@ -672,9 +672,8 @@ IntermediateProfile merge_profiles_by_lowest_limit(const std::vector<Intermediat
             // operationMode follows the period that contributed the winning setpoint.
             // If the new period has a setpoint and an operationMode, and the setpoint changed from
             // the previous value, the new period's operationMode takes precedence.
-            const bool new_period_has_setpoint =
-                !is_equal(new_period.current_setpoint.limit, NO_SETPOINT_SPECIFIED) ||
-                !is_equal(new_period.power_setpoint.limit, NO_SETPOINT_SPECIFIED);
+            const bool new_period_has_setpoint = !is_equal(new_period.current_setpoint.limit, NO_SETPOINT_SPECIFIED) ||
+                                                 !is_equal(new_period.power_setpoint.limit, NO_SETPOINT_SPECIFIED);
             if (new_period_has_setpoint && new_period.operationMode.has_value()) {
                 const bool setpoint_changed = (period.current_setpoint != prev_current_setpoint) ||
                                               (period.power_setpoint != prev_power_setpoint);

--- a/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
@@ -60,6 +60,7 @@ IntermediatePeriod default_intermediate_period() {
     empty.power_setpoint = {NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED};
     empty.numberPhases = std::nullopt;
     empty.phaseToUse = std::nullopt;
+    empty.operationMode = std::nullopt;
     return empty;
 }
 
@@ -111,6 +112,8 @@ void period_entry_t::init(const DateTime& in_start, int in_duration, const Charg
     setpoint.limit = in_period.setpoint.value_or(NO_SETPOINT_SPECIFIED);       // FIXME
     setpoint.limit_L2 = in_period.setpoint_L2.value_or(NO_SETPOINT_SPECIFIED); // FIXME
     setpoint.limit_L3 = in_period.setpoint_L3.value_or(NO_SETPOINT_SPECIFIED); // FIXME
+
+    operationMode = in_period.operationMode;
 
     min_charging_rate = in_profile.chargingSchedule.front().minChargingRate;
 }
@@ -463,6 +466,7 @@ IntermediateProfile generate_profile_from_periods(std::vector<period_entry_t>& p
             charging_schedule_period.current_discharge_limit = current_discharge_limit;
             charging_schedule_period.power_discharge_limit = power_discharge_limit;
             charging_schedule_period.numberPhases = chosen->number_phases;
+            charging_schedule_period.operationMode = chosen->operationMode;
             charging_schedule_period.phaseToUse = std::nullopt;
 
             // If the new ChargingSchedulePeriod.phaseToUse field is set, pass it on
@@ -594,6 +598,7 @@ IntermediateProfile merge_tx_profile_with_tx_default_profile(const IntermediateP
                 period.current_setpoint = it->current_setpoint;
                 period.power_setpoint = it->power_setpoint;
                 period.numberPhases = it->numberPhases;
+                period.operationMode = it->operationMode;
                 break;
             }
         }
@@ -654,11 +659,29 @@ IntermediateProfile merge_profiles_by_lowest_limit(const std::vector<Intermediat
             period.power_discharge_limit =
                 get_max_limit(period.power_discharge_limit, new_period.power_discharge_limit);
 
+            // Save setpoints before merge to detect which period's setpoint won
+            const auto prev_current_setpoint = period.current_setpoint;
+            const auto prev_power_setpoint = period.power_setpoint;
+
             // Only check value of first phase, as this one should be set as first.
             get_set_setpoint_limit(period.current_setpoint, new_period.current_setpoint, period.current_limit,
                                    period.current_discharge_limit);
             get_set_setpoint_limit(period.power_setpoint, new_period.power_setpoint, period.power_limit,
                                    period.power_discharge_limit);
+
+            // operationMode follows the period that contributed the winning setpoint.
+            // If the new period has a setpoint and an operationMode, and the setpoint changed from
+            // the previous value, the new period's operationMode takes precedence.
+            const bool new_period_has_setpoint =
+                !is_equal(new_period.current_setpoint.limit, NO_SETPOINT_SPECIFIED) ||
+                !is_equal(new_period.power_setpoint.limit, NO_SETPOINT_SPECIFIED);
+            if (new_period_has_setpoint && new_period.operationMode.has_value()) {
+                const bool setpoint_changed = (period.current_setpoint != prev_current_setpoint) ||
+                                              (period.power_setpoint != prev_power_setpoint);
+                if (setpoint_changed || !period.operationMode.has_value()) {
+                    period.operationMode = new_period.operationMode;
+                }
+            }
         }
 
         auto replace_max_with_no_limit = [](PeriodLimit& value, float max_value, float replacement) {
@@ -820,9 +843,12 @@ convert_intermediate_into_schedule(const IntermediateProfile& profile, ChargingR
                                                            period_out.setpoint_L2, period_out.setpoint_L3, true, false);
         }
 
+        period_out.operationMode = period.operationMode;
+
         if (output.empty() || (period_out.limit != output.back().limit) ||
             (period_out.numberPhases != output.back().numberPhases) || period_out.setpoint != output.back().setpoint ||
-            period_out.dischargeLimit != output.back().dischargeLimit) {
+            period_out.dischargeLimit != output.back().dischargeLimit ||
+            period_out.operationMode != output.back().operationMode) {
             output.push_back(period_out);
         }
     }

--- a/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
@@ -46,6 +46,10 @@ ocpp::DateTime floor_seconds(const ocpp::DateTime& dt) {
     return ocpp::DateTime(std::chrono::floor<seconds>(dt.to_time_point()));
 }
 
+OperationModeEnum effective_mode(const std::optional<OperationModeEnum>& mode) {
+    return mode.value_or(OperationModeEnum::ChargingOnly);
+}
+
 namespace {
 IntermediatePeriod default_intermediate_period() {
     IntermediatePeriod empty;
@@ -533,7 +537,8 @@ IntermediateProfile combine_list_of_profiles(const std::vector<IntermediateProfi
             (period.power_discharge_limit != combined.back().power_discharge_limit) ||
             (period.current_setpoint != combined.back().current_setpoint) ||
             (period.power_setpoint != combined.back().power_setpoint) ||
-            (period.numberPhases != combined.back().numberPhases)) {
+            (period.numberPhases != combined.back().numberPhases) ||
+            (effective_mode(period.operationMode) != effective_mode(combined.back().operationMode))) {
             combined.push_back(period);
         }
 
@@ -586,11 +591,16 @@ IntermediateProfile merge_tx_profile_with_tx_default_profile(const IntermediateP
         period.power_setpoint = {NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED};
 
         for (const auto& [it, end] : periods) {
+            // A non-default operationMode is itself enough to "pick" this period:
+            // setpoint-less V2X modes (LocalLoadBalancing, Idle, LocalFrequency,
+            // ExternalLimits) carry their meaning solely through operationMode and
+            // would otherwise be silently overruled by the lower-priority profile.
             if (it->current_limit != default_period.current_limit || it->power_limit != default_period.power_limit ||
                 it->current_discharge_limit != default_period.current_discharge_limit ||
                 it->power_discharge_limit != default_period.power_discharge_limit ||
                 it->current_setpoint != default_period.current_setpoint ||
-                it->power_setpoint != default_period.power_setpoint) {
+                it->power_setpoint != default_period.power_setpoint ||
+                effective_mode(it->operationMode) != OperationModeEnum::ChargingOnly) {
                 period.current_limit = it->current_limit;
                 period.power_limit = it->power_limit;
                 period.current_discharge_limit = it->current_discharge_limit;
@@ -659,26 +669,26 @@ IntermediateProfile merge_profiles_by_lowest_limit(const std::vector<Intermediat
             period.power_discharge_limit =
                 get_max_limit(period.power_discharge_limit, new_period.power_discharge_limit);
 
-            // Save setpoints before merge to detect which period's setpoint won
-            const auto prev_current_setpoint = period.current_setpoint;
-            const auto prev_power_setpoint = period.power_setpoint;
-
             // Only check value of first phase, as this one should be set as first.
             get_set_setpoint_limit(period.current_setpoint, new_period.current_setpoint, period.current_limit,
                                    period.current_discharge_limit);
             get_set_setpoint_limit(period.power_setpoint, new_period.power_setpoint, period.power_limit,
                                    period.power_discharge_limit);
 
-            // operationMode follows the period that contributed the winning setpoint.
-            // If the new period has a setpoint and an operationMode, and the setpoint changed from
-            // the previous value, the new period's operationMode takes precedence.
-            const bool new_period_has_setpoint = !is_equal(new_period.current_setpoint.limit, NO_SETPOINT_SPECIFIED) ||
-                                                 !is_equal(new_period.power_setpoint.limit, NO_SETPOINT_SPECIFIED);
-            if (new_period_has_setpoint && new_period.operationMode.has_value()) {
-                const bool setpoint_changed = (period.current_setpoint != prev_current_setpoint) ||
-                                              (period.power_setpoint != prev_power_setpoint);
-                if (setpoint_changed || !period.operationMode.has_value()) {
+            // Any non-default operationMode beats nullopt/ChargingOnly. On cross-purpose
+            // conflict (both contributors carry distinct non-default modes) the first
+            // contributor wins and a warning is logged; deterministic resolution requires
+            // SmartChargingCtrlr.SetpointPriority (OCPP 2.1 Edition 2 Q06.FR.20–22) which
+            // is not yet implemented.
+            if (effective_mode(new_period.operationMode) != OperationModeEnum::ChargingOnly) {
+                if (effective_mode(period.operationMode) == OperationModeEnum::ChargingOnly) {
                     period.operationMode = new_period.operationMode;
+                } else if (effective_mode(period.operationMode) != effective_mode(new_period.operationMode)) {
+                    EVLOG_warning << "Cross-purpose operationMode conflict: keeping "
+                                  << conversions::operation_mode_enum_to_string(period.operationMode.value())
+                                  << ", saw "
+                                  << conversions::operation_mode_enum_to_string(new_period.operationMode.value())
+                                  << " (SetpointPriority not yet implemented).";
                 }
             }
         }

--- a/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
@@ -46,6 +46,10 @@ ocpp::DateTime floor_seconds(const ocpp::DateTime& dt) {
     return ocpp::DateTime(std::chrono::floor<seconds>(dt.to_time_point()));
 }
 
+OperationModeEnum effective_mode(const std::optional<OperationModeEnum>& mode) {
+    return mode.value_or(OperationModeEnum::ChargingOnly);
+}
+
 namespace {
 IntermediatePeriod default_intermediate_period() {
     IntermediatePeriod empty;
@@ -60,6 +64,7 @@ IntermediatePeriod default_intermediate_period() {
     empty.power_setpoint = {NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED};
     empty.numberPhases = std::nullopt;
     empty.phaseToUse = std::nullopt;
+    empty.operationMode = std::nullopt;
     return empty;
 }
 
@@ -111,6 +116,8 @@ void period_entry_t::init(const DateTime& in_start, int in_duration, const Charg
     setpoint.limit = in_period.setpoint.value_or(NO_SETPOINT_SPECIFIED);       // FIXME
     setpoint.limit_L2 = in_period.setpoint_L2.value_or(NO_SETPOINT_SPECIFIED); // FIXME
     setpoint.limit_L3 = in_period.setpoint_L3.value_or(NO_SETPOINT_SPECIFIED); // FIXME
+
+    operationMode = in_period.operationMode;
 
     min_charging_rate = in_profile.chargingSchedule.front().minChargingRate;
 }
@@ -463,6 +470,7 @@ IntermediateProfile generate_profile_from_periods(std::vector<period_entry_t>& p
             charging_schedule_period.current_discharge_limit = current_discharge_limit;
             charging_schedule_period.power_discharge_limit = power_discharge_limit;
             charging_schedule_period.numberPhases = chosen->number_phases;
+            charging_schedule_period.operationMode = chosen->operationMode;
             charging_schedule_period.phaseToUse = std::nullopt;
 
             // If the new ChargingSchedulePeriod.phaseToUse field is set, pass it on
@@ -529,7 +537,8 @@ IntermediateProfile combine_list_of_profiles(const std::vector<IntermediateProfi
             (period.power_discharge_limit != combined.back().power_discharge_limit) ||
             (period.current_setpoint != combined.back().current_setpoint) ||
             (period.power_setpoint != combined.back().power_setpoint) ||
-            (period.numberPhases != combined.back().numberPhases)) {
+            (period.numberPhases != combined.back().numberPhases) ||
+            (effective_mode(period.operationMode) != effective_mode(combined.back().operationMode))) {
             combined.push_back(period);
         }
 
@@ -582,11 +591,16 @@ IntermediateProfile merge_tx_profile_with_tx_default_profile(const IntermediateP
         period.power_setpoint = {NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED};
 
         for (const auto& [it, end] : periods) {
+            // A non-default operationMode is itself enough to "pick" this period:
+            // setpoint-less V2X modes (LocalLoadBalancing, Idle, LocalFrequency,
+            // ExternalLimits) carry their meaning solely through operationMode and
+            // would otherwise be silently overruled by the lower-priority profile.
             if (it->current_limit != default_period.current_limit || it->power_limit != default_period.power_limit ||
                 it->current_discharge_limit != default_period.current_discharge_limit ||
                 it->power_discharge_limit != default_period.power_discharge_limit ||
                 it->current_setpoint != default_period.current_setpoint ||
-                it->power_setpoint != default_period.power_setpoint) {
+                it->power_setpoint != default_period.power_setpoint ||
+                effective_mode(it->operationMode) != OperationModeEnum::ChargingOnly) {
                 period.current_limit = it->current_limit;
                 period.power_limit = it->power_limit;
                 period.current_discharge_limit = it->current_discharge_limit;
@@ -594,6 +608,7 @@ IntermediateProfile merge_tx_profile_with_tx_default_profile(const IntermediateP
                 period.current_setpoint = it->current_setpoint;
                 period.power_setpoint = it->power_setpoint;
                 period.numberPhases = it->numberPhases;
+                period.operationMode = it->operationMode;
                 break;
             }
         }
@@ -659,6 +674,23 @@ IntermediateProfile merge_profiles_by_lowest_limit(const std::vector<Intermediat
                                    period.current_discharge_limit);
             get_set_setpoint_limit(period.power_setpoint, new_period.power_setpoint, period.power_limit,
                                    period.power_discharge_limit);
+
+            // Any non-default operationMode beats nullopt/ChargingOnly. On cross-purpose
+            // conflict (both contributors carry distinct non-default modes) the first
+            // contributor wins and a warning is logged; deterministic resolution requires
+            // SmartChargingCtrlr.SetpointPriority (OCPP 2.1 Edition 2 Q06.FR.20–22) which
+            // is not yet implemented.
+            if (effective_mode(new_period.operationMode) != OperationModeEnum::ChargingOnly) {
+                if (effective_mode(period.operationMode) == OperationModeEnum::ChargingOnly) {
+                    period.operationMode = new_period.operationMode;
+                } else if (effective_mode(period.operationMode) != effective_mode(new_period.operationMode)) {
+                    EVLOG_warning << "Cross-purpose operationMode conflict: keeping "
+                                  << conversions::operation_mode_enum_to_string(period.operationMode.value())
+                                  << ", saw "
+                                  << conversions::operation_mode_enum_to_string(new_period.operationMode.value())
+                                  << " (SetpointPriority not yet implemented).";
+                }
+            }
         }
 
         auto replace_max_with_no_limit = [](PeriodLimit& value, float max_value, float replacement) {
@@ -820,9 +852,12 @@ convert_intermediate_into_schedule(const IntermediateProfile& profile, ChargingR
                                                            period_out.setpoint_L2, period_out.setpoint_L3, true, false);
         }
 
+        period_out.operationMode = period.operationMode;
+
         if (output.empty() || (period_out.limit != output.back().limit) ||
             (period_out.numberPhases != output.back().numberPhases) || period_out.setpoint != output.back().setpoint ||
-            period_out.dischargeLimit != output.back().dischargeLimit) {
+            period_out.dischargeLimit != output.back().dischargeLimit ||
+            period_out.operationMode != output.back().operationMode) {
             output.push_back(period_out);
         }
     }

--- a/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
@@ -493,6 +493,11 @@ using period_iterator = IntermediateProfile::const_iterator;
 using period_pair_vector = std::vector<std::pair<period_iterator, period_iterator>>;
 using IntermediateProfileRef = std::reference_wrapper<const IntermediateProfile>;
 
+// Per OCPP 2.1 Q02.FR.01, a missing operationMode is equivalent to ChargingOnly.
+inline OperationModeEnum effective_operation_mode(const std::optional<OperationModeEnum>& mode) {
+    return mode.value_or(OperationModeEnum::ChargingOnly);
+}
+
 inline std::vector<IntermediateProfileRef> convert_to_ref_vector(const std::vector<IntermediateProfile>& profiles) {
     std::vector<IntermediateProfileRef> references{};
     references.reserve(profiles.size());
@@ -533,7 +538,9 @@ IntermediateProfile combine_list_of_profiles(const std::vector<IntermediateProfi
             (period.power_discharge_limit != combined.back().power_discharge_limit) ||
             (period.current_setpoint != combined.back().current_setpoint) ||
             (period.power_setpoint != combined.back().power_setpoint) ||
-            (period.numberPhases != combined.back().numberPhases)) {
+            (period.numberPhases != combined.back().numberPhases) ||
+            (effective_operation_mode(period.operationMode) !=
+             effective_operation_mode(combined.back().operationMode))) {
             combined.push_back(period);
         }
 
@@ -590,7 +597,8 @@ IntermediateProfile merge_tx_profile_with_tx_default_profile(const IntermediateP
                 it->current_discharge_limit != default_period.current_discharge_limit ||
                 it->power_discharge_limit != default_period.power_discharge_limit ||
                 it->current_setpoint != default_period.current_setpoint ||
-                it->power_setpoint != default_period.power_setpoint) {
+                it->power_setpoint != default_period.power_setpoint ||
+                effective_operation_mode(it->operationMode) != effective_operation_mode(default_period.operationMode)) {
                 period.current_limit = it->current_limit;
                 period.power_limit = it->power_limit;
                 period.current_discharge_limit = it->current_discharge_limit;

--- a/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
@@ -598,6 +598,7 @@ IntermediateProfile merge_tx_profile_with_tx_default_profile(const IntermediateP
                 it->power_discharge_limit != default_period.power_discharge_limit ||
                 it->current_setpoint != default_period.current_setpoint ||
                 it->power_setpoint != default_period.power_setpoint ||
+                it->numberPhases != default_period.numberPhases ||
                 effective_operation_mode(it->operationMode) != effective_operation_mode(default_period.operationMode)) {
                 period.current_limit = it->current_limit;
                 period.power_limit = it->power_limit;

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
@@ -134,6 +134,7 @@ public:
     using SmartCharging::get_valid_profiles;
     using SmartCharging::SmartCharging;
     using SmartCharging::validate_evse_exists;
+    using SmartCharging::validate_phase_conflict;
     using SmartCharging::validate_profile_schedules;
     using SmartCharging::validate_setpoint_within_limit_range;
     using SmartCharging::validate_tx_default_profile;

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
@@ -134,7 +134,9 @@ public:
     using SmartCharging::get_valid_profiles;
     using SmartCharging::SmartCharging;
     using SmartCharging::validate_evse_exists;
+    using SmartCharging::validate_phase_conflict;
     using SmartCharging::validate_profile_schedules;
+    using SmartCharging::validate_setpoint_within_limit_range;
     using SmartCharging::validate_tx_default_profile;
     using SmartCharging::validate_tx_profile;
     using SmartCharging::verify_no_conflicting_external_constraints_id;

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
@@ -135,6 +135,7 @@ public:
     using SmartCharging::SmartCharging;
     using SmartCharging::validate_evse_exists;
     using SmartCharging::validate_profile_schedules;
+    using SmartCharging::validate_setpoint_within_limit_range;
     using SmartCharging::validate_tx_default_profile;
     using SmartCharging::validate_tx_profile;
     using SmartCharging::verify_no_conflicting_external_constraints_id;

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_composite_schedule.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_composite_schedule.cpp
@@ -1267,6 +1267,7 @@ TEST_F(CompositeScheduleTestFixtureV2, OfflineDuration_Online) {
     expected_period.limit = 2000.0;
     expected_period.numberPhases = 3;
     expected_period.setpoint = -2000.0;
+    expected_period.operationMode = OperationModeEnum::CentralSetpoint;
     expected_period.startPeriod = 0;
 
     CompositeSchedule expected_schedule{};
@@ -1303,6 +1304,7 @@ TEST_F(CompositeScheduleTestFixtureV2, OfflineDuration_OfflineNotLongEnough) {
     expected_period.limit = 2000.0;
     expected_period.numberPhases = 3;
     expected_period.setpoint = -2000.0;
+    expected_period.operationMode = OperationModeEnum::CentralSetpoint;
     expected_period.startPeriod = 0;
 
     CompositeSchedule expected_schedule{};
@@ -1395,6 +1397,7 @@ TEST_F(CompositeScheduleTestFixtureV2, OfflineDuration_OfflineTooLong_ValidAfter
 
     // Profile with CentralSetpoint is preferred after being online again
     expected_period.setpoint = -2000.0;
+    expected_period.operationMode = OperationModeEnum::CentralSetpoint;
     expected_schedule.chargingSchedulePeriod = {expected_period};
 
     actual_schedule = handler->calculate_composite_schedule(start_time, end_time, DEFAULT_EVSE_ID,
@@ -1438,6 +1441,99 @@ TEST_F(CompositeScheduleTestFixtureV2, OfflineDuration_OfflineTooLong_InvalidAft
                                                                  ChargingRateUnitEnum::W, false, false);
 
     ASSERT_EQ(actual_schedule, expected_schedule);
+}
+
+TEST_F(CompositeScheduleTestFixtureV2, Q03_CentralSetpoint_PreservedInCompositeSchedule) {
+    // Create a TxProfile with CentralSetpoint operationMode and a setpoint
+    ChargingSchedulePeriod period{};
+    period.startPeriod = 0;
+    period.limit = 7000.0F;
+    period.setpoint = 5000.0F;
+    period.operationMode = OperationModeEnum::CentralSetpoint;
+    period.numberPhases = 3;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, {period}, ocpp::DateTime("2024-01-17T17:00:00")), TX_ID);
+
+    ON_CALL(*database_handler, get_charging_profiles_for_evse(DEFAULT_EVSE_ID))
+        .WillByDefault(testing::Return(std::vector<ChargingProfile>{profile}));
+
+    evse_manager->open_transaction(DEFAULT_EVSE_ID, TX_ID);
+
+    const DateTime start_time = ocpp::DateTime("2024-01-17T17:00:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-17T18:00:00");
+
+    CompositeSchedule result = handler->calculate_composite_schedule(start_time, end_time, DEFAULT_EVSE_ID,
+                                                                     ChargingRateUnitEnum::W, false, false);
+
+    ASSERT_FALSE(result.chargingSchedulePeriod.empty());
+    EXPECT_EQ(result.chargingSchedulePeriod.front().operationMode, OperationModeEnum::CentralSetpoint);
+    EXPECT_EQ(result.chargingSchedulePeriod.front().setpoint, 5000.0F);
+}
+
+TEST_F(CompositeScheduleTestFixtureV2, Q03_NoSetpoint_OperationModeIsNullopt) {
+    // Create a TxProfile with only a limit (no setpoint, no operationMode)
+    ChargingSchedulePeriod period{};
+    period.startPeriod = 0;
+    period.limit = 7000.0F;
+    period.numberPhases = 3;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, {period}, ocpp::DateTime("2024-01-17T17:00:00")), TX_ID);
+
+    ON_CALL(*database_handler, get_charging_profiles_for_evse(DEFAULT_EVSE_ID))
+        .WillByDefault(testing::Return(std::vector<ChargingProfile>{profile}));
+
+    evse_manager->open_transaction(DEFAULT_EVSE_ID, TX_ID);
+
+    const DateTime start_time = ocpp::DateTime("2024-01-17T17:00:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-17T18:00:00");
+
+    CompositeSchedule result = handler->calculate_composite_schedule(start_time, end_time, DEFAULT_EVSE_ID,
+                                                                     ChargingRateUnitEnum::W, false, false);
+
+    ASSERT_FALSE(result.chargingSchedulePeriod.empty());
+    EXPECT_FALSE(result.chargingSchedulePeriod.front().operationMode.has_value());
+}
+
+TEST_F(CompositeScheduleTestFixtureV2, Q03_MultiplePeriodsWithDifferentOperationModes) {
+    // Two periods: first ChargingOnly, second CentralSetpoint
+    ChargingSchedulePeriod period1{};
+    period1.startPeriod = 0;
+    period1.limit = 7000.0F;
+    period1.operationMode = OperationModeEnum::ChargingOnly;
+    period1.numberPhases = 3;
+
+    ChargingSchedulePeriod period2{};
+    period2.startPeriod = 1800;
+    period2.setpoint = 5000.0F;
+    period2.limit = 7000.0F;
+    period2.operationMode = OperationModeEnum::CentralSetpoint;
+    period2.numberPhases = 3;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, {period1, period2}, ocpp::DateTime("2024-01-17T17:00:00")),
+        TX_ID);
+
+    ON_CALL(*database_handler, get_charging_profiles_for_evse(DEFAULT_EVSE_ID))
+        .WillByDefault(testing::Return(std::vector<ChargingProfile>{profile}));
+
+    evse_manager->open_transaction(DEFAULT_EVSE_ID, TX_ID);
+
+    const DateTime start_time = ocpp::DateTime("2024-01-17T17:00:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-17T18:00:00");
+
+    CompositeSchedule result = handler->calculate_composite_schedule(start_time, end_time, DEFAULT_EVSE_ID,
+                                                                     ChargingRateUnitEnum::W, false, false);
+
+    ASSERT_GE(result.chargingSchedulePeriod.size(), 2);
+    // ChargingOnly with no setpoint results in nullopt operationMode (nullopt defaults to ChargingOnly)
+    EXPECT_FALSE(result.chargingSchedulePeriod[0].operationMode.has_value());
+    EXPECT_EQ(result.chargingSchedulePeriod[1].operationMode, OperationModeEnum::CentralSetpoint);
+    EXPECT_EQ(result.chargingSchedulePeriod[1].setpoint, 5000.0F);
 }
 
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_composite_schedule.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_composite_schedule.cpp
@@ -1530,8 +1530,10 @@ TEST_F(CompositeScheduleTestFixtureV2, Q03_MultiplePeriodsWithDifferentOperation
                                                                      ChargingRateUnitEnum::W, false, false);
 
     ASSERT_GE(result.chargingSchedulePeriod.size(), 2);
-    // ChargingOnly with no setpoint results in nullopt operationMode (nullopt defaults to ChargingOnly)
-    EXPECT_FALSE(result.chargingSchedulePeriod[0].operationMode.has_value());
+    // nullopt operationMode is equivalent to ChargingOnly; effective_mode()
+    // normalizes the comparison so an explicit ChargingOnly round-trips
+    // through the pipeline.
+    EXPECT_EQ(effective_mode(result.chargingSchedulePeriod[0].operationMode), OperationModeEnum::ChargingOnly);
     EXPECT_EQ(result.chargingSchedulePeriod[1].operationMode, OperationModeEnum::CentralSetpoint);
     EXPECT_EQ(result.chargingSchedulePeriod[1].setpoint, 5000.0F);
 }

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_composite_schedule.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_composite_schedule.cpp
@@ -1267,6 +1267,7 @@ TEST_F(CompositeScheduleTestFixtureV2, OfflineDuration_Online) {
     expected_period.limit = 2000.0;
     expected_period.numberPhases = 3;
     expected_period.setpoint = -2000.0;
+    expected_period.operationMode = OperationModeEnum::CentralSetpoint;
     expected_period.startPeriod = 0;
 
     CompositeSchedule expected_schedule{};
@@ -1303,6 +1304,7 @@ TEST_F(CompositeScheduleTestFixtureV2, OfflineDuration_OfflineNotLongEnough) {
     expected_period.limit = 2000.0;
     expected_period.numberPhases = 3;
     expected_period.setpoint = -2000.0;
+    expected_period.operationMode = OperationModeEnum::CentralSetpoint;
     expected_period.startPeriod = 0;
 
     CompositeSchedule expected_schedule{};
@@ -1395,6 +1397,7 @@ TEST_F(CompositeScheduleTestFixtureV2, OfflineDuration_OfflineTooLong_ValidAfter
 
     // Profile with CentralSetpoint is preferred after being online again
     expected_period.setpoint = -2000.0;
+    expected_period.operationMode = OperationModeEnum::CentralSetpoint;
     expected_schedule.chargingSchedulePeriod = {expected_period};
 
     actual_schedule = handler->calculate_composite_schedule(start_time, end_time, DEFAULT_EVSE_ID,
@@ -1438,6 +1441,101 @@ TEST_F(CompositeScheduleTestFixtureV2, OfflineDuration_OfflineTooLong_InvalidAft
                                                                  ChargingRateUnitEnum::W, false, false);
 
     ASSERT_EQ(actual_schedule, expected_schedule);
+}
+
+TEST_F(CompositeScheduleTestFixtureV2, Q03_CentralSetpoint_PreservedInCompositeSchedule) {
+    // Create a TxProfile with CentralSetpoint operationMode and a setpoint
+    ChargingSchedulePeriod period{};
+    period.startPeriod = 0;
+    period.limit = 7000.0F;
+    period.setpoint = 5000.0F;
+    period.operationMode = OperationModeEnum::CentralSetpoint;
+    period.numberPhases = 3;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, {period}, ocpp::DateTime("2024-01-17T17:00:00")), TX_ID);
+
+    ON_CALL(*database_handler, get_charging_profiles_for_evse(DEFAULT_EVSE_ID))
+        .WillByDefault(testing::Return(std::vector<ChargingProfile>{profile}));
+
+    evse_manager->open_transaction(DEFAULT_EVSE_ID, TX_ID);
+
+    const DateTime start_time = ocpp::DateTime("2024-01-17T17:00:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-17T18:00:00");
+
+    CompositeSchedule result = handler->calculate_composite_schedule(start_time, end_time, DEFAULT_EVSE_ID,
+                                                                     ChargingRateUnitEnum::W, false, false);
+
+    ASSERT_FALSE(result.chargingSchedulePeriod.empty());
+    EXPECT_EQ(result.chargingSchedulePeriod.front().operationMode, OperationModeEnum::CentralSetpoint);
+    EXPECT_EQ(result.chargingSchedulePeriod.front().setpoint, 5000.0F);
+}
+
+TEST_F(CompositeScheduleTestFixtureV2, Q03_NoSetpoint_OperationModeIsNullopt) {
+    // Create a TxProfile with only a limit (no setpoint, no operationMode)
+    ChargingSchedulePeriod period{};
+    period.startPeriod = 0;
+    period.limit = 7000.0F;
+    period.numberPhases = 3;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, {period}, ocpp::DateTime("2024-01-17T17:00:00")), TX_ID);
+
+    ON_CALL(*database_handler, get_charging_profiles_for_evse(DEFAULT_EVSE_ID))
+        .WillByDefault(testing::Return(std::vector<ChargingProfile>{profile}));
+
+    evse_manager->open_transaction(DEFAULT_EVSE_ID, TX_ID);
+
+    const DateTime start_time = ocpp::DateTime("2024-01-17T17:00:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-17T18:00:00");
+
+    CompositeSchedule result = handler->calculate_composite_schedule(start_time, end_time, DEFAULT_EVSE_ID,
+                                                                     ChargingRateUnitEnum::W, false, false);
+
+    ASSERT_FALSE(result.chargingSchedulePeriod.empty());
+    EXPECT_FALSE(result.chargingSchedulePeriod.front().operationMode.has_value());
+}
+
+TEST_F(CompositeScheduleTestFixtureV2, Q03_MultiplePeriodsWithDifferentOperationModes) {
+    // Two periods: first ChargingOnly, second CentralSetpoint
+    ChargingSchedulePeriod period1{};
+    period1.startPeriod = 0;
+    period1.limit = 7000.0F;
+    period1.operationMode = OperationModeEnum::ChargingOnly;
+    period1.numberPhases = 3;
+
+    ChargingSchedulePeriod period2{};
+    period2.startPeriod = 1800;
+    period2.setpoint = 5000.0F;
+    period2.limit = 7000.0F;
+    period2.operationMode = OperationModeEnum::CentralSetpoint;
+    period2.numberPhases = 3;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, {period1, period2}, ocpp::DateTime("2024-01-17T17:00:00")),
+        TX_ID);
+
+    ON_CALL(*database_handler, get_charging_profiles_for_evse(DEFAULT_EVSE_ID))
+        .WillByDefault(testing::Return(std::vector<ChargingProfile>{profile}));
+
+    evse_manager->open_transaction(DEFAULT_EVSE_ID, TX_ID);
+
+    const DateTime start_time = ocpp::DateTime("2024-01-17T17:00:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-17T18:00:00");
+
+    CompositeSchedule result = handler->calculate_composite_schedule(start_time, end_time, DEFAULT_EVSE_ID,
+                                                                     ChargingRateUnitEnum::W, false, false);
+
+    ASSERT_GE(result.chargingSchedulePeriod.size(), 2);
+    // nullopt operationMode is equivalent to ChargingOnly; effective_mode()
+    // normalizes the comparison so an explicit ChargingOnly round-trips
+    // through the pipeline.
+    EXPECT_EQ(effective_mode(result.chargingSchedulePeriod[0].operationMode), OperationModeEnum::ChargingOnly);
+    EXPECT_EQ(result.chargingSchedulePeriod[1].operationMode, OperationModeEnum::CentralSetpoint);
+    EXPECT_EQ(result.chargingSchedulePeriod[1].setpoint, 5000.0F);
 }
 
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_profile.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_profile.cpp
@@ -723,4 +723,107 @@ TEST(OCPPTypesTest, ChargingSchedule_Equality) {
     ASSERT_EQ(schedule1, schedule2);
 }
 
+TEST(ProfileEffectiveModeTest, NulloptMapsToChargingOnly) {
+    EXPECT_EQ(effective_mode(std::nullopt), OperationModeEnum::ChargingOnly);
+}
+
+TEST(ProfileEffectiveModeTest, ExplicitChargingOnlyMapsToChargingOnly) {
+    EXPECT_EQ(effective_mode(std::optional<OperationModeEnum>{OperationModeEnum::ChargingOnly}),
+              OperationModeEnum::ChargingOnly);
+}
+
+TEST(ProfileEffectiveModeTest, V2XModePassesThrough) {
+    EXPECT_EQ(effective_mode(std::optional<OperationModeEnum>{OperationModeEnum::LocalLoadBalancing}),
+              OperationModeEnum::LocalLoadBalancing);
+    EXPECT_EQ(effective_mode(std::optional<OperationModeEnum>{OperationModeEnum::Idle}), OperationModeEnum::Idle);
+    EXPECT_EQ(effective_mode(std::optional<OperationModeEnum>{OperationModeEnum::CentralSetpoint}),
+              OperationModeEnum::CentralSetpoint);
+}
+
+namespace {
+// Build an IntermediatePeriod with all numeric fields at their "unspecified"
+// sentinel values, leaving only startPeriod and operationMode meaningful.
+// Used by tests that need to differentiate periods solely by operationMode.
+IntermediatePeriod make_default_period(std::int32_t start_period,
+                                       std::optional<OperationModeEnum> op_mode = std::nullopt) {
+    IntermediatePeriod p;
+    p.startPeriod = start_period;
+    p.current_limit = {NO_LIMIT_SPECIFIED, NO_LIMIT_SPECIFIED, NO_LIMIT_SPECIFIED};
+    p.power_limit = {NO_LIMIT_SPECIFIED, NO_LIMIT_SPECIFIED, NO_LIMIT_SPECIFIED};
+    p.current_discharge_limit = {NO_DISCHARGE_LIMIT_SPECIFIED, NO_DISCHARGE_LIMIT_SPECIFIED,
+                                 NO_DISCHARGE_LIMIT_SPECIFIED};
+    p.power_discharge_limit = {NO_DISCHARGE_LIMIT_SPECIFIED, NO_DISCHARGE_LIMIT_SPECIFIED,
+                               NO_DISCHARGE_LIMIT_SPECIFIED};
+    p.current_setpoint = {NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED};
+    p.power_setpoint = {NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED};
+    p.numberPhases = std::nullopt;
+    p.phaseToUse = std::nullopt;
+    p.operationMode = op_mode;
+    return p;
+}
+} // namespace
+
+// Two adjacent intermediate periods that differ only in operationMode must not
+// be collapsed by the merge dedup. The relevant scenarios are setpoint-less V2X
+// modes whose meaning is carried by operationMode alone (LocalLoadBalancing,
+// Idle, LocalFrequency, ExternalLimits — see OperationModeEnum table at p.505
+// of the OCPP 2.1 Edition 2 spec).
+TEST(MergeLowestLimitDedupTest, AdjacentPeriodsWithDifferentOperationModesNotCollapsed) {
+    IntermediateProfile profile = {
+        make_default_period(0, OperationModeEnum::LocalLoadBalancing),
+        make_default_period(1800, OperationModeEnum::Idle),
+    };
+
+    auto merged = merge_profiles_by_lowest_limit({profile}, OcppProtocolVersion::v21);
+    ASSERT_EQ(merged.size(), 2);
+    EXPECT_EQ(effective_mode(merged[0].operationMode), OperationModeEnum::LocalLoadBalancing);
+    EXPECT_EQ(effective_mode(merged[1].operationMode), OperationModeEnum::Idle);
+}
+
+// A non-default operationMode on any contributor must propagate even when the
+// period carries no setpoint. LocalLoadBalancing is the canonical example: per
+// the OCPP 2.1 Edition 2 operation-mode table (p.505), the mode has neither a
+// limit nor a setpoint of its own; the setpoint is computed from load readings.
+TEST(MergeLowestLimitOperationModeTest, NoSetpointModePropagates) {
+    IntermediateProfile llb_profile = {
+        make_default_period(0, OperationModeEnum::LocalLoadBalancing),
+    };
+    IntermediateProfile limit_profile = {make_default_period(0)};
+    limit_profile[0].current_limit = {16.0F, 16.0F, 16.0F};
+
+    auto merged = merge_profiles_by_lowest_limit({llb_profile, limit_profile}, OcppProtocolVersion::v21);
+    ASSERT_FALSE(merged.empty());
+    EXPECT_EQ(effective_mode(merged[0].operationMode), OperationModeEnum::LocalLoadBalancing);
+    EXPECT_FLOAT_EQ(merged[0].current_limit.limit, 16.0F);
+}
+
+// On a cross-purpose conflict (two contributors with distinct non-default
+// operationModes), the first contributor's mode wins deterministically.
+// Proper resolution requires SmartChargingCtrlr.SetpointPriority (Q06.FR.20–22)
+// which is not implemented yet.
+TEST(MergeLowestLimitOperationModeTest, ConflictKeepsFirstContributor) {
+    IntermediateProfile a = {make_default_period(0, OperationModeEnum::LocalLoadBalancing)};
+    IntermediateProfile b = {make_default_period(0, OperationModeEnum::Idle)};
+
+    auto merged = merge_profiles_by_lowest_limit({a, b}, OcppProtocolVersion::v21);
+    ASSERT_FALSE(merged.empty());
+    EXPECT_EQ(effective_mode(merged[0].operationMode), OperationModeEnum::LocalLoadBalancing);
+}
+
+// Per OCPP 2.1 Edition 2 §3.6, TxProfile overrules TxDefaultProfile. A TxProfile
+// period whose only override is a non-default operationMode (e.g. LocalLoadBalancing
+// with no numeric fields) must win the pick — otherwise the TxDefaultProfile's
+// limits leak through and the V2X mode is silently dropped.
+TEST(MergeTxWithDefaultTest, TxProfileWithOnlyOperationModeWins) {
+    IntermediateProfile tx = {make_default_period(0, OperationModeEnum::LocalLoadBalancing)};
+
+    IntermediateProfile tx_default = {make_default_period(0)};
+    tx_default[0].current_limit = {32.0F, 32.0F, 32.0F};
+
+    auto merged = merge_tx_profile_with_tx_default_profile(tx, tx_default);
+    ASSERT_FALSE(merged.empty());
+    EXPECT_EQ(effective_mode(merged[0].operationMode), OperationModeEnum::LocalLoadBalancing);
+    EXPECT_TRUE(is_equal(merged[0].current_limit.limit, NO_LIMIT_SPECIFIED));
+}
+
 } // namespace

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_profile.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_profile.cpp
@@ -781,6 +781,27 @@ TEST(MergeTxProfileTest, ExplicitChargingOnlyTxProfilePeriod_TreatedAsDefault) {
     EXPECT_EQ(merged.front().current_limit.limit, 32.0F);
 }
 
+TEST(MergeTxProfileTest, NumberPhasesOnlyTxProfilePeriod_TxProfileWins) {
+    // tx_profile period sets numberPhases with otherwise default limits/setpoints.
+    // The merge must treat that as a meaningful contribution so numberPhases propagates
+    // instead of silently falling through to tx_default.
+    auto tx_period = make_default_intermediate_period();
+    tx_period.numberPhases = 1;
+
+    auto default_period = make_default_intermediate_period();
+    default_period.current_limit = {32.0F, 32.0F, 32.0F};
+    default_period.numberPhases = 3;
+
+    IntermediateProfile tx_profile{tx_period};
+    IntermediateProfile tx_default_profile{default_period};
+
+    IntermediateProfile merged = merge_tx_profile_with_tx_default_profile(tx_profile, tx_default_profile);
+
+    ASSERT_FALSE(merged.empty());
+    ASSERT_TRUE(merged.front().numberPhases.has_value());
+    EXPECT_EQ(merged.front().numberPhases.value(), 1);
+}
+
 TEST(MergeTxProfileTest, EmptyTxProfilePeriod_TxDefaultWins) {
     // Regression guard: a fully-default tx_profile period still falls through to tx_default.
     auto tx_period = make_default_intermediate_period();

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_profile.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_profile.cpp
@@ -723,4 +723,78 @@ TEST(OCPPTypesTest, ChargingSchedule_Equality) {
     ASSERT_EQ(schedule1, schedule2);
 }
 
+// Mirrors the private default_intermediate_period() helper in profile.cpp so we can build
+// baseline IntermediatePeriod instances from tests without reaching into the anonymous namespace.
+IntermediatePeriod make_default_intermediate_period(std::int32_t start = 0) {
+    IntermediatePeriod p;
+    p.startPeriod = start;
+    p.current_limit = {NO_LIMIT_SPECIFIED, NO_LIMIT_SPECIFIED, NO_LIMIT_SPECIFIED};
+    p.power_limit = {NO_LIMIT_SPECIFIED, NO_LIMIT_SPECIFIED, NO_LIMIT_SPECIFIED};
+    p.current_discharge_limit = {NO_DISCHARGE_LIMIT_SPECIFIED, NO_DISCHARGE_LIMIT_SPECIFIED,
+                                 NO_DISCHARGE_LIMIT_SPECIFIED};
+    p.power_discharge_limit = {NO_DISCHARGE_LIMIT_SPECIFIED, NO_DISCHARGE_LIMIT_SPECIFIED,
+                               NO_DISCHARGE_LIMIT_SPECIFIED};
+    p.current_setpoint = {NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED};
+    p.power_setpoint = {NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED, NO_SETPOINT_SPECIFIED};
+    p.numberPhases = std::nullopt;
+    p.phaseToUse = std::nullopt;
+    p.operationMode = std::nullopt;
+    return p;
+}
+
+TEST(MergeTxProfileTest, OperationModeOnlyTxProfilePeriod_TxProfileWins) {
+    // tx_profile period carries a non-ChargingOnly operationMode with otherwise default limits/setpoints.
+    // The merge must treat that as a meaningful contribution so the operationMode propagates instead of
+    // silently falling through to tx_default.
+    auto tx_period = make_default_intermediate_period();
+    tx_period.operationMode = OperationModeEnum::CentralSetpoint;
+
+    auto default_period = make_default_intermediate_period();
+    default_period.current_limit = {32.0F, 32.0F, 32.0F};
+
+    IntermediateProfile tx_profile{tx_period};
+    IntermediateProfile tx_default_profile{default_period};
+
+    IntermediateProfile merged = merge_tx_profile_with_tx_default_profile(tx_profile, tx_default_profile);
+
+    ASSERT_FALSE(merged.empty());
+    ASSERT_TRUE(merged.front().operationMode.has_value());
+    EXPECT_EQ(merged.front().operationMode.value(), OperationModeEnum::CentralSetpoint);
+}
+
+TEST(MergeTxProfileTest, ExplicitChargingOnlyTxProfilePeriod_TreatedAsDefault) {
+    // Per OCPP 2.1 Q02.FR.01, a missing operationMode is equivalent to ChargingOnly. A tx_profile
+    // period that explicitly names ChargingOnly with no other content must therefore still be
+    // treated as "default", so tx_default wins the merge.
+    auto tx_period = make_default_intermediate_period();
+    tx_period.operationMode = OperationModeEnum::ChargingOnly;
+
+    auto default_period = make_default_intermediate_period();
+    default_period.current_limit = {32.0F, 32.0F, 32.0F};
+
+    IntermediateProfile tx_profile{tx_period};
+    IntermediateProfile tx_default_profile{default_period};
+
+    IntermediateProfile merged = merge_tx_profile_with_tx_default_profile(tx_profile, tx_default_profile);
+
+    ASSERT_FALSE(merged.empty());
+    EXPECT_EQ(merged.front().current_limit.limit, 32.0F);
+}
+
+TEST(MergeTxProfileTest, EmptyTxProfilePeriod_TxDefaultWins) {
+    // Regression guard: a fully-default tx_profile period still falls through to tx_default.
+    auto tx_period = make_default_intermediate_period();
+
+    auto default_period = make_default_intermediate_period();
+    default_period.current_limit = {32.0F, 32.0F, 32.0F};
+
+    IntermediateProfile tx_profile{tx_period};
+    IntermediateProfile tx_default_profile{default_period};
+
+    IntermediateProfile merged = merge_tx_profile_with_tx_default_profile(tx_profile, tx_default_profile);
+
+    ASSERT_FALSE(merged.empty());
+    EXPECT_EQ(merged.front().current_limit.limit, 32.0F);
+}
+
 } // namespace

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
@@ -774,8 +774,7 @@ TEST_F(SmartChargingTestV21, V2X05_SetpointExceedsLimit_Rejected) {
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
-    auto mock_evse = testing::NiceMock<EvseMock>();
-    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+    auto sut = smart_charging.validate_setpoint_within_limit_range(profile);
 
     EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange);
 }
@@ -791,8 +790,7 @@ TEST_F(SmartChargingTestV21, V2X05_SetpointBelowDischargeLimit_Rejected) {
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
-    auto mock_evse = testing::NiceMock<EvseMock>();
-    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+    auto sut = smart_charging.validate_setpoint_within_limit_range(profile);
 
     EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange);
 }
@@ -809,8 +807,7 @@ TEST_F(SmartChargingTestV21, V2X05_SetpointWithinRange_Accepted) {
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
-    auto mock_evse = testing::NiceMock<EvseMock>();
-    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+    auto sut = smart_charging.validate_setpoint_within_limit_range(profile);
 
     EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
 }
@@ -825,8 +822,7 @@ TEST_F(SmartChargingTestV21, V2X05_SetpointWithNoLimits_Accepted) {
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
-    auto mock_evse = testing::NiceMock<EvseMock>();
-    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+    auto sut = smart_charging.validate_setpoint_within_limit_range(profile);
 
     EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
 }

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
@@ -763,4 +763,121 @@ TEST_F(SmartChargingTestV21, AllSetpointsSameSign) {
 
     EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
 }
+// V2X.05: Reject if setpoint exceeds limit
+TEST_F(SmartChargingTestV21, V2X05_SetpointExceedsLimit_Rejected) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 8000.0F;
+    periods.at(0).limit = 5000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_setpoint_within_limit_range(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange);
+}
+
+// V2X.05: Reject if setpoint below dischargeLimit
+TEST_F(SmartChargingTestV21, V2X05_SetpointBelowDischargeLimit_Rejected) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = -5000.0F;
+    periods.at(0).dischargeLimit = -3000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_setpoint_within_limit_range(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange);
+}
+
+// V2X.05: Accept if setpoint within range
+TEST_F(SmartChargingTestV21, V2X05_SetpointWithinRange_Accepted) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 5000.0F;
+    periods.at(0).limit = 7000.0F;
+    periods.at(0).dischargeLimit = -3000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_setpoint_within_limit_range(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
+}
+
+// V2X.05: Accept if setpoint with no limits (limits are optional per Q03.FR.03)
+TEST_F(SmartChargingTestV21, V2X05_SetpointWithNoLimits_Accepted) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 5000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_setpoint_within_limit_range(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
+}
+
+// V2X.10 (V2X.09 branch): reject non-TxProfile carrying _L2/_L3 fields with PhaseConflict
+TEST_F(SmartChargingTestV21, V2X10_NonTxProfile_WithDischargeLimitL2_Rejected) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).dischargeLimit_L2 = -2000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut = smart_charging.validate_phase_conflict(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict);
+}
+
+TEST_F(SmartChargingTestV21, V2X10_NonTxProfile_WithSetpointReactiveL3_Rejected) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).setpointReactive_L3 = 1000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut = smart_charging.validate_phase_conflict(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict);
+}
+
+TEST_F(SmartChargingTestV21, V2X10_TxProfile_WithDischargeLimitL2_Accepted) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).dischargeLimit_L2 = -2000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_phase_conflict(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
+}
+
+TEST_F(SmartChargingTestV21, V2X10_NonTxProfile_NoL2L3Fields_Accepted) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).limit = 16.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut = smart_charging.validate_phase_conflict(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
+}
+
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
@@ -763,4 +763,72 @@ TEST_F(SmartChargingTestV21, AllSetpointsSameSign) {
 
     EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
 }
+// V2X.05: Reject if setpoint exceeds limit
+TEST_F(SmartChargingTestV21, V2X05_SetpointExceedsLimit_Rejected) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 8000.0F;
+    periods.at(0).limit = 5000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange);
+}
+
+// V2X.05: Reject if setpoint below dischargeLimit
+TEST_F(SmartChargingTestV21, V2X05_SetpointBelowDischargeLimit_Rejected) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = -5000.0F;
+    periods.at(0).dischargeLimit = -3000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange);
+}
+
+// V2X.05: Accept if setpoint within range
+TEST_F(SmartChargingTestV21, V2X05_SetpointWithinRange_Accepted) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 5000.0F;
+    periods.at(0).limit = 7000.0F;
+    periods.at(0).dischargeLimit = -3000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
+}
+
+// V2X.05: Accept if setpoint with no limits (limits are optional per Q03.FR.03)
+TEST_F(SmartChargingTestV21, V2X05_SetpointWithNoLimits_Accepted) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 5000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
+}
+
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
@@ -827,4 +827,57 @@ TEST_F(SmartChargingTestV21, V2X05_SetpointWithNoLimits_Accepted) {
     EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
 }
 
+// V2X.10 (V2X.09 branch): reject non-TxProfile carrying _L2/_L3 fields with PhaseConflict
+TEST_F(SmartChargingTestV21, V2X10_NonTxProfile_WithDischargeLimitL2_Rejected) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).dischargeLimit_L2 = -2000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut = smart_charging.validate_phase_conflict(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict);
+}
+
+TEST_F(SmartChargingTestV21, V2X10_NonTxProfile_WithSetpointReactiveL3_Rejected) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).setpointReactive_L3 = 1000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut = smart_charging.validate_phase_conflict(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict);
+}
+
+TEST_F(SmartChargingTestV21, V2X10_TxProfile_WithDischargeLimitL2_Accepted) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).dischargeLimit_L2 = -2000.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_phase_conflict(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
+}
+
+TEST_F(SmartChargingTestV21, V2X10_NonTxProfile_NoL2L3Fields_Accepted) {
+    auto periods = create_charging_schedule_periods(0, 1, std::nullopt, std::nullopt);
+    periods.at(0).limit = 16.0F;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut = smart_charging.validate_phase_conflict(profile);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::Valid);
+}
+
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/test_composite_schedule.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/test_composite_schedule.cpp
@@ -19,24 +19,27 @@ TEST_F(CompositeScheduleTestFixtureV21, setpoint_tx_profile) {
     period1.numberPhases = 1;
     period1.setpoint = 1500.0; // overriden by limit
     period1.dischargeLimit = -2000.0;
+    period1.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period2;
     period2.startPeriod = 1080;
     period2.limit = 11000.0;
     period2.numberPhases = 1;
     period2.setpoint = -8000.0;
     period2.dischargeLimit = -10000.0;
+    period2.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period3;
     period3.startPeriod = 14000;
     period3.limit = 6000.0;
     period3.numberPhases = 1;
     period3.setpoint = -5000.0; // overriden by dischargeLimit
     period3.dischargeLimit = -5000.0;
+    period3.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period4;
     period4.startPeriod = 28000;
     period4.limit = 15000.0;
     period4.numberPhases = 1;
     period4.setpoint = -4000.0;
-    // period4.operationMode = OperationModeEnum::CentralSetpoint;
+    period4.operationMode = OperationModeEnum::CentralSetpoint;
     CompositeSchedule expected;
     expected.chargingSchedulePeriod = {period1, period2, period3, period4};
     expected.evseId = DEFAULT_EVSE_ID;
@@ -64,22 +67,26 @@ TEST_F(CompositeScheduleTestFixtureV21, V2MaxOverridesHigherLimits) {
     period1.dischargeLimit = -23.0;
     period1.setpoint = 10.0;
     period1.numberPhases = 1;
+    period1.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period2;
     period2.startPeriod = 3600;
     period2.limit = 20.0;
     period2.dischargeLimit = -23.0;
     period2.setpoint = 20.0;
     period2.numberPhases = 1;
+    period2.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period3;
     period3.startPeriod = 7200;
     period3.limit = 30.0;
     period3.setpoint = 28.0;
     period3.numberPhases = 1;
+    period3.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period4;
     period4.startPeriod = 10800;
     period4.limit = 40.0;
     period4.setpoint = 28.0;
     period4.numberPhases = 1;
+    period4.operationMode = OperationModeEnum::CentralSetpoint;
     CompositeSchedule expected;
     expected.chargingSchedulePeriod = {period1, period2, period3, period4};
     expected.evseId = DEFAULT_EVSE_ID;
@@ -217,6 +224,7 @@ TEST_F(CompositeScheduleTestFixtureV21, V2ChargingRateUnitCombine) {
     period1.dischargeLimit = -1000.0;
     period1.dischargeLimit_L2 = -1000.0;
     period1.dischargeLimit_L3 = -1000.0;
+    period1.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period2; // TxProfile stacklevel 0
     period2.startPeriod = 2400;
     period2.limit = 400.0;
@@ -229,6 +237,7 @@ TEST_F(CompositeScheduleTestFixtureV21, V2ChargingRateUnitCombine) {
     period2.setpoint = 400.0;
     period2.setpoint_L2 = 400.0;
     period2.setpoint_L3 = 400.0;
+    period2.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period3; // Charging station max profile
     period3.startPeriod = 3000;
     period3.limit = 43700.0;
@@ -275,6 +284,7 @@ TEST_F(CompositeScheduleTestFixtureV21, V2Different_Number_Phases) {
     period1.numberPhases = 1;
     period1.dischargeLimit = -900.0;
     period1.setpoint = 160.0;
+    period1.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period2; // Charging station max profile
     period2.startPeriod = 3000;
     period2.limit = 190.0;
@@ -314,6 +324,7 @@ TEST_F(CompositeScheduleTestFixtureV21, V2Different_Number_Phases_W) {
     period1.numberPhases = 1;
     period1.dischargeLimit = -900.0 * 230;
     period1.setpoint = 160.0 * 230;
+    period1.operationMode = OperationModeEnum::CentralSetpoint;
     ChargingSchedulePeriod period2; // Charging station max profile
     period2.startPeriod = 3000;
     period2.limit = 190.0 * 230;


### PR DESCRIPTION
Preserve operationMode through the composite schedule pipeline so that CentralSetpoint (and other V2X operation modes) propagate from charging profiles to the final schedule sent to the energy system.

Changes:
- Add operationMode field to IntermediatePeriod and period_entry_t
- Carry operationMode through all merge functions (tx/txDefault merge, lowest-limit merge) following the winning setpoint source
- Write operationMode to output in convert_intermediate_into_schedule
- Add V2X.05 validation: reject SetChargingProfile when setpoint lies outside the [dischargeLimit, limit] range
- Fix status document: correct Q03 title, add missing Q03.FR.03 and Q04 section, add V2X.06-V2X.10 generic rules
- Add unit tests for composite schedule operationMode preservation, V2X.05 validation, and update existing V21 test expectations

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

