### PR TITLE
feat(io): allow binding udp/tcp clients to network device

### DIFF
--- a/lib/everest/io/include/everest/io/socket/socket.hpp
+++ b/lib/everest/io/include/everest/io/socket/socket.hpp
@@ -16,19 +16,23 @@ namespace everest::lib::io::socket {
 /**
  * @brief Open a UDP socket in server mode
  * @param[in] port The port to listen to
+ * @param[in] device Optional interface name (e.g. "eth0"). When non-empty the socket is bound
+ * to that device via SO_BINDTODEVICE. Requires CAP_NET_RAW or root.
  * @return The managed file descriptor of the socket
  * @throws std::runtime_error if the operation fails.
  */
-event::unique_fd open_udp_server_socket(std::uint16_t port);
+event::unique_fd open_udp_server_socket(std::uint16_t port, std::string const& device = {});
 
 /**
  * @brief Open a UDP socket in client mode
  * @param[in] host The host to connect to
  * @param[in] port The port to listen to
+ * @param[in] device Optional interface name (e.g. "eth0"). When non-empty the socket is bound
+ * to that device via SO_BINDTODEVICE before connect. Requires CAP_NET_RAW or root.
  * @return The managed file descriptor of the socket
  * @throws std::runtime_error if the operation fails.
  */
-event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t port);
+event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t port, std::string const& device = {});
 
 /**
  * @brief Open a UDP socket with <a href="https://man7.org/linux/man-pages/man7/ip.7.html">multicast</a>
@@ -65,17 +69,36 @@ event::unique_fd open_mdns_socket(std::string const& interface_name);
  * @return The managed file descriptor of the socket
  * @throws std::runtime_error if the operation fails.
  */
-event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port);
+event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port, const std::string& device = {});
 
 /**
  * @brief Open a TCP socket in client mode
  * @param[in] host The host to connect to
  * @param[in] port The port to listen to.
  * @param[in] timeout_ms Timeout for the operation in ms
+ * @param[in] device Optional interface name (e.g. "eth0"). When non-empty the socket is bound
+ * to that device via SO_BINDTODEVICE before connect. If the caller lacks CAP_NET_RAW, falls back
+ * to source-IP bind using the interface's IPv4 address (no privilege needed).
  * @return The managed file descriptor of the socket
  * @throws std::runtime_error if the operation fails.
  */
-event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint16_t port, unsigned int timeout_ms);
+event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint16_t port, unsigned int timeout_ms,
+                                              const std::string& device = {});
+
+/**
+ * @brief Bind a socket to a specific network interface.
+ * @details Tries SO_BINDTODEVICE first (needs CAP_NET_RAW). On EPERM/EACCES, falls back to:
+ *   - IP_UNICAST_IF (AF_INET) or IPV6_UNICAST_IF (AF_INET6) to restrict the outgoing
+ *     interface for unicast packets — no privilege required, works for both v4 and v6
+ *     client sockets.
+ *   - As a last resort for AF_INET, a source-IP bind() to the interface's IPv4 address.
+ * The IPV6 source-IP fallback is not implemented; IPv6 sockets must succeed via
+ * SO_BINDTODEVICE or IPV6_UNICAST_IF. No-op when @p device is empty.
+ * @param[in] fd Open socket file descriptor
+ * @param[in] device Interface name (e.g. "eth0"). Empty string is a no-op.
+ * @throws std::runtime_error if all viable strategies fail.
+ */
+void bind_socket_to_device(int fd, std::string const& device);
 
 #ifndef EVEREST_NO_PACKET_IGNORE_OUTGOING
 /**

--- a/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
+++ b/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
@@ -40,9 +40,10 @@ public:
      * Implementation for \p ClientPolicy optional async capabilities
      * @param[in] remote The host to connect to
      * @param[in] port The port on host
+     * @param[in] device Optional interface name to bind to via SO_BINDTODEVICE. Empty = no binding.
      * @return True on success, false otherwise.
      */
