### PR TITLE
fix(framework): use explicit get<Mapping>() in ModuleTierMappings::from_json

### DIFF
--- a/lib/everest/framework/lib/types.cpp
+++ b/lib/everest/framework/lib/types.cpp
@@ -135,11 +135,11 @@ ModuleTierMappings adl_serializer<ModuleTierMappings>::from_json(const json& j) 
     ModuleTierMappings m;
     if (!j.is_null()) {
         if (j.contains("module")) {
-            m.module = j.at("module");
+            m.module = j.at("module").get<Mapping>();
         }
         if (j.contains("implementations")) {
             for (auto& impl : j.at("implementations").items()) {
-                m.implementations[impl.key()] = impl.value();
+                m.implementations[impl.key()] = impl.value().get<Mapping>();
             }
         }
     }

--- a/lib/everest/framework/tests/test_conversions.cpp
+++ b/lib/everest/framework/tests/test_conversions.cpp
@@ -72,4 +72,48 @@ SCENARIO("Check conversions", "[!throws]") {
             CHECK(tp_from_slow == tp_from_fast);
         }
     }
+
+    GIVEN("ModuleTierMappings json with module mapping only") {
+        THEN("It should parse without throwing") {
+            const json j = {{"module", {{"evse", 1}, {"connector", 2}}}};
+            ModuleTierMappings m;
+            REQUIRE_NOTHROW(m = j.get<ModuleTierMappings>());
+            REQUIRE(m.module.has_value());
+            CHECK(m.module.value().evse == 1);
+            REQUIRE(m.module.value().connector.has_value());
+            CHECK(m.module.value().connector.value() == 2);
+            CHECK(m.implementations.empty());
+        }
+    }
+
+    GIVEN("ModuleTierMappings json with module and implementations") {
+        THEN("It should parse without throwing") {
+            const json j = {{"module", {{"evse", 1}}},
+                            {"implementations", {{"main", {{"evse", 1}, {"connector", 1}}}, {"sink", {{"evse", 2}}}}}};
+            ModuleTierMappings m;
+            REQUIRE_NOTHROW(m = j.get<ModuleTierMappings>());
+            REQUIRE(m.module.has_value());
+            CHECK(m.module.value().evse == 1);
+            CHECK_FALSE(m.module.value().connector.has_value());
+            REQUIRE(m.implementations.count("main") == 1);
+            REQUIRE(m.implementations.at("main").has_value());
+            CHECK(m.implementations.at("main").value().evse == 1);
+            REQUIRE(m.implementations.at("main").value().connector.has_value());
+            CHECK(m.implementations.at("main").value().connector.value() == 1);
+            REQUIRE(m.implementations.count("sink") == 1);
+            REQUIRE(m.implementations.at("sink").has_value());
+            CHECK(m.implementations.at("sink").value().evse == 2);
+            CHECK_FALSE(m.implementations.at("sink").value().connector.has_value());
+        }
+    }
+
+    GIVEN("Null ModuleTierMappings json") {
+        THEN("It should yield an empty mapping") {
+            const json j = nullptr;
+            ModuleTierMappings m;
+            REQUIRE_NOTHROW(m = j.get<ModuleTierMappings>());
+            CHECK_FALSE(m.module.has_value());
+            CHECK(m.implementations.empty());
+        }
+    }
 }


### PR DESCRIPTION
## Describe your changes

`ModuleTierMappings::from_json` in `lib/everest/framework/lib/types.cpp` previously did:

```cpp
m.module = j.at("module");
m.implementations[k] = impl.value();
```

This relies on implicit conversion from `nlohmann::json` to `std::optional<Mapping>` / `Mapping`, which does **not** dispatch to the custom `adl_serializer<Mapping>::from_json` defined a few lines above. At runtime it throws:

```
[json.exception.type_error.302] type must be string, but is object
```

…whenever any module config supplies a non-null tier mapping. This crashes every module that uses tier mappings — `evse_manager`, `grid_connection_point`, OCPP connector sinks, etc. — i.e. essentially every real-world charger configuration.

The fix is to force dispatch to `adl_serializer<Mapping>::from_json` with an explicit `.get<Mapping>()`:

```cpp
m.module = j.at("module").get<Mapping>();
m.implementations[k] = impl.value().get<Mapping>();
```

Two-line change. Tested in production on a TI AM625-based DC charger (Titan rev1/rev2) running the framework code pinned at `everest-core@b666184e` (the `stable/2026.02` SRCREV used by `meta-everest`).

### Repro

Any config with module-level or implementation-level tier mappings, e.g.:

```yaml
active_modules:
  evse_manager_1:
    module: EvseManager
    mappings:
      module:
        evse: 1
        connector: 1
```

…will crash during framework config parsing without this fix.

### Scope of the bug

The buggy code is byte-identical between `everest-framework v0.24.0`, `v0.25.0`, and current `main` (now living at `everest-core@main:lib/everest/framework/lib/types.cpp`). `nlohmann_json` is pinned to `v3.12.0` on both sides, so the trigger was not a library bump. The faulty path has been there since `ModuleTierMappings` was introduced in #198 / #206 — it was just only exercised in real-world tier-mapped configs starting recently.

### Tests added

`lib/everest/framework/tests/test_conversions.cpp` gains three `GIVEN` blocks under the existing `Check conversions` scenario:

1. `ModuleTierMappings json with module mapping only` — the smallest case that reproduces the crash.
2. `ModuleTierMappings json with module and implementations` — exercises both deserialization paths.
3. `Null ModuleTierMappings json` — preserves existing accepted-shape behavior.

Without the fix the first two throw `json::type_error.302` and the test target aborts. With the fix all three pass.

## Issue ticket number and link

No issue filed — this is a bugfix per the contributing guide ("Pull requests for bugfixes do not necessarily need to link an issue").

### Backport request

Please consider applying the `backport stable/2026.02` label — the same defective code is present on `stable/2026.02`, which is the branch consumed by `meta-everest` (the Yocto layer many production downstream projects use).

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (n/a — no public API change; tests added)
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements