### PR TITLE
fix(OVMSimulator): prevent OVM simulator from publishing 0V

### DIFF
--- a/config/bringup/config-bringup-ovm-sil.yaml
+++ b/config/bringup/config-bringup-ovm-sil.yaml
@@ -13,3 +13,7 @@ active_modules:
         simulate_error_shutdown: true
         simulate_emergency_shutdown: false
         simulate_error_delay: 5
+    connections:
+      power_supply:
+        - module_id: powersupply_dc
+          implementation_id: main

--- a/config/config-sil-dc-consumer-api.yaml
+++ b/config/config-sil-dc-consumer-api.yaml
@@ -119,6 +119,10 @@ active_modules:
       main:
         simulate_emergency_shutdown: false
         simulate_error_delay: 5
+    connections:
+      power_supply:
+        - module_id: powersupply_dc
+          implementation_id: main
   ev_manager:
     module: EvManager
     config_module:

--- a/config/config-sil-dc-rpcapi.yaml
+++ b/config/config-sil-dc-rpcapi.yaml
@@ -69,6 +69,10 @@ active_modules:
       main:
         simulate_emergency_shutdown: false
         simulate_error_delay: 5
+    connections:
+      power_supply:
+        - module_id: powersupply_dc
+          implementation_id: main
   ev_manager:
     module: EvManager
     config_module:

--- a/config/config-sil-dc.yaml
+++ b/config/config-sil-dc.yaml
@@ -67,6 +67,10 @@ active_modules:
       main:
         simulate_emergency_shutdown: false
         simulate_error_delay: 5
+    connections:
+      power_supply:
+        - module_id: powersupply_dc
+          implementation_id: main
   ev_manager:
     module: EvManager
     config_module:

--- a/modules/Simulation/OVMSimulator/OVMSimulator.hpp
+++ b/modules/Simulation/OVMSimulator/OVMSimulator.hpp
@@ -13,6 +13,9 @@
 // headers for provided interface implementations
 #include <generated/interfaces/over_voltage_monitor/Implementation.hpp>
 
+// headers for required interface implementations
+#include <generated/interfaces/power_supply_DC/Interface.hpp>
+
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
@@ -25,11 +28,17 @@ class OVMSimulator : public Everest::ModuleBase {
 public:
     OVMSimulator() = delete;
     OVMSimulator(const ModuleInfo& info, Everest::MqttProvider& mqtt_provider,
-                 std::unique_ptr<over_voltage_monitorImplBase> p_main, Conf& config) :
-        ModuleBase(info), mqtt(mqtt_provider), p_main(std::move(p_main)), config(config){};
+                 std::unique_ptr<over_voltage_monitorImplBase> p_main,
+                 std::vector<std::unique_ptr<power_supply_DCIntf>> r_power_supply, Conf& config) :
+        ModuleBase(info),
+        mqtt(mqtt_provider),
+        p_main(std::move(p_main)),
+        r_power_supply(std::move(r_power_supply)),
+        config(config){};
 
     Everest::MqttProvider& mqtt;
     const std::unique_ptr<over_voltage_monitorImplBase> p_main;
+    const std::vector<std::unique_ptr<power_supply_DCIntf>> r_power_supply;
     const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1

--- a/modules/Simulation/OVMSimulator/main/over_voltage_monitorImpl.cpp
+++ b/modules/Simulation/OVMSimulator/main/over_voltage_monitorImpl.cpp
@@ -26,6 +26,12 @@ void over_voltage_monitorImpl::init() {
 }
 
 void over_voltage_monitorImpl::ready() {
+    if (!this->mod->r_power_supply.empty() && this->mod->r_power_supply[0]) {
+        this->mod->r_power_supply[0]->subscribe_voltage_current(
+            [this](types::power_supply_DC::VoltageCurrent measurement) {
+                this->voltage_measurement_V = static_cast<float>(measurement.voltage_V);
+            });
+    }
 }
 
 void over_voltage_monitorImpl::handle_set_limits(double& emergency_over_voltage_limit_V,

--- a/modules/Simulation/OVMSimulator/manifest.yaml
+++ b/modules/Simulation/OVMSimulator/manifest.yaml
@@ -16,6 +16,11 @@ provides:
         description: Simulate over voltage error N seconds after start of charging
         type: integer
         default: 5
+requires:
+  power_supply:
+    interface: power_supply_DC
+    min_connections: 0
+    max_connections: 1
 enable_external_mqtt: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
## Describe your changes
    
This bugfix is required because otherwise DC SIL aborts after a few seconds
with evse_manager/VoltagePlausibilityFault, triggered by inconsistent
measurement values published by the simulation modules (OVM vs PSU).
    
Summary:

- Wire OVMSimulator to power_supply_DC and forward PSU voltage as OVM
   measurement to keep values consistent for the plausibility check.
- Add the required interface and update SIL DC configs to connect OVM to
   powersupply_dc.

## Issue ticket number and link

[Issue 2074](https://github.com/EVerest/EVerest/issues/2074)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

