### PR TITLE
fix(ocpp16): fall back to DB for FinalCost arriving after StopTransaction.conf

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v16/database_handler.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/database_handler.hpp
@@ -73,6 +73,9 @@ public:
     /// table
     void update_transaction_csms_ack(const std::int32_t transaction_id);
 
+    /// \brief Returns the TransactionEntry for the given \p transaction_id, or std::nullopt if not found.
+    std::optional<TransactionEntry> get_transaction(const std::int32_t transaction_id);
+
     /// \brief Updates the START_TRANSACTION_MESSAGE_ID column for the transaction with the given \p session_id in the
     /// TRANSACTIONS table
     void update_start_transaction_message_id(const std::string& session_id,

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -3380,22 +3380,26 @@ DataTransferResponse ChargePointImpl::handle_set_session_cost(const RunningCostS
 
     const std::int32_t connector_id =
         this->transaction_handler->get_connector_from_transaction_id(std::stoi(cost.transaction_id));
-    std::string session_id = cost.transaction_id;
-    if (connector_id == -1) {
-        EVLOG_warning << "Set session cost failed: Could not set session id because transaction with transaction id "
-                      << cost.transaction_id << " is not found.";
-        return response;
-    }
 
-    const std::shared_ptr<Connector> connector = this->connectors.at(connector_id);
-    const std::shared_ptr<Transaction> transaction = this->transaction_handler->get_transaction(connector_id);
-    if (transaction == nullptr) {
-        EVLOG_warning << "Set session cost failed: Could not set session id because transaction with transaction id "
-                      << cost.transaction_id << " for connector " << connector_id << " is not found.";
-        return response;
-    }
+    std::string session_id;
+    std::shared_ptr<Connector> connector = nullptr;
 
-    session_id = transaction->get_session_id();
+    const auto transaction = (connector_id != -1) ? this->transaction_handler->get_transaction(connector_id) : nullptr;
+    if (transaction != nullptr) {
+        session_id = transaction->get_session_id();
+        connector = this->connectors.at(connector_id);
+    } else {
+        // Transaction is no longer in memory (FinalCost arrived after StopTransaction.conf).
+        // Fall back to the database, which durably stores the full transaction entry.
+        const auto db_entry = this->database_handler->get_transaction(std::stoi(cost.transaction_id));
+        if (!db_entry.has_value()) {
+            EVLOG_warning << "Set session cost failed: Could not find session_id for transaction_id "
+                          << cost.transaction_id << " in memory or database.";
+            return response;
+        }
+        session_id = db_entry.value().session_id;
+        connector = this->connectors.at(db_entry.value().connector);
+    }
 
     cost.transaction_id = session_id;
     cost.state = type;

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -3386,22 +3386,26 @@ DataTransferResponse ChargePointImpl::handle_set_session_cost(const RunningCostS
 
     const std::int32_t connector_id =
         this->transaction_handler->get_connector_from_transaction_id(std::stoi(cost.transaction_id));
-    std::string session_id = cost.transaction_id;
-    if (connector_id == -1) {
-        EVLOG_warning << "Set session cost failed: Could not set session id because transaction with transaction id "
-                      << cost.transaction_id << " is not found.";
-        return response;
-    }
 
-    const std::shared_ptr<Connector> connector = this->connectors.at(connector_id);
-    const std::shared_ptr<Transaction> transaction = this->transaction_handler->get_transaction(connector_id);
-    if (transaction == nullptr) {
-        EVLOG_warning << "Set session cost failed: Could not set session id because transaction with transaction id "
-                      << cost.transaction_id << " for connector " << connector_id << " is not found.";
-        return response;
-    }
+    std::string session_id;
+    std::shared_ptr<Connector> connector = nullptr;
 
-    session_id = transaction->get_session_id();
+    const auto transaction = (connector_id != -1) ? this->transaction_handler->get_transaction(connector_id) : nullptr;
+    if (transaction != nullptr) {
+        session_id = transaction->get_session_id();
+        connector = this->connectors.at(connector_id);
+    } else {
+        // Transaction is no longer in memory (FinalCost arrived after StopTransaction.conf).
+        // Fall back to the database, which durably stores the full transaction entry.
+        const auto db_entry = this->database_handler->get_transaction(std::stoi(cost.transaction_id));
+        if (!db_entry.has_value()) {
+            EVLOG_warning << "Set session cost failed: Could not find session_id for transaction_id "
+                          << cost.transaction_id << " in memory or database.";
+            return response;
+        }
+        session_id = db_entry.value().session_id;
+        connector = this->connectors.at(db_entry.value().connector);
+    }
 
     cost.transaction_id = session_id;
     cost.state = type;

--- a/lib/everest/ocpp/lib/ocpp/v16/database_handler.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/database_handler.cpp
@@ -141,6 +141,49 @@ void DatabaseHandler::update_transaction_csms_ack(const std::int32_t transaction
     }
 }
 
+std::optional<TransactionEntry> DatabaseHandler::get_transaction(const std::int32_t transaction_id) {
+    const std::string sql = "SELECT * FROM TRANSACTIONS WHERE TRANSACTION_ID==@transaction_id";
+    auto stmt = this->database->new_statement(sql);
+    stmt->bind_int("@transaction_id", transaction_id);
+    if (stmt->step() != SQLITE_ROW) {
+        return std::nullopt;
+    }
+    TransactionEntry entry;
+    entry.session_id = stmt->column_text(0);
+    entry.transaction_id = stmt->column_int(1);
+    entry.connector = stmt->column_int(2);
+    entry.id_tag_start = stmt->column_text(3);
+    entry.time_start = stmt->column_text(4);
+    entry.meter_start = stmt->column_int(5);
+    entry.csms_ack = bool(stmt->column_int(6));
+    entry.meter_last = stmt->column_int(7);
+    entry.meter_last_time = stmt->column_text(8);
+    entry.last_update = stmt->column_text(9);
+    if (stmt->column_type(10) != SQLITE_NULL) {
+        entry.reservation_id.emplace(stmt->column_int(10));
+    }
+    if (stmt->column_type(11) != SQLITE_NULL) {
+        entry.parent_id_tag.emplace(stmt->column_text(11));
+    }
+    if (stmt->column_type(12) != SQLITE_NULL) {
+        entry.id_tag_end.emplace(stmt->column_text(12));
+    }
+    if (stmt->column_type(13) != SQLITE_NULL) {
+        entry.time_end.emplace(stmt->column_text(13));
+    }
+    if (stmt->column_type(14) != SQLITE_NULL) {
+        entry.meter_stop.emplace(stmt->column_int(14));
+    }
+    if (stmt->column_type(15) != SQLITE_NULL) {
+        entry.stop_reason.emplace(stmt->column_text(15));
+    }
+    entry.start_transaction_message_id = stmt->column_text(16);
+    if (stmt->column_type(17) != SQLITE_NULL) {
+        entry.stop_transaction_message_id = stmt->column_text(17);
+    }
+    return entry;
+}
+
 void DatabaseHandler::update_start_transaction_message_id(const std::string& /*session_id*/,
                                                           const std::string& start_transaction_message_id) {
     const std::string sql = "UPDATE TRANSACTIONS SET START_TRANSACTION_MESSAGE_ID=@start_transaction_message_id, "

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/database_tests.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/database_tests.cpp
@@ -310,6 +310,25 @@ TEST_F(DatabaseTest, test_insert_and_get_transaction_without_id_tag) {
     ASSERT_FALSE(transaction.id_tag_end);
 }
 
+TEST_F(DatabaseTest, test_get_transaction_by_id_found) {
+    this->db_handler->insert_transaction("session-abc", 42, 1, "RFID1", "2022-08-18T09:42:41", 0, false, std::nullopt,
+                                         "msg-1");
+
+    const auto entry = this->db_handler->get_transaction(42);
+
+    ASSERT_TRUE(entry.has_value());
+    ASSERT_EQ(entry->session_id, "session-abc");
+    ASSERT_EQ(entry->transaction_id, 42);
+    ASSERT_EQ(entry->connector, 1);
+}
+
+TEST_F(DatabaseTest, test_get_transaction_by_id_not_found) {
+    // No transaction inserted — unknown transaction_id must return nullopt.
+    const auto entry = this->db_handler->get_transaction(99999);
+
+    ASSERT_EQ(entry, std::nullopt);
+}
+
 TEST_F(DatabaseTest, test_insert_and_get_profiles) {
     // TODO enable again on fixing https://github.com/EVerest/libocpp/issues/384
     GTEST_SKIP() << "validFrom/validTo checks are failing. See https://github.com/EVerest/libocpp/issues/384";

--- a/tests/ocpp_tests/test_sets/ocpp16/california_pricing_ocpp16.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/california_pricing_ocpp16.py
@@ -422,6 +422,69 @@ class TestOcpp16CostAndPrice:
     @pytest.mark.probe_module
     @pytest.mark.everest_config_adaptions(ProbeModuleCostAndPriceSessionCostConfigurationAdjustment())
     @pytest.mark.asyncio
+    async def test_cost_and_price_final_cost_after_transaction(self, test_config: OcppTestConfiguration,
+                                                               test_utility: TestUtility,
+                                                               test_controller: TestController, probe_module,
+                                                               central_system: CentralSystem):
+        """
+        FinalCost arrives after StopTransaction.req and StopTransaction.conf have both been
+        processed and the session_cost callback must still be invoked correctly.
+        """
+        logging.info("######### test_cost_and_price_final_cost_after_transaction #########")
+
+        session_cost_mock = Mock()
+        probe_module.subscribe_variable("session_cost", "session_cost", session_cost_mock)
+
+        probe_module.start()
+        await probe_module.wait_to_be_ready()
+
+        chargepoint_with_pm = await central_system.wait_for_chargepoint()
+
+        # Start a transaction.
+        await self.start_transaction(test_controller, test_utility, chargepoint_with_pm, test_config)
+
+        # Stop the transaction by unplugging.
+        test_controller.plug_out()
+
+        # Wait for StopTransaction.req and connector to become available
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StopTransaction", {})
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "StatusNotification",
+                                           call.StatusNotification(1, ChargePointErrorCode.no_error,
+                                                                   ChargePointStatus.available))
+
+        # Send FinalCost after the transaction is gone from memory.
+        await chargepoint_with_pm.data_transfer_req(vendor_id="org.openchargealliance.costmsg",
+                                                    message_id="FinalCost",
+                                                    data=json.dumps(self.final_cost_data))
+
+        # Validate FinalCost can be processed successfully
+        assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "DataTransfer",
+                                           call_result.DataTransfer(DataTransferStatus.accepted), timeout=5)
+
+        received_data = {'cost_chunks': [{'cost': {'value': 33100}}], 'currency': {'decimals': 4}, 'message': [{
+            'content': 'GBP 2.81 @ 0.12/kWh, GBP 0.50 @ 1/h, TOTAL KWH: 23.4 TIME: 03.50 COST: GBP 3.31. '
+                       'Visit www.cpo.com/invoices/13546 for an invoice of your session.'},
+            {
+                'content': '€2.81 @ €0.12/kWh, €0.50 @ €1/h, TOTAL KWH: 23.4 TIME: 03.50 COST: €3.31. '
+                           'Bezoek www.cpo.com/invoices/13546 voor een factuur van uw laadsessie.',
+                'format': 'UTF8',
+                'language': 'nl'},
+            {
+                'content': '€2,81 @ €0,12/kWh, €0,50 @ €1/h, GESAMT-KWH: 23,4 ZEIT: 03:50 KOSTEN: €3,31. '
+                           'Besuchen Sie www.cpo.com/invoices/13546 um eine Rechnung für Ihren Ladevorgang zu erhalten.',
+                'format': 'UTF8',
+                'language': 'de'}],
+            'qr_code': 'https://www.cpo.com/invoices/13546', 'session_id': ANY, 'status': 'Finished'}
+
+        # The session_cost callback must be invoked with the correct data.
+        await self.await_mock_called(session_cost_mock)
+        assert session_cost_mock.call_count == 1
+        session_cost_mock.assert_called_once_with(received_data)
+
+    @pytest.mark.everest_core_config(get_everest_config_path_str('everest-config-ocpp16-costandprice.yaml'))
+    @pytest.mark.probe_module
+    @pytest.mark.everest_config_adaptions(ProbeModuleCostAndPriceSessionCostConfigurationAdjustment())
+    @pytest.mark.asyncio
     async def test_cost_and_price_running_cost(self, test_config: OcppTestConfiguration,
                                                test_controller: TestController,
                                                test_utility: TestUtility, probe_module,


### PR DESCRIPTION

## Describe your changes

When the in-memory transaction is gone, look up the TransactionEntry via the new DatabaseHandler::get_transaction(transaction_id) to recover both session_id and connector for the session_cost_callback

Figure 3 from California Whitepaper shows that FinalCost arrives after `StopTransaction.req/conf`

<img width="2290" height="1512" alt="image" src="https://github.com/user-attachments/assets/2efe2188-3fce-48af-9c31-968a888b7610" />


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

