### PR TITLE
docs(github): Update issue templates for mono-repository structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,49 +6,69 @@ body:
     id: description
     attributes:
       label: Describe the bug
-      description: A clear and concise description of what the bug is. If applicable, add screenshots or logfiles to help explain your problem.
+      description: A clear and concise description of what the bug is. If applicable, add screenshots or log files to help explain your problem.
     validations:
       required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+
   - type: dropdown
     id: affected-domain
     attributes:
       label: EVerest Domain
-      description: Can you specify a specific domain is affected by the issue? Mark multiple if applicable.
+      description: Which domain is affected by the issue? Mark multiple if applicable.
       options:
         - Authorization
+        - Build System
         - Charge Control
         - CHAdeMO
+        - DIN70121
+        - Documentation
         - Energy Management
+        - Framework
         - Hardware Drivers
-        - ISO15118
-        - Power Supplies
-        - OCPP
-        - OCPP1.6
-        - OCPP2.0.1
+        - ISO 15118-2
+        - ISO 15118-20
+        - OCPP 1.6
+        - OCPP 2.0.1
+        - OCPP 2.1
+        - Security
         - Simulation
         - SLAC
-        - Compilation
-        - Utility
         - Testing
+        - Utilities
         - Other
       multiple: true
     validations:
       required: true
 
   - type: textarea
-    id: affected-module
+    id: affected-component
     attributes:
-      label: Affected EVerest Module
+      label: Affected Component
       description: |
-        Please specify the module where the bug is located. If you are not sure, please leave this field empty.
+        Please specify the component where the bug is located, if known.
+        Examples: a module (e.g. `modules/EnergyManagement`), a library (e.g. `lib/ocpp`, `lib/iso15118`),
+        or an application (e.g. `applications/everest_dev_tool`). Leave empty if unsure.
+
+  - type: input
+    id: version
+    attributes:
+      label: EVerest Version
+      description: Git tag, release version, or commit hash (e.g. `2026.02.0`, `abc1234`).
+      placeholder: e.g. 2026.02.0
 
   - type: textarea
     id: reproduction
     attributes:
       label: To Reproduce
       description: |
-        If applicable describe the steps to and additional information to reproduce the behavior
-        like EVerest configuration files, EVerest version, compile options and your system information.
+        Describe the steps and any additional information needed to reproduce the behavior:
+        EVerest configuration files, compile options, and system information.
 
   - type: textarea
     id: other

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,49 +6,68 @@ body:
     id: description
     attributes:
       label: Describe the bug
-      description: A clear and concise description of what the bug is. If applicable, add screenshots or logfiles to help explain your problem.
+      description: A clear and concise description of what the bug is. If applicable, add screenshots or log files to help explain your problem.
     validations:
       required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+
   - type: dropdown
     id: affected-domain
     attributes:
       label: EVerest Domain
-      description: Can you specify a specific domain is affected by the issue? Mark multiple if applicable.
+      description: Which domain is affected by the issue? Mark multiple if applicable.
       options:
         - Authorization
+        - Build System
         - Charge Control
         - CHAdeMO
+        - Documentation
         - Energy Management
+        - Framework
         - Hardware Drivers
-        - ISO15118
-        - Power Supplies
-        - OCPP
-        - OCPP1.6
-        - OCPP2.0.1
+        - ISO 15118-2
+        - ISO 15118-20
+        - OCPP 1.6
+        - OCPP 2.0.1
+        - OCPP 2.1
+        - Security
         - Simulation
         - SLAC
-        - Compilation
-        - Utility
         - Testing
+        - Utilities
         - Other
       multiple: true
     validations:
       required: true
 
   - type: textarea
-    id: affected-module
+    id: affected-component
     attributes:
-      label: Affected EVerest Module
+      label: Affected Component
       description: |
-        Please specify the module where the bug is located. If you are not sure, please leave this field empty.
+        Please specify the component where the bug is located, if known.
+        Examples: a module (e.g. `modules/EnergyManagement`), a library (e.g. `lib/ocpp`, `lib/iso15118`),
+        or an application (e.g. `applications/everest_dev_tool`). Leave empty if unsure.
+
+  - type: input
+    id: version
+    attributes:
+      label: EVerest Version
+      description: Git tag, release version, or commit hash (e.g. `2026-02.0`, `abc1234`).
+      placeholder: e.g. 2026-02.0
 
   - type: textarea
     id: reproduction
     attributes:
       label: To Reproduce
       description: |
-        If applicable describe the steps to and additional information to reproduce the behavior
-        like EVerest configuration files, EVerest version, compile options and your system information.
+        Describe the steps and any additional information needed to reproduce the behavior:
+        EVerest configuration files, compile options, and system information.
 
   - type: textarea
     id: other

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -26,6 +26,7 @@ body:
         - Build System
         - Charge Control
         - CHAdeMO
+        - DIN70121
         - Documentation
         - Energy Management
         - Framework
@@ -58,8 +59,8 @@ body:
     id: version
     attributes:
       label: EVerest Version
