### PR TITLE
EvseSlac: Add 0xA14E message filtering

### DIFF
--- a/lib/everest/slac/include/slac/slac.hpp
+++ b/lib/everest/slac/include/slac/slac.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
+// Copyright 2022 - 2026 Pionix GmbH and Contributors to EVerest
 #ifndef SLAC_SLAC_HPP
 #define SLAC_SLAC_HPP
 
@@ -72,6 +72,7 @@ const uint16_t MMTYPE_LINK_STATUS = 0xA0B8;
 const uint16_t MMTYPE_OP_ATTR = 0xA068;
 const uint16_t MMTYPE_NW_INFO = 0xA038;
 const uint16_t MMTYPE_GET_SW = 0xA000;
+const uint16_t MMTYPE_VS_ATTENUATION_CHARACTERISTICS = 0xA14E;
 } // namespace qualcomm
 
 // Lumissil Vendor MMEs

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2022 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2022 - 2026 Pionix GmbH and Contributors to EVerest
 
 #include "slacImpl.hpp"
 
@@ -116,9 +116,8 @@ void slacImpl::run() {
     // MMTYPE and logs "Received non-expected SLAC message of type 0xA14E" per frame, which
     // adds RX/log load. Drop it pre-FSM. Other MMTYPEs (incl. CM_SET_KEY.CNF, CM_ATTEN_PROFILE.IND)
     // pass through unchanged.
-    constexpr uint16_t MMTYPE_QCA_VS_ATTENUATION_CHARACTERISTICS = 0xA14E;
     slac_io.run([](slac::messages::HomeplugMessage& msg) {
-        if (msg.get_mmtype() == MMTYPE_QCA_VS_ATTENUATION_CHARACTERISTICS) {
+        if (msg.get_mmtype() == slac::defs::qualcomm::MMTYPE_VS_ATTENUATION_CHARACTERISTICS) {
             return;
         }
         fsm_ctrl->signal_new_slac_message(msg);

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -111,7 +111,18 @@ void slacImpl::run() {
 
     fsm_ctrl = std::make_unique<FSMController>(fsm_ctx);
 
-    slac_io.run([](slac::messages::HomeplugMessage& msg) { fsm_ctrl->signal_new_slac_message(msg); });
+    // Qualcomm PLC chip emits VS_ATTENUATION_CHARACTERISTICS (vendor MMTYPE 0xA14E) as
+    // unsolicited broadcasts during sounding from a sibling MAC. FSM does not handle this
+    // MMTYPE and logs "Received non-expected SLAC message of type 0xA14E" per frame, which
+    // adds RX/log load. Drop it pre-FSM. Other MMTYPEs (incl. CM_SET_KEY.CNF, CM_ATTEN_PROFILE.IND)
+    // pass through unchanged.
+    constexpr uint16_t MMTYPE_QCA_VS_ATTENUATION_CHARACTERISTICS = 0xA14E;
+    slac_io.run([](slac::messages::HomeplugMessage& msg) {
+        if (msg.get_mmtype() == MMTYPE_QCA_VS_ATTENUATION_CHARACTERISTICS) {
+            return;
+        }
+        fsm_ctrl->signal_new_slac_message(msg);
+    });
 
     fsm_ctrl->run();
 }


### PR DESCRIPTION
## Describe your changes

Qualcomm PLC chip emits VS_ATTENUATION_CHARACTERISTICS (vendor MMTYPE 0xA14E) as unsolicited broadcasts during sounding from a sibling MAC. FSM does not handle this MMTYPE and logs "Received non-expected SLAC message of type 0xA14E" per frame, which adds RX/log load. Drop it pre-FSM. Other MMTYPEs (incl. CM_SET_KEY.CNF, CM_ATTEN_PROFILE.IND) pass through unchanged.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

