### PR TITLE
[OCPP] EVSE Manager publishing updated energy limit

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <generated/types/powermeter.hpp>
 #include <math.h>
+#include <optional>
 #include <string.h>
 #include <thread>
 #include <type_traits>
@@ -215,7 +216,7 @@ void Charger::run_state_machine() {
                     shared_context.hlc_charging_active = true;
                 }
                 shared_context.hlc_allow_close_contactor = false;
-                shared_context.max_current_cable = 0;
+                shared_context.max_current_cable.reset();
                 shared_context.hlc_charging_terminate_pause = HlcTerminatePause::Unknown;
                 shared_context.legacy_wakeup_done = false;
                 shared_context.hlc_d20_active = false;
@@ -305,10 +306,10 @@ void Charger::run_state_machine() {
 
             // Read PP value in case of AC socket
             if (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket and
-                shared_context.max_current_cable == 0) {
-                shared_context.max_current_cable = bsp->read_pp_ampacity();
+                not shared_context.max_current_cable.has_value()) {
                 // retry if the value is not yet available. Some BSPs may take some time to measure the PP.
-                if (shared_context.max_current_cable == 0) {
+                shared_context.max_current_cable = bsp->read_pp_ampacity();
+                if (not shared_context.max_current_cable.has_value()) {
                     if (not internal_context.pp_warning_printed) {
                         EVLOG_warning << "PP ampacity is zero, still waiting for BSP to report it...";
                         internal_context.pp_warning_printed = true;
@@ -1817,10 +1818,11 @@ std::string Charger::evse_state_to_string(EvseState s) {
 
 float Charger::get_max_current_internal() {
     auto maxc = shared_context.max_current;
+    const auto max_current_cable = shared_context.max_current_cable.value_or(0.0);
 
     if (connector_type == types::evse_board_support::Connector_type::IEC62196Type2Socket and
-        shared_context.max_current_cable < maxc and shared_context.current_state not_eq EvseState::Idle) {
-        maxc = shared_context.max_current_cable;
+        max_current_cable < maxc and shared_context.current_state not_eq EvseState::Idle) {
+        maxc = max_current_cable;
     }
 
     return maxc;

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -306,7 +306,7 @@ private:
         bool matching_started;
         float max_current;
         std::chrono::time_point<std::chrono::steady_clock> max_current_valid_until;
-        float max_current_cable{0.};
+        std::optional<double> max_current_cable;
         std::atomic_bool flag_transaction_active;
         bool session_active;
         std::string session_uuid;

--- a/modules/EVSE/EvseManager/IECStateMachine.cpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <math.h>
+#include <optional>
 #include <string.h>
 
 namespace module {
@@ -447,8 +448,12 @@ void IECStateMachine::set_pp_ampacity(types::board_support_common::ProximityPilo
 // High level state machine requests reading PP ampacity value.
 // The high level state machine will never call this if it is not used
 // (e.g. in DC or AC tethered charging)
-double IECStateMachine::read_pp_ampacity() {
-    return pp_ampacity;
+std::optional<double> IECStateMachine::read_pp_ampacity() {
+    const double tmp = pp_ampacity;
+    if (tmp == 0.0) {
+        return std::nullopt;
+    }
+    return tmp;
 }
 
 // Forward special request to switch the number of phases during charging. BSP will need to implement a special

--- a/modules/EVSE/EvseManager/IECStateMachine.hpp
+++ b/modules/EVSE/EvseManager/IECStateMachine.hpp
@@ -81,7 +81,7 @@ public:
     void allow_power_on(bool value, types::evse_board_support::Reason reason);
 
     void set_pp_ampacity(types::board_support_common::ProximityPilot const& pp);
-    double read_pp_ampacity();
+    std::optional<double> read_pp_ampacity();
     void switch_three_phases_while_charging(bool n);
     void setup(bool has_ventilation);
 

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -372,9 +372,6 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
     if (value.uuid == energy_flow_request.uuid) {
         // EVLOG_info << "Incoming enforce limits" << value;
 
-        // publish for e.g. OCPP module
-        mod->p_evse->publish_enforced_limits(value);
-
         //   set hardware limit
         float limit = 0.;
         int active_phasecount = mod->ac_nr_phases_active;
@@ -420,7 +417,11 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
             }
         }
 
-        auto enforced_limit = limit;
+        // update based on the PP cable rating
+        const float pp_rating = mod->bsp->read_pp_ampacity();
+        limit = std::min(limit, pp_rating);
+
+        const auto enforced_limit = limit;
 
         // check if we need to add a random delay for UK smart charging regs
         if (mod->random_delay_enabled) {
@@ -477,6 +478,13 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
         }
 
         last_enforced_limit = enforced_limit;
+
+        // publish for e.g. OCPP module with the updated limit
+        if (value.limits_root_side.ac_max_current_A) {
+            types::energy::NumberWithSource nws_updated{limit, value.limits_root_side.ac_max_current_A.value().source};
+            value.limits_root_side.ac_max_current_A = std::move(nws_updated);
+        }
+        mod->p_evse->publish_enforced_limits(value);
 
         // update limit at the charger
         const auto valid_until = steady_clock::now() + seconds(value.valid_for);

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -276,12 +276,14 @@ void energyImpl::request_energy_from_energy_manager(bool priority_request) {
 
         // Cap by PP cable rating so the EnergyManager cannot allocate more than the cable allows
         if (mod->config.charge_mode == "AC") {
-            const float pp_rating = mod->bsp->read_pp_ampacity();
-            const std::string source_pp = source_base + "/pp_ampacity";
-            for (auto& e : energy_flow_request.schedule_import) {
-                if (e.limits_to_root.ac_max_current_A.has_value() &&
-                    e.limits_to_root.ac_max_current_A.value().value > pp_rating) {
-                    e.limits_to_root.ac_max_current_A = {pp_rating, source_pp};
+            const auto pp_rating = mod->bsp->read_pp_ampacity();
+            if (pp_rating) {
+                const std::string source_pp = source_base + "/pp_ampacity";
+                for (auto& e : energy_flow_request.schedule_import) {
+                    if (e.limits_to_root.ac_max_current_A.has_value() &&
+                        e.limits_to_root.ac_max_current_A.value().value > pp_rating.value()) {
+                        e.limits_to_root.ac_max_current_A = {static_cast<float>(pp_rating.value()), source_pp};
+                    }
                 }
             }
         }
@@ -490,10 +492,12 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
         // publish for e.g. OCPP module with the updated limit
         if (value.limits_root_side.ac_max_current_A) {
             // update based on the PP cable rating
-            const float pp_rating = mod->bsp->read_pp_ampacity();
-            types::energy::NumberWithSource nws_updated{std::min(limit, pp_rating),
-                                                        value.limits_root_side.ac_max_current_A.value().source};
-            value.limits_root_side.ac_max_current_A = std::move(nws_updated);
+            const auto pp_rating = mod->bsp->read_pp_ampacity();
+            if (pp_rating) {
+                types::energy::NumberWithSource nws_updated{std::min(limit, static_cast<float>(pp_rating.value())),
+                                                            value.limits_root_side.ac_max_current_A.value().source};
+                value.limits_root_side.ac_max_current_A = std::move(nws_updated);
+            }
         }
         mod->p_evse->publish_enforced_limits(value);
 

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -372,9 +372,6 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
     if (value.uuid == energy_flow_request.uuid) {
         // EVLOG_info << "Incoming enforce limits" << value;
 
-        // publish for e.g. OCPP module
-        mod->p_evse->publish_enforced_limits(value);
-
         //   set hardware limit
         float limit = 0.;
         int active_phasecount = mod->ac_nr_phases_active;
@@ -420,7 +417,7 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
             }
         }
 
-        auto enforced_limit = limit;
+        const auto enforced_limit = limit;
 
         // check if we need to add a random delay for UK smart charging regs
         if (mod->random_delay_enabled) {
@@ -477,6 +474,16 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
         }
 
         last_enforced_limit = enforced_limit;
+
+        // publish for e.g. OCPP module with the updated limit
+        if (value.limits_root_side.ac_max_current_A) {
+            // update based on the PP cable rating
+            const float pp_rating = mod->bsp->read_pp_ampacity();
+            types::energy::NumberWithSource nws_updated{std::min(limit, pp_rating),
+                                                        value.limits_root_side.ac_max_current_A.value().source};
+            value.limits_root_side.ac_max_current_A = std::move(nws_updated);
+        }
+        mod->p_evse->publish_enforced_limits(value);
 
         // update limit at the charger
         const auto valid_until = steady_clock::now() + seconds(value.valid_for);

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -274,6 +274,18 @@ void energyImpl::request_energy_from_energy_manager(bool priority_request) {
             e.limits_to_root.ac_number_of_active_phases = mod->ac_nr_phases_active;
         }
 
+        // Cap by PP cable rating so the EnergyManager cannot allocate more than the cable allows
+        if (mod->config.charge_mode == "AC") {
+            const float pp_rating = mod->bsp->read_pp_ampacity();
+            const std::string source_pp = source_base + "/pp_ampacity";
+            for (auto& e : energy_flow_request.schedule_import) {
+                if (e.limits_to_root.ac_max_current_A.has_value() &&
+                    e.limits_to_root.ac_max_current_A.value().value > pp_rating) {
+                    e.limits_to_root.ac_max_current_A = {pp_rating, source_pp};
+                }
+            }
+        }
+
         if (mod->config.charge_mode == "DC") {
             // For DC mode remove amp limit on leave side if any
             for (auto& e : energy_flow_request.schedule_import) {

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -6,6 +6,7 @@
 
 #include <Charger.hpp>
 #include <memory>
+#include <optional>
 
 namespace {
 using namespace module;
@@ -705,8 +706,8 @@ void IECStateMachine::process_bsp_event(const types::board_support_common::BspEv
 void IECStateMachine::allow_power_on(bool value, types::evse_board_support::Reason reason) {
 }
 
-double IECStateMachine::read_pp_ampacity() {
-    return 0.0;
+std::optional<double> IECStateMachine::read_pp_ampacity() {
+    return std::nullopt;
 }
 void IECStateMachine::switch_three_phases_while_charging(bool n) {
 }


### PR DESCRIPTION
## Describe your changes

The EVSE Manager publishes enforced_limits (which is used by OCPP). Unfortunately the ac_max_current_A published is before any adjustments have been made. This PR ensures that the updated limit is in ac_max_current_A in particular taking into account the PP current rating

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

