### PR TITLE
Drop max charger current limitation

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1230,26 +1230,24 @@ float Charger::ampere_to_duty_cycle(float ampere) {
 
 bool Charger::set_max_current(float c, std::chrono::time_point<std::chrono::steady_clock> validUntil) {
     float c_abs{std::fabs(c)};
-    if (c_abs <= CHARGER_ABSOLUTE_MAX_CURRENT) {
 
-        // is it still valid?
-        if (validUntil > std::chrono::steady_clock::now()) {
-            {
-                Everest::scoped_lock_timeout lock(state_machine_mutex,
-                                                  Everest::MutexDescription::Charger_set_max_current);
-                shared_context.max_current = c_abs;
-                shared_context.max_current_valid_until = validUntil;
-            }
-            // now after max_current is updated with c_abs we can update c_abs with the internal max current which
-            // considers the cable limit as well
-            c_abs = get_max_current_internal();
-            bsp->set_overcurrent_limit(c_abs);
-            // the max_current is internally an absolute value. The sign of c is now used to signal
-            // if it is charging (c>0) or discharging (c<0)
-            signal_max_current(c < 0.0f ? -c_abs : c_abs);
-            return true;
+    // is it still valid?
+    if (validUntil > std::chrono::steady_clock::now()) {
+        {
+            Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_set_max_current);
+            shared_context.max_current = c_abs;
+            shared_context.max_current_valid_until = validUntil;
         }
+        // now after max_current is updated with c_abs we can update c_abs with the internal max current which
+        // considers the cable limit as well
+        c_abs = get_max_current_internal();
+        bsp->set_overcurrent_limit(c_abs);
+        // the max_current is internally an absolute value. The sign of c is now used to signal
+        // if it is charging (c>0) or discharging (c<0)
+        signal_max_current(c < 0.0f ? -c_abs : c_abs);
+        return true;
     }
+
     return false;
 }
 

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -430,7 +430,6 @@ private:
     EventQueue<ErrorHandlingEvents> error_handling_event_queue;
 
     // constants
-    static constexpr float CHARGER_ABSOLUTE_MAX_CURRENT{1000.};
     constexpr static int LEGACY_WAKEUP_TIMEOUT{30000};
     constexpr static int PREPARING_TIMEOUT_PAUSED_BY_EV{10000};
     // valid Length of BCB toggles


### PR DESCRIPTION
In MCS mode we are handling high current, power, and voltage values.
Up to now, there is a limitation of the max current for the charger of 1000A, defined in standard IEC61851-1. When the current exceeds the max current limitation, the current will not be updated anymore by the evsemanager. This leads to a rampdown of current to 0A and a warning message 'Power budget expire...', which is flooding the log. This PR should get rid of this behavior.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

