### PR TITLE
Fix/ocpp/charging profiles non finite floats

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
@@ -57,6 +57,7 @@ enum class ProfileValidationResultEnum {
     ChargingProfileUnsupportedKind,
     ChargingProfileNotDynamic,
     ChargingScheduleChargingRateUnitUnsupported,
+    ChargingScheduleNonFiniteValue,
     ChargingSchedulePriorityExtranousDuration,
     ChargingScheduleRandomizedDelay,
     ChargingScheduleUnsupportedLocalTime,
@@ -79,7 +80,8 @@ enum class ProfileValidationResultEnum {
     DuplicateTxDefaultProfileFound,
     DuplicateProfileValidityPeriod,
     RequestStartTransactionNonTxProfile,
-    ChargingProfileEmptyChargingSchedules
+    ChargingProfileEmptyChargingSchedules,
+    ChargingSchedulePeriodNonFiniteValue
 };
 
 /// \brief This is used to associate charging profiles with a source.

--- a/lib/everest/ocpp/lib/ocpp/v16/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/smart_charging.cpp
@@ -3,6 +3,7 @@
 
 #include "ocpp/v16/charge_point_configuration_interface.hpp"
 #include <chrono>
+#include <cmath>
 #include <ocpp/common/constants.hpp>
 #include <ocpp/common/types.hpp>
 #include <ocpp/common/utils.hpp>
@@ -84,7 +85,16 @@ bool validate_schedule(const ChargingSchedule& schedule, const int charging_sche
         return false;
     }
 
+    if (!std::isfinite(schedule.minChargingRate.value_or(0.0))) {
+        EVLOG_warning << "INVALID SCHEDULE - Non-finite minChargingRate: " << schedule.minChargingRate.value_or(0.0);
+        return false;
+    }
+
     for (const auto& period : schedule.chargingSchedulePeriod) {
+        if (!std::isfinite(period.limit)) {
+            EVLOG_warning << "INVALID SCHEDULE - Non-finite limit: " << period.limit;
+            return false;
+        }
         if (period.numberPhases.has_value()) {
             const auto& number_phases = period.numberPhases.value();
             if (number_phases <= 0 or number_phases > DEFAULT_AND_MAX_NUMBER_PHASES) {

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -3,6 +3,7 @@
 
 #include <ocpp/v2/functional_blocks/smart_charging.hpp>
 
+#include <cmath>
 #include <optional>
 
 #include <ocpp/common/constants.hpp>
@@ -67,6 +68,56 @@ void conform_validity_periods(ChargingProfile& profile) {
         profile.validTo = validTo;
     }
 }
+
+/// \brief Check if a float value is non-finite (infinity or NaN)
+template <typename T> bool non_finite(const T& value) = delete;
+
+template <> constexpr bool non_finite<float>(const float& value) {
+    return !std::isfinite(value);
+}
+
+template <> constexpr bool non_finite<std::optional<float>>(const std::optional<float>& value) {
+    return !std::isfinite(value.value_or(0.0));
+}
+
+template <typename T, typename... Values> constexpr bool non_finite(const T& value, const Values&... values) {
+    return non_finite(value) || non_finite(values...);
+}
+
+/// \brief Returns true if any float field in \p period is non-finite (infinity or NaN).
+/// Such values originate from float overflow (e.g. a max-double sent by a CSMS) and would be
+/// serialized as JSON null
+bool has_non_finite_float(const ChargingSchedulePeriod& period) {
+    if (non_finite(period.limit, period.limit_L2, period.limit_L3, period.dischargeLimit, period.dischargeLimit_L2,
+                   period.dischargeLimit_L3, period.setpoint, period.setpoint_L2, period.setpoint_L3,
+                   period.setpointReactive, period.setpointReactive_L2, period.setpointReactive_L3,
+                   period.v2xBaseline)) {
+        return true;
+    }
+    if (period.v2xFreqWattCurve.has_value()) {
+        for (const auto& point : period.v2xFreqWattCurve.value()) {
+            if (non_finite(point.frequency, point.power)) {
+                return true;
+            }
+        }
+    }
+    if (period.v2xSignalWattCurve.has_value()) {
+        for (const auto& point : period.v2xSignalWattCurve.value()) {
+            if (non_finite(point.power)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/// \brief Returns true if any float field in \p schedule is non-finite (infinity or NaN).
+bool has_non_finite_float(const ChargingSchedule& schedule) {
+    if (non_finite(schedule.minChargingRate, schedule.powerTolerance)) {
+        return true;
+    }
+    return schedule.limitAtSoC.has_value() && non_finite(schedule.limitAtSoC.value().limit);
+}
 } // namespace
 namespace conversions {
 std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
@@ -109,6 +160,8 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingProfileNotDynamic";
     case ProfileValidationResultEnum::ChargingScheduleChargingRateUnitUnsupported:
         return "ChargingScheduleChargingRateUnitUnsupported";
+    case ProfileValidationResultEnum::ChargingScheduleNonFiniteValue:
+        return "ChargingScheduleNonFiniteValue";
     case ProfileValidationResultEnum::ChargingSchedulePriorityExtranousDuration:
         return "ChargingSchedulePriorityExtranousDuration";
     case ProfileValidationResultEnum::ChargingScheduleRandomizedDelay:
@@ -155,6 +208,8 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "RequestStartTransactionNonTxProfile";
     case ProfileValidationResultEnum::ChargingProfileEmptyChargingSchedules:
         return "ChargingProfileEmptyChargingSchedules";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue:
+        return "ChargingSchedulePeriodNonFiniteValue";
     }
 
     throw EnumToStringException{e, "ProfileValidationResultEnum"};
@@ -190,6 +245,7 @@ std::string profile_validation_result_to_reason_code(ProfileValidationResultEnum
     case ProfileValidationResultEnum::ChargingProfileMissingRequiredStartSchedule:
     case ProfileValidationResultEnum::ChargingProfileExtraneousStartSchedule:
     case ProfileValidationResultEnum::ChargingProfileEmptyChargingSchedules:
+    case ProfileValidationResultEnum::ChargingScheduleNonFiniteValue:
     case ProfileValidationResultEnum::ChargingSchedulePriorityExtranousDuration:
     case ProfileValidationResultEnum::ChargingScheduleRandomizedDelay:
     case ProfileValidationResultEnum::ChargingScheduleUnsupportedLocalTime:
@@ -205,6 +261,7 @@ std::string profile_validation_result_to_reason_code(ProfileValidationResultEnum
     case ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedOperationMode:
     case ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedLimitSetpoint:
     case ProfileValidationResultEnum::ChargingSchedulePeriodSignDifference:
+    case ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue:
         return "InvalidSchedule";
     case ProfileValidationResultEnum::ChargingSchedulePeriodNoPhaseForDC:
         return "NoPhaseForDC";
@@ -807,6 +864,10 @@ ProfileValidationResultEnum SmartCharging::validate_profile_schedules(ChargingPr
             return ProfileValidationResultEnum::ChargingProfileNoChargingSchedulePeriods;
         }
 
+        if (has_non_finite_float(schedule)) {
+            return ProfileValidationResultEnum::ChargingScheduleNonFiniteValue;
+        }
+
         if (this->context.ocpp_version == OcppProtocolVersion::v21) {
             // K01.FR.95 Other profiles than TxProfle or TxDefaultProfile can not have a randomized delay.
             if (profile.chargingProfilePurpose != ChargingProfilePurposeEnum::TxProfile &&
@@ -867,6 +928,11 @@ ProfileValidationResultEnum SmartCharging::validate_profile_schedules(ChargingPr
 
         for (auto i = 0; i < schedule.chargingSchedulePeriod.size(); i++) {
             auto& charging_schedule_period = schedule.chargingSchedulePeriod[i];
+
+            if (has_non_finite_float(charging_schedule_period)) {
+                return ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue;
+            }
+
             // K01.FR.48 and K01.FR.19
             if (charging_schedule_period.numberPhases != 1 && charging_schedule_period.phaseToUse.has_value()) {
                 return ProfileValidationResultEnum::ChargingSchedulePeriodInvalidPhaseToUse;

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_smart_charging_handler.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_smart_charging_handler.cpp
@@ -6,6 +6,7 @@ namespace fs = std::filesystem;
 
 #include <database_handler_mock.hpp>
 #include <evse_security_mock.hpp>
+#include <limits>
 #include <ocpp/common/call_types.hpp>
 #include <ocpp/v16/charge_point_configuration.hpp>
 #include <ocpp/v16/smart_charging.hpp>
@@ -446,6 +447,34 @@ TEST_F(ChargepointTestFixture, ValidateProfile__ValidProfile_InvalidChargingSche
     auto handler = createSmartChargingHandler();
 
     const std::vector<ChargingRateUnit>& charging_schedule_allowed_charging_rate_units{ChargingRateUnit::W};
+    bool sut = handler->validate_profile(profile, connector_id, ignore_no_transaction, profile_max_stack_level,
+                                         max_charging_profiles_installed, charging_schedule_max_periods,
+                                         charging_schedule_allowed_charging_rate_units);
+
+    ASSERT_FALSE(sut);
+}
+
+TEST_F(ChargepointTestFixture, ValidateProfile__PeriodLimitIsInfinity__ReturnsFalse) {
+    auto profile = createChargingProfile(createChargeSchedule(ChargingRateUnit::A));
+    profile.chargingSchedule.chargingSchedulePeriod = {
+        ChargingSchedulePeriod{0, std::numeric_limits<float>::infinity(), std::nullopt}};
+    auto handler = createSmartChargingHandler();
+
+    const std::vector<ChargingRateUnit>& charging_schedule_allowed_charging_rate_units{ChargingRateUnit::A};
+    bool sut = handler->validate_profile(profile, connector_id, ignore_no_transaction, profile_max_stack_level,
+                                         max_charging_profiles_installed, charging_schedule_max_periods,
+                                         charging_schedule_allowed_charging_rate_units);
+
+    ASSERT_FALSE(sut);
+}
+
+TEST_F(ChargepointTestFixture, ValidateProfile__MinChargingRateIsInfinity__ReturnsFalse) {
+    auto profile = createChargingProfile(createChargeSchedule(ChargingRateUnit::A));
+    profile.chargingSchedule.chargingSchedulePeriod = {ChargingSchedulePeriod{0, 10.0f, std::nullopt}};
+    profile.chargingSchedule.minChargingRate = std::numeric_limits<float>::infinity();
+    auto handler = createSmartChargingHandler();
+
+    const std::vector<ChargingRateUnit>& charging_schedule_allowed_charging_rate_units{ChargingRateUnit::A};
     bool sut = handler->validate_profile(profile, connector_id, ignore_no_transaction, profile_max_stack_level,
                                          max_charging_profiles_installed, charging_schedule_max_periods,
                                          charging_schedule_allowed_charging_rate_units);

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_smart_charging.cpp
@@ -27,6 +27,7 @@
 #include <evse_manager_fake.hpp>
 #include <evse_mock.hpp>
 #include <evse_security_mock.hpp>
+#include <limits>
 #include <ocpp/common/call_types.hpp>
 #include <ocpp/v2/evse.hpp>
 #include <ocpp/v2/ocpp_enums.hpp>
@@ -310,6 +311,96 @@ TEST_F(SmartChargingTest, K01FR35_IfChargingSchedulePeriodsAreNotInChonologicalO
     auto sut = smart_charging.validate_profile_schedules(profile);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodsOutOfOrder));
+}
+
+TEST_F(SmartChargingTest, IfChargingSchedulePeriodLimitIsInfinity_ThenProfileIsInvalid) {
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    period.limit = std::numeric_limits<float>::infinity();
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A, {period}), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue));
+}
+
+TEST_F(SmartChargingTest, IfChargingSchedulePeriodLimitIsNaN_ThenProfileIsInvalid) {
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    period.limit = std::numeric_limits<float>::quiet_NaN();
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A, {period}), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue));
+}
+
+TEST_F(SmartChargingTest, IfChargingScheduleMinChargingRateIsInfinity_ThenProfileIsInvalid) {
+    auto schedule = create_charge_schedule(ChargingRateUnitEnum::A, create_charging_schedule_periods(0));
+    schedule.minChargingRate = std::numeric_limits<float>::infinity();
+    auto profile =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile, schedule, DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingScheduleNonFiniteValue));
+}
+
+TEST_F(SmartChargingTest, IfChargingSchedulePowerToleranceIsNaN_ThenProfileIsInvalid) {
+    auto schedule = create_charge_schedule(ChargingRateUnitEnum::A, create_charging_schedule_periods(0));
+    schedule.powerTolerance = std::numeric_limits<float>::quiet_NaN();
+    auto profile =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile, schedule, DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingScheduleNonFiniteValue));
+}
+
+TEST_F(SmartChargingTest, IfChargingScheduleLimitAtSoCIsInfinity_ThenProfileIsInvalid) {
+    auto schedule = create_charge_schedule(ChargingRateUnitEnum::A, create_charging_schedule_periods(0));
+    LimitAtSoC limit_at_soc;
+    limit_at_soc.soc = 80;
+    limit_at_soc.limit = std::numeric_limits<float>::infinity();
+    schedule.limitAtSoC = limit_at_soc;
+    auto profile =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile, schedule, DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingScheduleNonFiniteValue));
+}
+
+TEST_F(SmartChargingTest, IfV2XFreqWattCurveFrequencyIsInfinity_ThenProfileIsInvalid) {
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    V2XFreqWattPoint point;
+    point.frequency = std::numeric_limits<float>::infinity();
+    point.power = 1000.0f;
+    period.v2xFreqWattCurve = {point};
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A, {period}), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue));
+}
+
+TEST_F(SmartChargingTest, IfV2XSignalWattCurvePowerIsNaN_ThenProfileIsInvalid) {
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    V2XSignalWattPoint point;
+    point.signal = 0;
+    point.power = std::numeric_limits<float>::quiet_NaN();
+    period.v2xSignalWattCurve = {point};
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A, {period}), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue));
 }
 
 TEST_F(SmartChargingTest, K01_ValidateChargingStationMaxProfile_NotChargingStationMaxProfile_Invalid) {


### PR DESCRIPTION
## Describe your changes

SetChargingProfile messages containing float values that overflow to +infinity (e.g. a max-double) are silently persisted as null by nlohmann::json. On the next startup, deserializing null into a numeric field throws an error, resulting in an EVerest crash.

Adds std::isfinite validation across all float fields in ChargingSchedule and ChargingSchedulePeriod for both v16 and v2x, rejecting affected profiles before they reach the database.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

