### PR TITLE
EvseSlac: add HACK config option to disable regenerate NMK on reset

### DIFF
--- a/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
+++ b/lib/everest/slac/fsm/evse/include/everest/slac/fsm/evse/context.hpp
@@ -190,6 +190,8 @@ struct EvseSlacConfig {
     int sounding_atten_adjustment = 0;
 
     bool reset_instead_of_fail{false};
+
+    bool regenerate_key_on_reset{true};
 };
 
 struct Context {

--- a/lib/everest/slac/fsm/evse/src/states/others.cpp
+++ b/lib/everest/slac/fsm/evse/src/states/others.cpp
@@ -31,7 +31,9 @@ static auto create_cm_set_key_req(uint8_t const* session_nmk) {
 
 void ResetState::enter() {
     ctx.log_info("Entered Reset state");
-    ctx.slac_config.generate_nmk();
+    if (ctx.slac_config.regenerate_key_on_reset) {
+        ctx.slac_config.generate_nmk();
+    }
 }
 
 FSMSimpleState::HandleEventReturnType ResetState::handle_event(AllocatorType& sa, Event ev) {

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -105,6 +105,8 @@ void slacImpl::run() {
 
     fsm_ctx.slac_config.reset_instead_of_fail = config.reset_instead_of_fail;
 
+    fsm_ctx.slac_config.regenerate_key_on_reset = config.regenerate_key_on_reset;
+
     fsm_ctx.slac_config.generate_nmk();
 
     memcpy(fsm_ctx.evse_mac, slac_io.get_mac_addr(), ETH_ALEN);

--- a/modules/EVSE/EvseSlac/main/slacImpl.cpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.cpp
@@ -105,7 +105,7 @@ void slacImpl::run() {
 
     fsm_ctx.slac_config.reset_instead_of_fail = config.reset_instead_of_fail;
 
-    fsm_ctx.slac_config.regenerate_key_on_reset = config.regenerate_key_on_reset;
+    fsm_ctx.slac_config.regenerate_key_on_reset = !config.hack_disable_regenerate_key_on_reset;
 
     fsm_ctx.slac_config.generate_nmk();
 

--- a/modules/EVSE/EvseSlac/main/slacImpl.hpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.hpp
@@ -37,6 +37,7 @@ struct Conf {
     bool reset_instead_of_fail;
     int startup_delay_ms;
     int slac_init_timeout_ms;
+    bool regenerate_key_on_reset;
 };
 
 class slacImpl : public slacImplBase {

--- a/modules/EVSE/EvseSlac/main/slacImpl.hpp
+++ b/modules/EVSE/EvseSlac/main/slacImpl.hpp
@@ -37,7 +37,7 @@ struct Conf {
     bool reset_instead_of_fail;
     int startup_delay_ms;
     int slac_init_timeout_ms;
-    bool regenerate_key_on_reset;
+    bool hack_disable_regenerate_key_on_reset;
 };
 
 class slacImpl : public slacImplBase {

--- a/modules/EVSE/EvseSlac/manifest.yaml
+++ b/modules/EVSE/EvseSlac/manifest.yaml
@@ -90,11 +90,11 @@ provides:
         minimum: 10000
         maximum: 50000
         default: 40000
-      regenerate_key_on_reset:
+      hack_disable_regenerate_key_on_reset:
         description: >-
-          Regenerate NMK on reset
+          Hack: Do not regenerate NMK on reset, this is not spec compliant and should only be set for debugging purposes.
         type: boolean
-        default: true
+        default: false
 metadata:
   base_license: https://directory.fsf.org/wiki/License:BSD-3-Clause-Clear
   license: https://opensource.org/licenses/Apache-2.0

--- a/modules/EVSE/EvseSlac/manifest.yaml
+++ b/modules/EVSE/EvseSlac/manifest.yaml
@@ -90,6 +90,11 @@ provides:
         minimum: 10000
         maximum: 50000
         default: 40000
+      regenerate_key_on_reset:
+        description: >-
+          Regenerate NMK on reset
+        type: boolean
+        default: true
 metadata:
   base_license: https://directory.fsf.org/wiki/License:BSD-3-Clause-Clear
   license: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
## Describe your changes
Defaults to true, but allows to disable this if not desired

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

