### PR TITLE
build(io): make MQTT support optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ option(EVEREST_ENABLE_GLOBAL_COMPILE_WARNINGS "Enable compile warnings set in th
 option(EVEREST_ENABLE_DEBUG_BUILD "Enable debug build" OFF)
 option(EVEREST_BUILD_APPLICATIONS "Build applications like drivers for the EVerest stable API" ON)
 option(EVEREST_LIBS_ONLY "Only build libraries, skip modules/applications/config" OFF)
+option(EVEREST_IO_WITH_MQTT "Build MQTT (mosquitto) support in everest::io" ON)
 set(EVEREST_INCLUDE_LIBS "" CACHE STRING "Semicolon-separated allowlist of libraries to build (empty = all)")
 set(EVEREST_EXCLUDE_LIBS "" CACHE STRING "Semicolon-separated blocklist of libraries to skip")
 # list of compile options that are passed to modules if EVEREST_ENABLE_COMPILE_WARNINGS=ON

--- a/applications/pionix_chargebridge/CMakeLists.txt
+++ b/applications/pionix_chargebridge/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 
+if(DEFINED EVEREST_IO_WITH_MQTT AND NOT EVEREST_IO_WITH_MQTT)
+    message(FATAL_ERROR "pionix_chargebridge requires MQTT support in everest::io. "
+            "Set EVEREST_IO_WITH_MQTT=ON or disable EVEREST_BUILD_APPLICATIONS.")
+endif()
+
 find_package(ryml QUIET)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/lib/everest/framework/CMakeLists.txt
+++ b/lib/everest/framework/CMakeLists.txt
@@ -6,6 +6,12 @@ project(everest-framework
     LANGUAGES CXX C
 )
 
+if(DEFINED EVEREST_IO_WITH_MQTT AND NOT EVEREST_IO_WITH_MQTT)
+    message(FATAL_ERROR "everest-framework requires MQTT support in everest::io. "
+            "Set EVEREST_IO_WITH_MQTT=ON or exclude framework from the build "
+            "(e.g. via EVEREST_EXCLUDE_LIBS=framework).")
+endif()
+
 find_package(everest-cmake 0.5 REQUIRED
     PATHS ../everest-cmake
 )

--- a/lib/everest/io/CMakeLists.txt
+++ b/lib/everest/io/CMakeLists.txt
@@ -1,5 +1,6 @@
 option(BUILD_DOC "Build documentation" OFF)
 option(BUILD_EXAMPLES "Build examples" OFF)
+option(EVEREST_IO_WITH_MQTT "Build MQTT (mosquitto) support in everest::io" ON)
 
 add_subdirectory(src)
 

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -26,8 +26,6 @@ target_sources(everest_io
         serial/event_pty.cpp
         mdns/mdns.cpp
         mdns/mdns_socket.cpp
-        mqtt/mosquitto_cpp.cpp
-        mqtt/mqtt_client.cpp
         tun_tap/tap_handler.cpp
         tcp/tcp_socket.cpp
         netlink/vcan_netlink_manager.cpp
@@ -37,9 +35,20 @@ target_sources(everest_io
 target_include_directories(everest_io
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-        $<BUILD_INTERFACE:${mosquitto_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
+
+if(EVEREST_IO_WITH_MQTT)
+    target_sources(everest_io
+        PRIVATE
+            mqtt/mosquitto_cpp.cpp
+            mqtt/mqtt_client.cpp
+    )
+    target_include_directories(everest_io
+        PUBLIC
+            $<BUILD_INTERFACE:${mosquitto_SOURCE_DIR}/include>
+    )
+endif()
 
 target_link_libraries(everest_io
     PUBLIC
@@ -79,23 +88,25 @@ set_target_properties(everest_io
         POSITION_INDEPENDENT_CODE ON
 )
 
-if(DISABLE_EDM)
-  target_link_libraries(everest_io
-    PRIVATE
-    mosquitto
-  )
-else()
-  target_link_libraries(everest_io
-    PRIVATE
-    libmosquitto
-  )
-  install(TARGETS libmosquitto
-      EXPORT everest-core-targets
-      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  )
+if(EVEREST_IO_WITH_MQTT)
+  if(DISABLE_EDM)
+    target_link_libraries(everest_io
+      PRIVATE
+      mosquitto
+    )
+  else()
+    target_link_libraries(everest_io
+      PRIVATE
+      libmosquitto
+    )
+    install(TARGETS libmosquitto
+        EXPORT everest-core-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+  endif()
 endif()
 
 install(TARGETS everest_io
@@ -106,7 +117,15 @@ install(TARGETS everest_io
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/everest
-    DESTINATION include
-    FILES_MATCHING PATTERN "*.hpp"
-)
+if(EVEREST_IO_WITH_MQTT)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/everest
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.hpp"
+    )
+else()
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/everest
+        DESTINATION include
+        FILES_MATCHING PATTERN "*.hpp"
+        PATTERN "mqtt" EXCLUDE
+    )
+endif()


### PR DESCRIPTION
Add EVEREST_IO_WITH_MQTT option (default ON) gating mosquitto sources, link, and header install in everest::io. Allows minimal io builds without an MQTT broker dependency.

Hard-fail at configure time when the option is OFF but framework or pionix_chargebridge is included, since both hard-depend on everest::io MQTT.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