-      description: Git tag, release version, or commit hash (e.g. `2026-02.0`, `abc1234`).
-      placeholder: e.g. 2026-02.0
+      description: Git tag, release version, or commit hash (e.g. `2026.02.0`, `abc1234`).
+      placeholder: e.g. 2026.02.0
 
   - type: textarea
     id: reproduction

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -7,8 +7,7 @@ body:
     attributes:
       label: Describe the problem
       description: What problem is your feature request targeting and why is it a problem? Please describe.
-      placeholder: |
-        A clear and concise description of what the problem is.
+      placeholder: A clear and concise description of what the problem is.
     validations:
       required: true
 
@@ -16,42 +15,53 @@ body:
     id: affected-domain
     attributes:
       label: EVerest Domain
-      description: Can you specify a specific domain for which the feature is requested? Mark multiple if applicable.
+      description: Which domain is this feature request for? Mark multiple if applicable.
       options:
         - Authorization
+        - Build System
         - Charge Control
         - CHAdeMO
+        - DIN70121
+        - Documentation
         - Energy Management
+        - Framework
         - Hardware Drivers
-        - ISO15118
-        - Power Supplies
-        - OCPP
-        - OCPP1.6
-        - OCPP2.0.1
+        - ISO 15118-2
+        - ISO 15118-20
+        - OCPP 1.6
+        - OCPP 2.0.1
+        - OCPP 2.1
+        - Security
         - Simulation
         - SLAC
-        - Compilation
-        - Utility
         - Testing
+        - Utilities
         - Other
       multiple: true
     validations:
       required: true
 
   - type: textarea
-    id: affected-module
+    id: affected-component
     attributes:
-      label: Affected EVerest Module
+      label: Affected Component
       description: |
-        Can you specify a module in which this feature shall be implemented? If you are not sure, please leave this field empty.
+        Can you specify where the feature should be implemented, if known?
+        Examples: a module (e.g. `modules/EnergyManagement`), a library (e.g. `lib/ocpp`, `lib/iso15118`),
+        or an application (e.g. `applications/everest_dev_tool`). Leave empty if unsure.
 
   - type: textarea
     id: solution
     attributes:
       label: Describe your solution
-      description: Describe the solution you'd like
-      placeholder: |
-        A clear and concise description of what you want to happen.
+      description: Describe the solution you'd like.
+      placeholder: A clear and concise description of what you want to happen.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered alternative solutions or workarounds? If so, describe them here.
 
   - type: textarea
     id: other

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -7,8 +7,7 @@ body:
     attributes:
       label: Describe the problem
       description: What problem is your feature request targeting and why is it a problem? Please describe.
-      placeholder: |
-        A clear and concise description of what the problem is.
+      placeholder: A clear and concise description of what the problem is.
     validations:
       required: true
 
@@ -16,42 +15,52 @@ body:
     id: affected-domain
     attributes:
       label: EVerest Domain
-      description: Can you specify a specific domain for which the feature is requested? Mark multiple if applicable.
+      description: Which domain is this feature request for? Mark multiple if applicable.
       options:
         - Authorization
+        - Build System
         - Charge Control
         - CHAdeMO
+        - Documentation
         - Energy Management
+        - Framework
         - Hardware Drivers
-        - ISO15118
-        - Power Supplies
-        - OCPP
-        - OCPP1.6
-        - OCPP2.0.1
+        - ISO 15118-2
+        - ISO 15118-20
+        - OCPP 1.6
+        - OCPP 2.0.1
+        - OCPP 2.1
+        - Security
         - Simulation
         - SLAC
-        - Compilation
-        - Utility
         - Testing
+        - Utilities
         - Other
       multiple: true
     validations:
       required: true
 
   - type: textarea
-    id: affected-module
+    id: affected-component
     attributes:
-      label: Affected EVerest Module
+      label: Affected Component
       description: |
-        Can you specify a module in which this feature shall be implemented? If you are not sure, please leave this field empty.
+        Can you specify where the feature should be implemented, if known?
+        Examples: a module (e.g. `modules/EnergyManagement`), a library (e.g. `lib/ocpp`, `lib/iso15118`),
+        or an application (e.g. `applications/everest_dev_tool`). Leave empty if unsure.
 
   - type: textarea
     id: solution
     attributes:
       label: Describe your solution
-      description: Describe the solution you'd like
-      placeholder: |
-        A clear and concise description of what you want to happen.
+      description: Describe the solution you'd like.
+      placeholder: A clear and concise description of what you want to happen.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered alternative solutions or workarounds? If so, describe them here.
 
   - type: textarea
     id: other

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -21,6 +21,7 @@ body:
         - Build System
         - Charge Control
         - CHAdeMO
+        - DIN70121
         - Documentation
         - Energy Management
         - Framework


### PR DESCRIPTION

## Describe your changes

The issue templates were kind of outdated in the new mono repository structure.

Update issue templates for mono-repository structure. Added additional domains and allow contributor to specify components inlcuding libraries and tools instead of just modules:

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

