### PR TITLE
feat(libiso15118): use portable network byte-order APIs instead of endian.h (#1851)

### DIFF
--- a/lib/everest/iso15118/README.md
+++ b/lib/everest/iso15118/README.md
@@ -37,14 +37,14 @@ ISO 15118 Support
 ISO15118 support is distributed accross multiple repositories and modules in EVerest. Please see the following references of other ISO15118 related development:
 
 - Some functionality of part 2 of ISO 15118 is integrated in the
-  [EvseManager module in the EVerest repository](https://github.com/EVerest/EVerest/tree/main/modules/EvseManager).
+  [EvseManager module in the EVerest repository](https://github.com/EVerest/EVerest/tree/main/modules/EVSE/EvseManager).
 - Current development for an EXI code generator (as used in the
   ISO 15118 protocol suite) is ongoing in the
   [cbexigen repository](https://github.com/EVerest/cbexigen).
 - The [repository libSlac](https://github.com/EVerest/libslac) contains
   definitions of SLAC messages that are used for ISO 15118 communication.
 - DIN70121 & ISO15118-2 functionality can be found in
-  [EVerest module EvseV2G](https://github.com/EVerest/EVerest/tree/main/modules/EvseV2G)
+  [EVerest module EvseV2G](https://github.com/EVerest/EVerest/tree/main/modules/EVSE/EvseV2G)
 
 Dependencies
 ------------

--- a/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
@@ -8,7 +8,7 @@
 #include <cstring>
 #include <thread>
 
-#include <endian.h>
+#include <arpa/inet.h>
 #include <unistd.h>
 
 #include <iso15118/detail/helper.hpp>
@@ -36,7 +36,7 @@ ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& 
     }
 
     // before bind, set the port
-    address.sin6_port = htobe16(end_point.port);
+    address.sin6_port = htons(end_point.port);
 
     int optval_tmp{1};
     const auto set_reuseaddr = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp));

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <vector>
 
+#include <arpa/inet.h>
 #include <sys/socket.h>
 
 #include <openssl/bio.h>
@@ -341,7 +342,7 @@ ConnectionSSL::ConnectionSSL(PollManager& poll_manager_, const std::string& inte
     }
 
     // before bind, set the port
-    address.sin6_port = htobe16(end_point.port);
+    address.sin6_port = htons(end_point.port);
 
     int optval_tmp{1};
     const auto set_reuseaddr = setsockopt(ssl->fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp));

--- a/lib/everest/iso15118/src/iso15118/io/sdp_packet.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/sdp_packet.cpp
@@ -6,7 +6,7 @@
 #include <cstring>
 #include <limits>
 
-#include <endian.h>
+#include <arpa/inet.h>
 
 namespace iso15118::io {
 
@@ -14,7 +14,7 @@ v2gtp::PayloadType SdpPacket::get_payload_type() const {
     uint16_t tmp;
     std::memcpy(&tmp, buffer + 2, sizeof(tmp));
 
-    return static_cast<v2gtp::PayloadType>(be16toh(tmp));
+    return static_cast<v2gtp::PayloadType>(ntohs(tmp));
 }
 
 size_t SdpPacket::get_remaining_bytes_to_read() const {
@@ -55,7 +55,7 @@ void SdpPacket::parse_header() {
     std::memcpy(&tmp, buffer + 4, sizeof(tmp));
 
     // check if length would overflow
-    const auto len_in_buffer = be32toh(tmp);
+    const auto len_in_buffer = ntohl(tmp);
     if (len_in_buffer > std::numeric_limits<uint32_t>::max() - V2GTP_HEADER_SIZE) {
         state = State::INVALID_HEADER;
         return;

--- a/lib/everest/iso15118/src/iso15118/io/sdp_server.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/sdp_server.cpp
@@ -4,7 +4,6 @@
 
 #include <cstring>
 
-#include <endian.h>
 #include <netdb.h>
 #include <unistd.h>
 
@@ -49,7 +48,7 @@ SdpServer::SdpServer(const std::string& interface_name) {
     struct sockaddr_in6 socket_address;
     bzero(&socket_address, sizeof(socket_address));
     socket_address.sin6_family = AF_INET6;
-    socket_address.sin6_port = htobe16(v2gtp::SDP_SERVER_PORT);
+    socket_address.sin6_port = htons(v2gtp::SDP_SERVER_PORT);
     memcpy(&socket_address.sin6_addr, &in6addr_any, sizeof(socket_address.sin6_addr));
 
     char addr_res[INET6_ADDRSTRLEN];
@@ -152,7 +151,7 @@ void SdpServer::send_response(const PeerRequestContext& request, const Ipv6EndPo
     uint8_t* sdp_response = v2g_packet + 8;
     memcpy(sdp_response, ipv6_endpoint.address, sizeof(ipv6_endpoint.address));
 
-    uint16_t port = htobe16(ipv6_endpoint.port);
+    uint16_t port = htons(ipv6_endpoint.port);
     memcpy(sdp_response + 16, &port, sizeof(port));
 
     // FIXME (aw): which values to take here?

--- a/lib/everest/iso15118/src/iso15118/session/iso.cpp
+++ b/lib/everest/iso15118/src/iso15118/session/iso.cpp
@@ -7,7 +7,7 @@
 #include <cstring>
 #include <thread>
 
-#include <endian.h>
+#include <arpa/inet.h>
 
 #include <iso15118/d20/state/supported_app_protocol.hpp>
 
@@ -110,11 +110,11 @@ static size_t setup_response_header(uint8_t* buffer, iso15118::io::v2gtp::Payloa
     buffer[1] = iso15118::io::SDP_INVERSE_PROTOCOL_VERSION;
 
     const uint16_t response_payload_type =
-        htobe16(static_cast<std::underlying_type_t<iso15118::io::v2gtp::PayloadType>>(payload_type));
+        htons(static_cast<std::underlying_type_t<iso15118::io::v2gtp::PayloadType>>(payload_type));
 
     std::memcpy(buffer + 2, &response_payload_type, sizeof(response_payload_type));
 
-    const uint32_t tmp32 = htobe32(size);
+    const uint32_t tmp32 = htonl(size);
 
     std::memcpy(buffer + 4, &tmp32, sizeof(tmp32));
 


### PR DESCRIPTION
<endian.h> is not portable and is effectively Linux/glibc-oriented. This works for macOS and MCUs with TCP/IP stacks as well now.

The change is a portability swap, not a behavior change. Before, the code used Linux-style endian helpers. Those APIs are not reliably available on macOS. I replaced them with the standard socket byte-order APIs from <arpa/inet.h>:

- `htons` instead of `htobe16`
- `htonl` instead of `htobe32`
- `ntohs` instead of `be16toh`
- `ntohl` instead of `be32toh`

The protocol fields being encoded here are network-order fields, network byte order is big-endian & htons/htonl and ntohs/ntohl are specifically defined for host-to-network and network-to-host conversion.

Let's see if the tests pass now.