### PR TITLE
test(tls): drop NUL terminator in base64_decode test inputs

### DIFF
--- a/lib/everest/tls/include/everest/tls/openssl_util.hpp
+++ b/lib/everest/tls/include/everest/tls/openssl_util.hpp
@@ -263,6 +263,9 @@ bool sha_512(const void* data, std::size_t len, sha_512_digest_t& digest);
  * \param[in] text the base64 string (does not need to be \0 terminated)
  * \param[in] len the length of the string (excluding any terminating \0)
  * \return binary array or empty on error
+ * \note tolerates stray '\0', '\t', '\n', '\v', '\f', '\r', ' ' (matching
+ *       EVP_Decode*'s B64_WS set); other non-alphabet bytes cause the
+ *       underlying BIO_f_base64 to fail and an empty vector is returned.
  */
 std::vector<std::uint8_t> base64_decode(const char* text, std::size_t len);
 

--- a/lib/everest/tls/include/everest/tls/openssl_util.hpp
+++ b/lib/everest/tls/include/everest/tls/openssl_util.hpp
@@ -263,6 +263,11 @@ bool sha_512(const void* data, std::size_t len, sha_512_digest_t& digest);
  * \param[in] text the base64 string (does not need to be \0 terminated)
  * \param[in] len the length of the string (excluding any terminating \0)
  * \return binary array or empty on error
+ * \note tolerates stray '\t', '\n', '\v', '\f', '\r', ' ' (matching
+ *       EVP_Decode*'s B64_WS set); other non-alphabet bytes cause the
+ *       underlying BIO_f_base64 to fail and an empty vector is returned.
+ *       An embedded '\0' terminates the scan: anything past the first
+ *       '\0' is ignored.
  */
 std::vector<std::uint8_t> base64_decode(const char* text, std::size_t len);
 

--- a/lib/everest/tls/src/openssl_util.cpp
+++ b/lib/everest/tls/src/openssl_util.cpp
@@ -319,14 +319,25 @@ std::vector<std::uint8_t> base64_decode(const char* text, std::size_t len) {
     assert(text != nullptr);
     assert(len > 0);
 
-    // remove \n
+    // Strip whitespace + NUL; pass everything else to BIO_f_base64.
+    // Byte set matches EVP_Decode*'s B64_WS table so this stays drop-in
+    // equivalent to the evse_security path (consolidation target).
     auto input = std::make_unique<std::uint8_t[]>(len);
     std::size_t input_len{0};
 
     for (std::size_t i = 0; i < len; i++) {
         const auto item = text[i];
-        if (item != '\n') {
-            input.get()[input_len++] = item;
+        switch (item) {
+        case '\0':
+        case '\t':
+        case '\n':
+        case '\v':
+        case '\f':
+        case '\r':
+        case ' ':
+            continue;
+        default:
+            input.get()[input_len++] = static_cast<std::uint8_t>(item);
         }
     }
 

--- a/lib/everest/tls/src/openssl_util.cpp
+++ b/lib/everest/tls/src/openssl_util.cpp
@@ -316,8 +316,9 @@ bool sha_512(const void* data, std::size_t len, sha_512_digest_t& digest) {
 }
 
 std::vector<std::uint8_t> base64_decode(const char* text, std::size_t len) {
-    assert(text != nullptr);
-    assert(len > 0);
+    if (text == nullptr || len == 0) {
+        return {};
+    }
 
     // Strip whitespace + NUL; pass everything else to BIO_f_base64.
     // Byte set matches EVP_Decode*'s B64_WS table so this stays drop-in
@@ -381,8 +382,9 @@ bool base64_decode(const char* text, std::size_t len, std::uint8_t* out_data, st
 }
 
 std::string base64_encode(const std::uint8_t* data, std::size_t len, bool newLine) {
-    assert(data != nullptr);
-    assert(len > 0);
+    if (data == nullptr || len == 0) {
+        return {};
+    }
 
     auto* b64 = BIO_new(BIO_f_base64());
     auto* mem = BIO_new(BIO_s_mem());

--- a/lib/everest/tls/src/openssl_util.cpp
+++ b/lib/everest/tls/src/openssl_util.cpp
@@ -316,17 +316,29 @@ bool sha_512(const void* data, std::size_t len, sha_512_digest_t& digest) {
 }
 
 std::vector<std::uint8_t> base64_decode(const char* text, std::size_t len) {
-    assert(text != nullptr);
-    assert(len > 0);
-
-    // remove \n
+    // Strip whitespace; pass everything else to BIO_f_base64. Byte set matches
+    // EVP_Decode*'s B64_WS table so this stays drop-in equivalent to the
+    // evse_security path (consolidation target). NUL terminates the scan: an
+    // embedded NUL almost certainly indicates a length-parameter error and
+    // continuing would feed garbage to the decoder.
     auto input = std::make_unique<std::uint8_t[]>(len);
     std::size_t input_len{0};
 
     for (std::size_t i = 0; i < len; i++) {
         const auto item = text[i];
-        if (item != '\n') {
-            input.get()[input_len++] = item;
+        if (item == '\0') {
+            break;
+        }
+        switch (item) {
+        case '\t':
+        case '\n':
+        case '\v':
+        case '\f':
+        case '\r':
+        case ' ':
+            continue;
+        default:
+            input.get()[input_len++] = static_cast<std::uint8_t>(item);
         }
     }
 
@@ -370,9 +382,6 @@ bool base64_decode(const char* text, std::size_t len, std::uint8_t* out_data, st
 }
 
 std::string base64_encode(const std::uint8_t* data, std::size_t len, bool newLine) {
-    assert(data != nullptr);
-    assert(len > 0);
-
     auto* b64 = BIO_new(BIO_f_base64());
     auto* mem = BIO_new(BIO_s_mem());
     BIO_push(b64, mem);

--- a/lib/everest/tls/tests/openssl_util_test.cpp
+++ b/lib/everest/tls/tests/openssl_util_test.cpp
@@ -89,6 +89,18 @@ constexpr std::uint8_t iso_exi_sig[] = {0x4c, 0x8f, 0x20, 0xc1, 0x40, 0x0b, 0xa6
 const char iso_exi_a_hash_b64[] = "0bXgPQBlvuVrMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=";
 const char iso_exi_a_hash_b64_nl[] = "0bXgPQBlvuVrMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=\n";
 
+// Embedded NUL mid-buffer; pre-pass must skip it.
+const char iso_exi_a_hash_b64_embedded_nul[] = {
+    '0', 'b', 'X', 'g', 'P', 'Q', 'B', 'l', 'v', 'u', 'V', 'r', '\0', 'M', 'X', 'm', 'E', 'R', 'T', 'B', 'R', '6', '1',
+    'T', 'K', 'G', 'P', 'w', 'O', 'C', 'R', 'Y', 'X', 'T', '4', 's',  '8', 'd', '6', 'm', 'P', 'S', 'q', 'k', '=',
+};
+constexpr std::size_t iso_exi_a_hash_b64_embedded_nul_len = sizeof(iso_exi_a_hash_b64_embedded_nul);
+
+const char iso_exi_a_hash_b64_crlf[] = "0bXgPQBlvuVrMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=\r\n";
+const char iso_exi_a_hash_b64_cr[] = "0bXgPQBlvuVrMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=\r";
+const char iso_exi_a_hash_b64_spaces[] = "0bXgPQBlvuVr MXmERTBR61TK GPwOCRYXT4s8d6mPSqk=";
+const char iso_exi_a_hash_b64_tabs[] = "0bXgPQBlvuVr\tMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=";
+
 const char iso_exi_sig_b64[] =
     "TI8gwUALpnYGqkgRVyovGtPBUInZVCA2NDC7JrSdsQTwjfqL+AVeY6S3Wo0xaSBvqNVDCLpY8FZrlrr2ks5ZUA==";
 const char iso_exi_sig_b64_nl[] =
@@ -285,6 +297,56 @@ TEST(openssl, base64DecodeNl) {
                                        buffer_len));
     ASSERT_EQ(buffer_len, sizeof(iso_exi_a_hash));
     EXPECT_EQ(std::memcmp(buffer.data(), &iso_exi_a_hash[0], buffer_len), 0);
+}
+
+TEST(openssl, base64DecodeEmbeddedNul) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_embedded_nul[0], iso_exi_a_hash_b64_embedded_nul_len);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeCrlf) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_crlf[0], sizeof(iso_exi_a_hash_b64_crlf) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeCrOnly) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_cr[0], sizeof(iso_exi_a_hash_b64_cr) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeInternalSpaces) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_spaces[0], sizeof(iso_exi_a_hash_b64_spaces) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeTabs) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_tabs[0], sizeof(iso_exi_a_hash_b64_tabs) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeTrailingNulIsTolerated) {
+    // sizeof(literal) includes the trailing NUL; impl must skip it.
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64));
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeVerticalTabAndFormFeed) {
+    const char vt_ff[] = "0bXgPQBlvuVr\vMXmERTBR61TKGPwOC\fRYXT4s8d6mPSqk=";
+    auto res = openssl::base64_decode(&vt_ff[0], sizeof(vt_ff) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeInvalidByteRejected) {
+    // Non-whitespace non-alphabet bytes still produce empty output.
+    auto res = openssl::base64_decode("@@@@", 4);
+    EXPECT_TRUE(res.empty());
 }
 
 TEST(openssl, sha256) {

--- a/lib/everest/tls/tests/openssl_util_test.cpp
+++ b/lib/everest/tls/tests/openssl_util_test.cpp
@@ -349,6 +349,21 @@ TEST(openssl, base64DecodeInvalidByteRejected) {
     EXPECT_TRUE(res.empty());
 }
 
+TEST(openssl, base64DecodeEmptyInputReturnsEmpty) {
+    auto res = openssl::base64_decode("", 0);
+    EXPECT_TRUE(res.empty());
+
+    std::array<std::uint8_t, 16> buffer{};
+    std::size_t buffer_len = buffer.size();
+    EXPECT_FALSE(openssl::base64_decode("", 0, buffer.data(), buffer_len));
+}
+
+TEST(openssl, base64EncodeEmptyInputReturnsEmpty) {
+    const std::uint8_t empty_buf[1] = {0};
+    auto res = openssl::base64_encode(empty_buf, 0);
+    EXPECT_TRUE(res.empty());
+}
+
 TEST(openssl, sha256) {
     openssl::sha_256_digest_t digest;
     EXPECT_TRUE(openssl::sha_256(sha_256_test[0].input, 0, digest));

--- a/lib/everest/tls/tests/openssl_util_test.cpp
+++ b/lib/everest/tls/tests/openssl_util_test.cpp
@@ -254,26 +254,10 @@ TEST(openssl, base64EncodeNl) {
 }
 
 TEST(openssl, base64Decode) {
-    auto res = openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64));
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64) - 1);
     ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
     EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
