### PR TITLE
feat(everestpy): expose runtime config service to Python modules

### DIFF
--- a/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/probe_module_configuration_strategy.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/probe_module_configuration_strategy.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from everest.testing.core_utils.common import Requirement
 from everest.testing.core_utils._configuration.everest_configuration_strategies.everest_configuration_strategy import \
@@ -11,10 +11,12 @@ class ProbeModuleConfigurationStrategy(EverestConfigAdjustmentStrategy):
 
     def __init__(self,
                  connections: Dict[str, List[Requirement]],
-                 module_id: str = "probe"
+                 module_id: str = "probe",
+                 access: Optional[Dict] = None
                  ):
         self._module_id = module_id
         self._connections = connections
+        self._access = access
 
     def adjust_everest_configuration(self, everest_config: Dict) -> Dict:
         adjusted_config = deepcopy(everest_config)
@@ -25,9 +27,13 @@ class ProbeModuleConfigurationStrategy(EverestConfigAdjustmentStrategy):
             for requirement_id, requirements_list in self._connections.items()}
 
         active_modules = adjusted_config.setdefault("active_modules", {})
-        active_modules[self._module_id] = {
+        probe_config = {
             'connections': probe_connections,
             'module': 'ProbeModule'
         }
+        if self._access is not None:
+            probe_config['access'] = self._access
+
+        active_modules[self._module_id] = probe_config
 
         return adjusted_config

--- a/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_environment_setup.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_environment_setup.py
@@ -70,6 +70,7 @@ class EverestEnvironmentCoreConfiguration:
 class EverestEnvironmentProbeModuleConfiguration:
     connections: Dict[str, List[Requirement]] = field(default_factory=dict)
     module_id: str = "probe"
+    access: Optional[Dict] = None
 
 
 class EverestTestEnvironmentSetup:
@@ -237,7 +238,8 @@ class EverestTestEnvironmentSetup:
         if self._probe_config:
             configuration_strategies.append(
                 ProbeModuleConfigurationStrategy(connections=self._probe_config.connections,
-                                                 module_id=self._probe_config.module_id))
+                                                 module_id=self._probe_config.module_id,
+                                                 access=self._probe_config.access))
 
         if self._evse_security_config:
             configuration_strategies.append(

--- a/applications/utils/everest-testing/src/everest/testing/core_utils/probe_module.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/probe_module.py
@@ -141,6 +141,64 @@ class ProbeModule:
         """
         self._mod.subscribe_error(self._setup.connections[connection_id][0], error_type, callback, clear_callback)
 
+    async def set_config_value(self, module_id: str, param_name: str, value: str,
+                               impl_id: Optional[str] = None) -> dict:
+        """
+        Set a configuration parameter of a module at runtime via the config service.
+        - module_id: the id of the target module
+        - param_name: the name of the configuration parameter
+        - value: the new value as a string (regardless of the underlying type)
+        - impl_id: optional implementation id (defaults to module-level scope)
+        returns: dict with keys 'status' (Ok/Error/AccessDenied), 'status_info', and
+                 'set_status' (Accepted/Rejected/RebootRequired)
+        Note: Requires the probe module to have write access to the target module in the EVerest config.
+        """
+        try:
+            async with asyncio.timeout(30):
+                return await asyncio.to_thread(
+                    lambda: self._mod.set_config_value(module_id, param_name, value, impl_id)
+                )
+        except TimeoutError as e:
+            error_message = (f"Timeout in set_config_value for {module_id}.{param_name}: "
+                             f"{type(e)}: {e}")
+            logging.error(error_message)
+            raise RuntimeError(error_message)
+
+    async def get_config_value(self, module_id: str, param_name: str,
+                               impl_id: Optional[str] = None) -> dict:
+        """
+        Get a configuration parameter of a module via the config service.
+        - module_id: the id of the target module
+        - param_name: the name of the configuration parameter
+        - impl_id: optional implementation id (defaults to module-level scope)
+        returns: dict with keys 'status' (Ok/Error/AccessDenied), 'status_info', and
+                 'value' (the current value as a string, present when status is Ok)
+        Note: Requires the probe module to have read access to the target module in the EVerest config.
+        """
+        try:
+            async with asyncio.timeout(30):
+                return await asyncio.to_thread(
+                    lambda: self._mod.get_config_value(module_id, param_name, impl_id)
+                )
+        except TimeoutError as e:
+            error_message = (f"Timeout in get_config_value for {module_id}.{param_name}: "
+                             f"{type(e)}: {e}")
+            logging.error(error_message)
+            raise RuntimeError(error_message)
+
+    def register_config_change_handler(self, param_name: str,
+                                       handler: Callable[[str], dict]):
+        """
+        Register a handler for runtime configuration changes of a parameter owned by this probe module.
+        This subscribes to incoming set_request messages for the given parameter name.
+        - param_name: the name of the configuration parameter to handle
+        - handler: a callable that takes the new value string and returns a dict with key
+                   'status' (Accepted/Rejected/RebootRequired) and optionally 'reason' (for Rejected)
+        Note: Must be called before start().
+        Note: The handler runs in a separate thread!
+        """
+        self._mod.register_config_change_handler(param_name, handler)
+
     def subscribe_all_errors(self, connection_id: str,
                             callback: Callable[[error.Error], None],
                             clear_callback: Callable[[error.Error], None]):

--- a/lib/everest/framework/everestpy/src/everest/everestpy.cpp
+++ b/lib/everest/framework/everestpy/src/everest/everestpy.cpp
@@ -153,6 +153,12 @@ PYBIND11_MODULE(everestpy, m) {
         .def("subscribe_error", &Module::subscribe_error)
         .def("subscribe_all_errors", &Module::subscribe_all_errors)
         .def("get_error_state_monitor_req", &Module::get_error_state_monitor_req)
+        .def("set_config_value", &Module::set_config_value, py::arg("module_id"), py::arg("param_name"),
+             py::arg("value"), py::arg("impl_id") = py::none())
+        .def("get_config_value", &Module::get_config_value, py::arg("module_id"), py::arg("param_name"),
+             py::arg("impl_id") = py::none())
+        .def("register_config_change_handler", &Module::register_config_change_handler, py::arg("param_name"),
+             py::arg("handler"))
         .def_property_readonly("fulfillments", &Module::get_fulfillments)
         .def_property_readonly("implementations", &Module::get_implementations)
         .def_property_readonly("requirements", &Module::get_requirements)

--- a/lib/everest/framework/everestpy/src/everest/module.cpp
+++ b/lib/everest/framework/everestpy/src/everest/module.cpp
@@ -8,6 +8,7 @@
 #include <utils/error/error_manager_impl.hpp>
 #include <utils/error/error_manager_req.hpp>
 #include <utils/error/error_state_monitor.hpp>
+#include <utils/mqtt_config_service.hpp>
 
 std::unique_ptr<Everest::Everest>
 Module::create_everest_instance(const std::string& module_id, const Everest::Config& config,
@@ -61,6 +62,12 @@ Module::Module(const std::string& module_id_, const RuntimeSession& session_) :
         const std::string interface_name = requirement.value().at("interface");
         const auto& interface_def = config.get_interface_definition(interface_name);
         requirements.emplace(requirement_id, create_everest_interface_from_definition(interface_def));
+    }
+}
+
+Module::~Module() {
+    if (handle) {
+        handle->disconnect();
     }
 }
 
@@ -142,4 +149,42 @@ void Module::subscribe_all_errors(const Fulfillment& fulfillment, const Everest:
 std::shared_ptr<Everest::error::ErrorStateMonitor>
 Module::get_error_state_monitor_req(const Fulfillment& fulfillment) const {
     return handle->get_error_state_monitor_req(fulfillment.requirement);
+}
+
+json Module::set_config_value(const std::string& module_id, const std::string& param_name, const std::string& value,
+                              const std::optional<std::string>& impl_id) {
+    everest::config::ConfigurationParameterIdentifier identifier;
+    identifier.module_id = module_id;
+    identifier.configuration_parameter_name = param_name;
+    identifier.module_implementation_id = impl_id;
+
+    const pybind11::gil_scoped_release release;
+    return json(handle->get_config_service_client()->set_config_value(identifier, value));
+}
+
+json Module::get_config_value(const std::string& module_id, const std::string& param_name,
+                              const std::optional<std::string>& impl_id) {
+    everest::config::ConfigurationParameterIdentifier identifier;
+    identifier.module_id = module_id;
+    identifier.configuration_parameter_name = param_name;
+    identifier.module_implementation_id = impl_id;
+
+    const pybind11::gil_scoped_release release;
+    return json(handle->get_config_service_client()->get_config_value(identifier));
+}
+
+void Module::register_config_change_handler(const std::string& param_name,
+                                            std::function<json(const std::string&)> handler) {
+    auto& stored = config_change_handlers.emplace_back(std::move(handler));
+    handle->get_config_service_client()->register_config_change_handler(
+        param_name, [&stored](const std::string& new_value) -> Everest::config::ConfigChangeResult {
+            pybind11::gil_scoped_acquire acquire;
+            try {
+                return stored(new_value).get<Everest::config::ConfigChangeResult>();
+            } catch (const pybind11::error_already_set& e) {
+                return Everest::config::ConfigChangeResult::Rejected(e.what());
+            } catch (const std::exception& e) {
+                return Everest::config::ConfigChangeResult::Rejected(e.what());
+            }
+        });
 }

--- a/lib/everest/framework/everestpy/src/everest/module.hpp
+++ b/lib/everest/framework/everestpy/src/everest/module.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -15,10 +16,17 @@
 
 #include "misc.hpp"
 
+namespace Everest {
+namespace config {
+class ConfigServiceClient;
+}
+} // namespace Everest
+
 class Module {
 public:
     Module(const RuntimeSession&);
     Module(const std::string&, const RuntimeSession&);
+    ~Module();
 
     ModuleSetup say_hello();
 
@@ -66,6 +74,12 @@ public:
     std::shared_ptr<Everest::error::ErrorStateMonitor>
     get_error_state_monitor_req(const Fulfillment& fulfillment) const;
 
+    json set_config_value(const std::string& module_id, const std::string& param_name, const std::string& value,
+                          const std::optional<std::string>& impl_id = std::nullopt);
+    json get_config_value(const std::string& module_id, const std::string& param_name,
+                          const std::optional<std::string>& impl_id = std::nullopt);
+    void register_config_change_handler(const std::string& param_name, std::function<json(const std::string&)> handler);
+
     const auto& get_fulfillments() const {
         return fulfillments;
     }
@@ -98,6 +112,7 @@ private:
     std::deque<std::function<void(json)>> subscription_callbacks{};
     std::deque<std::function<void(json)>> err_susbcription_callbacks{};
     std::deque<std::function<void(json)>> err_cleared_susbcription_callbacks{};
+    std::deque<std::function<json(const std::string&)>> config_change_handlers{};
 
     static std::unique_ptr<Everest::Everest>
     create_everest_instance(const std::string& module_id, const Everest::Config& config,

--- a/lib/everest/framework/include/utils/config/config_service_core.hpp
+++ b/lib/everest/framework/include/utils/config/config_service_core.hpp
@@ -42,7 +42,8 @@ public:
     SetActiveSlotStatus mark_active_slot(int slot_id) override;
     DeleteSlotStatus delete_slot(int slot_id) override;
     DuplicateSlotResult duplicate_slot(int slot_id, std::optional<std::string> description) override;
-    LoadFromYamlResult load_from_yaml(const std::string& raw_yaml, std::optional<std::string> description, std::optional<int> slot_id) override;
+    LoadFromYamlResult load_from_yaml(const std::string& raw_yaml, std::optional<std::string> description,
+                                      std::optional<int> slot_id) override;
 
     // --- Slot-scoped configuration ---
     GetConfigurationResult get_configuration(int slot_id) override;

--- a/lib/everest/framework/include/utils/config_service_interface.hpp
+++ b/lib/everest/framework/include/utils/config_service_interface.hpp
@@ -132,7 +132,8 @@ public:
     virtual SetActiveSlotStatus mark_active_slot(int slot_id) = 0;
     virtual DeleteSlotStatus delete_slot(int slot_id) = 0;
     virtual DuplicateSlotResult duplicate_slot(int slot_id, std::optional<std::string> description) = 0;
-    virtual LoadFromYamlResult load_from_yaml(const std::string& raw_yaml, std::optional<std::string> description, std::optional<int> slot_id) = 0;
+    virtual LoadFromYamlResult load_from_yaml(const std::string& raw_yaml, std::optional<std::string> description,
+                                              std::optional<int> slot_id) = 0;
 
     // --- Active-slot in-memory access ---
     virtual const everest::config::ModuleConfigurations& get_active_module_configurations() const = 0;

--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -84,7 +84,6 @@ private:
     std::vector<std::string> retained_topics;
     std::unordered_set<std::string> subscribed_topics;
 
-    Thread mqtt_mainloop_thread;
     std::shared_future<void> main_loop_future;
 
     std::string mqtt_server_socket_path;
@@ -96,6 +95,9 @@ private:
     std::unique_ptr<everest::lib::io::mqtt::mqtt_client> mqtt_client;
     everest::lib::io::event::event_fd disconnect_event;
     everest::lib::io::event::fd_event_handler ev_handler;
+
+    // This must be destroyed first.
+    Thread mqtt_mainloop_thread;
 
     void on_mqtt_message(const Message& message);
     void on_mqtt_connect();

--- a/lib/everest/framework/include/utils/mqtt_config_service.hpp
+++ b/lib/everest/framework/include/utils/mqtt_config_service.hpp
@@ -244,6 +244,18 @@ void from_json(const nlohmann::json& j, Request& r);
 void to_json(nlohmann::json& j, const Response& r);
 
 void from_json(const nlohmann::json& j, Response& r);
+
+void to_json(nlohmann::json& j, const SetConfigResult& r);
+
+void from_json(const nlohmann::json& j, SetConfigResult& r);
+
+void to_json(nlohmann::json& j, const GetConfigResult& r);
+
+void from_json(const nlohmann::json& j, GetConfigResult& r);
+
+void to_json(nlohmann::json& j, const ConfigChangeResult& r);
+
+void from_json(const nlohmann::json& j, ConfigChangeResult& r);
 } // namespace config
 } // namespace Everest
 

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -88,6 +88,9 @@ MQTTAbstractionImpl::MQTTAbstractionImpl(const MQTTSettings& mqtt_settings) :
 }
 
 MQTTAbstractionImpl::~MQTTAbstractionImpl() {
+    if (this->running.load()) {
+        this->disconnect();
+    }
     // this->mqtt_mainloop_thread.join();
 }
 

--- a/lib/everest/framework/lib/mqtt_config_service.cpp
+++ b/lib/everest/framework/lib/mqtt_config_service.cpp
@@ -846,6 +846,55 @@ void from_json(const nlohmann::json& j, Response& r) {
     }
 }
 
+void to_json(nlohmann::json& j, const SetConfigResult& r) {
+    j = {
+        {"status", conversions::response_status_to_string(r.status)},
+        {"status_info", r.status_info},
+        {"set_status", conversions::set_response_status_to_string(
+                           conversions::set_config_status_to_set_response_status(r.set_status))},
+    };
+}
+
+void from_json(const nlohmann::json& j, SetConfigResult& r) {
+    r.status = conversions::string_to_response_status(j.at("status"));
+    r.status_info = j.value("status_info", "");
+    r.set_status = conversions::set_response_status_to_set_config_status(
+        conversions::string_to_set_response_status(j.at("set_status")));
+}
+
+void to_json(nlohmann::json& j, const GetConfigResult& r) {
+    j = {
+        {"status", conversions::response_status_to_string(r.status)},
+        {"status_info", r.status_info},
+        {"value", r.configuration_parameter.value},
+    };
+}
+
+void from_json(const nlohmann::json& j, GetConfigResult& r) {
+    r.status = conversions::string_to_response_status(j.at("status"));
+    r.status_info = j.value("status_info", "");
+    r.configuration_parameter.value = j.at("value").get<everest::config::ConfigEntry>();
+}
+
+void to_json(nlohmann::json& j, const ConfigChangeResult& r) {
+    j = {
+        {"status", conversions::set_response_status_to_string(r.status)},
+        {"reason", r.reason},
+    };
+}
+
+void from_json(const nlohmann::json& j, ConfigChangeResult& r) {
+    const std::string status = j.value("status", "Rejected");
+    const std::string reason = j.value("reason", "");
+    if (status == "Accepted") {
+        r = ConfigChangeResult::Accepted();
+    } else if (status == "RebootRequired") {
+        r = ConfigChangeResult::AcceptedRebootRequired();
+    } else {
+        r = ConfigChangeResult::Rejected(reason);
+    }
+}
+
 } // namespace config
 } // namespace Everest
 

--- a/lib/everest/framework/tests/test_config_service.cpp
+++ b/lib/everest/framework/tests/test_config_service.cpp
@@ -35,7 +35,8 @@ struct StubConfigService : Everest::config::ConfigServiceInterface {
     DuplicateSlotResult duplicate_slot(int, std::optional<std::string>) override {
         return {};
     }
-    LoadFromYamlResult load_from_yaml(const std::string&, std::optional<std::string>, std::optional<int> slot_id) override {
+    LoadFromYamlResult load_from_yaml(const std::string&, std::optional<std::string>,
+                                      std::optional<int> slot_id) override {
         return {};
     }
     GetConfigurationResult get_configuration(int) override {

--- a/tests/everest-core_tests/config/config-test-cpp-config-service.yaml
+++ b/tests/everest-core_tests/config/config-test-cpp-config-service.yaml
@@ -1,0 +1,8 @@
+active_modules:
+  test_config_target:
+    module: TestConfigTarget
+    config_module:
+      rw_param: "initial_value"
+      rw_reboot_param: "reboot_value"
+      rw_reject_param: "reject_value"
+      ro_param: "read_only_value"

--- a/tests/everest-core_tests/modules/CMakeLists.txt
+++ b/tests/everest-core_tests/modules/CMakeLists.txt
@@ -1,1 +1,2 @@
 ev_add_module(TestErrorHandling SKIP_DOC_GENERATION)
+ev_add_module(TestConfigTarget SKIP_DOC_GENERATION)

--- a/tests/everest-core_tests/modules/TestConfigTarget/CMakeLists.txt
+++ b/tests/everest-core_tests/modules/TestConfigTarget/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+# template version 3
+#
+
+# module setup:
+#   - ${MODULE_NAME}: module name
+ev_setup_cpp_module()
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+# insert your custom targets and additional config variables here
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+
+target_sources(${MODULE_NAME}
+    PRIVATE
+        "main/emptyImpl.cpp"
+)
+
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/tests/everest-core_tests/modules/TestConfigTarget/TestConfigTarget.cpp
+++ b/tests/everest-core_tests/modules/TestConfigTarget/TestConfigTarget.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "TestConfigTarget.hpp"
+
+namespace module {
+
+void TestConfigTarget::init() {
+    invoke_init(*p_main);
+}
+
+void TestConfigTarget::ready() {
+    invoke_ready(*p_main);
+}
+
+TestConfigTarget::ConfigChangeResult TestConfigTarget::on_rw_param_changed(const std::string& value) {
+    rw_config.rw_param = value;
+    return ConfigChangeResult::Accepted();
+}
+
+TestConfigTarget::ConfigChangeResult TestConfigTarget::on_rw_reboot_param_changed(const std::string& value) {
+    rw_config.rw_reboot_param = value;
+    return ConfigChangeResult::AcceptedRebootRequired();
+}
+
+TestConfigTarget::ConfigChangeResult TestConfigTarget::on_rw_reject_param_changed(const std::string& /* value */) {
+    return ConfigChangeResult::Rejected("test rejection reason");
+}
+
+} // namespace module

--- a/tests/everest-core_tests/modules/TestConfigTarget/TestConfigTarget.hpp
+++ b/tests/everest-core_tests/modules/TestConfigTarget/TestConfigTarget.hpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef TEST_CONFIG_TARGET_HPP
+#define TEST_CONFIG_TARGET_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 2
+//
+
+#include "ld-ev.hpp"
+
+// headers for provided interface implementations
+#include <generated/interfaces/empty/Implementation.hpp>
+
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+// insert your custom include headers here
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
+
+struct RwConf {
+    std::string rw_param;
+    std::string rw_reboot_param;
+    std::string rw_reject_param;
+};
+
+struct RwConfUpdate {
+    using ConfigChangeResult = Everest::config::ConfigChangeResult;
+
+    virtual ~RwConfUpdate() = default;
+
+    // override in class TestConfigTarget adding the implementation to
+    // TestConfigTarget.cpp or inline e.g. ConfigChangeResult
+    // on_rw_param_changed(const std::string& value) override {
+    //     rw_config.rw_param = value;
+    //     return ConfigChangeResult::Accepted();
+    // }
+
+    virtual ConfigChangeResult on_rw_param_changed(const std::string& /* value */) {
+        return ConfigChangeResult::Rejected("handler not implemented");
+    }
+    virtual ConfigChangeResult on_rw_reboot_param_changed(const std::string& /* value */) {
+        return ConfigChangeResult::Rejected("handler not implemented");
+    }
+    virtual ConfigChangeResult on_rw_reject_param_changed(const std::string& /* value */) {
+        return ConfigChangeResult::Rejected("handler not implemented");
+    }
+};
+
+struct Conf {
+    std::string ro_param;
+
+    const std::string& rw_param;
+    const std::string& rw_reboot_param;
+    const std::string& rw_reject_param;
+
+    Conf(const RwConf& rw) :
+        rw_param(rw.rw_param), rw_reboot_param(rw.rw_reboot_param), rw_reject_param(rw.rw_reject_param) {
+    }
+};
+
+class TestConfigTarget : public Everest::ModuleBase, public RwConfUpdate {
+public:
+    TestConfigTarget() = delete;
+    TestConfigTarget(const ModuleInfo& info, std::unique_ptr<emptyImplBase> p_main, Conf& config, RwConf& rw_config) :
+        ModuleBase(info), p_main(std::move(p_main)), config(config), rw_config(rw_config){};
+
+    const std::unique_ptr<emptyImplBase> p_main;
+    const Conf& config;
+    RwConf& rw_config;
+
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+    // insert your public definitions here
+    ConfigChangeResult on_rw_param_changed(const std::string& value) override;
+    ConfigChangeResult on_rw_reboot_param_changed(const std::string& value) override;
+    ConfigChangeResult on_rw_reject_param_changed(const std::string& value) override;
+
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+
+protected:
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+    // insert your protected definitions here
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+
+private:
+    friend class LdEverest;
+    void init();
+    void ready();
+
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+    // insert your private definitions here
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+};
+
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+// insert other definitions here
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+
+} // namespace module
+
+#endif // TEST_CONFIG_TARGET_HPP

--- a/tests/everest-core_tests/modules/TestConfigTarget/docs/index.rst
+++ b/tests/everest-core_tests/modules/TestConfigTarget/docs/index.rst
@@ -1,0 +1,24 @@
+.. _everest_modules_handwritten_TestConfigTarget:
+
+..  This file is a placeholder for optional multiple files
+    handwritten documentation for the TestConfigTarget module.
+    
+..  This handwritten documentation is optional. In case
+    you do not want to write it, you can delete the doc/ directory.
+
+..  The documentation can be written in reStructuredText,
+    and will be converted to HTML and PDF by Sphinx.
+    This index.rst file is the entry point for the module documentation.
+
+..  Use underlined-only headlines inside this document (highest-level
+    sub-section headline should use "=" characters)
+
+..  The content of this file will be included in the auto-generated HTML
+    page for the module. You can link to it using the following
+    reference: everest_modules_TestConfigTarget.
+
+.. *******************************************
+.. TestConfigTarget
+.. *******************************************
+
+Test module for config service integration tests

--- a/tests/everest-core_tests/modules/TestConfigTarget/main/emptyImpl.cpp
+++ b/tests/everest-core_tests/modules/TestConfigTarget/main/emptyImpl.cpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "emptyImpl.hpp"
+
+namespace module {
+namespace main {
+
+void emptyImpl::init() {
+}
+
+void emptyImpl::ready() {
+}
+
+} // namespace main
+} // namespace module

--- a/tests/everest-core_tests/modules/TestConfigTarget/main/emptyImpl.hpp
+++ b/tests/everest-core_tests/modules/TestConfigTarget/main/emptyImpl.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef MAIN_EMPTY_IMPL_HPP
+#define MAIN_EMPTY_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/empty/Implementation.hpp>
+
+#include "../TestConfigTarget.hpp"
+
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+// insert your custom include headers here
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+
+namespace module {
+namespace main {
+
+struct Conf {};
+
+class emptyImpl : public emptyImplBase {
+public:
+    emptyImpl() = delete;
+    emptyImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<TestConfigTarget>& mod, Conf& config) :
+        emptyImplBase(ev, "main"), mod(mod), config(config){};
+
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+    // insert your public definitions here
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+
+protected:
+    // no commands defined for this interface
+
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+    // insert your protected definitions here
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+
+private:
+    const Everest::PtrContainer<TestConfigTarget>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+    // insert your private definitions here
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+};
+
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+// insert other definitions here
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+
+} // namespace main
+} // namespace module
+
+#endif // MAIN_EMPTY_IMPL_HPP

--- a/tests/everest-core_tests/modules/TestConfigTarget/manifest.yaml
+++ b/tests/everest-core_tests/modules/TestConfigTarget/manifest.yaml
@@ -1,0 +1,29 @@
+description: "Test module for config service integration tests"
+metadata:
+  license: "https://opensource.org/licenses/Apache-2.0"
+  authors: ["Piet Gömpel"]
+config:
+  rw_param:
+    description: "A ReadWrite string parameter for testing runtime config changes"
+    type: string
+    default: "initial_value"
+    mutability: ReadWrite
+  rw_reboot_param:
+    description: "A ReadWrite parameter whose handler signals a reboot is required"
+    type: string
+    default: "reboot_value"
+    mutability: ReadWrite
+  rw_reject_param:
+    description: "A ReadWrite parameter whose handler rejects the change"
+    type: string
+    default: "reject_value"
+    mutability: ReadWrite
+  ro_param:
+    description: "A ReadOnly string parameter for testing reboot-required responses"
+    type: string
+    default: "read_only_value"
+    mutability: ReadOnly
+provides:
+  main:
+    description: "main implementation"
+    interface: "empty"

--- a/tests/framework_tests/cpp_tests.py
+++ b/tests/framework_tests/cpp_tests.py
@@ -11,6 +11,17 @@ from everest.testing.core_utils.fixtures import *
 from everest.testing.core_utils.everest_core import EverestCore
 from everest.testing.core_utils.probe_module import ProbeModule
 
+PROBE_CONFIG_SERVICE_ACCESS = {
+    "config": {
+        "modules": {
+            "test_config_target": {
+                "allow_read": True,
+                "allow_write": True,
+            }
+        }
+    }
+}
+
 from dataclasses import dataclass
 @dataclass
 class ErrorHandlingTesterState:
@@ -737,3 +748,78 @@ class TestErrorHandling:
         raised_error = error_handling_tester.test_error_handling['errors_global_all'][0]
         cleared_error = error_handling_tester.test_error_handling['errors_cleared_global_all'][0]
         assert raised_error['type'] == cleared_error['type'], 'Raised error does not match cleared error'
+
+
+@pytest.mark.probe_module(
+    connections={},
+    access=PROBE_CONFIG_SERVICE_ACCESS,
+)
+@pytest.mark.everest_core_config('config-test-cpp-config-service.yaml')
+class TestConfigService:
+    """
+    Tests for the runtime config service (set/get config values via the framework manager).
+    """
+
+    @pytest.fixture
+    def probe_module(self, started_test_controller, everest_core):
+        return ProbeModule(everest_core.get_runtime_session())
+
+    @pytest.mark.asyncio
+    async def test_config_service_operations(self, probe_module: ProbeModule):
+        # get initial value
+        result = await probe_module.get_config_value(
+            module_id="test_config_target",
+            param_name="rw_param",
+        )
+        assert result["status"] == "Ok", f"Expected Ok status, got: {result}"
+        assert result["value"] == "initial_value", f"Expected initial_value, got: {result}"
+
+        # set ReadWrite param - accepted immediately
+        result = await probe_module.set_config_value(
+            module_id="test_config_target",
+            param_name="rw_param",
+            value="updated_value",
+        )
+        assert result["status"] == "Ok", f"Expected Ok status, got: {result}"
+        assert result["set_status"] == "Accepted", f"Expected Accepted set_status, got: {result}"
+
+        # get after set - value should reflect the change
+        result = await probe_module.get_config_value(
+            module_id="test_config_target",
+            param_name="rw_param",
+        )
+        assert result["status"] == "Ok", f"Expected Ok status, got: {result}"
+        assert result["value"] == "updated_value", f"Expected updated_value, got: {result}"
+
+        # set ReadWrite param whose handler returns RebootRequired
+        result = await probe_module.set_config_value(
+            module_id="test_config_target",
+            param_name="rw_reboot_param",
+            value="new_reboot_value",
+        )
+        assert result["status"] == "Ok", f"Expected Ok status, got: {result}"
+        assert result["set_status"] == "RebootRequired", f"Expected RebootRequired set_status, got: {result}"
+
+        # set ReadWrite param whose handler rejects the change
+        result = await probe_module.set_config_value(
+            module_id="test_config_target",
+            param_name="rw_reject_param",
+            value="some_value",
+        )
+        assert result["set_status"] == "Rejected", f"Expected Rejected set_status, got: {result}"
+
+        # set ReadOnly param - rejected by the manager
+        result = await probe_module.set_config_value(
+            module_id="test_config_target",
+            param_name="ro_param",
+            value="new_ro_value",
+        )
+        assert result["set_status"] == "Rejected", f"Expected Rejected set_status, got: {result}"
+
+        # set non-existent param - error status
+        result = await probe_module.set_config_value(
+            module_id="test_config_target",
+            param_name="nonexistent_param",
+            value="some_value",
+        )
+        assert result["status"] != "Ok", f"Expected error status for unknown param, got: {result}"


### PR DESCRIPTION

## Describe your changes

- Add set_config_value, get_config_value, and register_config_change_handler to the everestpy Module binding and the ProbeModule test utility
- Add to_json/from_json conversions for SetConfigResult, GetConfigResult, and ConfigChangeResult in the framework
- Add TestConfigTarget module with ReadWrite, RebootRequired, Rejected, and ReadOnly parameter variants, and a TestConfigService integration test to test the config service API


## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