-    bool open(std::string const& remote, uint16_t port);
+    bool open(std::string const& remote, uint16_t port, std::string const& device = {});
 
     /**
      * @brief Prepare the setup a TCP socket.
@@ -50,9 +51,10 @@ public:
      * @param[in] remote The host to connect to
      * @param[in] port The port on host
      * @param[in] timeout_ms Timeout for connecting to the remote
+     * @param[in] device Optional interface name to bind to via SO_BINDTODEVICE. Empty = no binding.
      * @return True on success, false otherwise.
      */
-    bool setup(std::string const& remote, uint16_t port, int timeout_ms);
+    bool setup(std::string const& remote, uint16_t port, int timeout_ms, std::string const& device = {});
 
     /**
      * @brief Long running part of the TCP connection process
@@ -129,6 +131,7 @@ private:
     uint16_t m_port{0};
     event::unique_fd m_fd;
     int m_timeout_ms{0};
+    std::string m_device;
     static constexpr size_t default_buffer_size{1500};
 };
 } // namespace everest::lib::io::tcp

--- a/lib/everest/io/include/everest/io/udp/udp_socket.hpp
+++ b/lib/everest/io/include/everest/io/udp/udp_socket.hpp
@@ -47,18 +47,20 @@ public:
      * @brief Open the socket as a server
      * @details Sets the socket non blocking
      * @param[in] port The port to listen to
+     * @param[in] device Optional interface name to bind to via SO_BINDTODEVICE. Empty = no binding.
      * @return True on success, false otherwise
      */
-    bool open_as_server(uint16_t port);
+    bool open_as_server(uint16_t port, std::string const& device = {});
 
     /**
      * @brief Open the socket as a server
      * @details Sets the socket non blocking
      * @param[in] remote The host to connect to
      * @param[in] port The port to listen to
+     * @param[in] device Optional interface name to bind to via SO_BINDTODEVICE. Empty = no binding.
      * @return True on success, false otherwise
      */
-    bool open_as_client(std::string const& remote, uint16_t port);
+    bool open_as_client(std::string const& remote, uint16_t port, std::string const& device = {});
 
     /**
      * @brief Check if the objects owns a socket
@@ -143,9 +145,10 @@ public:
      * Implementation for \p ClientPolicy
      * @param[in] remote The host to connect to
      * @param[in] port The port on host
+     * @param[in] device Optional interface name to bind to via SO_BINDTODEVICE. Empty = no binding.
      * @return True on success, false otherwise.
      */
-    bool open(std::string const& remote, uint16_t port);
+    bool open(std::string const& remote, uint16_t port, std::string const& device = {});
 
     /**
      * @brief Prepare the setup a UDP socket.
@@ -153,9 +156,10 @@ public:
      * @param[in] remote The host to connect to
      * @param[in] port The port on host
      * @param[in] timeout_ms Timeout for connecting to the remote
+     * @param[in] device Optional interface name to bind to via SO_BINDTODEVICE. Empty = no binding.
      * @return True on success, false otherwise.
      */
-    bool setup(std::string const& remote, uint16_t port, int timeout_ms);
+    bool setup(std::string const& remote, uint16_t port, int timeout_ms, std::string const& device = {});
 
     /**
      * @brief Long running part of the UDP connection process
@@ -183,6 +187,7 @@ private:
     std::string m_remote;
     uint16_t m_port{0};
     int m_timeout_ms{0};
+    std::string m_device;
 
     std::array<uint8_t, udp_payload::max_size> rx_buffer;
 };
@@ -213,9 +218,10 @@ public:
      * @details Sets the socket non blocking. <br>
      * Implementation for \p ClientPolicy
      * @param[in] port The port on host
+     * @param[in] device Optional interface name to bind to via SO_BINDTODEVICE. Empty = no binding.
      * @return True on success, false otherwise.
      */