-    res = openssl::base64_decode(&iso_exi_sig_b64[0], sizeof(iso_exi_sig_b64));
-    ASSERT_EQ(res.size(), sizeof(iso_exi_sig));
-    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_sig[0], res.size()), 0);
-
-    std::array<std::uint8_t, 512> buffer{};
-    std::size_t buffer_len = buffer.size();
-
-    EXPECT_TRUE(openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64), buffer.data(), buffer_len));
-    ASSERT_EQ(buffer_len, sizeof(iso_exi_a_hash));
-    EXPECT_EQ(std::memcmp(buffer.data(), &iso_exi_a_hash[0], buffer_len), 0);
-}
-
-TEST(openssl, base64DecodeNl) {
-    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_nl[0], sizeof(iso_exi_a_hash_b64_nl));
-    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
-    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
-    res = openssl::base64_decode(&iso_exi_sig_b64_nl[0], sizeof(iso_exi_sig_b64_nl));
+    res = openssl::base64_decode(&iso_exi_sig_b64[0], sizeof(iso_exi_sig_b64) - 1);
     ASSERT_EQ(res.size(), sizeof(iso_exi_sig));
     EXPECT_EQ(std::memcmp(res.data(), &iso_exi_sig[0], res.size()), 0);
 
@@ -281,7 +265,24 @@ TEST(openssl, base64DecodeNl) {
     std::size_t buffer_len = buffer.size();
 
     EXPECT_TRUE(
-        openssl::base64_decode(&iso_exi_a_hash_b64_nl[0], sizeof(iso_exi_a_hash_b64_nl), buffer.data(), buffer_len));
+        openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64) - 1, buffer.data(), buffer_len));
+    ASSERT_EQ(buffer_len, sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(buffer.data(), &iso_exi_a_hash[0], buffer_len), 0);
+}
+
+TEST(openssl, base64DecodeNl) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_nl[0], sizeof(iso_exi_a_hash_b64_nl) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+    res = openssl::base64_decode(&iso_exi_sig_b64_nl[0], sizeof(iso_exi_sig_b64_nl) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_sig));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_sig[0], res.size()), 0);
+
+    std::array<std::uint8_t, 512> buffer{};
+    std::size_t buffer_len = buffer.size();
+
+    EXPECT_TRUE(openssl::base64_decode(&iso_exi_a_hash_b64_nl[0], sizeof(iso_exi_a_hash_b64_nl) - 1, buffer.data(),
+                                       buffer_len));
     ASSERT_EQ(buffer_len, sizeof(iso_exi_a_hash));
     EXPECT_EQ(std::memcmp(buffer.data(), &iso_exi_a_hash[0], buffer_len), 0);
 }

