### PR TITLE
feat(iso15118 ev d20): PowerDelivery EV state

### DIFF
--- a/lib/everest/iso15118/include/iso15118/ev/d20/state/power_delivery.hpp
+++ b/lib/everest/iso15118/include/iso15118/ev/d20/state/power_delivery.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include "../states.hpp"
+#include <iso15118/message/power_delivery.hpp>
+
+namespace iso15118::ev::d20::state {
+
+struct PowerDelivery : public StateBase {
+public:
+    PowerDelivery(Context& ctx, message_20::datatypes::Progress charge_progress) :
+        StateBase(ctx, StateID::PowerDelivery), m_charge_progress(charge_progress) {
+    }
+
+    void enter() final;
+    Result feed(Event) final;
+
+private:
+    message_20::datatypes::Progress m_charge_progress;
+};
+
+} // namespace iso15118::ev::d20::state

--- a/lib/everest/iso15118/src/iso15118/CMakeLists.txt
+++ b/lib/everest/iso15118/src/iso15118/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(iso15118
         ev/d20/state/authorization_setup.cpp
         ev/d20/state/authorization.cpp
         ev/d20/state/dc_charge_parameter_discovery.cpp
+        ev/d20/state/power_delivery.cpp
         ev/d20/state/session_stop.cpp
         ev/session/feedback.cpp
 

--- a/lib/everest/iso15118/src/iso15118/ev/d20/state/power_delivery.cpp
+++ b/lib/everest/iso15118/src/iso15118/ev/d20/state/power_delivery.cpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <iso15118/detail/helper.hpp>
+#include <iso15118/ev/d20/context.hpp>
+#include <iso15118/ev/d20/state/power_delivery.hpp>
+#include <iso15118/ev/detail/d20/context_helper.hpp>
+#include <iso15118/message/power_delivery.hpp>
+
+#include <optional>
+
+namespace iso15118::ev::d20::state {
+
+namespace {
+
+using ResponseCode = message_20::datatypes::ResponseCode;
+
+bool check_response_code(ResponseCode response_code) {
+    switch (response_code) {
+    case ResponseCode::OK:
+    case ResponseCode::OK_PowerToleranceConfirmed:
+        return true;
+    case ResponseCode::WARNING_PowerToleranceNotConfirmed:
+    case ResponseCode::WARNING_StandbyNotAllowed:
+    case ResponseCode::WARNING_WPT:
+        // TODO: spec-defined recoveries (fall back to agreed profile / renegotiate /
+        // WPT_FinePositioningSetupReq). Accept for now; recovery flows tracked separately.
+        logf_warning("PowerDeliveryResponse warning code: %d", static_cast<int>(response_code));
+        return true;
+    case ResponseCode::FAILED:
+    case ResponseCode::FAILED_SequenceError:
+    case ResponseCode::FAILED_UnknownSession:
+    case ResponseCode::FAILED_SignatureError:
+    case ResponseCode::FAILED_ContactorError:
+    case ResponseCode::FAILED_EVPowerProfileInvalid:
+    case ResponseCode::FAILED_ScheduleSelectionInvalid:
+    case ResponseCode::FAILED_PowerDeliveryNotApplied:
+    case ResponseCode::FAILED_PowerToleranceNotConfirmed:
+        return false;
+    default:
+        logf_warning("Unexpected response code received: %d", static_cast<int>(response_code));
+        return iso15118::ev::d20::check_response_code(response_code);
+    }
+}
+
+message_20::PowerDeliveryRequest
+make_request(const Session& session, message_20::datatypes::Progress charge_progress,
+             std::optional<message_20::datatypes::Processing> processing = std::nullopt) {
+    message_20::PowerDeliveryRequest req;
+    setup_header(req.header, session);
+    req.processing = processing.value_or(message_20::datatypes::Processing::Finished);
+    req.charge_progress = charge_progress;
+    // power_profile + channel_selection deliberately left nullopt
+    return req;
+}
+
+} // namespace
+
+void PowerDelivery::enter() {
+    m_ctx.respond(make_request(m_ctx.get_session(), m_charge_progress));
+}
+
+Result PowerDelivery::feed(Event ev) {
+    if (ev != Event::V2GTP_MESSAGE) {
+        return {};
+    }
+
+    const auto variant = m_ctx.pull_response();
+
+    const auto res = variant->get_if<message_20::PowerDeliveryResponse>();
+    if (res == nullptr) {
+        logf_error("Expected PowerDeliveryResponse, got code type id: %d", static_cast<int>(variant->get_type()));
+        m_ctx.stop_session(true);
+        return {};
+    }
+
+    if (res->header.session_id != m_ctx.get_session().get_id()) {
+        logf_error("PowerDeliveryResponse session_id does not match current session");
+        m_ctx.stop_session(true);
+        return {};
+    }
+
+    if (not check_response_code(res->response_code)) {
+        logf_error("PowerDeliveryResponse rejected with response_code: %d", static_cast<int>(res->response_code));
+        m_ctx.stop_session(true);
+        return {};
+    }
+
+    using Progress = message_20::datatypes::Progress;
+    switch (m_charge_progress) {
+    case Progress::Start:
+        // Next state: DC_ChargeLoop (not yet implemented)
+        return {};
+    case Progress::Stop:
+        // Next state: DC_WeldingDetection or SessionStop, decided by the caller's energy-service selection
+        return {};
+    case Progress::Standby:
+        // Stay in PowerDelivery; see evse-side state for re-entry pattern
+        return {};
+    case Progress::ScheduleRenegotiation:
+        // Next state: ScheduleExchange (not yet implemented)
+        return {};
+    }
+    return {};
+}
+
+} // namespace iso15118::ev::d20::state

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/CMakeLists.txt
@@ -16,4 +16,5 @@ endfunction()
 
 create_ev_fsm_test_target(session_setup)
 create_ev_fsm_test_target(authorization_setup)
+create_ev_fsm_test_target(power_delivery)
 create_ev_fsm_test_target(session_stop)

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/power_delivery.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/power_delivery.cpp
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_test_macros.hpp>
+
+#include "helper.hpp"
+
+#include <iso15118/ev/d20/state/power_delivery.hpp>
+#include <iso15118/message/authorization.hpp>
+#include <iso15118/message/power_delivery.hpp>
+#include <iso15118/message/type.hpp>
+
+using namespace iso15118;
+
+namespace {
+constexpr auto SESSION_HEADER =
+    message_20::Header{std::array<uint8_t, 8>{0x10, 0x34, 0xAB, 0x7A, 0x01, 0xF3, 0x95, 0x02}, 1691411798};
+
+ev::d20::Context& prime_context(FsmStateHelper& helper) {
+    auto& ctx = helper.get_context();
+    ctx.get_session().set_id(SESSION_HEADER.session_id);
+    return ctx;
+}
+} // namespace
+
+SCENARIO("ISO15118-20 EV PowerDelivery sends Finished + chosen progress on enter") {
+    const ev::d20::session::feedback::Callbacks callbacks{};
+    auto state_helper = FsmStateHelper(callbacks);
+    auto& ctx = prime_context(state_helper);
+
+    fsm::v2::FSM<ev::d20::StateBase> fsm{
+        ctx.create_state<ev::d20::state::PowerDelivery>(message_20::datatypes::Progress::Start)};
+
+    const auto request_message = ctx.get_request<message_20::PowerDeliveryRequest>();
+    REQUIRE(request_message.has_value());
+    REQUIRE(request_message->header.session_id == SESSION_HEADER.session_id);
+    REQUIRE(request_message->processing == message_20::datatypes::Processing::Finished);
+    REQUIRE(request_message->charge_progress == message_20::datatypes::Progress::Start);
+    REQUIRE_FALSE(request_message->power_profile.has_value());
+    REQUIRE_FALSE(request_message->channel_selection.has_value());
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery stays on OK response") {
+    const ev::d20::session::feedback::Callbacks callbacks{};
+    auto state_helper = FsmStateHelper(callbacks);
+    auto& ctx = prime_context(state_helper);
+
+    fsm::v2::FSM<ev::d20::StateBase> fsm{
+        ctx.create_state<ev::d20::state::PowerDelivery>(message_20::datatypes::Progress::Start)};
+
+    const auto res =
+        message_20::PowerDeliveryResponse{SESSION_HEADER, message_20::datatypes::ResponseCode::OK, std::nullopt};
+    state_helper.handle_response(res);
+
+    const auto result = fsm.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(ctx.is_session_stopped() == false);
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery stops session on FAILED response") {
+    const ev::d20::session::feedback::Callbacks callbacks{};
+    auto state_helper = FsmStateHelper(callbacks);
+    auto& ctx = prime_context(state_helper);
+
+    fsm::v2::FSM<ev::d20::StateBase> fsm{
+        ctx.create_state<ev::d20::state::PowerDelivery>(message_20::datatypes::Progress::Start)};
+
+    const auto res =
+        message_20::PowerDeliveryResponse{SESSION_HEADER, message_20::datatypes::ResponseCode::FAILED, std::nullopt};
+    state_helper.handle_response(res);
+
+    const auto result = fsm.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(ctx.is_session_stopped() == true);
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery stops session on mismatched response session_id") {
+    const ev::d20::session::feedback::Callbacks callbacks{};
+    auto state_helper = FsmStateHelper(callbacks);
+    auto& ctx = prime_context(state_helper);
+
+    fsm::v2::FSM<ev::d20::StateBase> fsm{
+        ctx.create_state<ev::d20::state::PowerDelivery>(message_20::datatypes::Progress::Start)};
+
+    constexpr auto WRONG_HEADER =
+        message_20::Header{std::array<uint8_t, 8>{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00, 0x00, 0x00}, 1691411798};
+    const auto res =
+        message_20::PowerDeliveryResponse{WRONG_HEADER, message_20::datatypes::ResponseCode::OK, std::nullopt};
+    state_helper.handle_response(res);
+
+    const auto result = fsm.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(ctx.is_session_stopped() == true);
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery stops session on wrong variant") {
+    const ev::d20::session::feedback::Callbacks callbacks{};
+    auto state_helper = FsmStateHelper(callbacks);
+    auto& ctx = prime_context(state_helper);
+
+    fsm::v2::FSM<ev::d20::StateBase> fsm{
+        ctx.create_state<ev::d20::state::PowerDelivery>(message_20::datatypes::Progress::Start)};
+
+    const auto wrong = message_20::AuthorizationResponse{SESSION_HEADER, message_20::datatypes::ResponseCode::OK,
+                                                         message_20::datatypes::Processing::Finished};
+    state_helper.handle_response(wrong);
+
+    const auto result = fsm.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(ctx.is_session_stopped() == true);
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery accepts OK_PowerToleranceConfirmed") {
+    const ev::d20::session::feedback::Callbacks callbacks{};
+    auto state_helper = FsmStateHelper(callbacks);
+    auto& ctx = prime_context(state_helper);
+
+    fsm::v2::FSM<ev::d20::StateBase> fsm{
+        ctx.create_state<ev::d20::state::PowerDelivery>(message_20::datatypes::Progress::Start)};
+
+    const auto res = message_20::PowerDeliveryResponse{
+        SESSION_HEADER, message_20::datatypes::ResponseCode::OK_PowerToleranceConfirmed, std::nullopt};
+    state_helper.handle_response(res);
+
+    const auto result = fsm.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(ctx.is_session_stopped() == false);
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery accepts WARNING_StandbyNotAllowed") {
+    const ev::d20::session::feedback::Callbacks callbacks{};
+    auto state_helper = FsmStateHelper(callbacks);
+    auto& ctx = prime_context(state_helper);
+
+    fsm::v2::FSM<ev::d20::StateBase> fsm{
+        ctx.create_state<ev::d20::state::PowerDelivery>(message_20::datatypes::Progress::Standby)};
+
+    const auto res = message_20::PowerDeliveryResponse{
+        SESSION_HEADER, message_20::datatypes::ResponseCode::WARNING_StandbyNotAllowed, std::nullopt};
+    state_helper.handle_response(res);
+
+    const auto result = fsm.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(ctx.is_session_stopped() == false);
+}
+
+SCENARIO("ISO15118-20 EV PowerDelivery stops session on FAILED_ContactorError") {
+    const ev::d20::session::feedback::Callbacks callbacks{};
+    auto state_helper = FsmStateHelper(callbacks);
+    auto& ctx = prime_context(state_helper);
+
+    fsm::v2::FSM<ev::d20::StateBase> fsm{
+        ctx.create_state<ev::d20::state::PowerDelivery>(message_20::datatypes::Progress::Start)};
+
+    const auto res = message_20::PowerDeliveryResponse{
+        SESSION_HEADER, message_20::datatypes::ResponseCode::FAILED_ContactorError, std::nullopt};
+    state_helper.handle_response(res);
+
+    const auto result = fsm.feed(ev::d20::Event::V2GTP_MESSAGE);
+
+    REQUIRE(result.transitioned() == false);
+    REQUIRE(fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
+    REQUIRE(ctx.is_session_stopped() == true);
+}


### PR DESCRIPTION
Add PowerDelivery EV-side D20 state.

- enter() sends PowerDeliveryRequest with charge_progress
- feed() validates response variant, session_id, and code
- per-state check_response_code whitelist sourced from ISO 15118-20 Table 224
- 8 Catch2 scenarios cover happy path, warnings, FAILED codes, wrong variant, and session_id mismatch

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

