### PR TITLE
Allow to set retain for external MQTT

### DIFF
--- a/lib/everest/framework/include/framework/ModuleAdapter.hpp
+++ b/lib/everest/framework/include/framework/ModuleAdapter.hpp
@@ -84,7 +84,7 @@ struct ModuleAdapter {
     using GetGlobalErrorManagerFunc = std::function<std::shared_ptr<error::ErrorManagerReqGlobal>()>;
     using GetGlobalErrorStateMonitorFunc = std::function<std::shared_ptr<error::ErrorStateMonitor>()>;
     using GetErrorStateMonitorReqFunc = std::function<std::shared_ptr<error::ErrorStateMonitor>(const Requirement&)>;
-    using ExtMqttPublishFunc = std::function<void(const std::string&, const std::string&)>;
+    using ExtMqttPublishFunc = std::function<void(const std::string&, const std::string&, bool)>;
     using ExtMqttSubscribeFunc = std::function<UnsubscribeToken(const std::string&, StringHandler)>;
     using ExtMqttSubscribePairFunc = std::function<UnsubscribeToken(const std::string&, StringPairHandler)>;
     using TelemetryPublishFunc =
@@ -119,17 +119,17 @@ class MqttProvider {
 public:
     MqttProvider(ModuleAdapter& ev);
 
-    void publish(const std::string& topic, const std::string& data);
+    void publish(const std::string& topic, const std::string& data, bool retain = false);
 
-    void publish(const std::string& topic, const char* data);
+    void publish(const std::string& topic, const char* data, bool retain = false);
 
-    void publish(const std::string& topic, bool data);
+    void publish(const std::string& topic, bool data, bool retain = false);
 
-    void publish(const std::string& topic, int data);
+    void publish(const std::string& topic, int data, bool retain = false);
 
-    void publish(const std::string& topic, double data, int precision);
+    void publish(const std::string& topic, double data, int precision, bool retain = false);
 
-    void publish(const std::string& topic, double data);
+    void publish(const std::string& topic, double data, bool retain = false);
 
     UnsubscribeToken subscribe(const std::string& topic, StringHandler handler) const;
 

--- a/lib/everest/framework/include/framework/everest.hpp
+++ b/lib/everest/framework/include/framework/everest.hpp
@@ -130,9 +130,9 @@ public:
     std::shared_ptr<config::ConfigServiceClient> get_config_service_client() const;
 
     ///
-    /// \brief publishes the given \p data on the given \p topic
+    /// \brief publishes the given \p data on the given \p topic with the given \p retain
     ///
-    void external_mqtt_publish(const std::string& topic, const std::string& data);
+    void external_mqtt_publish(const std::string& topic, const std::string& data, bool retain);
 
     ///
     /// \brief Allows a module to indicate that it provides a external mqtt \p handler at the given \p topic

--- a/lib/everest/framework/lib/everest.cpp
+++ b/lib/everest/framework/lib/everest.cpp
@@ -737,10 +737,10 @@ void Everest::publish_cleared_error(const std::string& impl_id, const error::Err
     this->mqtt_abstraction->publish(error_topic, payload, QOS::QOS2);
 }
 
-void Everest::external_mqtt_publish(const std::string& topic, const std::string& data) {
+void Everest::external_mqtt_publish(const std::string& topic, const std::string& data, bool retain) {
     BOOST_LOG_FUNCTION();
     check_external_mqtt();
-    this->mqtt_abstraction->publish(fmt::format("{}{}", this->mqtt_external_prefix, topic), data);
+    this->mqtt_abstraction->publish(fmt::format("{}{}", this->mqtt_external_prefix, topic), data, QOS::QOS2, retain);
 }
 
 UnsubscribeToken Everest::provide_external_mqtt_handler(const std::string& topic, const StringHandler& handler) {

--- a/lib/everest/framework/lib/module_adapter.cpp
+++ b/lib/everest/framework/lib/module_adapter.cpp
@@ -26,34 +26,34 @@ void ModuleAdapter::gather_cmds(ImplementationBase& impl) {
 
 MqttProvider::MqttProvider(ModuleAdapter& ev) : ev(ev){};
 
-void MqttProvider::publish(const std::string& topic, const std::string& data) {
-    ev.ext_mqtt_publish(topic, data);
+void MqttProvider::publish(const std::string& topic, const std::string& data, bool retain) {
+    ev.ext_mqtt_publish(topic, data, retain);
 }
 
-void MqttProvider::publish(const std::string& topic, const char* data) {
-    ev.ext_mqtt_publish(topic, std::string(data));
+void MqttProvider::publish(const std::string& topic, const char* data, bool retain) {
+    ev.ext_mqtt_publish(topic, std::string(data), retain);
 }
 
-void MqttProvider::publish(const std::string& topic, bool data) {
+void MqttProvider::publish(const std::string& topic, bool data, bool retain) {
     if (data) {
-        ev.ext_mqtt_publish(topic, "true");
+        ev.ext_mqtt_publish(topic, "true", retain);
     } else {
-        ev.ext_mqtt_publish(topic, "false");
+        ev.ext_mqtt_publish(topic, "false", retain);
     }
 }
 
-void MqttProvider::publish(const std::string& topic, int data) {
-    ev.ext_mqtt_publish(topic, std::to_string(data));
+void MqttProvider::publish(const std::string& topic, int data, bool retain) {
+    ev.ext_mqtt_publish(topic, std::to_string(data), retain);
 }
 
-void MqttProvider::publish(const std::string& topic, double data, int precision) {
+void MqttProvider::publish(const std::string& topic, double data, int precision, bool retain) {
     std::stringstream stream;
     stream << std::fixed << std::setprecision(precision) << data;
-    ev.ext_mqtt_publish(topic, stream.str());
+    ev.ext_mqtt_publish(topic, stream.str(), retain);
 }
 
-void MqttProvider::publish(const std::string& topic, double data) {
-    this->publish(topic, data, mqtt_provider_default_precision);
+void MqttProvider::publish(const std::string& topic, double data, bool retain) {
+    this->publish(topic, data, mqtt_provider_default_precision, retain);
 }
 
 UnsubscribeToken MqttProvider::subscribe(const std::string& topic, StringHandler handler) const {

--- a/lib/everest/framework/lib/runtime.cpp
+++ b/lib/everest/framework/lib/runtime.cpp
@@ -568,7 +568,8 @@ int ModuleLoader::initialize() {
 
         // NOLINTNEXTLINE(modernize-avoid-bind): prefer bind here for readability
         module_adapter.ext_mqtt_publish =
-            std::bind(&Everest::Everest::external_mqtt_publish, &everest, std::placeholders::_1, std::placeholders::_2);
+            std::bind(&Everest::Everest::external_mqtt_publish, &everest, std::placeholders::_1, std::placeholders::_2,
+                      std::placeholders::_3);
 
         module_adapter.ext_mqtt_subscribe = [&everest](const std::string& topic, const StringHandler& handler) {
             return everest.provide_external_mqtt_handler(topic, handler);

--- a/tests/include/ModuleAdapterStub.hpp
+++ b/tests/include/ModuleAdapterStub.hpp
@@ -38,7 +38,9 @@ struct ModuleAdapterStub : public Everest::ModuleAdapter {
         };
         get_global_error_manager = [this]() { return this->get_global_error_manager_fn(); };
         get_global_error_state_monitor = [this]() { return this->get_global_error_state_monitor_fn(); };
-        ext_mqtt_publish = [this](const std::string& s1, const std::string& s2) { this->ext_mqtt_publish_fn(s1, s2); };
+        ext_mqtt_publish = [this](const std::string& s1, const std::string& s2, bool retain) {
+            this->ext_mqtt_publish_fn(s1, s2);
+        };
         ext_mqtt_subscribe = [this](const std::string& str, StringHandler sh) {
             return this->ext_mqtt_subscribe_fn(str, sh);
         };


### PR DESCRIPTION
## Describe your changes
The external Mqtt facility which can be activated in the modules manifest did not allow to set the retain flag when publishing.

This change allows to do so.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