--- a/lib/everest/tls/tests/openssl_util_test.cpp
+++ b/lib/everest/tls/tests/openssl_util_test.cpp
@@ -89,6 +89,11 @@ constexpr std::uint8_t iso_exi_sig[] = {0x4c, 0x8f, 0x20, 0xc1, 0x40, 0x0b, 0xa6
 const char iso_exi_a_hash_b64[] = "0bXgPQBlvuVrMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=";
 const char iso_exi_a_hash_b64_nl[] = "0bXgPQBlvuVrMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=\n";
 
+const char iso_exi_a_hash_b64_crlf[] = "0bXgPQBlvuVrMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=\r\n";
+const char iso_exi_a_hash_b64_cr[] = "0bXgPQBlvuVrMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=\r";
+const char iso_exi_a_hash_b64_spaces[] = "0bXgPQBlvuVr MXmERTBR61TK GPwOCRYXT4s8d6mPSqk=";
+const char iso_exi_a_hash_b64_tabs[] = "0bXgPQBlvuVr\tMXmERTBR61TKGPwOCRYXT4s8d6mPSqk=";
+
 const char iso_exi_sig_b64[] =
     "TI8gwUALpnYGqkgRVyovGtPBUInZVCA2NDC7JrSdsQTwjfqL+AVeY6S3Wo0xaSBvqNVDCLpY8FZrlrr2ks5ZUA==";
 const char iso_exi_sig_b64_nl[] =
@@ -254,26 +259,10 @@ TEST(openssl, base64EncodeNl) {
 }
 
 TEST(openssl, base64Decode) {
-    auto res = openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64));
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64) - 1);
     ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
     EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
