### PR TITLE
evcli: use python_setuptools_build_meta class

### DIFF
--- a/yocto/scarthgap/meta-everest/recipes-core/everest-devtools/evcli_git.bb
+++ b/yocto/scarthgap/meta-everest/recipes-core/everest-devtools/evcli_git.bb
@@ -4,19 +4,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 # ev-cli move to everest-core, include the version from there in this recipe
 require ../everest/everest-core_git.inc
 
-SETUPTOOLS_SETUP_PATH = "${S}/applications/utils/ev-dev-tools"
+inherit python_setuptools_build_meta
 
-inherit setuptools3
-
-do_configure:prepend() {
-cat > ${SETUPTOOLS_SETUP_PATH}/setup.py <<-EOF
-from setuptools import setup
-
-setup()
-EOF
-}
-
-DEPENDS = "python3-pip-native"
+PEP517_SOURCE_PATH = "${S}/applications/utils/ev-dev-tools"
 
 RDEPENDS:${PN} = " \
     pip-stringcase \


### PR DESCRIPTION
## Describe your changes
The project has a pyproject.toml and uses setuptools.build_meta as build-backend. So use this instead.

This is based on the PR https://github.com/EVerest/meta-everest/pull/99 from @tafilz in the depreacted meta-everest repository

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

