### PR TITLE
fix(framework): use steady clock for measurements

### DIFF
--- a/lib/everest/framework/everestjs/everestjs.cpp
+++ b/lib/everest/framework/everestjs/everestjs.cpp
@@ -561,7 +561,7 @@ static Napi::Value is_condition_satisfied_req(const Requirement& req, const Napi
 static Napi::Value boot_module(const Napi::CallbackInfo& info) {
     BOOST_LOG_FUNCTION();
 
-    const auto start_time = std::chrono::system_clock::now();
+    const auto start_time = std::chrono::steady_clock::now();
 
     auto env = info.Env();
 
@@ -943,7 +943,7 @@ static Napi::Value boot_module(const Napi::CallbackInfo& info) {
         ctx->js_cb = std::make_unique<JsExecCtx>(env, callback_wrapper);
         ctx->everest->register_on_ready_handler(framework_ready_handler);
 
-        const auto end_time = std::chrono::system_clock::now();
+        const auto end_time = std::chrono::steady_clock::now();
         EVLOG_info << "Module " << fmt::format(Everest::TERMINAL_STYLE_BLUE, "{}", module_id) << " initialized ["
                    << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms]";
 

--- a/lib/everest/framework/everestpy/src/everest/module.cpp
+++ b/lib/everest/framework/everestpy/src/everest/module.cpp
@@ -21,7 +21,7 @@ Module::Module(const RuntimeSession& session) : Module(get_variable_from_env("EV
 }
 
 Module::Module(const std::string& module_id_, const RuntimeSession& session_) :
-    module_id(module_id_), session(session_), start_time(std::chrono::system_clock::now()) {
+    module_id(module_id_), session(session_), start_time(std::chrono::steady_clock::now()) {
 
     this->mqtt_abstraction =
         std::shared_ptr<Everest::MQTTAbstraction>(Everest::make_mqtt_abstraction(session.get_mqtt_settings()));

--- a/lib/everest/framework/everestpy/src/everest/module.hpp
+++ b/lib/everest/framework/everestpy/src/everest/module.hpp
@@ -29,7 +29,7 @@ public:
             handle->register_on_ready_handler(on_ready_handler);
         }
 
-        const auto end_time = std::chrono::system_clock::now();
+        const auto end_time = std::chrono::steady_clock::now();
         EVLOG_info << "Module " << fmt::format(Everest::TERMINAL_STYLE_BLUE, "{}", this->module_id) << " initialized ["
                    << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - this->start_time).count()
                    << "ms]";
@@ -85,7 +85,7 @@ public:
 private:
     const std::string module_id;
     const RuntimeSession& session;
-    const std::chrono::time_point<std::chrono::system_clock> start_time;
+    const std::chrono::time_point<std::chrono::steady_clock> start_time;
     std::unique_ptr<Everest::RuntimeSettings> rs;
     std::shared_ptr<Everest::MQTTAbstraction> mqtt_abstraction;
     std::unique_ptr<Everest::Config> config_;

--- a/lib/everest/framework/lib/config.cpp
+++ b/lib/everest/framework/lib/config.cpp
@@ -755,11 +755,11 @@ std::tuple<json, int64_t> ManagerConfig::load_and_validate_with_schema(const fs:
     const json json_to_validate = load_yaml(file_path);
     int64_t validation_ms = 0;
 
-    const auto start_time_validate = std::chrono::system_clock::now();
+    const auto start_time_validate = std::chrono::steady_clock::now();
     json_validator validator(loader, format_checker);
     validator.set_root_schema(schema);
     validator.validate(json_to_validate);
-    const auto end_time_validate = std::chrono::system_clock::now();
+    const auto end_time_validate = std::chrono::steady_clock::now();
     EVLOG_debug
         << "YAML validation of " << file_path.string() << " took: "
         << std::chrono::duration_cast<std::chrono::milliseconds>(end_time_validate - start_time_validate).count()
@@ -1022,7 +1022,7 @@ void ManagerConfig::parse(ModuleConfigurations& module_configs) {
     if (this->ms.runtime_settings.validate_schema) {
         int64_t total_time_validation_ms = 0, total_time_parsing_ms = 0;
         for (auto const& types_entry : fs::recursive_directory_iterator(this->ms.types_dir)) {
-            const auto start_time = std::chrono::system_clock::now();
+            const auto start_time = std::chrono::steady_clock::now();
             const auto& type_file_path = types_entry.path();
             if (fs::is_regular_file(type_file_path) && type_file_path.extension() == ".yaml") {
                 const auto type_path =
@@ -1042,7 +1042,7 @@ void ManagerConfig::parse(ModuleConfigurations& module_configs) {
                         "Failed to load and parse type file '{}', reason: {}", type_file_path.string(), e.what())));
                 }
             }
-            const auto end_time = std::chrono::system_clock::now();
+            const auto end_time = std::chrono::steady_clock::now();
             total_time_parsing_ms +=
                 std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
             EVLOG_debug << "Parsing of type " << types_entry.path().string() << " took: "
@@ -1056,7 +1056,7 @@ void ManagerConfig::parse(ModuleConfigurations& module_configs) {
     if (this->ms.runtime_settings.validate_schema) {
         int64_t total_time_validation_ms = 0, total_time_parsing_ms = 0;
         for (auto const& errors_entry : fs::recursive_directory_iterator(this->ms.errors_dir)) {
-            const auto start_time = std::chrono::system_clock::now();
+            const auto start_time = std::chrono::steady_clock::now();
             const auto& error_file_path = errors_entry.path();
             if (fs::is_regular_file(error_file_path) && error_file_path.extension() == ".yaml") {
                 try {
@@ -1072,7 +1072,7 @@ void ManagerConfig::parse(ModuleConfigurations& module_configs) {
                         "Failed to load and parse error file '{}', reason: {}", error_file_path.string(), e.what())));
                 }
             }
-            const auto end_time = std::chrono::system_clock::now();
+            const auto end_time = std::chrono::steady_clock::now();
             total_time_parsing_ms +=
                 std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
             EVLOG_debug << "Parsing of error " << errors_entry.path().string() << " took: "

--- a/lib/everest/framework/lib/runtime.cpp
+++ b/lib/everest/framework/lib/runtime.cpp
@@ -448,14 +448,14 @@ int ModuleLoader::initialize() {
     }
     Logging::init(this->logging_config_file.string(), this->module_id);
 
-    const auto start_time = std::chrono::system_clock::now();
+    const auto start_time = std::chrono::steady_clock::now();
 
     this->mqtt = std::shared_ptr<MQTTAbstraction>(make_mqtt_abstraction(this->mqtt_settings));
     this->mqtt->connect();
     this->mqtt->spawn_main_loop_thread();
 
     const auto result = get_module_config(this->mqtt, this->module_id);
-    const auto get_config_time = std::chrono::system_clock::now();
+    const auto get_config_time = std::chrono::steady_clock::now();
     EVLOG_debug << "Module " << fmt::format(TERMINAL_STYLE_OK, "{}", module_id) << " get_config() ["
                 << std::chrono::duration_cast<std::chrono::milliseconds>(get_config_time - start_time).count() << "ms]";
 
@@ -479,7 +479,7 @@ int ModuleLoader::initialize() {
 
     try {
         const auto config = Config(this->mqtt_settings, result);
-        const auto config_instantiation_time = std::chrono::system_clock::now();
+        const auto config_instantiation_time = std::chrono::steady_clock::now();
         EVLOG_debug
             << "Module " << fmt::format(TERMINAL_STYLE_OK, "{}", module_id) << " after Config() instantiation ["
             << std::chrono::duration_cast<std::chrono::milliseconds>(config_instantiation_time - start_time).count()
@@ -617,7 +617,7 @@ int ModuleLoader::initialize() {
         // the module should now be ready
         everest.signal_ready();
 
-        const auto end_time = std::chrono::system_clock::now();
+        const auto end_time = std::chrono::steady_clock::now();
         EVLOG_info << "Module " << fmt::format(TERMINAL_STYLE_BLUE, "{}", module_id) << " initialized ["
                    << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms]";
 

--- a/lib/everest/framework/src/manager.cpp
+++ b/lib/everest/framework/src/manager.cpp
@@ -42,7 +42,7 @@ using namespace Everest;
 
 const auto PARENT_DIED_SIGNAL = SIGTERM;
 const int CONTROLLER_IPC_READ_TIMEOUT_MS = 50;
-const auto complete_start_time = std::chrono::system_clock::now();
+const auto complete_start_time = std::chrono::steady_clock::now();
 
 #ifdef ENABLE_ADMIN_PANEL
 class ControllerHandle {
@@ -414,7 +414,7 @@ std::map<pid_t, std::string> start_modules(ManagerConfig& config, MQTTAbstractio
             }
             if (std::all_of(modules_ready.begin(), modules_ready.end(),
                             [](const auto& element) { return element.second.ready; })) {
-                const auto complete_end_time = std::chrono::system_clock::now();
+                const auto complete_end_time = std::chrono::steady_clock::now();
                 status_fifo.update(StatusFifo::ALL_MODULES_STARTED);
                 if (not retain_topics) {
                     EVLOG_info << "Clearing retained topics published by manager during startup";
@@ -713,7 +713,7 @@ int boot(const po::variables_map& vm) {
 
     const bool retain_topics = (vm.count("retain-topics") != 0);
 
-    const auto start_time = std::chrono::system_clock::now();
+    const auto start_time = std::chrono::steady_clock::now();
     std::shared_ptr<ManagerConfig> config; // TODO: maybe this can stay unique when we re-work start_modules()
     try {
         config = std::make_shared<ManagerConfig>(ms);
@@ -729,7 +729,7 @@ int boot(const po::variables_map& vm) {
         EVLOG_critical << fmt::format("Caught top level std::exception:\n{}", boost::diagnostic_information(e, true));
         return EXIT_FAILURE;
     }
-    const auto end_time = std::chrono::system_clock::now();
+    const auto end_time = std::chrono::steady_clock::now();
     EVLOG_info << "Config loading completed in "
                << std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() << "ms";
 


### PR DESCRIPTION
This avoids skew when the system clock jumps while measuring (e.g. via NTP while EVerest is launching after boot).

## Describe your changes
Replace `std::chrono::system_clock` with `std::chrono::steady_clock`.

## Issue ticket number and link
Fixes https://github.com/EVerest/EVerest/issues/2204.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

