### PR TITLE
fix(timer): drop mutex before join in dtor

### DIFF
--- a/lib/everest/timer/include/everest/timer.hpp
+++ b/lib/everest/timer/include/everest/timer.hpp
@@ -55,16 +55,22 @@ public:
         work(boost::asio::make_work_guard(*io_context)) {
     }
 
+    /// \brief Cancel the asio timer and join the io_context thread.
+    ///
+    /// The mutex is released BEFORE joining the io_context thread. A timer callback running on
+    /// that thread may re-enter \ref at, \ref timeout, \ref interval, or \ref stop — each of which
+    /// takes the mutex; if the destructor still held it, \c join would deadlock waiting for the
+    /// callback to exit while the callback waited for the mutex.
     ~Timer() {
-        std::lock_guard<std::mutex> lock(this->mutex);
-        if (this->timer) {
-            // stop asio timer
-            this->timer->cancel();
-
-            if (this->timer_thread) {
-                this->io_context.stop();
-                this->timer_thread->join();
+        {
+            std::lock_guard<std::mutex> lock(this->mutex);
+            if (this->timer) {
+                this->timer->cancel();
             }
+        }
+        if (this->timer_thread) {
+            this->io_context.stop();
+            this->timer_thread->join();
         }
     }
 

--- a/lib/everest/timer/tests/CMakeLists.txt
+++ b/lib/everest/timer/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(${TEST_TARGET_NAME}
 
 target_link_libraries(${TEST_TARGET_NAME} PRIVATE
         ${GTEST_LIBRARIES}
+        everest::timer
 )
 
 add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})

--- a/lib/everest/timer/tests/libtimer_unit_test.cpp
+++ b/lib/everest/timer/tests/libtimer_unit_test.cpp
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 #include <gtest/gtest.h>
+
+#include <everest/timer.hpp>
+
 namespace libtimer {
 class LibTimerUnitTest : public ::testing::Test {
 protected:
@@ -14,5 +21,46 @@ protected:
 
 TEST_F(LibTimerUnitTest, just_an_example) {
     ASSERT_TRUE(1 == 1);
+}
+
+// Regression: callback re-arms its own timer; pre-fix destructor deadlocks here.
+TEST_F(LibTimerUnitTest, destructor_does_not_deadlock_on_reentrant_callback) {
+    std::atomic<bool> finished{false};
+    std::atomic<int> fire_count{0};
+    std::thread watchdog([&finished]() {
+        for (int i = 0; i < 50; ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            if (finished.load()) {
+                return;
+            }
+        }
+        ADD_FAILURE() << "Timer destructor deadlocked on re-entrant callback";
+        finished.store(true);
+    });
+
+    {
+        Everest::SteadyTimer timer;
+        std::atomic<bool> in_callback{false};
+
+        timer.interval(
+            [&timer, &fire_count, &in_callback]() {
+                in_callback.store(true);
+                fire_count.fetch_add(1);
+                // Sleep long enough for the main thread to enter ~Timer and start
+                // blocking on the mutex before this callback calls stop().
+                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                timer.stop();
+                in_callback.store(false);
+            },
+            std::chrono::milliseconds(1));
+
+        while (!in_callback.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+
+    finished.store(true);
+    watchdog.join();
+    EXPECT_GE(fire_count.load(), 1);
 }
 } // namespace libtimer


### PR DESCRIPTION
Original ~Timer holds the mutex across timer_thread->join(). The same mutex is also taken by Timer::at, Timer::timeout, Timer::interval and Timer::stop. A timer callback running on the io_context thread that re-enters any of those methods would deadlock: the destructor blocks in join() holding the mutex while the callback blocks waiting for it.

Cancel the asio timer under the lock, drop the lock, then stop the io_context and join. After cancel() and io_context.stop() no further callbacks run, so join() is safe without the mutex held.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

