### PR TITLE
feat(io): dual-stack udp server (v6 + v4-mapped)

### DIFF
--- a/lib/everest/io/include/everest/io/socket/socket.hpp
+++ b/lib/everest/io/include/everest/io/socket/socket.hpp
@@ -54,6 +54,22 @@ event::unique_fd open_udp_client_socket(std::string const& host, std::uint16_t p
 event::unique_fd open_udp_unconnected_socket(udp::endpoint const& target, std::string const& iface = {});
 
 /**
+ * @brief Open a dual-stack (IPv6 + IPv4-mapped) UDP server socket.
+ * @details AF_INET6/SOCK_DGRAM, IPV6_V6ONLY=0, non-blocking, SO_REUSEADDR,
+ * bound to [::]:@p port so it receives both native IPv6 and IPv4-mapped
+ * traffic. @p device (optional) is applied best-effort via
+ * bind_socket_to_device (SO_BINDTODEVICE → IPV6_UNICAST_IF); the wildcard
+ * bind is always kept. If IPv6 is unavailable (socket(AF_INET6) fails with
+ * EAFNOSUPPORT) it falls back to AF_INET bound to 0.0.0.0:@p port.
+ * @param[in] port Local UDP port; 0 picks an ephemeral port.
+ * @param[in] device Optional interface name. Empty = no binding.
+ * @return The managed file descriptor of the socket.
+ * @throws std::runtime_error on any failure other than the EAFNOSUPPORT
+ * v6→v4 fallback.
+ */
+event::unique_fd open_udp_dualstack_server_socket(std::uint16_t port, std::string const& device = {});
+
+/**
  * @brief Open a UDP socket with <a href="https://man7.org/linux/man-pages/man7/ip.7.html">multicast</a>
  * enabled
  * @details Description

--- a/lib/everest/io/include/everest/io/udp/endpoint.hpp
+++ b/lib/everest/io/include/everest/io/udp/endpoint.hpp
@@ -86,6 +86,19 @@ public:
     std::string const& iface() const;
 
     /**
+     * @brief True iff this is an IPv4-mapped IPv6 address (::ffff:a.b.c.d).
+     */
+    bool is_v4_mapped() const;
+
+    /**
+     * @brief IPv4 view of a v4-mapped address.
+     * @return If @ref is_v4_mapped(): an AF_INET endpoint with the embedded
+     * IPv4 address and the same port. Otherwise a default endpoint
+     * (family AF_UNSPEC, sa_len()==0).
+     */
+    endpoint as_v4() const;
+
+    /**
      * @brief Value equality (family, address, port, IPv6 scope id).
      */
     bool operator==(endpoint const& other) const;

--- a/lib/everest/io/include/everest/io/udp/udp_dualstack_server.hpp
+++ b/lib/everest/io/include/everest/io/udp/udp_dualstack_server.hpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include <everest/io/event/fd_event_client.hpp>
+#include <everest/io/udp/udp_dualstack_server_socket.hpp>
+
+namespace everest::lib::io::udp {
+
+/**
+ * @var udp_dualstack_server
+ * @brief Dual-stack (IPv6 + IPv4-mapped) UDP server implemented in terms of
+ * \ref event::fd_event_client and \ref udp::udp_dualstack_server_socket
+ */
+using udp_dualstack_server = event::fd_event_client<udp_dualstack_server_socket>::type;
+
+} // namespace everest::lib::io::udp

--- a/lib/everest/io/include/everest/io/udp/udp_dualstack_server_socket.hpp
+++ b/lib/everest/io/include/everest/io/udp/udp_dualstack_server_socket.hpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <everest/io/event/unique_fd.hpp>
+#include <everest/io/udp/endpoint.hpp>
+#include <everest/io/udp/udp_payload.hpp>
+
+namespace everest::lib::io::udp {
+
+/**
+ * @class udp_dualstack_server_socket
+ * @brief A dual-stack (IPv6 + IPv4-mapped) unconnected UDP *server* socket.
+ *
+ * Binds [::]:port via socket::open_udp_dualstack_server_socket, records the
+ * last datagram's source, and replies to it. Synchronous ClientPolicy of
+ * event::fd_event_client.
+ */
+class udp_dualstack_server_socket {
+public:
+    using PayloadT = udp_payload;
+
+    udp_dualstack_server_socket() = default;
+
+    /**
+     * @brief Open the server. Never throws (sync policy).
+     * @param[in] port Local UDP port; 0 picks an ephemeral port.
+     * @param[in] device Optional interface name. Empty = no binding.
+     * @return True on success.
+     */
+    bool open(std::uint16_t port, std::string device = {});
+
+    /**
+     * @brief Reply to the most recent source.
+     * @return False if nothing has been received yet.
+     */
+    bool tx(udp_payload const& payload);
+
+    /**
+     * @brief Receive a datagram; records last_source().
+     */
+    bool rx(udp_payload& payload);
+
+    int get_fd() const;
+    int get_error() const;
+
+    std::optional<endpoint> last_source() const {
+        return m_last_source;
+    }
+
+private:
+    event::unique_fd m_owned_udp_fd;
+    std::optional<endpoint> m_last_source;
+    std::array<uint8_t, udp_payload::max_size> m_rx_buffer;
+};
+
+} // namespace everest::lib::io::udp

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(everest_io
         event/fd_event_client.cpp
         udp/udp_socket.cpp
         udp/udp_unconnected_socket.cpp
+        udp/udp_dualstack_server_socket.cpp
         udp/endpoint.cpp
         udp/udp_payload.cpp
         utilities/stop_watch.cpp

--- a/lib/everest/io/src/socket/socket.cpp
+++ b/lib/everest/io/src/socket/socket.cpp
@@ -781,6 +781,59 @@ event::unique_fd open_udp_unconnected_socket(udp::endpoint const& target, std::s
     return sock;
 }
 
+event::unique_fd open_udp_dualstack_server_socket(std::uint16_t port, std::string const& device) {
+    event::unique_fd sock(::socket(AF_INET6, SOCK_DGRAM, 0));
+    if (not sock.is_fd() && errno == EAFNOSUPPORT) {
+        // IPv6 unavailable on this host: v4-only fallback.
+        event::unique_fd v4(::socket(AF_INET, SOCK_DGRAM, 0));
+        if (not v4.is_fd()) {
+            throw std::runtime_error(build_errno_string("socket(AF_INET, SOCK_DGRAM) failed"));
+        }
+        set_reuse_address(v4);
+        set_non_blocking(v4);
+        sockaddr_in local{};
+        local.sin_family = AF_INET;
+        local.sin_addr.s_addr = htonl(INADDR_ANY);
+        local.sin_port = htons(port);
+        if (::bind(v4, reinterpret_cast<sockaddr*>(&local), sizeof(local)) < 0) {
+            throw std::runtime_error(build_errno_string("bind(0.0.0.0:" + std::to_string(port) + ") failed"));
+        }
+        if (not device.empty()) {
+            try {
+                bind_socket_to_device(v4, device);
+            } catch (const std::exception&) {
+                // best-effort; wildcard bind retained
+            }
+        }
+        return v4;
+    }
+
+    if (not sock.is_fd()) {
+        throw std::runtime_error(build_errno_string("socket(AF_INET6, SOCK_DGRAM) failed"));
+    }
+    int v6only = 0;
+    if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) < 0) {
+        throw std::runtime_error(build_errno_string("setsockopt(IPV6_V6ONLY=0) failed"));
+    }
+    set_reuse_address(sock);
+    set_non_blocking(sock);
+    sockaddr_in6 local{};
+    local.sin6_family = AF_INET6;
+    local.sin6_addr = in6addr_any;
+    local.sin6_port = htons(port);
+    if (::bind(sock, reinterpret_cast<sockaddr*>(&local), sizeof(local)) < 0) {
+        throw std::runtime_error(build_errno_string("bind([::]:" + std::to_string(port) + ") failed"));
+    }
+    if (not device.empty()) {
+        try {
+            bind_socket_to_device(sock, device);
+        } catch (const std::exception&) {
+            // best-effort; wildcard bind retained
+        }
+    }
+    return sock;
+}
+
 event::unique_fd open_udp_multicast_socket(std::string const& multicast_group, std::uint16_t port,
                                            std::string interface_address, std::string listen_address,
                                            bool reuse_address, bool reuse_port) {

--- a/lib/everest/io/src/udp/endpoint.cpp
+++ b/lib/everest/io/src/udp/endpoint.cpp
@@ -114,6 +114,27 @@ std::string const& endpoint::iface() const {
     return m_iface;
 }
 
+bool endpoint::is_v4_mapped() const {
+    if (m_storage.ss_family != AF_INET6) {
+        return false;
+    }
+    auto const* s6 = reinterpret_cast<sockaddr_in6 const*>(&m_storage);
+    return IN6_IS_ADDR_V4MAPPED(&s6->sin6_addr);
+}
+
+endpoint endpoint::as_v4() const {
+    if (not is_v4_mapped()) {
+        return endpoint{};
+    }
+    auto const* s6 = reinterpret_cast<sockaddr_in6 const*>(&m_storage);
+    sockaddr_storage ss{};
+    auto* s4 = reinterpret_cast<sockaddr_in*>(&ss);
+    s4->sin_family = AF_INET;
+    s4->sin_port = s6->sin6_port; // network order preserved
+    std::memcpy(&s4->sin_addr.s_addr, reinterpret_cast<uint8_t const*>(&s6->sin6_addr) + 12, 4);
+    return endpoint(ss, sizeof(sockaddr_in));
+}
+
 bool endpoint::operator==(endpoint const& other) const {
     if (m_storage.ss_family != other.m_storage.ss_family) {
         return false;

--- a/lib/everest/io/src/udp/udp_dualstack_server_socket.cpp
+++ b/lib/everest/io/src/udp/udp_dualstack_server_socket.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/udp/udp_dualstack_server_socket.hpp>
+
+#include <exception>
+#include <utility>
+
+#include <sys/socket.h>
+
+#include <everest/io/socket/socket.hpp>
+
+namespace everest::lib::io::udp {
+
+bool udp_dualstack_server_socket::open(std::uint16_t port, std::string device) {
+    try {
+        m_owned_udp_fd = socket::open_udp_dualstack_server_socket(port, device);
+        return socket::get_pending_error(m_owned_udp_fd) == 0;
+    } catch (const std::exception&) {
+    }
+    return false;
+}
+
+bool udp_dualstack_server_socket::tx(udp_payload const& payload) {
+    if (not m_owned_udp_fd.is_fd() or not m_last_source) {
+        return false;
+    }
+    const auto nbytes = ::sendto(m_owned_udp_fd, payload.buffer.data(), payload.size(), 0, m_last_source->sa(),
+                                 m_last_source->sa_len());
+    return nbytes == static_cast<ssize_t>(payload.size());
+}
+
+bool udp_dualstack_server_socket::rx(udp_payload& payload) {
+    if (not m_owned_udp_fd.is_fd()) {
+        return false;
+    }
+
+    sockaddr_storage src{};
+    socklen_t src_len = sizeof(src);
+    const auto nbytes = ::recvfrom(m_owned_udp_fd, m_rx_buffer.data(), m_rx_buffer.size(), 0,
+                                   reinterpret_cast<sockaddr*>(&src), &src_len);
+    if (nbytes < 0) {
+        return false;
+    }
+
+    payload.set_message(m_rx_buffer.data(), static_cast<size_t>(nbytes));
+    m_last_source = endpoint(src, src_len);
+    return true;
+}
+
+int udp_dualstack_server_socket::get_fd() const {
+    return m_owned_udp_fd;
+}
+
+int udp_dualstack_server_socket::get_error() const {
+    return socket::get_pending_error(m_owned_udp_fd);
+}
+
+} // namespace everest::lib::io::udp

--- a/lib/everest/io/test/CMakeLists.txt
+++ b/lib/everest/io/test/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(everest_io_tests
   endpoint_test.cpp
   udp_client_v6_test.cpp
   udp_unconnected_socket_test.cpp
+  udp_dualstack_server_socket_test.cpp
 )
 
 target_link_libraries(everest_io_tests

--- a/lib/everest/io/test/endpoint_test.cpp
+++ b/lib/everest/io/test/endpoint_test.cpp
@@ -87,6 +87,36 @@ TEST(endpoint_test, equality_distinguishes_port) {
     EXPECT_TRUE(a != b);
 }
 
+TEST(endpoint_test, v4_mapped_detected_and_unmapped) {
+    // Build a v4-mapped endpoint the way recvfrom on a dual-stack socket would.
+    sockaddr_storage ss{};
+    auto* s6 = reinterpret_cast<sockaddr_in6*>(&ss);
+    s6->sin6_family = AF_INET6;
+    s6->sin6_port = htons(40123);
+    inet_pton(AF_INET6, "::ffff:127.0.0.1", &s6->sin6_addr);
+    endpoint mapped(ss, sizeof(sockaddr_in6));
+
+    EXPECT_TRUE(mapped.is_v4_mapped());
+    auto v4 = mapped.as_v4();
+    EXPECT_EQ(v4.family(), AF_INET);
+    EXPECT_EQ(v4.addr_str(), "127.0.0.1");
+    EXPECT_EQ(v4.port(), 40123);
+}
+
+TEST(endpoint_test, native_v6_is_not_v4_mapped_and_as_v4_is_empty) {
+    endpoint v6("::1", 9000);
+    EXPECT_FALSE(v6.is_v4_mapped());
+    auto e = v6.as_v4();
+    EXPECT_EQ(e.family(), AF_UNSPEC);
+    EXPECT_EQ(e.sa_len(), 0);
+}
+
+TEST(endpoint_test, already_v4_is_not_mapped_and_as_v4_is_empty) {
+    endpoint v4("127.0.0.1", 1234);
+    EXPECT_FALSE(v4.is_v4_mapped());
+    EXPECT_EQ(v4.as_v4().family(), AF_UNSPEC);
+}
+
 // The raw sockaddr/len pair must be directly usable by sendto(): send one
 // datagram to a bound loopback UDP socket and read it back.
 TEST(endpoint_test, sa_usable_by_sendto) {

--- a/lib/everest/io/test/udp_dualstack_server_socket_test.cpp
+++ b/lib/everest/io/test/udp_dualstack_server_socket_test.cpp
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/socket/socket.hpp>
+#include <everest/io/udp/endpoint.hpp>
+#include <everest/io/udp/udp_dualstack_server.hpp>
+#include <everest/io/udp/udp_dualstack_server_socket.hpp>
+// event_client_async_policy_v arrives transitively via udp_dualstack_server.hpp
+// (fd_event_client.hpp); that header has no include guard, so do not include it
+// a second time directly here.
+
+#include <cstring>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+using namespace everest::lib::io;
+using everest::lib::io::udp::endpoint;
+using everest::lib::io::udp::udp_dualstack_server_socket;
+using everest::lib::io::udp::udp_payload;
+using everest::lib::io::utilities::event_client_async_policy_v;
+
+// Open only, no setup/connect: must be the synchronous client policy.
+static_assert(not event_client_async_policy_v<udp_dualstack_server_socket>,
+              "udp_dualstack_server_socket must be a synchronous client policy");
+
+namespace {
+
+bool wait_readable(int fd, int timeout_ms) {
+    pollfd pfd{fd, POLLIN, 0};
+    return ::poll(&pfd, 1, timeout_ms) > 0 && (pfd.revents & POLLIN) != 0;
+}
+
+bool rx_with_timeout(udp_dualstack_server_socket& s, udp_payload& out, int timeout_ms = 1000) {
+    if (not wait_readable(s.get_fd(), timeout_ms)) {
+        return false;
+    }
+    return s.rx(out);
+}
+
+std::uint16_t bound_port(int fd) {
+    sockaddr_storage ss{};
+    socklen_t len = sizeof(ss);
+    EXPECT_EQ(::getsockname(fd, reinterpret_cast<sockaddr*>(&ss), &len), 0);
+    return ntohs(ss.ss_family == AF_INET6 ? reinterpret_cast<sockaddr_in6*>(&ss)->sin6_port
+                                          : reinterpret_cast<sockaddr_in*>(&ss)->sin_port);
+}
+
+} // namespace
+
+TEST(udp_dualstack_factory_test, binds_dualstack_v6_any) {
+    auto fd = socket::open_udp_dualstack_server_socket(0); // ephemeral
+    ASSERT_GE(static_cast<int>(fd), 0);
+
+    int v6only = 1;
+    socklen_t l = sizeof(v6only);
+    ASSERT_EQ(::getsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, &l), 0);
+    EXPECT_EQ(v6only, 0); // dual-stack
+
+    sockaddr_storage ss{};
+    socklen_t sl = sizeof(ss);
+    ASSERT_EQ(::getsockname(fd, reinterpret_cast<sockaddr*>(&ss), &sl), 0);
+    EXPECT_EQ(ss.ss_family, AF_INET6);
+}
+
+TEST(udp_dualstack_factory_test, device_empty_is_ok) {
+    EXPECT_GE(static_cast<int>(socket::open_udp_dualstack_server_socket(0, {})), 0);
+}
+
+TEST(udp_dualstack_server_socket_test, v6_roundtrip_loopback) {
+    udp_dualstack_server_socket S;
+    ASSERT_TRUE(S.open(0));
+    const std::uint16_t srv_port = bound_port(S.get_fd());
+
+    int cl = ::socket(AF_INET6, SOCK_DGRAM, 0);
+    ASSERT_GE(cl, 0);
+    sockaddr_in6 cl_bind{};
+    cl_bind.sin6_family = AF_INET6;
+    cl_bind.sin6_addr = in6addr_loopback;
+    ASSERT_EQ(::bind(cl, reinterpret_cast<sockaddr*>(&cl_bind), sizeof(cl_bind)), 0);
+    const std::uint16_t cl_port = bound_port(cl);
+
+    sockaddr_in6 dst{};
+    dst.sin6_family = AF_INET6;
+    dst.sin6_addr = in6addr_loopback;
+    dst.sin6_port = htons(srv_port);
+    udp_payload ping("ping6");
+    ASSERT_EQ(::sendto(cl, ping.buffer.data(), ping.size(), 0, reinterpret_cast<sockaddr*>(&dst), sizeof(dst)),
+              static_cast<ssize_t>(ping.size()));
+
+    udp_payload got;
+    ASSERT_TRUE(rx_with_timeout(S, got));
+    EXPECT_EQ(got, udp_payload("ping6"));
+
+    auto src = S.last_source();
+    ASSERT_TRUE(src.has_value());
+    EXPECT_EQ(src->family(), AF_INET6);
+    EXPECT_EQ(src->port(), cl_port);
+    EXPECT_FALSE(src->is_v4_mapped());
+
+    ASSERT_TRUE(S.tx(udp_payload("pong6")));
+    char buf[64]{};
+    ASSERT_TRUE(wait_readable(cl, 1000));
+    auto n = ::recv(cl, buf, sizeof(buf), 0);
+    ASSERT_GT(n, 0);
+    EXPECT_STREQ(buf, "pong6");
+    ::close(cl);
+}
+
+TEST(udp_dualstack_server_socket_test, v4_mapped_roundtrip_loopback) {
+    udp_dualstack_server_socket S;
+    ASSERT_TRUE(S.open(0));
+    const std::uint16_t srv_port = bound_port(S.get_fd());
+
+    int cl = ::socket(AF_INET, SOCK_DGRAM, 0);
+    ASSERT_GE(cl, 0);
+    sockaddr_in cl_bind{};
+    cl_bind.sin_family = AF_INET;
+    cl_bind.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    ASSERT_EQ(::bind(cl, reinterpret_cast<sockaddr*>(&cl_bind), sizeof(cl_bind)), 0);
+    const std::uint16_t cl_port = bound_port(cl);
+
+    sockaddr_in dst{};
+    dst.sin_family = AF_INET;
+    dst.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    dst.sin_port = htons(srv_port);
+    udp_payload ping("ping4");
+    ASSERT_EQ(::sendto(cl, ping.buffer.data(), ping.size(), 0, reinterpret_cast<sockaddr*>(&dst), sizeof(dst)),
+              static_cast<ssize_t>(ping.size()));
+
+    udp_payload got;
+    ASSERT_TRUE(rx_with_timeout(S, got));
+    EXPECT_EQ(got, udp_payload("ping4"));
+
+    auto src = S.last_source();
+    ASSERT_TRUE(src.has_value());
+    EXPECT_EQ(src->family(), AF_INET6); // v4-mapped is carried in a v6 sockaddr
+    EXPECT_TRUE(src->is_v4_mapped());
+    auto v4 = src->as_v4();
+    EXPECT_EQ(v4.family(), AF_INET);
+    EXPECT_EQ(v4.addr_str(), "127.0.0.1");
+    EXPECT_EQ(v4.port(), cl_port);
+
+    // Reply must reach the v4 client via the verbatim mapped sockaddr.
+    ASSERT_TRUE(S.tx(udp_payload("pong4")));
+    char buf[64]{};
+    ASSERT_TRUE(wait_readable(cl, 1000));
+    auto n = ::recv(cl, buf, sizeof(buf), 0);
+    ASSERT_GT(n, 0);
+    EXPECT_STREQ(buf, "pong4");
+    ::close(cl);
+}
+
+TEST(udp_dualstack_server_socket_test, tx_before_rx_is_false) {
+    udp_dualstack_server_socket S;
+    ASSERT_TRUE(S.open(0));
+    EXPECT_FALSE(S.tx(udp_payload("nope")));
+}


### PR DESCRIPTION
Add an isolated parallel UDP server type that accepts native IPv6 and IPv4-mapped clients on one socket and replies to the correct source.

- endpoint: is_v4_mapped() / as_v4() accessors
- socket::open_udp_dualstack_server_socket (AF_INET6, IPV6_V6ONLY=0, EAFNOSUPPORT -> AF_INET fallback)
- udp_dualstack_server_socket sync policy + udp_dualstack_server alias

Shared udp_socket_base and existing udp_server/udp_client/mdns untouched.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

