### PR TITLE
[Backport stable/2026.02] fix(framework): ensure clean module shutdown on init exceptions (#2144)

### DIFF
--- a/lib/everest/framework/lib/message_handler.cpp
+++ b/lib/everest/framework/lib/message_handler.cpp
@@ -202,7 +202,7 @@ void MessageHandler::run_operation_dispatcher() {
         dispatch_operation_message(std::move(message.value()));
     }
 
-    EVLOG_info << "Operation dispatcher thread stopped";
+    EVLOG_debug << "Operation dispatcher thread stopped";
 }
 
 void MessageHandler::dispatch_operation_message(ParsedMessage&& message) {
@@ -276,14 +276,14 @@ void MessageHandler::run_result_message_worker() {
     while (auto message = result_message_queue.wait_and_pop()) {
         handle_result_message(message->topic, message->data);
     }
-    EVLOG_info << "Cmd result worker thread stopped";
+    EVLOG_debug << "Cmd result worker thread stopped";
 }
 
 void MessageHandler::run_external_mqtt_worker() {
     while (auto message = external_mqtt_message_queue.wait_and_pop()) {
         handle_external_mqtt_message(message->topic, message->data);
     }
-    EVLOG_info << "External MQTT worker thread stopped";
+    EVLOG_debug << "External MQTT worker thread stopped";
 }
 
 void MessageHandler::handle_operation_message(const std::string& topic, const json& payload) {

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -83,9 +83,8 @@ MQTTAbstractionImpl::MQTTAbstractionImpl(const std::string& mqtt_server_socket_p
 }
 
 MQTTAbstractionImpl::~MQTTAbstractionImpl() {
-    // FIXME (aw): verify that disconnecting is thread-safe!
-    if (this->mqtt_is_connected) {
-        disconnect();
+    if (this->running.load()) {
+        this->disconnect();
     }
     // this->mqtt_mainloop_thread.join();
 }

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -83,7 +83,7 @@ MQTTAbstractionImpl::MQTTAbstractionImpl(const std::string& mqtt_server_socket_p
 }
 
 MQTTAbstractionImpl::~MQTTAbstractionImpl() {
-    if (this->running.load()) {
+    if (this->mqtt_is_connected) {
         this->disconnect();
     }
     // this->mqtt_mainloop_thread.join();

--- a/lib/everest/framework/lib/runtime.cpp
+++ b/lib/everest/framework/lib/runtime.cpp
@@ -467,6 +467,16 @@ int ModuleLoader::initialize() {
     }
 
     const auto& rs = this->runtime_settings;
+    const auto shutdown_mqtt = [this]() {
+        if (this->mqtt) {
+            try {
+                this->mqtt->disconnect();
+            } catch (const std::exception& e) {
+                EVLOG_critical << fmt::format("MQTT disconnect in exception path failed: {}", e.what());
+            }
+        }
+    };
+
     try {
         const auto config = Config(this->mqtt_settings, result);
         const auto config_instantiation_time = std::chrono::system_clock::now();
@@ -615,11 +625,15 @@ int ModuleLoader::initialize() {
         EVLOG_info << "Exiting...";
     } catch (boost::exception& e) {
         EVLOG_critical << fmt::format("Caught top level boost::exception:\n{}", boost::diagnostic_information(e, true));
+        shutdown_mqtt();
+        return EXIT_FAILURE;
     } catch (std::exception& e) {
         EVLOG_critical << fmt::format("Caught top level std::exception:\n{}", boost::diagnostic_information(e, true));
+        shutdown_mqtt();
+        return EXIT_FAILURE;
     }
 
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays): pass-through of argc and argv from main()


### PR DESCRIPTION
# Description

Backport of https://github.com/EVerest/EVerest/pull/2144 to stable/2026.02.
