### PR TITLE
test(iso15118-ev-d20): drop stale post-transition checks

### DIFF
--- a/lib/everest/iso15118/test/iso15118/ev/fsm/dc_pre_charge.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/dc_pre_charge.cpp
@@ -51,11 +51,6 @@ SCENARIO("ISO15118-20 EV DC_PreCharge transitions to PowerDelivery on OK respons
     REQUIRE(result.transitioned() == true);
     REQUIRE(fsm.get_current_state_id() == ev::d20::StateID::PowerDelivery);
     REQUIRE(ctx.is_session_stopped() == false);
-
-    // After response, a Finished request must have been enqueued.
-    const auto request_message = ctx.get_request<message_20::DC_PreChargeRequest>();
-    REQUIRE(request_message.has_value());
-    REQUIRE(request_message->processing == message_20::datatypes::Processing::Finished);
 }
 
 SCENARIO("ISO15118-20 EV DC_PreCharge stops session on FAILED response") {

--- a/lib/everest/iso15118/test/iso15118/ev/fsm/dc_welding_detection.cpp
+++ b/lib/everest/iso15118/test/iso15118/ev/fsm/dc_welding_detection.cpp
@@ -48,11 +48,6 @@ SCENARIO("ISO15118-20 EV DC_WeldingDetection transitions to SessionStop on OK re
     REQUIRE(result.transitioned() == true);
     REQUIRE(fsm.get_current_state_id() == ev::d20::StateID::SessionStop);
     REQUIRE(ctx.is_session_stopped() == false);
-
-    // After response, a Finished request must have been enqueued.
-    const auto request_message = ctx.get_request<message_20::DC_WeldingDetectionRequest>();
-    REQUIRE(request_message.has_value());
-    REQUIRE(request_message->processing == message_20::datatypes::Processing::Finished);
 }
 
 SCENARIO("ISO15118-20 EV DC_WeldingDetection stops session on FAILED response") {


### PR DESCRIPTION
DC_PreCharge/DC_WeldingDetection enqueue a Finished request, then transition. The next state's enter() overwrites the request, so the post-feed get_request<...>() returned nullopt. Drop the stale asserts; matches dc_cable_check/session_stop test pattern.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

