### PR TITLE
bazel: fix rustc linking error on openSUSE Tumbleweed

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,12 @@
 # This flag can be removed once all dependencies are updated for Bazel 9.
 build --incompatible_autoload_externally=+cc_library,+cc_binary,+cc_test,+cc_shared_library,+cc_import,+cc_toolchain,+py_binary,+py_library,+py_test,+sh_binary,+sh_library,+sh_test
 
+# Force -fPIC on C/C++ compilation so static archives can be linked into PIE
+# binaries. Required because modern rustc defaults to producing PIE executables
+# on x86_64-unknown-linux-gnu, and any static C++ library mixed into a Rust
+# binary therefore has to be position-independent.
+build --copt=-fPIC
+
 # CI config: smaller binaries, shared repo cache, disk cache for artifacts.
 build:ci -c opt
 build:ci --strip=always

--- a/third-party/bazel/BUILD.libwebsockets.bazel
+++ b/third-party/bazel/BUILD.libwebsockets.bazel
@@ -20,6 +20,7 @@ cmake(
     name = "libwebsockets",
     cache_entries = {
         "CMAKE_POLICY_DEFAULT_CMP0077": "NEW",
+        "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
         "LWS_ROLE_RAW_FILE": "OFF",
         "LWS_UNIX_SOCK": "OFF",
         "LWS_WITH_SYS_STATE": "OFF",


### PR DESCRIPTION
## Describe your changes

Building with bazel on a fully up-to-date openSUSE Tumbleweed failed, because the static libraries were not built position independent, but rustc defaults to building position independent executables now.
This PR fixes that by enabling position independent code for library builds

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

