### PR TITLE
fix(libframework): update cmake target properties for framework library versioning

### DIFF
--- a/lib/everest/framework/lib/CMakeLists.txt
+++ b/lib/everest/framework/lib/CMakeLists.txt
@@ -10,7 +10,10 @@ set(DEFAULT_LINKAGE SHARED)
 add_library(framework ${DEFAULT_LINKAGE})
 add_library(everest::framework ALIAS framework)
 
-set_target_properties(framework PROPERTIES SOVERSION ${PROJECT_VERSION})
+set_target_properties(framework PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)
 
 target_sources(framework
     PRIVATE

--- a/lib/everest/framework/lib/CMakeLists.txt
+++ b/lib/everest/framework/lib/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(everest::framework ALIAS framework)
 
 set_target_properties(framework PROPERTIES
     VERSION ${PROJECT_VERSION}
-    SOVERSION ${PROJECT_VERSION_MAJOR}
+    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
 )
 
 target_sources(framework


### PR DESCRIPTION
## Describe your changes
Set both `VERSION` and `SOVERSION` on the `framework` CMake target so the build produces a properly versioned shared library with the full version encoded in the filename.

This improves ABI decoupling: consumers link against the SONAME (`libframework.so.0`), while the real file carries the full version (`libframework.so.0.25.0`), allowing parallel installation and easier rollback.

**Before** — no versioned file, only the bare SONAME:
```
-rwxr-xr-x  1 root root  2624864  /usr/lib/libframework.so.0
```

**After** — symlink chain with full version:
```
lrwxrwxrwx  1 root root       22  /usr/lib/libframework.so.0 -> libframework.so.0.25.0
-rwxr-xr-x  1 root root  2624864  /usr/lib/libframework.so.0.25.0
```

Consumers correctly reference the SONAME, not the full path:
```
$ readelf -d /usr/libexec/everest/modules/LemDCBM400600/LemDCBM400600
  (NEEDED) Shared library: [libframework.so.0]
```

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

