### PR TITLE
fix(ocpp1.6): reject invalid boolean ChangeConfiguration values

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -3574,7 +3574,11 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
         EVLOG_warning << "Attempt to change AuthorizationKey to value with < 8 characters";
         return ConfigurationStatus::Rejected;
     } else if (key == "AuthorizeRemoteTxRequests") {
-        this->setAuthorizeRemoteTxRequests(ocpp::conversions::string_to_bool(value.get()));
+        if (isBool(value.get())) {
+            this->setAuthorizeRemoteTxRequests(ocpp::conversions::string_to_bool(value.get()));
+        } else {
+            return ConfigurationStatus::Rejected;
+        }
     } else if (key == "BlinkRepeat") {
         if (this->getBlinkRepeat() == std::nullopt) {
             return ConfigurationStatus::NotSupported;
@@ -3625,7 +3629,11 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
         if (this->getCentralContractValidationAllowed() == std::nullopt) {
             return ConfigurationStatus::NotSupported;
         }
-        this->setCentralContractValidationAllowed(ocpp::conversions::string_to_bool(value.get()));
+        if (isBool(value.get())) {
+            this->setCentralContractValidationAllowed(ocpp::conversions::string_to_bool(value.get()));
+        } else {
+            return ConfigurationStatus::Rejected;
+        }
     } else if (key == "CertSigningWaitMinimum") {
         if (this->getCertSigningWaitMinimum() == std::nullopt) {
             return ConfigurationStatus::NotSupported;
@@ -3657,11 +3665,19 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
             return ConfigurationStatus::Rejected;
         }
     } else if (key == "ContractValidationOffline") {
-        this->setContractValidationOffline(ocpp::conversions::string_to_bool(value.get()));
+        if (isBool(value.get())) {
+            this->setContractValidationOffline(ocpp::conversions::string_to_bool(value.get()));
+        } else {
+            return ConfigurationStatus::Rejected;
+        }
     } else if (key == "CpoName") {
         this->setCpoName(value.get());
     } else if (key == "DisableSecurityEventNotifications") {
-        this->setDisableSecurityEventNotifications(ocpp::conversions::string_to_bool(value.get()));
+        if (isBool(value.get())) {
+            this->setDisableSecurityEventNotifications(ocpp::conversions::string_to_bool(value.get()));
+        } else {
+            return ConfigurationStatus::Rejected;
+        }
     } else if (key == "HeartbeatInterval") {
         try {
             auto [valid, interval] = is_positive_integer(value.get());
@@ -3675,9 +3691,17 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
             return ConfigurationStatus::Rejected;
         }
     } else if (key == "ISO15118CertificateManagementEnabled") {
-        this->setISO15118CertificateManagementEnabled(ocpp::conversions::string_to_bool(value.get()));
+        if (isBool(value.get())) {
+            this->setISO15118CertificateManagementEnabled(ocpp::conversions::string_to_bool(value.get()));
+        } else {
+            return ConfigurationStatus::Rejected;
+        }
     } else if (key == "ISO15118PnCEnabled") {
-        this->setISO15118PnCEnabled(ocpp::conversions::string_to_bool(value.get()));
+        if (isBool(value.get())) {
+            this->setISO15118PnCEnabled(ocpp::conversions::string_to_bool(value.get()));
+        } else {
+            return ConfigurationStatus::Rejected;
+        }
     } else if (key == "LightIntensity") {
         if (this->getLightIntensity() == std::nullopt) {
             return ConfigurationStatus::NotSupported;
@@ -3976,10 +4000,13 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
             return ConfigurationStatus::NotSupported;
         }
     } else if (key == "AllowChargingProfileWithoutStartSchedule") {
-        if (this->getAllowChargingProfileWithoutStartSchedule().has_value()) {
+        if (!this->getAllowChargingProfileWithoutStartSchedule().has_value()) {
+            return ConfigurationStatus::NotSupported;
+        }
+        if (isBool(value.get())) {
             this->setAllowChargingProfileWithoutStartSchedule(ocpp::conversions::string_to_bool(value.get()));
         } else {
-            return ConfigurationStatus::NotSupported;
+            return ConfigurationStatus::Rejected;
         }
     } else if (key.get().find("DefaultPriceText") == 0) {
         const ConfigurationStatus result = this->setDefaultPriceText(key, value);
@@ -4007,7 +4034,11 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
             return result;
         }
     } else if (key == "CustomIdleFeeAfterStop") {
-        this->setCustomIdleFeeAfterStop(ocpp::conversions::string_to_bool(value));
+        if (isBool(value.get())) {
+            this->setCustomIdleFeeAfterStop(ocpp::conversions::string_to_bool(value.get()));
+        } else {
+            return ConfigurationStatus::Rejected;
+        }
     } else if (key == "Language") {
         this->setLanguage(value);
     } else if (key == "WaitForSetUserPriceTimeout") {

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_configuration.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_configuration.cpp
@@ -151,4 +151,34 @@ TEST_F(ConfigurationTester, DefaultPriceText) {
     EXPECT_EQ(set_result, ConfigurationStatus::Accepted);
 }
 
+// Boolean ChangeConfiguration values must be validated rather than silently
+// coerced to false. See EVerest/EVerest#2182.
+TEST_F(ConfigurationTester, BooleanKeyAcceptsValidLiterals) {
+    const std::vector<std::string> accepted_values = {"true", "false", "True", "FALSE", "tRuE"};
+    for (const auto& v : accepted_values) {
+        auto result = config->set("AuthorizeRemoteTxRequests", v);
+        ASSERT_TRUE(result.has_value()) << "value=" << v;
+        EXPECT_EQ(result.value(), ConfigurationStatus::Accepted) << "value=" << v;
+    }
+}
+
+TEST_F(ConfigurationTester, BooleanKeyRejectsInvalidLiterals) {
+    auto initial = config->get("AuthorizeRemoteTxRequests");
+    ASSERT_TRUE(initial.has_value());
+    ASSERT_TRUE(initial.value().value.has_value());
+    const auto initial_value = initial.value().value.value();
+
+    const std::vector<std::string> rejected_values = {"maybe", "", "1", "0", "yes", "no", "tru", "falsey"};
+    for (const auto& v : rejected_values) {
+        auto result = config->set("AuthorizeRemoteTxRequests", v);
+        ASSERT_TRUE(result.has_value()) << "value=" << v;
+        EXPECT_EQ(result.value(), ConfigurationStatus::Rejected) << "value=" << v;
+
+        auto current = config->get("AuthorizeRemoteTxRequests");
+        ASSERT_TRUE(current.has_value());
+        ASSERT_TRUE(current.value().value.has_value()) << "value=" << v;
+        EXPECT_EQ(current.value().value.value(), initial_value) << "value=" << v;
+    }
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

Fixes EVerest/EVerest#2182.

In OCPP 1.6, `ChangeConfiguration` on a boolean `ConfigurationKey` previously returned `status = Accepted` for any non-`"true"` value while silently storing `false`, because `string_to_bool()` coerces unknown input to `false` without signalling an error. The CSMS and the charger end up with divergent views of the configuration with no error surfaced.

This PR validates the input for the previously-unprotected boolean keys and returns `ConfigurationStatus::Rejected` for non-boolean values, leaving the existing value unchanged.

The implementation reuses the existing `ChargePointConfigurationBase::isBool()` helper (case-insensitive `"true"`/`"false"` only) and mirrors the validation pattern already used in the same file for:

- other boolean keys: `AllowOfflineTxForUnknownId`, `AuthorizationCacheEnabled`, `LocalAuthorizeOffline`, `LocalPreAuthorize`, `StopTransactionOnInvalidId`, `UnlockConnectorOnEVSideDisconnect`, `StopTransactionIfUnlockNotSupported`, `LocalAuthListEnabled`, `VerifyCsmsAllowWildcards`
- integer keys: `BlinkRepeat`, `ClockAlignedDataInterval`, etc. (via `is_positive_integer()`)

## Affected keys

- `AuthorizeRemoteTxRequests`
- `CentralContractValidationAllowed`
- `ContractValidationOffline`
- `DisableSecurityEventNotifications`
- `ISO15118CertificateManagementEnabled`
- `ISO15118PnCEnabled`
- `AllowChargingProfileWithoutStartSchedule`
- `CustomIdleFeeAfterStop`

## Behaviour change

Before:
```
ChangeConfiguration{ key: "AuthorizeRemoteTxRequests", value: "maybe" }
-> { status: "Accepted" }
GetConfiguration{ key: "AuthorizeRemoteTxRequests" }
-> { value: "false" }   // silently coerced
```

After:
```
ChangeConfiguration{ key: "AuthorizeRemoteTxRequests", value: "maybe" }
-> { status: "Rejected" }
GetConfiguration{ key: "AuthorizeRemoteTxRequests" }
-> { value: "true" }    // unchanged
```

Valid case-insensitive boolean literals (`"true"`, `"false"`, `"True"`, `"FALSE"`, etc.) continue to be accepted.

## Tests

Adds two test cases in `lib/everest/ocpp/tests/lib/ocpp/v16/test_configuration.cpp` keyed off `AuthorizeRemoteTxRequests`:

- `BooleanKeyAcceptsValidLiterals` — `"true"`, `"false"`, `"True"`, `"FALSE"`, `"tRuE"` -> `Accepted`
- `BooleanKeyRejectsInvalidLiterals` — `"maybe"`, `""`, `"1"`, `"0"`, `"yes"`, `"no"`, `"tru"`, `"falsey"` -> `Rejected`, and verifies the stored value is unchanged after each rejection.

## Notes

- No public API change. `string_to_bool()` is left untouched for backward compatibility; only the OCPP 1.6 `ChangeConfiguration` handler now validates input before calling it.
- The custom-key path at `charge_point_configuration.cpp:3015` is intentionally left untouched in this PR — that branch is covered by JSON schema validation (libocpp PR #853) and is out of scope for this issue.
- Issue #2182 was confirmed by @Pietfried as a reasonable fix direction.