### PR TITLE
certificate sign request - according to ISO 15118-2:2014 page 315 tab…

### DIFF
--- a/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
+++ b/lib/everest/evse_security/lib/evse_security/crypto/openssl/openssl_crypto_supplier.cpp
@@ -725,7 +725,7 @@ CertificateSignRequestResult OpenSSLSupplier::x509_generate_csr(const Certificat
 
     STACK_OF(X509_EXTENSION)* extensions = sk_X509_EXTENSION_new_null();
     X509_EXTENSION* ext_key_usage =
-        X509V3_EXT_conf_nid(nullptr, nullptr, NID_key_usage, "digitalSignature, keyAgreement");
+        X509V3_EXT_conf_nid(nullptr, nullptr, NID_key_usage, "critical, digitalSignature, keyAgreement");
     X509_EXTENSION* ext_basic_constraints =
         X509V3_EXT_conf_nid(nullptr, nullptr, NID_basic_constraints, "critical,CA:false");
     sk_X509_EXTENSION_push(extensions, ext_key_usage);


### PR DESCRIPTION
certificate sign request - according to ISO 15118-2:2014 page 315 table F.2 the certificate keyusage must be critical

## Describe your changes
change keyusage for certificate generation to critical

the issue with keyusge = non-critical was identified during Hubject PnC Pre-Certification tests

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