-    res = openssl::base64_decode(&iso_exi_sig_b64[0], sizeof(iso_exi_sig_b64));
-    ASSERT_EQ(res.size(), sizeof(iso_exi_sig));
-    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_sig[0], res.size()), 0);
-
-    std::array<std::uint8_t, 512> buffer{};
-    std::size_t buffer_len = buffer.size();
-
-    EXPECT_TRUE(openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64), buffer.data(), buffer_len));
-    ASSERT_EQ(buffer_len, sizeof(iso_exi_a_hash));
-    EXPECT_EQ(std::memcmp(buffer.data(), &iso_exi_a_hash[0], buffer_len), 0);
-}
-
-TEST(openssl, base64DecodeNl) {
-    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_nl[0], sizeof(iso_exi_a_hash_b64_nl));
-    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
-    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
-    res = openssl::base64_decode(&iso_exi_sig_b64_nl[0], sizeof(iso_exi_sig_b64_nl));
+    res = openssl::base64_decode(&iso_exi_sig_b64[0], sizeof(iso_exi_sig_b64) - 1);
     ASSERT_EQ(res.size(), sizeof(iso_exi_sig));
     EXPECT_EQ(std::memcmp(res.data(), &iso_exi_sig[0], res.size()), 0);
 
@@ -281,9 +270,85 @@ TEST(openssl, base64DecodeNl) {
     std::size_t buffer_len = buffer.size();
 
     EXPECT_TRUE(
-        openssl::base64_decode(&iso_exi_a_hash_b64_nl[0], sizeof(iso_exi_a_hash_b64_nl), buffer.data(), buffer_len));
+        openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64) - 1, buffer.data(), buffer_len));
     ASSERT_EQ(buffer_len, sizeof(iso_exi_a_hash));
     EXPECT_EQ(std::memcmp(buffer.data(), &iso_exi_a_hash[0], buffer_len), 0);