-    bool open(uint16_t port);
+    bool open(uint16_t port, std::string const& device = {});
 
     /**
      * @brief Write a \ref udp_payload to the socket

--- a/lib/everest/io/src/socket/socket.cpp
+++ b/lib/everest/io/src/socket/socket.cpp
@@ -77,7 +77,7 @@ namespace socket {
 namespace {
 // Returns true when SO_BINDTODEVICE succeeded. Returns false on EPERM/EACCES
 // (caller decides on a fallback). Throws on any other failure.
-bool try_so_bindtodevice(int fd, std::string const& device) {
+bool apply_so_bindtodevice(int fd, std::string const& device) {
     if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, device.c_str(), device.length()) == 0) {
         return true;
     }
@@ -102,7 +102,7 @@ sa_family_t get_socket_family(int fd) {
 // IPv6: IPV6_UNICAST_IF takes int (ifindex in host byte order).
 // Returns true on success; false if the socket family is neither AF_INET nor AF_INET6.
 // Throws if the interface lookup fails or if setsockopt fails with a non-permission error.
-bool try_unicast_if(int fd, std::string const& device) {
+bool apply_unicast_if(int fd, std::string const& device) {
     unsigned int ifindex = if_nametoindex(device.c_str());
     if (ifindex == 0) {
         throw std::runtime_error(build_errno_string("if_nametoindex(\"" + device + "\") failed"));
@@ -193,12 +193,12 @@ void bind_socket_to_device(int fd, std::string const& device) {
     if (device.empty()) {
         return;
     }
-    if (try_so_bindtodevice(fd, device)) {
+    if (apply_so_bindtodevice(fd, device)) {
         return;
     }
     // Try IP[_V6]_UNICAST_IF for outgoing unicast routing without privilege. Works for both
     // IPv4 and IPv6 client sockets.
-    if (try_unicast_if(fd, device)) {
+    if (apply_unicast_if(fd, device)) {
         return;
     }
     // Last resort for IPv4 sockets with an unusable family: bind a source IP belonging to the
@@ -223,40 +223,26 @@ event::unique_fd open_udp_server_socket(std::uint16_t port, std::string const& d
 
     // open the first possible socket
     for (auto* p = servinfo; p != NULL; p = p->ai_next) {
-        const auto socket_fd = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
-        set_reuse_address(socket_fd);
+        auto socket_fd = event::unique_fd(::socket(p->ai_family, p->ai_socktype, p->ai_protocol));
         if (socket_fd == -1) {
             continue;
         }
+        set_reuse_address(socket_fd);
 
-        bool use_interface_address_bind = false;
         if (!device.empty()) {
-            try {
-                use_interface_address_bind = !try_so_bindtodevice(socket_fd, device);
-            } catch (...) {
-                close(socket_fd);
-                throw;
-            }
-        }
-
-        if (use_interface_address_bind) {
-            // SO_BINDTODEVICE not permitted: bind to (interface_ip:port) instead of wildcard,
-            // so the server only receives traffic addressed to that interface's IPv4.
-            try {
+            if (!apply_so_bindtodevice(socket_fd, device)) {
+                // SO_BINDTODEVICE not permitted: bind to (interface_ip:port) instead of wildcard,
+                // so the server only receives traffic addressed to that interface's IPv4.
                 bind_socket_to_interface_address(socket_fd, device, port);
-            } catch (...) {
-                close(socket_fd);
-                throw;
+                return socket_fd;
             }
-            return event::unique_fd{socket_fd};
         }
 
         if (bind(socket_fd, p->ai_addr, p->ai_addrlen) == -1) {
-            close(socket_fd);
             continue;
         }
 
-        return event::unique_fd{socket_fd};
+        return socket_fd;
     }
     throw std::runtime_error(std::string("Could not open a socket for localhost:") + std::to_string(port));
 }

--- a/lib/everest/io/src/socket/socket.cpp
+++ b/lib/everest/io/src/socket/socket.cpp
@@ -74,7 +74,139 @@ namespace socket {
 // socket.hpp implementations
 //
 
-event::unique_fd open_udp_server_socket(std::uint16_t port) {
+namespace {
+// Returns true when SO_BINDTODEVICE succeeded. Returns false on EPERM/EACCES
+// (caller decides on a fallback). Throws on any other failure.
+bool try_so_bindtodevice(int fd, std::string const& device) {
+    if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, device.c_str(), device.length()) == 0) {
+        return true;
+    }
+    if (errno == EPERM || errno == EACCES) {
+        return false;
+    }
+    throw std::runtime_error(build_errno_string("Failed to bind socket to device " + device));
+}
+
+// Returns the socket's address family via getsockname(). Returns AF_UNSPEC if unknown.
+sa_family_t get_socket_family(int fd) {
+    sockaddr_storage ss{};
+    socklen_t len = sizeof(ss);
+    if (getsockname(fd, reinterpret_cast<struct sockaddr*>(&ss), &len) < 0) {
+        return AF_UNSPEC;
+    }
+    return ss.ss_family;
+}
+
+// Restrict the outgoing interface for unicast packets without requiring CAP_NET_RAW.
+// IPv4: IP_UNICAST_IF takes uint32_t (ifindex in network byte order via in_addr layout).
+// IPv6: IPV6_UNICAST_IF takes int (ifindex in host byte order).
+// Returns true on success; false if the socket family is neither AF_INET nor AF_INET6.
+// Throws if the interface lookup fails or if setsockopt fails with a non-permission error.
+bool try_unicast_if(int fd, std::string const& device) {
+    unsigned int ifindex = if_nametoindex(device.c_str());
+    if (ifindex == 0) {
+        throw std::runtime_error(build_errno_string("if_nametoindex(\"" + device + "\") failed"));
+    }
+    sa_family_t family = get_socket_family(fd);
+    if (family == AF_INET) {
+        std::uint32_t opt = htonl(ifindex);
+        if (setsockopt(fd, IPPROTO_IP, IP_UNICAST_IF, &opt, sizeof(opt)) == 0) {
+            return true;
+        }
+        throw std::runtime_error(build_errno_string("setsockopt(IP_UNICAST_IF, " + device + ") failed"));
+    }
+    if (family == AF_INET6) {
+        int opt = static_cast<int>(ifindex);
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_IF, &opt, sizeof(opt)) == 0) {
+            return true;
+        }
+        throw std::runtime_error(build_errno_string("setsockopt(IPV6_UNICAST_IF, " + device + ") failed"));
+    }
+    return false;
+}
+
+// Steer multicast egress to @p device. SO_BINDTODEVICE and IP[V6]_UNICAST_IF do not
+// affect the multicast TX path; the kernel needs IP_MULTICAST_IF / IPV6_MULTICAST_IF
+// independently. For IPv6 we additionally populate sin6_scope_id on the destination
+// sockaddr so connect()/sendto() can resolve scope bound groups (ff02::/16). For IPv4
+// we use ip_mreqn so the interface is selected by index, avoiding the need for the
+// iface IPv4 address up front (works even before DHCP has assigned one). Returns
+// without action when not a multicast destination or device is empty.
+void set_multicast_if(int fd, std::string const& device, struct sockaddr* ai_addr) {
+    if (device.empty() || ai_addr == nullptr) {
+        return;
+    }
+    if (ai_addr->sa_family == AF_INET6) {
+        auto* sin6 = reinterpret_cast<sockaddr_in6*>(ai_addr);
+        if (!IN6_IS_ADDR_MULTICAST(&sin6->sin6_addr)) {
+            return;
+        }
+        unsigned int ifindex = if_nametoindex(device.c_str());
+        if (ifindex == 0) {
+            throw std::runtime_error(build_errno_string("if_nametoindex(\"" + device + "\") failed"));
+        }
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &ifindex, sizeof(ifindex)) != 0) {
+            throw std::runtime_error(build_errno_string("setsockopt(IPV6_MULTICAST_IF, " + device + ") failed"));
+        }
+        sin6->sin6_scope_id = ifindex;
+        return;
+    }
+    if (ai_addr->sa_family == AF_INET) {
+        auto* sin = reinterpret_cast<sockaddr_in*>(ai_addr);
+        if (!IN_MULTICAST(ntohl(sin->sin_addr.s_addr))) {
+            return;
+        }
+        unsigned int ifindex = if_nametoindex(device.c_str());
+        if (ifindex == 0) {
+            throw std::runtime_error(build_errno_string("if_nametoindex(\"" + device + "\") failed"));
+        }
+        struct ip_mreqn mreq {};
+        mreq.imr_ifindex = static_cast<int>(ifindex);
+        if (setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, &mreq, sizeof(mreq)) != 0) {
+            throw std::runtime_error(build_errno_string("setsockopt(IP_MULTICAST_IF, " + device + ") failed"));
+        }
+    }
+}
+
+// IPv4 source-IP bind to the address belonging to @p device. Used as a fallback
+// when SO_BINDTODEVICE is not permitted. @p port == 0 picks an ephemeral port.
+void bind_socket_to_interface_address(int fd, std::string const& device, std::uint16_t port) {
+    std::string ip = get_interface_address(device);
+    if (ip.empty()) {
+        throw std::runtime_error("Cannot bind socket to device " + device +
+                                 ": no IPv4 address on interface (and SO_BINDTODEVICE not permitted)");
+    }
+    sockaddr_in local{};
+    local.sin_family = AF_INET;
+    local.sin_port = htons(port);
+    if (inet_pton(AF_INET, ip.c_str(), &local.sin_addr) != 1) {
+        throw std::runtime_error("Failed to parse interface address " + ip);
+    }
+    if (::bind(fd, reinterpret_cast<struct sockaddr*>(&local), sizeof(local)) < 0) {
+        throw std::runtime_error(build_errno_string("Fallback bind to interface " + device + " (" + ip + ":" +
+                                                    std::to_string(port) + ") failed"));
+    }
+}
+} // namespace
+
+void bind_socket_to_device(int fd, std::string const& device) {
+    if (device.empty()) {
+        return;
+    }
+    if (try_so_bindtodevice(fd, device)) {
+        return;
+    }
+    // Try IP[_V6]_UNICAST_IF for outgoing unicast routing without privilege. Works for both
+    // IPv4 and IPv6 client sockets.
+    if (try_unicast_if(fd, device)) {
+        return;
+    }
+    // Last resort for IPv4 sockets with an unusable family: bind a source IP belonging to the
+    // interface (IPv4 only).
+    bind_socket_to_interface_address(fd, device, 0);
+}
+
+event::unique_fd open_udp_server_socket(std::uint16_t port, std::string const& device) {
     struct addrinfo hints {};
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_DGRAM;
@@ -97,6 +229,28 @@ event::unique_fd open_udp_server_socket(std::uint16_t port) {
             continue;
         }
 
+        bool use_interface_address_bind = false;
+        if (!device.empty()) {
+            try {
+                use_interface_address_bind = !try_so_bindtodevice(socket_fd, device);
+            } catch (...) {
+                close(socket_fd);
+                throw;
+            }
+        }
+
+        if (use_interface_address_bind) {
+            // SO_BINDTODEVICE not permitted: bind to (interface_ip:port) instead of wildcard,
+            // so the server only receives traffic addressed to that interface's IPv4.
+            try {
+                bind_socket_to_interface_address(socket_fd, device, port);
+            } catch (...) {
+                close(socket_fd);
+                throw;
+            }
+            return event::unique_fd{socket_fd};
+        }
+
         if (bind(socket_fd, p->ai_addr, p->ai_addrlen) == -1) {
             close(socket_fd);
             continue;
@@ -107,7 +261,7 @@ event::unique_fd open_udp_server_socket(std::uint16_t port) {
     throw std::runtime_error(std::string("Could not open a socket for localhost:") + std::to_string(port));
 }
 
-event::unique_fd open_udp_client_socket(const std::string& host, std::uint16_t port) {
+event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t port, std::string const& device) {
     struct addrinfo hints {};
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_DGRAM;
@@ -128,6 +282,14 @@ event::unique_fd open_udp_client_socket(const std::string& host, std::uint16_t p
         if (socket_fd == -1)
             continue;
 
+        try {
+            bind_socket_to_device(socket_fd, device);
+            set_multicast_if(socket_fd, device, p->ai_addr);
+        } catch (...) {
+            close(socket_fd);
+            throw;
+        }
+
         if (-1 == ::connect(socket_fd, p->ai_addr, p->ai_addrlen)) {
             close(socket_fd);
             continue;
@@ -139,7 +301,8 @@ event::unique_fd open_udp_client_socket(const std::string& host, std::uint16_t p
     throw std::runtime_error(std::string("Could not open a socket for ") + host + ":" + std::to_string(port));
 }
 
-event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint16_t port, unsigned int timeout_ms) {
+event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint16_t port, unsigned int timeout_ms,
+                                              const std::string& device) {
     struct addrinfo hints {};
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
@@ -160,8 +323,14 @@ event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint
         if (socket_fd == -1)
             continue;
 
+        try {
+            bind_socket_to_device(socket_fd, device);
+        } catch (...) {
+            close(socket_fd);
+            throw;
+        }
+
         if (-1 == connect_with_timeout(socket_fd, p->ai_addr, p->ai_addrlen, timeout_ms)) {
-            //        if (-1 == ::connect(socket_fd, p->ai_addr, p->ai_addrlen)) {
             close(socket_fd);
             continue;
         }
@@ -172,7 +341,7 @@ event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint
     throw std::runtime_error(std::string("Could not open a socket for ") + host + ":" + std::to_string(port));
 }
 
-event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port) {
+event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port, const std::string& device) {
     struct addrinfo hints {};
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
@@ -192,6 +361,13 @@ event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port) {
 
         if (socket_fd == -1)
             continue;
+
+        try {
+            bind_socket_to_device(socket_fd, device);
+        } catch (...) {
+            close(socket_fd);
+            throw;
+        }
 
         if (-1 == connect(socket_fd, p->ai_addr, p->ai_addrlen)) {
             close(socket_fd);

--- a/lib/everest/io/src/tcp/tcp_socket.cpp
+++ b/lib/everest/io/src/tcp/tcp_socket.cpp
@@ -8,12 +8,13 @@
 
 namespace everest::lib::io::tcp {
 
-bool tcp_socket::open(std::string const& remote, uint16_t port) {
+bool tcp_socket::open(std::string const& remote, uint16_t port, std::string const& device) {
     m_remote = remote;
     m_port = port;
     m_timeout_ms = 1000;
+    m_device = device;
     try {
-        auto socket = socket::open_tcp_socket_with_timeout(remote, port, m_timeout_ms);
+        auto socket = socket::open_tcp_socket_with_timeout(remote, port, m_timeout_ms, m_device);
         socket::set_non_blocking(socket);
         m_fd = std::move(socket);
         return socket::get_pending_error(m_fd) == 0;
@@ -22,17 +23,18 @@ bool tcp_socket::open(std::string const& remote, uint16_t port) {
     return false;
 }
 
-bool tcp_socket::setup(std::string const& remote, uint16_t port, int timeout_ms) {
+bool tcp_socket::setup(std::string const& remote, uint16_t port, int timeout_ms, std::string const& device) {
     m_remote = remote;
     m_port = port;
     m_timeout_ms = timeout_ms;
+    m_device = device;
     m_fd.close();
     return true;
 }
 
 void tcp_socket::connect(std::function<void(bool, int)> const& setup_cb) {
     try {
-        auto socket = socket::open_tcp_socket_with_timeout(m_remote, m_port, m_timeout_ms);
+        auto socket = socket::open_tcp_socket_with_timeout(m_remote, m_port, m_timeout_ms, m_device);
         socket::set_non_blocking(socket);
         setup_cb(true, socket);
         m_fd = std::move(socket);

--- a/lib/everest/io/src/udp/udp_socket.cpp
+++ b/lib/everest/io/src/udp/udp_socket.cpp
@@ -19,9 +19,9 @@
 
 namespace everest::lib::io::udp {
 
-bool udp_socket_base::open_as_client(std::string const& remote, uint16_t port) {
+bool udp_socket_base::open_as_client(std::string const& remote, uint16_t port, std::string const& device) {
     try {
-        auto socket = socket::open_udp_client_socket(remote, port);
+        auto socket = socket::open_udp_client_socket(remote, port, device);
         socket::set_non_blocking(socket);
         m_owned_udp_fd = std::move(socket);
         return socket::get_pending_error(m_owned_udp_fd) == 0;
@@ -30,8 +30,8 @@ bool udp_socket_base::open_as_client(std::string const& remote, uint16_t port) {
     return false;
 }
 
-bool udp_socket_base::open_as_server(uint16_t port) {
-    auto socket = socket::open_udp_server_socket(port);
+bool udp_socket_base::open_as_server(uint16_t port, std::string const& device) {
+    auto socket = socket::open_udp_server_socket(port, device);
     socket::set_non_blocking(socket);
     m_owned_udp_fd = std::move(socket);
     return socket::get_pending_error(m_owned_udp_fd) == 0;
@@ -90,17 +90,18 @@ std::optional<udp_info> udp_socket_base::rx_impl(void* buffer, size_t buffer_siz
 
 /////////////////////////////////////////////////
 
-bool udp_client_socket::setup(std::string const& remote, uint16_t port, int timeout_ms) {
+bool udp_client_socket::setup(std::string const& remote, uint16_t port, int timeout_ms, std::string const& device) {
     m_remote = remote;
     m_port = port;
     m_timeout_ms = timeout_ms;
+    m_device = device;
     m_owned_udp_fd.close();
     return true;
 }
 
 void udp_client_socket::connect(std::function<void(bool, int)> const& setup_cb) {
     try {
-        auto socket = socket::open_udp_client_socket(m_remote, m_port);
+        auto socket = socket::open_udp_client_socket(m_remote, m_port, m_device);
         socket::set_non_blocking(socket);
         setup_cb(true, socket);
         m_owned_udp_fd = std::move(socket);
@@ -110,8 +111,8 @@ void udp_client_socket::connect(std::function<void(bool, int)> const& setup_cb) 
     }
 }
 
-bool udp_client_socket::open(std::string const& remote, uint16_t port) {
-    return open_as_client(remote, port);
+bool udp_client_socket::open(std::string const& remote, uint16_t port, std::string const& device) {
+    return open_as_client(remote, port, device);
 }
 
 bool udp_client_socket::tx(udp_payload const& payload) {
@@ -129,8 +130,8 @@ bool udp_client_socket::rx(udp_payload& payload) {
 
 //////////////////////////////////////////////////
 
-bool udp_server_socket::open(uint16_t port) {
-    return open_as_server(port);
+bool udp_server_socket::open(uint16_t port, std::string const& device) {
+    return open_as_server(port, device);
 }
 
 bool udp_server_socket::tx(udp_payload const& payload) {


### PR DESCRIPTION
Add optional `device` parameter (defaults to empty) to udp_client_socket, udp_server_socket and tcp_socket open/setup methods, plus the underlying open_udp_*_socket / open_tcp_socket[_with_timeout] helpers. When set, the socket is bound to the named interface via SO_BINDTODEVICE before connect/bind.

bind_socket_to_device degrades gracefully when SO_BINDTODEVICE is denied with EPERM/EACCES (no CAP_NET_RAW):
  - For client sockets, IP_UNICAST_IF (AF_INET) or IPV6_UNICAST_IF (AF_INET6) restricts the outgoing interface for unicast packets. No privilege required, works for both v4 and v6.
  - As a last resort for AF_INET, a source-IP bind() to the interface's IPv4 address. For UDP servers the fallback binds to (interface_ip:port) instead of the wildcard (IPv4 only).

For multicast destinations, additionally set IP_MULTICAST_IF (AF_INET, via ip_mreqn with ifindex) or IPV6_MULTICAST_IF (AF_INET6) and populate sin6_scope_id on the destination sockaddr. SO_BINDTODEVICE / IP[V6]_UNICAST_IF do not steer the multicast TX path; without these, connect() to a link-local group such as ff02::1 fails and the socket never reaches a usable state.

Threads transparently through generic_fd_event_client's variadic constructor, so udp_client(remote, port, timeout, "eth0") works without client-side changes.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

