### PR TITLE
Fix everest-core scarthgap yocto recipe

### DIFF
--- a/yocto/scarthgap/meta-everest/recipes-core/everest/everest-core_git.bb
+++ b/yocto/scarthgap/meta-everest/recipes-core/everest/everest-core_git.bb
@@ -45,6 +45,7 @@ INSANE_SKIP:chargebridge = "already-stripped useless-rpaths arch file-rdeps"
 PACKAGES:prepend = "chargebridge "
 
 FILES:${PN} += "${libdir}/everest/* ${datadir}/everest/* ${systemd_system_unitdir}/everest.service"
+FILES:${PN}-dev += "${libdir}/libeverest_io.so"
 
 FILES:chargebridge = " \
     ${bindir}/pionix_chargebridge \
@@ -87,7 +88,7 @@ EXTRA_OECMAKE:append = " -DPYBIND11_INTERFACE_INCLUDE_DIRECTORIES=${STAGING_INCD
 
 SYSTEMD_PACKAGES:append = " chargebridge"
 SYSTEMD_SERVICE:${PN} = "everest.service"
-SYSTEMD_SERVICE:chargebridge = "chargebridge.service"
+SYSTEMD_SERVICE:chargebridge = "${@bb.utils.contains('PACKAGECONFIG', 'applications', 'chargebridge.service', '', d)}"
 
 PACKAGECONFIG ??= "applications python ${@bb.utils.filter('DISTRO_FEATURES', 'tpm2', d)}"
 


### PR DESCRIPTION
## Describe your changes
- make chargebridge SYSTEMD_SERVICE conditional based on PACKAGECONFIG this is already done in the install step, but not earlier. When you remove "applications" from your PACKAGECONFIG this results in a QA error during packaging

- add libeverest_io.so to everest-core-dev package, otherwise this also leads to a packaging QA error
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