+}
+
+TEST(openssl, base64DecodeNl) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_nl[0], sizeof(iso_exi_a_hash_b64_nl) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+    res = openssl::base64_decode(&iso_exi_sig_b64_nl[0], sizeof(iso_exi_sig_b64_nl) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_sig));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_sig[0], res.size()), 0);
+
+    std::array<std::uint8_t, 512> buffer{};
+    std::size_t buffer_len = buffer.size();
+
+    EXPECT_TRUE(openssl::base64_decode(&iso_exi_a_hash_b64_nl[0], sizeof(iso_exi_a_hash_b64_nl) - 1, buffer.data(),
+                                       buffer_len));
+    ASSERT_EQ(buffer_len, sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(buffer.data(), &iso_exi_a_hash[0], buffer_len), 0);
+}
+
+TEST(openssl, base64DecodeCrlf) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_crlf[0], sizeof(iso_exi_a_hash_b64_crlf) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeCrOnly) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_cr[0], sizeof(iso_exi_a_hash_b64_cr) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeInternalSpaces) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_spaces[0], sizeof(iso_exi_a_hash_b64_spaces) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeTabs) {
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64_tabs[0], sizeof(iso_exi_a_hash_b64_tabs) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeTrailingNulIsTolerated) {
+    // sizeof(literal) includes the trailing NUL; impl must skip it.
+    auto res = openssl::base64_decode(&iso_exi_a_hash_b64[0], sizeof(iso_exi_a_hash_b64));
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeVerticalTabAndFormFeed) {
+    const char vt_ff[] = "0bXgPQBlvuVr\vMXmERTBR61TKGPwOC\fRYXT4s8d6mPSqk=";
+    auto res = openssl::base64_decode(&vt_ff[0], sizeof(vt_ff) - 1);
+    ASSERT_EQ(res.size(), sizeof(iso_exi_a_hash));
+    EXPECT_EQ(std::memcmp(res.data(), &iso_exi_a_hash[0], res.size()), 0);
+}
+
+TEST(openssl, base64DecodeInvalidByteRejected) {
+    // Non-whitespace non-alphabet bytes still produce empty output.
+    auto res = openssl::base64_decode("@@@@", 4);
+    EXPECT_TRUE(res.empty());
+}
+
+TEST(openssl, base64DecodeEmptyInputReturnsEmpty) {
+    auto res = openssl::base64_decode("", 0);
+    EXPECT_TRUE(res.empty());
+
+    std::array<std::uint8_t, 16> buffer{};
+    std::size_t buffer_len = buffer.size();
+    EXPECT_FALSE(openssl::base64_decode("", 0, buffer.data(), buffer_len));
+}
+
+TEST(openssl, base64EncodeEmptyInputReturnsEmpty) {
+    const std::uint8_t empty_buf[1] = {0};
+    auto res = openssl::base64_encode(empty_buf, 0);
+    EXPECT_TRUE(res.empty());
 }
 
 TEST(openssl, sha256) {


### PR DESCRIPTION
The fixture buffers are const char[] literals so sizeof() includes the trailing NUL. The cleanup loop in base64_decode only strips '\n', so NUL flowed into BIO_f_base64. OpenSSL <= 3.0 silently truncated at the NUL and returned the valid prefix, but OpenSSL 3.5 rejects the whole input on stray non-alphabet bytes and returns 0. Pass sizeof - 1 so the call mirrors what real callers do via std::string::size().

## Describe your changes

## Issue ticket number and link

Fixes issue #2131 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

