### PR TITLE
[Backport stable/2026.02] fix(mqtt): fix TOCTOU race causing messages to be silently dropped (#2159)

### DIFF
--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -143,7 +143,7 @@ public:
 
 private:
     static constexpr int mqtt_poll_timeout_ms{300000};
-    bool mqtt_is_connected;
+    std::atomic_bool mqtt_is_connected;
     MessageHandler message_handler;
     MessageQueue message_queue;
     std::vector<std::shared_ptr<MessageWithQOS>> messages_before_connected;

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -168,10 +168,12 @@ void MQTTAbstractionImpl::publish(const std::string& topic, const std::string& d
         }
     }
 
-    if (!this->mqtt_is_connected) {
+    {
         const std::lock_guard<std::mutex> lock(messages_before_connected_mutex);
-        this->messages_before_connected.push_back(std::make_shared<MessageWithQOS>(topic, data, qos, retain));
-        return;
+        if (!this->mqtt_is_connected) {
+            this->messages_before_connected.push_back(std::make_shared<MessageWithQOS>(topic, data, qos, retain));
+            return;
+        }
     }
 
     const MQTTErrors error = mqtt_publish(&this->mqtt_client, topic.c_str(), data.c_str(), data.size(), publish_flags);
@@ -446,14 +448,17 @@ void MQTTAbstractionImpl::on_mqtt_connect() {
 
     EVLOG_debug << "Connected to MQTT broker";
 
-    // this will allow new handlers to subscribe directly, if needed
+    // Drain the messages_before_connected under the lock, then publish outside it.
+    // publish() itself acquires the same lock, so calling it
+    // while holding the mutex would deadlock
+    std::vector<std::shared_ptr<MessageWithQOS>> to_publish;
     {
         const std::lock_guard<std::mutex> lock(messages_before_connected_mutex);
         this->mqtt_is_connected = true;
-        for (auto& message : this->messages_before_connected) {
-            this->publish(message->topic, message->payload, message->qos, message->retain);
-        }
-        this->messages_before_connected.clear();
+        to_publish = std::move(messages_before_connected);
+    }
+    for (auto& message : to_publish) {
+        this->publish(message->topic, message->payload, message->qos, message->retain);
     }
 }
 


### PR DESCRIPTION

## Describe your changes

* fix(mqtt): fix TOCTOU race causing messages to be silently dropped on connect
* publish() checked mqtt_is_connected outside the mutex before queuing, so on_mqtt_connect() could drain and clear messages_before_connected between the check and the push, losing mqtt messages and potentially causing modules to time out on startup.

(cherry picked from commit df67109)

Patch did not apply cleanly and required manual PR.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

