### PR TITLE
fix(libiso15118): rename misnomer EMPTY (#1851)

### DIFF
--- a/lib/everest/iso15118/include/iso15118/io/sdp_packet.hpp
+++ b/lib/everest/iso15118/include/iso15118/io/sdp_packet.hpp
@@ -18,13 +18,13 @@ class SdpPacket {
 public:
     static constexpr auto V2GTP_HEADER_SIZE = 8;
     enum class State {
-        EMPTY, // FIXME (aw): misnomer
+        BUFFER_EMPTY,
         HEADER_READ,
         COMPLETE,
 
         // failed states
         INVALID_HEADER,
-        PAYLOAD_TO_LONG,
+        PAYLOAD_TOO_LONG,
     };
 
     auto get_state() const {
@@ -64,7 +64,7 @@ public:
 private:
     void parse_header();
 
-    State state{State::EMPTY};
+    State state{State::BUFFER_EMPTY};
     uint8_t buffer[2048];
     size_t bytes_read{0};
     size_t length; // length includes V2GTP_HEADER_SIZE

--- a/lib/everest/iso15118/src/iso15118/io/sdp_packet.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/sdp_packet.cpp
@@ -19,7 +19,7 @@ v2gtp::PayloadType SdpPacket::get_payload_type() const {
 
 size_t SdpPacket::get_remaining_bytes_to_read() const {
     switch (state) {
-    case State::EMPTY:
+    case State::BUFFER_EMPTY:
         return V2GTP_HEADER_SIZE - bytes_read;
     case State::HEADER_READ:
         return length - bytes_read;
@@ -29,14 +29,14 @@ size_t SdpPacket::get_remaining_bytes_to_read() const {
 }
 
 void SdpPacket::update_read_bytes(size_t len) {
-    if ((state == State::COMPLETE) or (state == State::INVALID_HEADER) or (state == State::PAYLOAD_TO_LONG)) {
+    if ((state == State::COMPLETE) or (state == State::INVALID_HEADER) or (state == State::PAYLOAD_TOO_LONG)) {
         // nothing to do here - should also not happen, right?
         return;
     }
 
     bytes_read += len;
 
-    if ((state == State::EMPTY) and (bytes_read == V2GTP_HEADER_SIZE)) {
+    if ((state == State::BUFFER_EMPTY) and (bytes_read == V2GTP_HEADER_SIZE)) {
         parse_header();
     }
 
@@ -64,7 +64,7 @@ void SdpPacket::parse_header() {
     length = len_in_buffer + V2GTP_HEADER_SIZE;
 
     if (length > sizeof(buffer)) {
-        state = State::PAYLOAD_TO_LONG;
+        state = State::PAYLOAD_TOO_LONG;
         return;
     }
 

--- a/lib/everest/iso15118/src/iso15118/session/iso.cpp
+++ b/lib/everest/iso15118/src/iso15118/session/iso.cpp
@@ -47,7 +47,7 @@ void raise_invalid_packet_state(const io::SdpPacket& sdp_packet) {
     case PacketState::INVALID_HEADER:
         error += "invalid sdp packet header";
         break;
-    case PacketState::PAYLOAD_TO_LONG:
+    case PacketState::PAYLOAD_TOO_LONG:
         error += "packet too large for buffer";
         break;
     default:
@@ -64,7 +64,7 @@ bool read_single_sdp_packet(io::IConnection& connection, io::SdpPacket& sdp_pack
     //            main problem is, that it combines too much logic of the sdp packet and io related stuff
     using PacketState = io::SdpPacket::State;
 
-    assert(sdp_packet.get_state() == PacketState::EMPTY || sdp_packet.get_state() == PacketState::HEADER_READ);
+    assert(sdp_packet.get_state() == PacketState::BUFFER_EMPTY || sdp_packet.get_state() == PacketState::HEADER_READ);
 
     const auto first_try =
         connection.read(sdp_packet.get_current_buffer_pos(), sdp_packet.get_remaining_bytes_to_read());


### PR DESCRIPTION
Enum members with names like EMPTY, ERROR, SUCCESS, NONE are common macro collision targets on embedded and legacy platforms, we just hit it on Zephyr MCU compilation:

```
*** [.pio/build/nucleo_h723zg/libiso15118_session/iso.cpp.o] Error 1
In file included from lib/everest/libiso15118/include/iso15118/session/iso.hpp:18,
                 from src/iso15118_runtime/tbd_controller_port.hpp:9,
                 from src/iso15118_runtime/secc_runtime.hpp:10,
                 from src/everest_slac_runner.cpp:25:
lib/everest/libiso15118/include/iso15118/io/sdp_packet.hpp:23:14: error: expected identifier before ',' token
   23 |         EMPTY, // FIXME (aw): misnomer
      |              ^
lib/everest/libiso15118/include/iso15118/io/sdp_packet.hpp:71:29: error: expected unqualified-id before '}' token
   71 |     State state{State::EMPTY};
      |                             ^
lib/everest/libiso15118/include/iso15118/io/sdp_packet.hpp:71:29: error: cannot convert '<brace-enclosed initializer list>' to 'iso15118::io::SdpPacket::State' in initialization
```