### PR TITLE
feat(io): add IPv6 unconnected UDP datagram socket

### DIFF
--- a/lib/everest/io/examples/CMakeLists.txt
+++ b/lib/everest/io/examples/CMakeLists.txt
@@ -86,6 +86,19 @@ target_compile_features(test_udp_server PUBLIC cxx_std_17)
 target_compile_options(test_udp_server PRIVATE -fsanitize=address -g)
 target_link_options(test_udp_server PRIVATE -static-libasan -fsanitize=address)
 
+###
+
+add_executable(test_udp_unconnected_client test_udp_unconnected_client.cpp)
+
+target_link_libraries(test_udp_unconnected_client
+    PRIVATE
+        everest::io
+)
+
+target_compile_features(test_udp_unconnected_client PUBLIC cxx_std_17)
+target_compile_options(test_udp_unconnected_client PRIVATE -fsanitize=address -g)
+target_link_options(test_udp_unconnected_client PRIVATE -static-libasan -fsanitize=address)
+
 
 
 

--- a/lib/everest/io/examples/test_udp_unconnected_client.cpp
+++ b/lib/everest/io/examples/test_udp_unconnected_client.cpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+//
+// Example: how to use udp_unconnected_client (an unconnected UDP datagram
+// client, IPv4 or IPv6 auto-selected from the target). Sends a text message
+// once per second to <dest>:<port> and prints any datagram received back,
+// together with its source endpoint.
+//
+//   test_udp_unconnected_client <dest> <port> [iface]
+//
+// <dest> may be an IPv4 address, an IPv6 address, or a hostname. For IPv6
+// link-local / multicast destinations pass the optional <iface> (used as the
+// scope id and as a best-effort SO_BINDTODEVICE hint).
+
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/event/timer_fd.hpp>
+#include <everest/io/udp/endpoint.hpp>
+#include <everest/io/udp/udp_payload.hpp>
+#include <everest/io/udp/udp_unconnected_client.hpp>
+
+using namespace everest::lib::io::udp;
+using namespace everest::lib::io::event;
+using namespace std::chrono_literals;
+
+using generic_udp = typename udp_unconnected_client::interface;
+
+namespace {
+
+std::string to_text(udp_payload const& payload) {
+    return std::string(payload.buffer.begin(), payload.buffer.end());
+}
+
+bool parse_args(int argc, char* argv[], std::string& dest, uint16_t& port, std::string& iface) {
+    if (argc != 3 && argc != 4) {
+        std::cout << "USAGE: test_udp_unconnected_client <dest> <port> [iface]\n";
+        return false;
+    }
+    dest = argv[1];
+    try {
+        auto tmp = std::stoul(argv[2]);
+        if (tmp > std::numeric_limits<uint16_t>::max()) {
+            throw std::out_of_range("port");
+        }
+        port = static_cast<uint16_t>(tmp);
+    } catch (...) {
+        std::cout << "ERROR: '" << argv[2] << "' is not a valid port\n";
+        return false;
+    }
+    iface = argc == 4 ? argv[3] : "";
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    std::string dest;
+    std::string iface;
+    uint16_t port = 0;
+    if (not parse_args(argc, argv, dest, port, iface)) {
+        return 1;
+    }
+
+    endpoint target;
+    try {
+        target = endpoint(dest, port, iface);
+    } catch (std::exception const& e) {
+        std::cerr << "ERROR: " << e.what() << "\n";
+        return 1;
+    }
+
+    udp_unconnected_client client(target, iface);
+
+    client.set_error_handler([](int err, std::string const& msg) {
+        if (err) {
+            std::cerr << "ERROR (" << err << "): " << msg << "\n";
+        }
+    });
+    client.set_rx_handler([&](udp_payload const& payload, generic_udp&) {
+        std::cout << "RX (" << payload.size() << "): " << to_text(payload);
+        if (const auto src = client.get_raw_handler()->last_source()) {
+            std::cout << "  from [" << src->addr_str() << "]:" << src->port();
+        }
+        std::cout << "\n";
+    });
+
+    fd_event_handler ev;
+    ev.register_event_handler(client.get_poll_fd(), [&](auto&) { client.sync(); }, {poll_events::read});
+
+    timer_fd ticker;
+    ticker.set_timeout(1s);
+    int counter = 0;
+    fd_event_handler::event_handler_type on_tick = [&](fd_event_handler::event_list const&) {
+        ticker.set_timeout(1s); // re-arm
+        std::ostringstream msg;
+        msg << "ping #" << ++counter;
+        udp_payload payload;
+        payload.set_message(msg.str());
+        std::cout << "TX: " << msg.str() << " -> [" << target.addr_str() << "]:" << target.port() << "\n";
+        client.tx(payload);
+    };
+    ev.register_event_handler(&ticker, on_tick);
+
+    std::cout << "udp unconnected client: sending to [" << target.addr_str() << "]:" << target.port()
+              << (iface.empty() ? "" : (" via " + iface)) << " every 1s\n";
+    while (true) {
+        ev.poll();
+    }
+    return 0;
+}

--- a/lib/everest/io/include/everest/io/socket/socket.hpp
+++ b/lib/everest/io/include/everest/io/socket/socket.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <everest/io/event/unique_fd.hpp>
+#include <everest/io/udp/endpoint.hpp>
 
 namespace everest::lib::io::socket {
 
@@ -33,6 +34,24 @@ event::unique_fd open_udp_server_socket(std::uint16_t port, std::string const& d
  * @throws std::runtime_error if the operation fails.
  */
 event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t port, std::string const& device = {});
+
+/**
+ * @brief Open an unconnected UDP datagram socket (IPv4 or IPv6) for a target.
+ * @details Socket family is taken from @p target. SOCK_DGRAM, non-blocking,
+ * bound to the family wildcard address on an ephemeral port. For a multicast
+ * @p target the multicast egress interface is pinned (IP_MULTICAST_IF /
+ * IPV6_MULTICAST_IF) to @p iface (falling back to the interface carried by
+ * @p target); SO_BINDTODEVICE is applied best-effort for extra link
+ * confinement (tolerated to fail unprivileged). Performs neither ::connect()
+ * nor any multicast group join, so a unicast reply from an address other than
+ * the configured target is delivered on this same fd by destination address
+ * and port.
+ * @param[in] target Destination address; selects the socket family.
+ * @param[in] iface Optional interface name. Empty uses @p target's iface hint.
+ * @return The managed file descriptor of the socket.
+ * @throws std::runtime_error if the operation fails.
+ */
+event::unique_fd open_udp_unconnected_socket(udp::endpoint const& target, std::string const& iface = {});
 
 /**
  * @brief Open a UDP socket with <a href="https://man7.org/linux/man-pages/man7/ip.7.html">multicast</a>

--- a/lib/everest/io/include/everest/io/udp/endpoint.hpp
+++ b/lib/everest/io/include/everest/io/udp/endpoint.hpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+namespace everest::lib::io::udp {
+
+/**
+ * @class endpoint
+ * @brief A protocol-agnostic (IPv4 or IPv6) UDP address/port pair.
+ *
+ * Wraps a @c sockaddr_storage plus its valid length. The family is selected
+ * automatically from the host string: numeric IPv4 first, then numeric IPv6,
+ * then a name resolution via @c getaddrinfo (first result). The port is kept
+ * in host byte order at the API surface; @c htons / @c ntohs are applied only
+ * at the syscall boundary inside this class.
+ *
+ * For IPv6 link-local or multicast targets a non-empty @p iface is resolved to
+ * @c sin6_scope_id and additionally retained as a SO_BINDTODEVICE hint
+ * retrievable via @ref iface.
+ *
+ * Scoped to the unconnected UDP client; not a general networking primitive.
+ */
+class endpoint {
+public:
+    /**
+     * @brief Default constructed endpoint (family AF_UNSPEC, no address).
+     */
+    endpoint() = default;
+
+    /**
+     * @brief Construct from a host string and port.
+     * @param[in] host Numeric IPv4, numeric IPv6, or a resolvable name.
+     * @param[in] port Port in host byte order.
+     * @param[in] iface Optional interface name. Used as the scope id for IPv6
+     * link-local / multicast addresses and retained as a bind hint.
+     * @throws std::runtime_error if @p host cannot be parsed or resolved, or if
+     * @p iface is non-empty but unknown for a scoped IPv6 address.
+     */
+    endpoint(std::string const& host, std::uint16_t port, std::string iface = {});
+
+    /**
+     * @brief Construct from a raw source address (e.g. from @c recvfrom).
+     * @param[in] src The source address storage.
+     * @param[in] len The valid length of @p src.
+     */
+    endpoint(sockaddr_storage const& src, socklen_t len);
+
+    /**
+     * @brief Address family.
+     * @return AF_INET, AF_INET6, or AF_UNSPEC when default constructed.
+     */
+    sa_family_t family() const;
+
+    /**
+     * @brief Port in host byte order.
+     */
+    std::uint16_t port() const;
+
+    /**
+     * @brief Numeric address string (inet_ntop).
+     */
+    std::string addr_str() const;
+
+    /**
+     * @brief Pointer to the raw address, usable directly by @c sendto.
+     */
+    sockaddr const* sa() const;
+
+    /**
+     * @brief Valid length of the address returned by @ref sa.
+     */
+    socklen_t sa_len() const;
+
+    /**
+     * @brief Interface name hint supplied at construction (may be empty).
+     */
+    std::string const& iface() const;
+
+    /**
+     * @brief Value equality (family, address, port, IPv6 scope id).
+     */
+    bool operator==(endpoint const& other) const;
+    bool operator!=(endpoint const& other) const {
+        return not(*this == other);
+    }
+
+private:
+    sockaddr_storage m_storage{};
+    socklen_t m_len{0};
+    std::string m_iface;
+};
+
+} // namespace everest::lib::io::udp

--- a/lib/everest/io/include/everest/io/udp/udp_unconnected_client.hpp
+++ b/lib/everest/io/include/everest/io/udp/udp_unconnected_client.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include <everest/io/event/fd_event_client.hpp>
+#include <everest/io/udp/udp_unconnected_socket.hpp>
+
+namespace everest::lib::io::udp {
+
+/**
+ * @var udp_unconnected_client
+ * @brief Client for an unconnected UDP datagram socket (IPv4 or IPv6,
+ * auto-selected from the target endpoint) implemented in terms of
+ * \ref event::fd_event_client and \ref udp::udp_unconnected_socket
+ */
+using udp_unconnected_client = event::fd_event_client<udp_unconnected_socket>::type;
+
+} // namespace everest::lib::io::udp

--- a/lib/everest/io/include/everest/io/udp/udp_unconnected_socket.hpp
+++ b/lib/everest/io/include/everest/io/udp/udp_unconnected_socket.hpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include <array>
+#include <optional>
+#include <string>
+
+#include <everest/io/event/unique_fd.hpp>
+#include <everest/io/udp/endpoint.hpp>
+#include <everest/io/udp/udp_payload.hpp>
+
+namespace everest::lib::io::udp {
+
+/**
+ * An unconnected UDP datagram socket (IPv4 or IPv6, selected automatically from
+ * the target \ref endpoint). It sends to a fixed destination configured at
+ * \ref open and receives datagrams from any source (no ::connect, no multicast
+ * group join), recording the last sender. Designed to be used as the
+ * \p ClientPolicy of \ref event::fd_event_client (synchronous variant).
+ */
+class udp_unconnected_socket {
+public:
+    /**
+     * @var PayloadT
+     * @brief Type of the payload for TX and RX operations
+     */
+    using PayloadT = udp_payload;
+
+    /**
+     * @brief The class is default constructed
+     */
+    udp_unconnected_socket() = default;
+
+    /**
+     * @brief Open the socket and set the fixed send destination.
+     * @details Implementation for \p ClientPolicy (sync variant). Never throws.
+     * @param[in] target Destination for \ref tx; selects the socket family.
+     * @param[in] iface Optional interface name. Empty uses @p target's hint.
+     * @return True on success, false otherwise.
+     */
+    bool open(endpoint target, std::string iface = {});
+
+    /**
+     * @brief Send a \ref udp_payload to the configured destination.
+     * @details Implementation for \p ClientPolicy
+     * @param[in] payload Payload
+     * @return True on success, false otherwise.
+     */
+    bool tx(udp_payload const& payload);
+
+    /**
+     * @brief Receive a \ref udp_payload from the socket.
+     * @details Implementation for \p ClientPolicy. On success the sender
+     * endpoint is recorded and retrievable via \ref last_source.
+     * @param[out] payload Payload
+     * @return True on success, false otherwise.
+     */
+    bool rx(udp_payload& payload);
+
+    /**
+     * @brief Get the file descriptor of the socket
+     * @details Implementation for \p ClientPolicy
+     * @return The file descriptor of the socket
+     */
+    int get_fd() const;
+
+    /**
+     * @brief Get pending errors on the socket.
+     * @details Implementation for \p ClientPolicy
+     * @return The current errno of the socket. Zero with no pending error.
+     */
+    int get_error() const;
+
+    /**
+     * @brief Source endpoint of the most recently received datagram.
+     * @return The endpoint, or std::nullopt if nothing was received yet.
+     */
+    std::optional<endpoint> last_source() const {
+        return m_last_source;
+    }
+
+private:
+    event::unique_fd m_owned_udp_fd;
+    endpoint m_target;
+    std::optional<endpoint> m_last_source;
+    std::array<uint8_t, udp_payload::max_size> m_rx_buffer;
+};
+
+} // namespace everest::lib::io::udp

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -19,6 +19,8 @@ target_sources(everest_io
         utilities/generic_error_state.cpp
         event/fd_event_client.cpp
         udp/udp_socket.cpp
+        udp/udp_unconnected_socket.cpp
+        udp/endpoint.cpp
         udp/udp_payload.cpp
         utilities/stop_watch.cpp
         serial/serial.cpp

--- a/lib/everest/io/src/socket/socket.cpp
+++ b/lib/everest/io/src/socket/socket.cpp
@@ -25,6 +25,7 @@
 
 #include <everest/io/event/unique_fd.hpp>
 #include <everest/io/socket/socket.hpp>
+#include <everest/io/udp/endpoint.hpp>
 
 namespace {
 // a simple raii wrapper, which will call the given c-like deleter
@@ -722,6 +723,62 @@ std::vector<if_info> get_all_interaces() {
         interfaces.push_back({ifa->ifa_name, get_interface_address(ifa->ifa_name)});
     }
     return interfaces;
+}
+
+event::unique_fd open_udp_unconnected_socket(udp::endpoint const& target, std::string const& iface) {
+    const auto family = target.family();
+    if (family != AF_INET && family != AF_INET6) {
+        throw std::runtime_error("open_udp_unconnected_socket: target has no usable address family");
+    }
+
+    event::unique_fd sock(::socket(family, SOCK_DGRAM, 0));
+    if (not sock.is_fd()) {
+        throw std::runtime_error(build_errno_string("socket(SOCK_DGRAM) failed"));
+    }
+    set_non_blocking(sock);
+
+    // Wildcard bind on the target's family, ephemeral port. RX is by destination
+    // address and port; interface confinement (if any) comes from the options below.
+    if (family == AF_INET6) {
+        sockaddr_in6 local{};
+        local.sin6_family = AF_INET6;
+        local.sin6_addr = in6addr_any;
+        if (::bind(sock, reinterpret_cast<sockaddr*>(&local), sizeof(local)) < 0) {
+            throw std::runtime_error(build_errno_string("bind([::]:0) failed"));
+        }
+    } else {
+        sockaddr_in local{};
+        local.sin_family = AF_INET;
+        local.sin_addr.s_addr = htonl(INADDR_ANY);
+        if (::bind(sock, reinterpret_cast<sockaddr*>(&local), sizeof(local)) < 0) {
+            throw std::runtime_error(build_errno_string("bind(0.0.0.0:0) failed"));
+        }
+    }
+
+    const std::string& device = iface.empty() ? target.iface() : iface;
+
+    // Best-effort link confinement. Not required for the unicast-reply RX path
+    // (delivery is by destination address and port on the wildcard bind).
+    // Defense-in-depth only on multi-NIC hosts; unprivileged failure is tolerated.
+    if (not device.empty()) {
+        try {
+            bind_socket_to_device(sock, device);
+        } catch (const std::exception&) {
+            // ignore: multicast TX interface is pinned by set_multicast_if below
+        }
+    }
+
+    // Pin multicast egress to the chosen interface (no-op for unicast targets).
+    // A mutable copy is required: set_multicast_if writes sin6_scope_id, which
+    // is irrelevant here since the socket option is what matters.
+    sockaddr_storage ss{};
+    std::memcpy(&ss, target.sa(), target.sa_len());
+    set_multicast_if(sock, device, reinterpret_cast<sockaddr*>(&ss));
+
+    // No ::connect(), no group join: a connected datagram socket would drop a
+    // unicast reply whose source differs from the configured target; a group
+    // join is a receiver-side concern and is not needed to send to the group.
+    return sock;
 }
 
 event::unique_fd open_udp_multicast_socket(std::string const& multicast_group, std::uint16_t port,

--- a/lib/everest/io/src/udp/endpoint.cpp
+++ b/lib/everest/io/src/udp/endpoint.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/udp/endpoint.hpp>
+
+#include <cstring>
+#include <stdexcept>
+
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <netdb.h>
+
+namespace everest::lib::io::udp {
+
+namespace {
+
+// Set sin6_scope_id from @p iface for IPv6 addresses that need a scope
+// (link-local fe80::/10 or multicast ff00::/8). Throws if the interface is
+// unknown. No-op for global addresses or an empty interface.
+void apply_v6_scope(sockaddr_in6& sin6, std::string const& iface) {
+    if (iface.empty()) {
+        return;
+    }
+    if (not IN6_IS_ADDR_LINKLOCAL(&sin6.sin6_addr) && not IN6_IS_ADDR_MULTICAST(&sin6.sin6_addr)) {
+        return;
+    }
+    unsigned int ifindex = if_nametoindex(iface.c_str());
+    if (ifindex == 0) {
+        throw std::runtime_error("if_nametoindex(\"" + iface + "\") failed");
+    }
+    sin6.sin6_scope_id = ifindex;
+}
+
+} // namespace
+
+endpoint::endpoint(std::string const& host, std::uint16_t port, std::string iface) : m_iface(std::move(iface)) {
+    sockaddr_in v4{};
+    if (inet_pton(AF_INET, host.c_str(), &v4.sin_addr) == 1) {
+        v4.sin_family = AF_INET;
+        v4.sin_port = htons(port);
+        std::memcpy(&m_storage, &v4, sizeof(v4));
+        m_len = sizeof(v4);
+        return;
+    }
+
+    sockaddr_in6 v6{};
+    if (inet_pton(AF_INET6, host.c_str(), &v6.sin6_addr) == 1) {
+        v6.sin6_family = AF_INET6;
+        v6.sin6_port = htons(port);
+        apply_v6_scope(v6, m_iface);
+        std::memcpy(&m_storage, &v6, sizeof(v6));
+        m_len = sizeof(v6);
+        return;
+    }
+
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_DGRAM;
+    addrinfo* res = nullptr;
+    const auto err = ::getaddrinfo(host.c_str(), std::to_string(port).c_str(), &hints, &res);
+    if (err != 0 || res == nullptr) {
+        throw std::runtime_error("Failed to resolve endpoint \"" + host + "\": " + ::gai_strerror(err));
+    }
+    std::memcpy(&m_storage, res->ai_addr, res->ai_addrlen);
+    m_len = res->ai_addrlen;
+    ::freeaddrinfo(res);
+
+    if (m_storage.ss_family == AF_INET6) {
+        sockaddr_in6 scoped{};
+        std::memcpy(&scoped, &m_storage, sizeof(scoped));
+        scoped.sin6_port = htons(port);
+        apply_v6_scope(scoped, m_iface);
+        std::memcpy(&m_storage, &scoped, sizeof(scoped));
+    }
+}
+
+endpoint::endpoint(sockaddr_storage const& src, socklen_t len) : m_len(len) {
+    std::memcpy(&m_storage, &src, sizeof(m_storage));
+}
+
+sa_family_t endpoint::family() const {
+    return m_len == 0 ? AF_UNSPEC : m_storage.ss_family;
+}
+
+std::uint16_t endpoint::port() const {
+    if (m_storage.ss_family == AF_INET) {
+        return ntohs(reinterpret_cast<sockaddr_in const*>(&m_storage)->sin_port);
+    }
+    if (m_storage.ss_family == AF_INET6) {
+        return ntohs(reinterpret_cast<sockaddr_in6 const*>(&m_storage)->sin6_port);
+    }
+    return 0;
+}
+
+std::string endpoint::addr_str() const {
+    char buf[INET6_ADDRSTRLEN]{};
+    if (m_storage.ss_family == AF_INET) {
+        inet_ntop(AF_INET, &reinterpret_cast<sockaddr_in const*>(&m_storage)->sin_addr, buf, sizeof(buf));
+    } else if (m_storage.ss_family == AF_INET6) {
+        inet_ntop(AF_INET6, &reinterpret_cast<sockaddr_in6 const*>(&m_storage)->sin6_addr, buf, sizeof(buf));
+    }
+    return std::string(buf);
+}
+
+sockaddr const* endpoint::sa() const {
+    return reinterpret_cast<sockaddr const*>(&m_storage);
+}
+
+socklen_t endpoint::sa_len() const {
+    return m_len;
+}
+
+std::string const& endpoint::iface() const {
+    return m_iface;
+}
+
+bool endpoint::operator==(endpoint const& other) const {
+    if (m_storage.ss_family != other.m_storage.ss_family) {
+        return false;
+    }
+    if (m_storage.ss_family == AF_INET) {
+        auto const* a = reinterpret_cast<sockaddr_in const*>(&m_storage);
+        auto const* b = reinterpret_cast<sockaddr_in const*>(&other.m_storage);
+        return a->sin_port == b->sin_port && a->sin_addr.s_addr == b->sin_addr.s_addr;
+    }
+    if (m_storage.ss_family == AF_INET6) {
+        auto const* a = reinterpret_cast<sockaddr_in6 const*>(&m_storage);
+        auto const* b = reinterpret_cast<sockaddr_in6 const*>(&other.m_storage);
+        return a->sin6_port == b->sin6_port && a->sin6_scope_id == b->sin6_scope_id &&
+               std::memcmp(&a->sin6_addr, &b->sin6_addr, sizeof(in6_addr)) == 0;
+    }
+    return m_len == other.m_len;
+}
+
+} // namespace everest::lib::io::udp

--- a/lib/everest/io/src/udp/udp_unconnected_socket.cpp
+++ b/lib/everest/io/src/udp/udp_unconnected_socket.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/udp/udp_unconnected_socket.hpp>
+
+#include <exception>
+#include <utility>
+
+#include <sys/socket.h>
+
+#include <everest/io/socket/socket.hpp>
+
+namespace everest::lib::io::udp {
+
+bool udp_unconnected_socket::open(endpoint target, std::string iface) {
+    try {
+        m_owned_udp_fd = socket::open_udp_unconnected_socket(target, iface);
+        m_target = std::move(target);
+        return socket::get_pending_error(m_owned_udp_fd) == 0;
+    } catch (const std::exception&) {
+    }
+    return false;
+}
+
+bool udp_unconnected_socket::tx(udp_payload const& payload) {
+    if (not m_owned_udp_fd.is_fd()) {
+        return false;
+    }
+
+    const auto nbytes =
+        ::sendto(m_owned_udp_fd, payload.buffer.data(), payload.size(), 0, m_target.sa(), m_target.sa_len());
+    return nbytes == static_cast<ssize_t>(payload.size());
+}
+
+bool udp_unconnected_socket::rx(udp_payload& payload) {
+    if (not m_owned_udp_fd.is_fd()) {
+        return false;
+    }
+
+    sockaddr_storage src{};
+    socklen_t src_len = sizeof(src);
+    const auto nbytes = ::recvfrom(m_owned_udp_fd, m_rx_buffer.data(), m_rx_buffer.size(), 0,
+                                   reinterpret_cast<sockaddr*>(&src), &src_len);
+    if (nbytes < 0) {
+        return false;
+    }
+
+    payload.set_message(m_rx_buffer.data(), static_cast<size_t>(nbytes));
+    m_last_source = endpoint(src, src_len);
+    return true;
+}
+
+int udp_unconnected_socket::get_fd() const {
+    return m_owned_udp_fd;
+}
+
+int udp_unconnected_socket::get_error() const {
+    return socket::get_pending_error(m_owned_udp_fd);
+}
+
+} // namespace everest::lib::io::udp

--- a/lib/everest/io/test/CMakeLists.txt
+++ b/lib/everest/io/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(everest_io_tests
+  endpoint_test.cpp
+  udp_client_v6_test.cpp
+  udp_unconnected_socket_test.cpp
+)
+
+target_link_libraries(everest_io_tests
+  PRIVATE
+        GTest::gtest_main
+        everest::io
+)
+
+include(GoogleTest)
+gtest_discover_tests(everest_io_tests TEST_PREFIX "io.")

--- a/lib/everest/io/test/datagram_selftest.sh
+++ b/lib/everest/io/test/datagram_selftest.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# datagram_selftest.sh - privileged real-multicast self-test for the generic
+# unconnected UDP client (udp_unconnected_client / udp_unconnected_socket).
+#
+# NOT a ctest case. The gtest suite (lib/everest/io/test/) covers parsing,
+# loopback round-trips and connect-drop-absence on the loopback interface.
+# This script exercises the one thing loopback cannot: a *real* multicast
+# send on a dedicated NIC followed by a *unicast* reply from a source whose
+# address differs from the multicast group. A connected socket would drop
+# that reply; the unconnected client must deliver it.
+#
+# It is fully rootless: it runs inside a user+network namespace via
+#   unshare --user --map-root-user --net
+# so it needs no sudo and touches no host interface. It builds its own
+# `dummy` NIC, runs a group-joining responder that answers unicast, and
+# checks the example client receives the reply from the responder's unicast
+# address (!= group) for both an IPv4 and an IPv6 multicast group.
+#
+# Usage:
+#   lib/everest/io/test/datagram_selftest.sh [path-to-test_udp_unconnected_client]
+#
+# Exit status: 0 = both v4 and v6 passed; non-zero = failure.
+
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+DEFAULT_BIN="${ROOT:-.}/build/lib/everest/io/examples/test_udp_unconnected_client"
+CLIENT_BIN="${1:-$DEFAULT_BIN}"
+
+if [ ! -x "$CLIENT_BIN" ]; then
+    echo "ERROR: client example not found/executable: $CLIENT_BIN" >&2
+    echo "Build it with: cmake ... -DBUILD_EXAMPLES=ON && ninja -C build test_udp_unconnected_client" >&2
+    exit 2
+fi
+
+if ! unshare --user --map-root-user --net true 2>/dev/null; then
+    echo "ERROR: rootless 'unshare --user --map-root-user --net' unavailable on this host" >&2
+    exit 2
+fi
+
+# Everything below runs inside the fresh user+net namespace. The inner script
+# is single-quoted on purpose: it is interpreted by the namespaced bash, where
+# CLIENT_BIN arrives via the exported environment.
+export CLIENT_BIN
+# shellcheck disable=SC2016
+exec unshare --user --map-root-user --net -- bash -euo pipefail -c '
+IFACE=dt0
+V4_GROUP=239.55.0.1
+V4_IF_ADDR=10.55.0.1
+V6_GROUP=ff12::55
+V6_IF_ADDR=fd00:55::1
+PORT=49555
+
+ip link set lo up
+ip link add "$IFACE" type dummy
+ip addr add "$V4_IF_ADDR"/24 dev "$IFACE"
+ip -6 addr add "$V6_IF_ADDR"/64 dev "$IFACE" nodad
+ip link set "$IFACE" up
+# Route the admin-scoped multicast ranges out the dummy NIC.
+ip route add 239.0.0.0/8 dev "$IFACE"
+ip -6 route add ff00::/8 dev "$IFACE"
+
+RESPONDER=$(mktemp)
+trap "rm -f \"$RESPONDER\"" EXIT
+cat > "$RESPONDER" <<"PY"
+import socket, struct, sys
+fam = socket.AF_INET6 if sys.argv[1] == "6" else socket.AF_INET
+group, ifaddr, port = sys.argv[2], sys.argv[3], int(sys.argv[4])
+s = socket.socket(fam, socket.SOCK_DGRAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+if fam == socket.AF_INET:
+    s.bind(("", port))
+    mreq = socket.inet_pton(socket.AF_INET, group) + socket.inet_aton(ifaddr)
+    s.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+else:
+    s.bind(("", port))
+    ifidx = socket.if_nametoindex("dt0")
+    mreq = socket.inet_pton(socket.AF_INET6, group) + struct.pack("I", ifidx)
+    s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_JOIN_GROUP, mreq)
+s.settimeout(8)
+# Reply unicast from our interface address (source != multicast group).
+r = socket.socket(fam, socket.SOCK_DGRAM)
+r.bind((ifaddr, 0))
+try:
+    while True:
+        data, addr = s.recvfrom(2048)
+        r.sendto(b"reply:" + data, addr)
+except socket.timeout:
+    pass
+PY
+
+run_case() {
+    fam="$1"; group="$2"; ifaddr="$3"; label="$4"
+    python3 "$RESPONDER" "$fam" "$group" "$ifaddr" "$PORT" &
+    rpid=$!
+    sleep 0.7
+    out=$(stdbuf -oL timeout 4 stdbuf -oL "$CLIENT_BIN" "$group" "$PORT" "$IFACE" 2>&1 || true)
+    wait "$rpid" 2>/dev/null || true
+    echo "----- $label client output -----"
+    echo "$out" | grep -aE "TX:|RX \(" | head -6 || true
+    # Pass: an RX line whose source address is the responder unicast addr,
+    # which is NOT the multicast group.
+    if echo "$out" | grep -aq "RX (.*from \[${ifaddr}\]" && \
+       ! echo "$out" | grep -aq "RX (.*from \[${group}\]"; then
+        echo "PASS ($label): unicast reply from $ifaddr delivered (group $group)"
+        return 0
+    fi
+    echo "FAIL ($label): no unicast reply from $ifaddr (group $group)"
+    return 1
+}
+
+rc=0
+run_case 4 "$V4_GROUP" "$V4_IF_ADDR" "IPv4" || rc=1
+run_case 6 "$V6_GROUP" "$V6_IF_ADDR" "IPv6" || rc=1
+if [ "$rc" -eq 0 ]; then
+    echo "datagram_selftest: ALL PASS (v4 + v6)"
+else
+    echo "datagram_selftest: FAILURES" >&2
+fi
+exit "$rc"
+'

--- a/lib/everest/io/test/endpoint_test.cpp
+++ b/lib/everest/io/test/endpoint_test.cpp
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/udp/endpoint.hpp>
+
+#include <cstring>
+#include <stdexcept>
+
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+using everest::lib::io::udp::endpoint;
+
+TEST(endpoint_test, ipv4_literal) {
+    endpoint ep("127.0.0.1", 8080);
+    EXPECT_EQ(ep.family(), AF_INET);
+    EXPECT_EQ(ep.port(), 8080);
+    EXPECT_EQ(ep.addr_str(), "127.0.0.1");
+    EXPECT_EQ(ep.sa_len(), sizeof(sockaddr_in));
+    EXPECT_NE(ep.sa(), nullptr);
+}
+
+TEST(endpoint_test, ipv6_loopback_literal) {
+    endpoint ep("::1", 9000);
+    EXPECT_EQ(ep.family(), AF_INET6);
+    EXPECT_EQ(ep.port(), 9000);
+    EXPECT_EQ(ep.addr_str(), "::1");
+    EXPECT_EQ(ep.sa_len(), sizeof(sockaddr_in6));
+}
+
+TEST(endpoint_test, ipv6_multicast_literal) {
+    endpoint ep("ff02::1", 5353);
+    EXPECT_EQ(ep.family(), AF_INET6);
+    EXPECT_EQ(ep.port(), 5353);
+}
+
+TEST(endpoint_test, port_is_host_order) {
+    endpoint ep("127.0.0.1", 0x1234);
+    // Raw sockaddr must carry network byte order.
+    auto const* sin = reinterpret_cast<sockaddr_in const*>(ep.sa());
+    EXPECT_EQ(sin->sin_port, htons(0x1234));
+    EXPECT_EQ(ep.port(), 0x1234);
+}
+
+TEST(endpoint_test, ipv6_link_local_scope_id_from_iface) {
+    // Loopback always exists; it is not link-local, so no scope is applied.
+    // Use a synthetic link-local address with the loopback interface name to
+    // exercise the scope-id path deterministically.
+    unsigned int lo = if_nametoindex("lo");
+    ASSERT_NE(lo, 0u);
+    endpoint ep("fe80::1", 1234, "lo");
+    auto const* sin6 = reinterpret_cast<sockaddr_in6 const*>(ep.sa());
+    EXPECT_EQ(sin6->sin6_scope_id, lo);
+    EXPECT_EQ(ep.iface(), "lo");
+}
+
+TEST(endpoint_test, hostname_resolves) {
+    endpoint ep("localhost", 4711);
+    EXPECT_TRUE(ep.family() == AF_INET || ep.family() == AF_INET6);
+    EXPECT_EQ(ep.port(), 4711);
+}
+
+TEST(endpoint_test, invalid_host_throws) {
+    EXPECT_THROW(endpoint("definitely.not.a.host.invalid.", 80), std::runtime_error);
+}
+
+TEST(endpoint_test, from_recvfrom_source_round_trips) {
+    endpoint origin("127.0.0.1", 6543);
+    sockaddr_storage ss{};
+    std::memcpy(&ss, origin.sa(), origin.sa_len());
+    endpoint restored(ss, origin.sa_len());
+    EXPECT_EQ(restored.family(), AF_INET);
+    EXPECT_EQ(restored.port(), 6543);
+    EXPECT_EQ(restored.addr_str(), "127.0.0.1");
+    EXPECT_TRUE(restored == origin);
+}
+
+TEST(endpoint_test, equality_distinguishes_port) {
+    endpoint a("127.0.0.1", 1000);
+    endpoint b("127.0.0.1", 1001);
+    EXPECT_FALSE(a == b);
+    EXPECT_TRUE(a != b);
+}
+
+// The raw sockaddr/len pair must be directly usable by sendto(): send one
+// datagram to a bound loopback UDP socket and read it back.
+TEST(endpoint_test, sa_usable_by_sendto) {
+    int rx = ::socket(AF_INET, SOCK_DGRAM, 0);
+    ASSERT_GE(rx, 0);
+
+    sockaddr_in bind_addr{};
+    bind_addr.sin_family = AF_INET;
+    bind_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    bind_addr.sin_port = 0; // ephemeral
+    ASSERT_EQ(::bind(rx, reinterpret_cast<sockaddr*>(&bind_addr), sizeof(bind_addr)), 0);
+
+    sockaddr_in bound{};
+    socklen_t blen = sizeof(bound);
+    ASSERT_EQ(::getsockname(rx, reinterpret_cast<sockaddr*>(&bound), &blen), 0);
+
+    endpoint target("127.0.0.1", ntohs(bound.sin_port));
+
+    int tx = ::socket(AF_INET, SOCK_DGRAM, 0);
+    ASSERT_GE(tx, 0);
+    const char msg[] = "hello";
+    ASSERT_EQ(::sendto(tx, msg, sizeof(msg), 0, target.sa(), target.sa_len()), static_cast<ssize_t>(sizeof(msg)));
+
+    char buf[16]{};
+    ASSERT_EQ(::recv(rx, buf, sizeof(buf), 0), static_cast<ssize_t>(sizeof(msg)));
+    EXPECT_STREQ(buf, "hello");
+
+    ::close(tx);
+    ::close(rx);
+}

--- a/lib/everest/io/test/udp_client_v6_test.cpp
+++ b/lib/everest/io/test/udp_client_v6_test.cpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+//
+// Characterization test: the connected udp_client already works over IPv6.
+// This locks that guarantee so the unconnected-client refactor cannot regress
+// it. No udp_client / udp_socket production code is touched by this work.
+
+#include <everest/io/udp/udp_client.hpp>
+#include <everest/io/udp/udp_payload.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+using everest::lib::io::udp::udp_client;
+using everest::lib::io::udp::udp_payload;
+using namespace std::chrono_literals;
+
+namespace {
+
+// A minimal blocking IPv6 echo socket on [::1]. Bound in the test body so the
+// ephemeral port is known before the client connects; serviced by a thread.
+class v6_echo {
+public:
+    v6_echo() {
+        m_fd = ::socket(AF_INET6, SOCK_DGRAM, 0);
+        EXPECT_GE(m_fd, 0);
+        sockaddr_in6 addr{};
+        addr.sin6_family = AF_INET6;
+        addr.sin6_addr = in6addr_loopback;
+        addr.sin6_port = 0;
+        EXPECT_EQ(::bind(m_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+        socklen_t len = sizeof(addr);
+        EXPECT_EQ(::getsockname(m_fd, reinterpret_cast<sockaddr*>(&addr), &len), 0);
+        m_port = ntohs(addr.sin6_port);
+
+        timeval tv{};
+        tv.tv_usec = 200000; // 200ms so the loop can observe the stop flag
+        ::setsockopt(m_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+        m_thread = std::thread([this] { run(); });
+    }
+
+    ~v6_echo() {
+        m_stop = true;
+        if (m_thread.joinable()) {
+            m_thread.join();
+        }
+        ::close(m_fd);
+    }
+
+    std::uint16_t port() const {
+        return m_port;
+    }
+
+private:
+    void run() {
+        char buf[256];
+        while (not m_stop) {
+            sockaddr_in6 src{};
+            socklen_t slen = sizeof(src);
+            auto n = ::recvfrom(m_fd, buf, sizeof(buf), 0, reinterpret_cast<sockaddr*>(&src), &slen);
+            if (n > 0) {
+                ::sendto(m_fd, buf, static_cast<size_t>(n), 0, reinterpret_cast<sockaddr*>(&src), slen);
+            }
+        }
+    }
+
+    int m_fd{-1};
+    std::uint16_t m_port{0};
+    std::atomic<bool> m_stop{false};
+    std::thread m_thread;
+};
+
+} // namespace
+
+TEST(udp_client_v6_test, connected_roundtrip_over_ipv6_loopback) {
+    v6_echo echo;
+
+    udp_client client("::1", echo.port(), 1000);
+
+    std::atomic<bool> got{false};
+    udp_payload received;
+    client.set_rx_handler([&](udp_payload const& p, auto&) {
+        received = p;
+        got = true;
+    });
+
+    udp_payload msg("v6-roundtrip");
+
+    auto deadline = std::chrono::steady_clock::now() + 5s;
+    auto next_send = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() < deadline && not got) {
+        if (std::chrono::steady_clock::now() >= next_send) {
+            client.tx(msg);
+            next_send = std::chrono::steady_clock::now() + 500ms;
+        }
+        client.sync(100ms);
+    }
+
+    ASSERT_TRUE(got) << "no IPv6 loopback echo received within timeout";
+    EXPECT_EQ(received, msg);
+}

--- a/lib/everest/io/test/udp_unconnected_socket_test.cpp
+++ b/lib/everest/io/test/udp_unconnected_socket_test.cpp
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/udp/udp_unconnected_client.hpp>
+#include <everest/io/udp/udp_unconnected_socket.hpp>
+// event_client_async_policy_v arrives transitively via udp_unconnected_client.hpp
+// (fd_event_client.hpp); that header has no include guard, so do not include it
+// a second time directly here.
+
+#include <cstring>
+#include <string>
+
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+using everest::lib::io::udp::endpoint;
+using everest::lib::io::udp::udp_payload;
+using everest::lib::io::udp::udp_unconnected_socket;
+using everest::lib::io::utilities::event_client_async_policy_v;
+
+// Policy must be the synchronous variant (open only; no setup/connect), so
+// fd_event_client uses the in-thread open() path with no detached connect.
+static_assert(not event_client_async_policy_v<udp_unconnected_socket>,
+              "udp_unconnected_socket must be a synchronous client policy");
+
+namespace {
+
+const char* loopback(int family) {
+    return family == AF_INET6 ? "::1" : "127.0.0.1";
+}
+
+// A raw datagram peer bound to loopback on an ephemeral port.
+struct peer {
+    int fd{-1};
+    std::uint16_t port{0};
+
+    explicit peer(int family) {
+        fd = ::socket(family, SOCK_DGRAM, 0);
+        EXPECT_GE(fd, 0);
+        sockaddr_storage ss{};
+        socklen_t len = 0;
+        if (family == AF_INET6) {
+            auto* a = reinterpret_cast<sockaddr_in6*>(&ss);
+            a->sin6_family = AF_INET6;
+            a->sin6_addr = in6addr_loopback;
+            len = sizeof(*a);
+        } else {
+            auto* a = reinterpret_cast<sockaddr_in*>(&ss);
+            a->sin_family = AF_INET;
+            a->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+            len = sizeof(*a);
+        }
+        EXPECT_EQ(::bind(fd, reinterpret_cast<sockaddr*>(&ss), len), 0);
+        socklen_t blen = sizeof(ss);
+        EXPECT_EQ(::getsockname(fd, reinterpret_cast<sockaddr*>(&ss), &blen), 0);
+        port = ntohs(family == AF_INET6 ? reinterpret_cast<sockaddr_in6*>(&ss)->sin6_port
+                                        : reinterpret_cast<sockaddr_in*>(&ss)->sin_port);
+    }
+    ~peer() {
+        if (fd >= 0) {
+            ::close(fd);
+        }
+    }
+};
+
+std::uint16_t bound_port(int fd) {
+    sockaddr_storage ss{};
+    socklen_t len = sizeof(ss);
+    EXPECT_EQ(::getsockname(fd, reinterpret_cast<sockaddr*>(&ss), &len), 0);
+    return ntohs(ss.ss_family == AF_INET6 ? reinterpret_cast<sockaddr_in6*>(&ss)->sin6_port
+                                          : reinterpret_cast<sockaddr_in*>(&ss)->sin_port);
+}
+
+bool wait_readable(int fd, int timeout_ms) {
+    pollfd pfd{fd, POLLIN, 0};
+    return ::poll(&pfd, 1, timeout_ms) > 0 && (pfd.revents & POLLIN) != 0;
+}
+
+bool rx_with_timeout(udp_unconnected_socket& sock, udp_payload& out, int timeout_ms = 1000) {
+    if (not wait_readable(sock.get_fd(), timeout_ms)) {
+        return false;
+    }
+    return sock.rx(out);
+}
+
+void roundtrip_for_family(int family) {
+    peer p(family);
+
+    udp_unconnected_socket u;
+    ASSERT_TRUE(u.open(endpoint(loopback(family), p.port)));
+
+    udp_payload msg("ping");
+    ASSERT_TRUE(u.tx(msg));
+
+    // Peer receives, learns u's source, echoes back.
+    char buf[64];
+    sockaddr_storage src{};
+    socklen_t slen = sizeof(src);
+    ASSERT_TRUE(wait_readable(p.fd, 1000));
+    auto n = ::recvfrom(p.fd, buf, sizeof(buf), 0, reinterpret_cast<sockaddr*>(&src), &slen);
+    ASSERT_GT(n, 0);
+    ASSERT_EQ(::sendto(p.fd, buf, static_cast<size_t>(n), 0, reinterpret_cast<sockaddr*>(&src), slen),
+              static_cast<ssize_t>(n));
+
+    udp_payload reply;
+    ASSERT_TRUE(rx_with_timeout(u, reply));
+    EXPECT_EQ(reply, msg);
+
+    auto last = u.last_source();
+    ASSERT_TRUE(last.has_value());
+    EXPECT_EQ(last->family(), family);
+    EXPECT_EQ(last->port(), p.port);
+    EXPECT_EQ(last->addr_str(), loopback(family));
+}
+
+// connect-drop-absence: u targets an arbitrary endpoint, but a *different*
+// peer sends straight to u's ephemeral port. Because open() does no ::connect,
+// the unrelated source is still delivered, and last_source() reflects that
+// sender, not the configured target.
+void connect_drop_absence_for_family(int family) {
+    peer target(family); // configured tx destination; never receives here
+    udp_unconnected_socket u;
+    ASSERT_TRUE(u.open(endpoint(loopback(family), target.port)));
+
+    std::uint16_t u_port = bound_port(u.get_fd());
+
+    peer other(family); // a sender unrelated to the configured target
+    sockaddr_storage dst{};
+    socklen_t dlen = 0;
+    if (family == AF_INET6) {
+        auto* a = reinterpret_cast<sockaddr_in6*>(&dst);
+        a->sin6_family = AF_INET6;
+        a->sin6_addr = in6addr_loopback;
+        a->sin6_port = htons(u_port);
+        dlen = sizeof(*a);
+    } else {
+        auto* a = reinterpret_cast<sockaddr_in*>(&dst);
+        a->sin_family = AF_INET;
+        a->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        a->sin_port = htons(u_port);
+        dlen = sizeof(*a);
+    }
+    const char payload[] = "from-other";
+    ASSERT_EQ(::sendto(other.fd, payload, sizeof(payload), 0, reinterpret_cast<sockaddr*>(&dst), dlen),
+              static_cast<ssize_t>(sizeof(payload)));
+
+    udp_payload got;
+    ASSERT_TRUE(rx_with_timeout(u, got)) << "datagram from a non-target source was dropped (socket is connected?)";
+
+    auto last = u.last_source();
+    ASSERT_TRUE(last.has_value());
+    EXPECT_EQ(last->port(), other.port);
+    EXPECT_NE(last->port(), target.port);
+    EXPECT_FALSE(*last == endpoint(loopback(family), target.port));
+}
+
+} // namespace
+
+TEST(udp_unconnected_socket_test, roundtrip_ipv4) {
+    roundtrip_for_family(AF_INET);
+}
+
+TEST(udp_unconnected_socket_test, roundtrip_ipv6) {
+    roundtrip_for_family(AF_INET6);
+}
+
+TEST(udp_unconnected_socket_test, connect_drop_absence_ipv4) {
+    connect_drop_absence_for_family(AF_INET);
+}
+
+TEST(udp_unconnected_socket_test, connect_drop_absence_ipv6) {
+    connect_drop_absence_for_family(AF_INET6);
+}
+
+TEST(udp_unconnected_socket_test, multicast_egress_iface_set_ipv6) {
+    unsigned int lo = if_nametoindex("lo");
+    ASSERT_NE(lo, 0u);
+    udp_unconnected_socket u;
+    ASSERT_TRUE(u.open(endpoint("ff02::1", 5353, "lo")));
+
+    int ifindex = 0;
+    socklen_t len = sizeof(ifindex);
+    ASSERT_EQ(::getsockopt(u.get_fd(), IPPROTO_IPV6, IPV6_MULTICAST_IF, &ifindex, &len), 0);
+    EXPECT_EQ(static_cast<unsigned int>(ifindex), lo);
+}
+
+TEST(udp_unconnected_socket_test, multicast_egress_iface_set_ipv4) {
+    unsigned int lo = if_nametoindex("lo");
+    ASSERT_NE(lo, 0u);
+    udp_unconnected_socket u;
+    // set_multicast_if() throws if setsockopt(IP_MULTICAST_IF) fails, which
+    // would make open() return false; a successful open for a multicast v4
+    // target on a named interface proves the egress option was applied.
+    // (Linux getsockopt(IP_MULTICAST_IF) returns only a zeroed in_addr when
+    // set by interface index, so a value read-back is not possible here; the
+    // v6 case below asserts the index strictly via getsockopt.)
+    EXPECT_TRUE(u.open(endpoint("239.1.2.3", 5000, "lo")));
+}
+
+TEST(udp_unconnected_socket_test, client_alias_constructs) {
+    // The fd_event_client alias must instantiate against the sync policy and
+    // open the underlying socket synchronously in its constructor.
+    peer p(AF_INET);
+    everest::lib::io::udp::udp_unconnected_client client(endpoint("127.0.0.1", p.port));
+    EXPECT_GE(client.get_poll_fd(), 0);
+    auto const& raw = client.get_raw_handler();
+    ASSERT_NE(raw, nullptr);
+    EXPECT_GE(raw->get_fd(), 0);
+}


### PR DESCRIPTION
libio UDP was IPv4-only and connect()-based; a connected datagram socket drops unicast replies whose source != the connected peer. Add udp6_socket (unconnected AF_INET6 datagram: sendto a fixed target, recvfrom any source, no ::connect/no group join), the udp6_client fd_event_client alias, and a usage example.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

