### PR TITLE
feat(io/tls): TLS client and server policies (superseded by #2558 to #2565)

### DIFF
--- a/lib/everest/io/BUILD.bazel
+++ b/lib/everest/io/BUILD.bazel
@@ -43,6 +43,7 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
+        "//lib/everest/tls",
         "//lib/everest/util",
         "@mosquitto",
     ],

--- a/lib/everest/io/README.md
+++ b/lib/everest/io/README.md
@@ -28,7 +28,11 @@ callback. The receiver registers it with the same `fd_event_handler` via
 `register_event_handler(conn.get())` — the connection then drives the TLS
 handshake and rx/tx on the loop internally — and keeps it alive for the
 connection's lifetime. Drop the `unique_ptr` (e.g. `connections.clear()`) to tear
-a connection down.
+a connection down: the destructor unregisters the connection's fds from the
+handler, so dropping a still-registered endpoint is safe and leaves no stale
+handler entries. Calling `unregister_event_handler(conn.get())` before the drop
+is the tidy, explicit path. The `fd_event_handler` **must outlive** every
+endpoint registered on it — the endpoint's destructor unregisters from it.
 
 See `examples/test_tls_server.cpp` for a complete listener + echo example.
 
@@ -38,7 +42,9 @@ See `examples/test_tls_server.cpp` for a complete listener + echo example.
 interface. Register it with `register_event_handler(&client)`; the TLS handshake
 is driven internally on the loop by the class — no handshake hooks or
 `desired_events` wiring in user code. Tear it down with
-`unregister_event_handler(&client)`.
+`unregister_event_handler(&client)`, or simply destroy it: the destructor
+unregisters from the handler. As with the server side, the `fd_event_handler`
+must outlive the client.
 
 `host_for_sni` is sent in the TLS SNI extension. Setting
 `tls.verify_subject_name = true` additionally opts into RFC-6125 hostname

--- a/lib/everest/io/README.md
+++ b/lib/everest/io/README.md
@@ -46,14 +46,26 @@ is driven internally on the loop by the class — no handshake hooks or
 unregisters from the handler. As with the server side, the `fd_event_handler`
 must outlive the client.
 
-`host_for_sni` is sent in the TLS SNI extension. Setting
-`tls.verify_subject_name = true` additionally opts into RFC-6125 hostname
-verification: the server certificate's SAN/CN is matched against `host_for_sni`
-(not the TCP connect target). Hostname verification is only enforced when
-`tls.verify_server` is also true; with an IP-literal target and no matching SAN,
-leave `verify_subject_name` at its default (`false`).
+A DNS `host_for_sni` is sent in the TLS SNI extension; an IP literal is not (RFC
+6066). Setting `tls.verify_subject_name = true` additionally pins the peer
+certificate to `host_for_sni` — a DNS name via RFC-6125 SAN/CN matching, an IP
+literal via IP-SAN matching — not to the TCP connect target. Pinning is only
+enforced when `tls.verify_server` is also true; with an IP-literal target and no
+matching SAN, leave `verify_subject_name` at its default (`false`).
 
 See `examples/test_tls_client.cpp` for a complete event-loop-driven client example.
+
+### Threading and signals
+
+`tx()` and its queue are loop-thread-oriented: `tx()` enqueues a payload and wakes
+the loop through an internal `event_fd`. The queue itself is not synchronized, so
+call `tx()` only from the loop thread (e.g. from the rx handler or the on-ready
+action), never from another thread.
+
+OpenSSL drives its socket BIO through `write()` without `MSG_NOSIGNAL`, so a write
+to a peer-reset connection raises `SIGPIPE`. Processes using this layer must
+install `signal(SIGPIPE, SIG_IGN)` (the examples and the test main do); otherwise
+a peer reset during `tx()` aborts the process.
 
 Example binaries live in `lib/everest/io/examples/`:
  - `test_tls_server` — `tls_listener` + `tls_server` event-loop echo demo

--- a/lib/everest/io/README.md
+++ b/lib/everest/io/README.md
@@ -9,5 +9,46 @@ Currently there are clients for
  - PTY
  - TCP
  - TAP
+ - TLS (enabled via `EVEREST_IO_ENABLE_TLS=ON`, default ON)
 
 The clients are single threaded and epoll based. Utilities for file descriptor based event handling are provided and used.
+
+## TLS
+
+Drives the libtls (`everest::tls`) `Server` and `Client` through the same
+`fd_event_handler` pattern as the other clients. Disable with
+`-DEVEREST_IO_ENABLE_TLS=OFF` if libtls / OpenSSL are not desired.
+
+### Server side
+
+`tls_listener` owns the listen socket and an embedded `tls::Server`. For each
+accepted connection it yields a `std::unique_ptr<tls::tls_server>` (a
+`tls_endpoint_base<tls_server_socket>`-derived register interface) to the accept
+callback. The receiver registers it with the same `fd_event_handler` via
+`register_event_handler(conn.get())` — the connection then drives the TLS
+handshake and rx/tx on the loop internally — and keeps it alive for the
+connection's lifetime. Drop the `unique_ptr` (e.g. `connections.clear()`) to tear
+a connection down.
+
+See `examples/test_tls_server.cpp` for a complete listener + echo example.
+
+### Client side
+
+`tls_client` is a `tls_endpoint_base<tls_client_socket>`-derived register
+interface. Register it with `register_event_handler(&client)`; the TLS handshake
+is driven internally on the loop by the class — no handshake hooks or
+`desired_events` wiring in user code. Tear it down with
+`unregister_event_handler(&client)`.
+
+`host_for_sni` is sent in the TLS SNI extension. Setting
+`tls.verify_subject_name = true` additionally opts into RFC-6125 hostname
+verification: the server certificate's SAN/CN is matched against `host_for_sni`
+(not the TCP connect target). Hostname verification is only enforced when
+`tls.verify_server` is also true; with an IP-literal target and no matching SAN,
+leave `verify_subject_name` at its default (`false`).
+
+See `examples/test_tls_client.cpp` for a complete event-loop-driven client example.
+
+Example binaries live in `lib/everest/io/examples/`:
+ - `test_tls_server` — `tls_listener` + `tls_server` event-loop echo demo
+ - `test_tls_client` — event-loop-driven `tls_client` demo

--- a/lib/everest/io/examples/CMakeLists.txt
+++ b/lib/everest/io/examples/CMakeLists.txt
@@ -99,6 +99,22 @@ target_compile_features(test_udp_unconnected_client PUBLIC cxx_std_17)
 target_compile_options(test_udp_unconnected_client PRIVATE -fsanitize=address -g)
 target_link_options(test_udp_unconnected_client PRIVATE -static-libasan -fsanitize=address)
 
+###
+
+if(EVEREST_IO_ENABLE_TLS)
+    add_executable(test_tls_server test_tls_server.cpp)
+    target_link_libraries(test_tls_server PRIVATE everest::io)
+    target_compile_features(test_tls_server PUBLIC cxx_std_17)
+    target_compile_options(test_tls_server PRIVATE -fsanitize=address -g)
+    target_link_options(test_tls_server PRIVATE -static-libasan -fsanitize=address)
+
+    add_executable(test_tls_client test_tls_client.cpp)
+    target_link_libraries(test_tls_client PRIVATE everest::io)
+    target_compile_features(test_tls_client PUBLIC cxx_std_17)
+    target_compile_options(test_tls_client PRIVATE -fsanitize=address -g)
+    target_link_options(test_tls_client PRIVATE -static-libasan -fsanitize=address)
+endif()
+
 
 
 

--- a/lib/everest/io/examples/test_tls_client.cpp
+++ b/lib/everest/io/examples/test_tls_client.cpp
@@ -5,6 +5,7 @@
 #include <everest/io/tls/tls_client.hpp>
 
 #include <atomic>
+#include <csignal>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
@@ -18,6 +19,11 @@ using tls_endpoint = tls_endpoint_base<tls_client_socket>;
 
 int main(int argc, char* argv[]) {
     std::cout << "TLS echo client example" << std::endl;
+
+    // OpenSSL writes through its socket BIO without MSG_NOSIGNAL, so a write to a
+    // peer-reset connection raises SIGPIPE. Every process using this layer must
+    // ignore it or a peer reset during tx() aborts the process.
+    std::signal(SIGPIPE, SIG_IGN);
 
     std::string host = "127.0.0.1";
     std::uint16_t port = 8443;

--- a/lib/everest/io/examples/test_tls_client.cpp
+++ b/lib/everest/io/examples/test_tls_client.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/event/timer_fd.hpp>
+#include <everest/io/tls/tls_client.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+using namespace everest::lib::io::tls;
+using namespace everest::lib::io::event;
+
+using payload_t = tls_client::PayloadT;
+using tls_endpoint = tls_endpoint_base<tls_client_socket>;
+
+int main(int argc, char* argv[]) {
+    std::cout << "TLS echo client example" << std::endl;
+
+    std::string host = "127.0.0.1";
+    std::uint16_t port = 8443;
+    std::string trust_anchor = "server_root_cert.pem";
+
+    if (argc == 4) {
+        host = argv[1];
+        try {
+            auto tmp = std::stoul(argv[2]);
+            if (tmp > 65535u) {
+                throw std::invalid_argument("port out of range");
+            }
+            port = static_cast<std::uint16_t>(tmp);
+        } catch (...) {
+            std::cerr << "ERROR: invalid port '" << argv[2] << "'" << std::endl;
+            return 1;
+        }
+        trust_anchor = argv[3];
+    } else if (argc != 1) {
+        std::cout << "USAGE: test_tls_client [host port trust_anchor.pem]" << std::endl;
+        std::cout << "  Defaults: 127.0.0.1 8443 server_root_cert.pem" << std::endl;
+        return 1;
+    }
+
+    tls_client_socket::Config cfg{};
+    cfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    cfg.tls.ciphersuites = "";
+    cfg.tls.verify_locations_file = trust_anchor.c_str();
+    cfg.tls.io_timeout_ms = 5000;
+    cfg.tls.verify_server = true;
+    cfg.host_for_sni = host;
+
+    std::cout << "Connecting to " << host << ":" << port << " ..." << std::endl;
+
+    fd_event_handler ev_handler;
+    tls_client client(cfg, host, port, 5000);
+
+    std::atomic<bool> running{true};
+    int replies_received = 0;
+    const int expected_replies = 3;
+
+    client.set_error_handler([&running](int err, std::string const& msg) {
+        if (err != 0) {
+            std::cerr << "ERROR (" << err << "): " << msg << std::endl;
+            running = false;
+        }
+    });
+
+    client.set_rx_handler([&replies_received, &running, expected_replies](payload_t const& payload, tls_endpoint&) {
+        ++replies_received;
+        std::cout << "Reply (" << payload.size() << " bytes): " << std::string(payload.begin(), payload.end());
+        if (replies_received >= expected_replies) {
+            running = false;
+        }
+    });
+
+    client.set_on_ready_action([&client]() {
+        std::cout << "Handshake complete. Sending messages..." << std::endl;
+        for (const char* text : {"hello tls\n", "second message\n", "goodbye\n"}) {
+            payload_t msg(text, text + std::strlen(text));
+            client.tx(msg);
+        }
+    });
+
+    ev_handler.register_event_handler(&client);
+    ev_handler.run(running);
+
+    // Unregister before the client is destroyed. Required whenever the
+    // fd_event_handler outlives the client; safe (and recommended) here too.
+    ev_handler.unregister_event_handler(&client);
+
+    std::cout << "Done." << std::endl;
+    return 0;
+}

--- a/lib/everest/io/examples/test_tls_server.cpp
+++ b/lib/everest/io/examples/test_tls_server.cpp
@@ -6,6 +6,7 @@
 #include <everest/io/tls/tls_server_socket.hpp>
 
 #include <atomic>
+#include <csignal>
 #include <cstdint>
 #include <deque>
 #include <iostream>
@@ -17,6 +18,11 @@ using namespace everest::lib::io::event;
 
 int main(int argc, char* argv[]) {
     std::cout << "TLS echo server example" << std::endl;
+
+    // OpenSSL writes through its socket BIO without MSG_NOSIGNAL, so a write to a
+    // peer-reset connection raises SIGPIPE. Every process using this layer must
+    // ignore it or a peer reset during tx() aborts the process.
+    std::signal(SIGPIPE, SIG_IGN);
 
     std::uint16_t bind_port = 8443;
     std::string cert_chain = "server_chain.pem";

--- a/lib/everest/io/examples/test_tls_server.cpp
+++ b/lib/everest/io/examples/test_tls_server.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <deque>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using namespace everest::lib::io::tls;
+using namespace everest::lib::io::event;
+
+int main(int argc, char* argv[]) {
+    std::cout << "TLS echo server example" << std::endl;
+
+    std::uint16_t bind_port = 8443;
+    std::string cert_chain = "server_chain.pem";
+    std::string private_key = "server_priv.pem";
+    std::string trust_anchor = "server_root_cert.pem";
+
+    if (argc == 5) {
+        try {
+            auto tmp = std::stoul(argv[1]);
+            if (tmp > 65535u) {
+                throw std::invalid_argument("port out of range");
+            }
+            bind_port = static_cast<std::uint16_t>(tmp);
+        } catch (...) {
+            std::cerr << "ERROR: invalid port '" << argv[1] << "'" << std::endl;
+            return 1;
+        }
+        cert_chain = argv[2];
+        private_key = argv[3];
+        trust_anchor = argv[4];
+    } else if (argc != 1) {
+        std::cout << "USAGE: test_tls_server [port cert_chain.pem key.pem trust_anchor.pem]" << std::endl;
+        std::cout << "  Defaults: 8443 server_chain.pem server_priv.pem server_root_cert.pem" << std::endl;
+        return 1;
+    }
+
+    tls_listener::Config lcfg;
+    auto& chain = lcfg.tls.chains.emplace_back();
+    chain.certificate_chain_file = cert_chain.c_str();
+    chain.private_key_file = private_key.c_str();
+    chain.trust_anchor_file = trust_anchor.c_str();
+    lcfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    lcfg.tls.ciphersuites = "";
+    lcfg.tls.verify_client = false;
+    lcfg.tls.io_timeout_ms = 1000;
+    lcfg.bind_addr = "127.0.0.1";
+    lcfg.bind_port = bind_port;
+
+    fd_event_handler ev_handler;
+    tls_listener listener(std::move(lcfg));
+
+    std::cout << "Listener will accept on 127.0.0.1:" << listener.listen_port() << " once the event loop runs"
+              << std::endl;
+
+    // Keep accepted connections alive for the lifetime of the loop. Echo each
+    // received chunk back. The yielded tls_server is a register-interface
+    // endpoint driven by the loop once registered; it drives the TLS handshake
+    // internally.
+    std::deque<std::unique_ptr<tls_server>> connections;
+
+    listener.set_accept_callback([&ev_handler, &connections](std::unique_ptr<tls_server> conn,
+                                                             std::string const& peer_ip, std::uint16_t peer_port) {
+        std::cout << "Accepted from " << peer_ip << ":" << peer_port << std::endl;
+        conn->set_rx_handler([](tls_server_socket::PayloadT const& payload, auto& self) {
+            std::cout << "RX (" << payload.size() << " bytes): " << std::string(payload.begin(), payload.end())
+                      << std::flush;
+            self.tx(payload); // echo
+        });
+        ev_handler.register_event_handler(conn.get());
+        connections.push_back(std::move(conn));
+    });
+
+    ev_handler.register_event_handler(&listener);
+
+    std::atomic<bool> running{true};
+    ev_handler.run(running);
+
+    // Drop the accepted connections. Each tls_server destructor tears down its
+    // policy and closes the underlying TLS connection.
+    connections.clear();
+    return 0;
+}

--- a/lib/everest/io/include/everest/io/socket/socket.hpp
+++ b/lib/everest/io/include/everest/io/socket/socket.hpp
@@ -121,6 +121,22 @@ event::unique_fd open_tcp_socket_with_timeout(const std::string& host, std::uint
                                               const std::string& device = {});
 
 /**
+ * @brief Open a TCP socket in server mode (bound and listening).
+ * @details Creates a non-blocking, close-on-exec stream socket and binds it to
+ * @p bind_addr : @p port. The address family is AF_INET6 when @p ipv6_only is set
+ * or when @p bind_addr contains a ':' (a literal IPv6 address); otherwise AF_INET.
+ * SO_REUSEADDR and SO_REUSEPORT are set; for IPv6 sockets IPV6_V6ONLY reflects
+ * @p ipv6_only. Each setsockopt return is checked. @p port == 0 picks an
+ * ephemeral port. The socket is then put into the listening state.
+ * @param[in] bind_addr Numeric bind address (e.g. "0.0.0.0", "127.0.0.1", "::", "::1").
+ * @param[in] port The port to listen on (0 for an ephemeral port).
+ * @param[in] ipv6_only When true, force an IPv6 socket and set IPV6_V6ONLY.
+ * @return The managed file descriptor of the listening socket.
+ * @throws std::runtime_error if any step (socket, setsockopt, inet_pton, bind, listen) fails.
+ */
+event::unique_fd open_tcp_server_socket(std::string const& bind_addr, std::uint16_t port, bool ipv6_only);
+
+/**
  * @brief Bind a socket to a specific network interface.
  * @details Tries SO_BINDTODEVICE first (needs CAP_NET_RAW). On EPERM/EACCES, falls back to:
  *   - IP_UNICAST_IF (AF_INET) or IPV6_UNICAST_IF (AF_INET6) to restrict the outgoing

--- a/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
+++ b/lib/everest/io/include/everest/io/tcp/tcp_socket.hpp
@@ -109,6 +109,15 @@ public:
     void close();
 
     /**
+     * @brief Surrender ownership of the file descriptor without closing it.
+     * @details After this the socket holds no fd; close()/destruction become no-ops.
+     *          Used when another owner (e.g. a TLS BIO created with BIO_CLOSE) takes
+     *          over the fd's lifetime.
+     * @return The previously owned file descriptor (NO_DESCRIPTOR_SENTINEL if none).
+     */
+    int release();
+
+    /**
      * @brief Enable KEEPALIVE for the connection
      * @param[in] count  The maximum number of keepalive probes TCP should send
      *                   before dropping the connection.

--- a/lib/everest/io/include/everest/io/tls/tls_client.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_client.hpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/event/event_fd.hpp>
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_client_socket.hpp>
+#include <everest/io/tls/tls_endpoint_base.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <thread>
+
+namespace everest::lib::io::tls {
+
+// Event-loop-driven TLS client: registering it with an fd_event_handler is all
+// that is needed to drive it. The TCP connect runs on an owned worker thread
+// joined on teardown; the TLS handshake is then driven on the loop (the blocking
+// open() is not used).
+// The ctor args are forwarded to tls_client_socket::setup(cfg, host, port, timeout_ms).
+class tls_client : public tls_endpoint_base<tls_client_socket> {
+public:
+    tls_client(tls_client_socket::Config cfg, std::string host, std::uint16_t port, int timeout_ms);
+
+    tls_client(tls_client const&) = delete;
+    tls_client(tls_client&&) = delete;
+    tls_client& operator=(tls_client const&) = delete;
+    tls_client& operator=(tls_client&&) = delete;
+    ~tls_client() override;
+
+private:
+    void start(event::fd_event_handler& handler) override;
+    void stop() override;
+
+    event::event_fd m_connected;
+    // Written by the connect worker, read by the m_connected handler on the loop
+    // thread. Atomic: the eventfd wake is not a happens-before for this.
+    std::atomic<bool> m_connect_ok{false};
+    // Owns the TCP connect worker; joined on teardown (stop()/dtor) before the
+    // socket is closed so the worker cannot touch a torn-down m_socket.
+    std::thread m_worker;
+
+    tls_client_socket::Config m_cfg;
+    std::string m_host;
+    std::uint16_t m_port;
+    int m_timeout_ms;
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_client_socket.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_client_socket.hpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/tcp/tcp_socket.hpp>
+#include <everest/io/tls/tls_socket_base.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace everest::lib::io::tls {
+
+// TLS client connection policy: async TCP connect + handshake via setup()/connect().
+// Shared tx/rx/handshake/desired-events logic lives in tls_socket_base; this class
+// adds the connect machinery, the TCP-aware get_fd()/get_error()/close() overrides,
+// and the three socket-base hooks.
+class tls_client_socket : public tls_socket_base<tls_client_socket> {
+public:
+    struct Config {
+        ::tls::Client::config_t tls{};
+        // hostname sent in the TLS SNI extension; matched against the server cert
+        // when tls.verify_subject_name is set.
+        std::string host_for_sni;
+    };
+
+    tls_client_socket() = default;
+    tls_client_socket(tls_client_socket const&) = delete;
+    tls_client_socket(tls_client_socket&&) = default;
+    tls_client_socket& operator=(tls_client_socket const&) = delete;
+    tls_client_socket& operator=(tls_client_socket&&) = default;
+    ~tls_client_socket() = default;
+
+    // Build the SSL_CTX and start a non-blocking TCP connect; returns quickly.
+    // Must be followed by connect().
+    bool setup(Config cfg, std::string const& remote_host, std::uint16_t remote_port, int timeout_ms);
+
+    // Wrap the connected fd (no handshake; the loop drives that). Runs on a worker
+    // thread; calls cb(true, fd) on success, cb(false, -1) on failure.
+    void connect(std::function<void(bool, int)> const& cb);
+
+    // TLS connection fd once handshaking; the TCP fd otherwise; -1 if neither.
+    int get_fd() const;
+    int get_error() const;
+    void close();
+
+    // tls_socket_base hooks (public so the base can call them without friendship).
+    ::tls::Connection* connection() const;
+    ::tls::Connection::result_t step_handshake(); // one non-blocking connect(0)
+    void reset_connection();
+
+protected:
+    // protected so a unit-test subclass can confirm ownership was surrendered to
+    // the TLS connection's BIO (no double-close).
+    tcp::tcp_socket m_tcp{};
+
+private:
+    Config m_cfg{};
+    std::unique_ptr<::tls::Client> m_client{};
+    ::tls::Client::ConnectionPtr m_conn{};
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_client_socket.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_client_socket.hpp
@@ -46,6 +46,11 @@ public:
     int get_error() const;
     void close();
 
+    // Hand the connection (the fd's BIO_CLOSE owner) to a closer so the fd stays
+    // open until the closer runs; used by the endpoint to defer the close past the
+    // handler removal. No TLS shutdown is performed (the connection has faulted).
+    std::function<void()> release_closer();
+
     // tls_socket_base hooks (public so the base can call them without friendship).
     ::tls::Connection* connection() const;
     ::tls::Connection::result_t step_handshake(); // one non-blocking connect(0)

--- a/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
@@ -41,7 +41,9 @@ public:
 
     // Enqueue a payload and arm POLLOUT. Payloads enqueued before the handshake
     // completes are held in the queue and flushed once it does; tx() only
-    // rejects after the endpoint has errored.
+    // rejects after the endpoint has errored. Loop-thread only: the queue is not
+    // synchronized, so call tx() from the loop thread (rx handler / on-ready
+    // action), never from another thread.
     bool tx(PayloadT const& payload) {
         if (m_errored) {
             return false;

--- a/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
@@ -6,10 +6,12 @@
 #include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/event/fd_event_register_interface.hpp>
 
+#include <cerrno>
 #include <cstdint>
 #include <functional>
 #include <queue>
 #include <string>
+#include <sys/socket.h>
 #include <vector>
 
 namespace everest::lib::io::tls {
@@ -104,7 +106,7 @@ protected:
             [this, fd](auto events) {
                 using namespace event;
                 if (events.count(poll_events::error) || events.count(poll_events::hungup)) {
-                    fail(m_socket.get_error());
+                    fail(resolve_poll_error(fd));
                     return;
                 }
                 if (not m_socket.handshake_complete()) {
@@ -185,9 +187,33 @@ protected:
     // would destroy the executing std::function (use-after-free) and resize the
     // pollfds vector mid-iteration, so defer it via add_action() (mirrors
     // generic_fd_event_client error_handler). Idempotent within a connection.
+    // Resolve the error code for an EPOLLERR/EPOLLHUP dispatch. The socket's
+    // own error is preferred; when it is 0 (a live connection that has not yet
+    // failed a TLS op, e.g. a peer RST after the handshake) fall back to the
+    // socket-level SO_ERROR, then to ECONNRESET for a pure hangup. Never resolves
+    // to 0, so the error callback is never invoked with a code every caller ignores.
+    int resolve_poll_error(int fd) const {
+        int err = m_socket.get_error();
+        if (err != 0) {
+            return err;
+        }
+        int so_error = 0;
+        socklen_t len = sizeof(so_error);
+        if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &len) == 0 && so_error != 0) {
+            return so_error;
+        }
+        return ECONNRESET;
+    }
+
     void fail(int error_code) {
         if (m_errored) {
             return;
+        }
+        // Backstop the invariant that the error callback never sees 0: shipped
+        // examples branch on `if (err != 0)`, so a 0 would be silently dropped
+        // while m_errored latches the endpoint dead.
+        if (error_code == 0) {
+            error_code = ECONNRESET;
         }
         m_errored = true;
         if (m_error) {

--- a/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
@@ -37,7 +37,9 @@ public:
         m_rx = std::move(handler);
     }
 
-    // Enqueue a payload and arm POLLOUT. Rejected once the endpoint has errored.
+    // Enqueue a payload and arm POLLOUT. Payloads enqueued before the handshake
+    // completes are held in the queue and flushed once it does; tx() only
+    // rejects after the endpoint has errored.
     bool tx(PayloadT const& payload) {
         if (m_errored) {
             return false;
@@ -127,6 +129,12 @@ protected:
         if (m_socket.handshake_complete()) {
             maybe_fire_ready();
             arm_for(fd, event::poll_events::read);
+            // Payloads queued before the handshake completed consumed their
+            // one-shot tx-notify while the fd was not armed for write. Re-fire
+            // the notify so its handler re-arms POLLOUT through the usual path.
+            if (not m_tx_buffer.empty()) {
+                m_tx_notify.notify();
+            }
             return;
         }
         arm_for(fd, m_socket.desired_events());

--- a/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
@@ -191,7 +191,9 @@ protected:
         }
         m_errored = true;
         if (m_error) {
-            m_error(error_code, std::string{});
+            // The socket's close() below clears the error text, so the handler
+            // must fire first.
+            m_error(error_code, m_socket.get_error_string());
         }
         m_socket.close();
         if (m_fd >= 0 && m_handler != nullptr) {

--- a/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/event/event_fd.hpp>
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/event/fd_event_register_interface.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <queue>
+#include <string>
+#include <vector>
+
+namespace everest::lib::io::tls {
+
+// Base for the loop-driven TLS endpoints (client and server). Wires a single TLS
+// connection flat onto an fd_event_handler (the charge_bridge pattern) and drives
+// the handshake on the loop inside its own dispatch lambda, so the shared handler
+// never sees handshake state. tx() enqueues a payload and notifies an internal
+// event_fd, which arms POLLOUT on the connection fd.
+//
+// Templated on the concrete socket (tls_client_socket / tls_server_socket) and
+// owns it by value, so the socket's TCP-aware get_fd()/get_error()/close() resolve
+// under static typing: no slicing, no virtual dispatch on the rx/tx path. Derived
+// supplies only start() (kick the connection) and stop() (tear it down).
+template <class Socket> class tls_endpoint_base : public event::fd_event_register_interface {
+public:
+    using PayloadT = std::vector<std::uint8_t>;
+    // The endpoint passes itself so an rx handler can echo via tx() without naming
+    // the concrete derived type.
+    using cb_rx = std::function<void(PayloadT const&, tls_endpoint_base<Socket>&)>;
+
+    ~tls_endpoint_base() override = default;
+
+    void set_rx_handler(cb_rx handler) {
+        m_rx = std::move(handler);
+    }
+
+    // Enqueue a payload and arm POLLOUT. Rejected once the endpoint has errored.
+    bool tx(PayloadT const& payload) {
+        if (m_errored) {
+            return false;
+        }
+        m_tx_buffer.push(payload);
+        m_tx_notify.notify();
+        return true;
+    }
+
+    // Fired once, after the handshake completes (client and server).
+    void set_on_ready_action(std::function<void()> action) {
+        m_on_ready = std::move(action);
+    }
+
+    void set_error_handler(std::function<void(int, std::string const&)> handler) {
+        m_error = std::move(handler);
+    }
+
+    bool register_events(event::fd_event_handler& handler) override {
+        // Idempotent: a second register without an intervening unregister is
+        // rejected. Re-running start() would, for the client, move-assign a
+        // std::thread onto the still-joinable connect worker and std::terminate.
+        if (m_handler != nullptr) {
+            return false;
+        }
+        m_handler = &handler;
+        auto result = handler.register_event_handler(&m_tx_notify, [this]() {
+            // The client connection fd appears only after the async TCP connect
+            // completes, so arm POLLOUT only once it is live.
+            if (m_fd >= 0) {
+                m_handler->modify_event_handler(m_fd, event::poll_events::write, event::event_modification::add);
+            }
+        });
+        start(handler);
+        return result;
+    }
+
+    bool unregister_events(event::fd_event_handler& handler) override {
+        auto result = true;
+        if (m_fd >= 0) {
+            result = handler.remove_event_handler(m_fd) && result;
+            m_fd = -1;
+        }
+        result = handler.unregister_event_handler(&m_tx_notify) && result;
+        stop();
+        m_handler = nullptr;
+        return result;
+    }
+
+protected:
+    // Client: async TCP connect + handshake drive. Server: arm the accepted fd.
+    virtual void start(event::fd_event_handler& handler) = 0;
+    // Client: unregister its connect event then close. Server: close.
+    virtual void stop() = 0;
+
+    // Install the connection-fd dispatch lambda armed for `initial`: error/hangup
+    // -> fail(), handshake-in-progress -> drive_handshake(), otherwise rx/tx.
+    void register_connection_fd(event::fd_event_handler& handler, int fd, event::poll_events initial) {
+        m_fd = fd;
+        handler.register_event_handler(
+            fd,
+            [this, fd](auto events) {
+                using namespace event;
+                if (events.count(poll_events::error) || events.count(poll_events::hungup)) {
+                    fail(m_socket.get_error());
+                    return;
+                }
+                if (not m_socket.handshake_complete()) {
+                    drive_handshake(fd);
+                    return;
+                }
+                if (events.count(poll_events::read)) {
+                    flush_rx();
+                }
+                if (events.count(poll_events::write)) {
+                    flush_tx(fd);
+                }
+            },
+            initial);
+    }
+
+    void drive_handshake(int fd) {
+        if (not m_socket.handshake_step()) {
+            fail(m_socket.get_error());
+            return;
+        }
+        if (m_socket.handshake_complete()) {
+            maybe_fire_ready();
+            arm_for(fd, event::poll_events::read);
+            return;
+        }
+        arm_for(fd, m_socket.desired_events());
+    }
+
+    void flush_rx() {
+        if (m_socket.rx(m_rx_data)) {
+            if (m_rx) {
+                m_rx(m_rx_data, *this);
+            }
+        } else if (not m_socket.is_open()) {
+            fail(m_socket.get_error());
+        }
+    }
+
+    // Drain one queued payload; drop POLLOUT when the queue empties. A partial
+    // write keeps the front payload (written prefix already erased) and POLLOUT armed.
+    void flush_tx(int fd) {
+        if (m_tx_buffer.empty()) {
+            if (m_handler != nullptr) {
+                m_handler->modify_event_handler(fd, event::poll_events::write, event::event_modification::remove);
+            }
+            return;
+        }
+        auto& front = m_tx_buffer.front();
+        if (m_socket.tx(front)) {
+            m_tx_buffer.pop();
+            if (m_tx_buffer.empty() && m_handler != nullptr) {
+                m_handler->modify_event_handler(fd, event::poll_events::write, event::event_modification::remove);
+            }
+        } else if (not m_socket.is_open()) {
+            fail(m_socket.get_error());
+        }
+    }
+
+    void maybe_fire_ready() {
+        if (m_ready_fired || not m_on_ready) {
+            return;
+        }
+        m_ready_fired = true;
+        if (m_handler != nullptr) {
+            m_handler->add_action(m_on_ready);
+        }
+    }
+
+    // fail() runs from inside the connection-fd dispatch lambda, which poll_impl
+    // invokes through a reference into its event map. Removing the fd synchronously
+    // would destroy the executing std::function (use-after-free) and resize the
+    // pollfds vector mid-iteration, so defer it via add_action() (mirrors
+    // generic_fd_event_client error_handler). Idempotent within a connection.
+    void fail(int error_code) {
+        if (m_errored) {
+            return;
+        }
+        m_errored = true;
+        if (m_error) {
+            m_error(error_code, std::string{});
+        }
+        m_socket.close();
+        if (m_fd >= 0 && m_handler != nullptr) {
+            m_handler->add_action([handler = m_handler, fd = m_fd]() { handler->remove_event_handler(fd); });
+            m_fd = -1;
+        }
+    }
+
+    // Arm the connection fd for exactly one of read/write.
+    void arm_for(int fd, event::poll_events desired) {
+        if (m_handler == nullptr) {
+            return;
+        }
+        m_handler->modify_event_handler(fd, event::poll_events::read,
+                                        desired == event::poll_events::read ? event::event_modification::add
+                                                                            : event::event_modification::remove);
+        m_handler->modify_event_handler(fd, event::poll_events::write,
+                                        desired == event::poll_events::write ? event::event_modification::add
+                                                                             : event::event_modification::remove);
+    }
+
+    Socket m_socket;
+    event::fd_event_handler* m_handler{nullptr};
+    event::event_fd m_tx_notify;
+    std::queue<PayloadT> m_tx_buffer;
+    cb_rx m_rx;
+    std::function<void()> m_on_ready;
+    std::function<void(int, std::string const&)> m_error;
+    bool m_ready_fired{false};
+    bool m_errored{false};
+    int m_fd{-1};
+
+private:
+    PayloadT m_rx_data;
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_endpoint_base.hpp
@@ -217,14 +217,26 @@ protected:
         }
         m_errored = true;
         if (m_error) {
-            // The socket's close() below clears the error text, so the handler
-            // must fire first.
             m_error(error_code, m_socket.get_error_string());
         }
-        m_socket.close();
         if (m_fd >= 0 && m_handler != nullptr) {
-            m_handler->add_action([handler = m_handler, fd = m_fd]() { handler->remove_event_handler(fd); });
+            // Defer BOTH the handler removal and the fd close, ordered
+            // remove-then-close, so the fd number stays reserved until it is out
+            // of the handler. A synchronous close would free the number while the
+            // deferred remove-by-number is still pending, letting an accept in the
+            // same poll batch recycle it and the stale remove strand it. The
+            // connection is moved into the action (never `this`-captured) so a
+            // destroyed endpoint cannot use-after-free.
+            auto close_conn = m_socket.release_closer();
+            m_handler->add_action([handler = m_handler, fd = m_fd, close_conn = std::move(close_conn)]() mutable {
+                handler->remove_event_handler(fd);
+                close_conn();
+            });
             m_fd = -1;
+        } else {
+            // No live connection fd (e.g. failure before the fd was armed): the
+            // socket can be closed synchronously.
+            m_socket.close();
         }
     }
 

--- a/lib/everest/io/include/everest/io/tls/tls_listener.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_listener.hpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/event/fd_event_sync_interface.hpp>
+#include <everest/io/event/unique_fd.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace everest::lib::io::tls {
+
+// Listening TLS socket. Owns a ::tls::Server and a non-blocking listen fd;
+// registering it with an fd_event_handler drives accept events on the loop. Each
+// accepted connection is wrapped in a tls_server and handed to the accept
+// callback, which takes ownership of the unique_ptr.
+class tls_listener : public event::fd_event_sync_interface {
+public:
+    struct Config {
+        ::tls::Server::config_t tls{}; // chains, ciphers, verify mode, …
+        std::string bind_addr;
+        std::uint16_t bind_port{0}; // 0 selects an ephemeral port
+        bool ipv6_only{false};      // when true, AF_INET6 + IPV6_V6ONLY=1
+    };
+
+    using accept_cb =
+        std::function<void(std::unique_ptr<tls_server> conn, std::string peer_ip, std::uint16_t peer_port)>;
+
+    // Creates a non-blocking listen socket and builds the SSL_CTX. Throws
+    // std::runtime_error on a system-call or libtls init failure.
+    explicit tls_listener(Config cfg);
+
+    tls_listener(tls_listener const&) = delete;
+    tls_listener(tls_listener&&) = delete;
+    tls_listener& operator=(tls_listener const&) = delete;
+    tls_listener& operator=(tls_listener&&) = delete;
+
+    // The callback fires synchronously inside sync(), BEFORE the handshake: the
+    // receiver attaches an rx handler and registers the connection so the loop
+    // drives the handshake.
+    void set_accept_callback(accept_cb cb) {
+        m_cb = std::move(cb);
+    }
+
+    int get_poll_fd() override {
+        return static_cast<int>(m_listen_fd);
+    }
+
+    event::sync_status sync() override;
+
+    // Resolved local port (useful when bind_port was 0).
+    std::uint16_t listen_port() const {
+        return m_listen_port;
+    }
+
+private:
+    ::tls::Server m_server;
+    event::unique_fd m_listen_fd;
+    std::uint16_t m_listen_port{0};
+    accept_cb m_cb;
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_result.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_result.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/tls/tls.hpp>
+
+#include <cerrno>
+
+namespace everest::lib::io::tls {
+
+// Map a terminal TLS result to an errno-style code so get_error() reports a
+// meaningful POSIX error rather than a bare -1.
+inline int errno_from_result(::tls::Connection::result_t r) {
+    switch (r) {
+    case ::tls::Connection::result_t::closed:
+        return ECONNRESET;
+    case ::tls::Connection::result_t::timeout:
+        return ETIMEDOUT;
+    default:
+        return EPROTO;
+    }
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_server.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_server.hpp
@@ -27,7 +27,7 @@ public:
     tls_server(tls_server&&) = delete;
     tls_server& operator=(tls_server const&) = delete;
     tls_server& operator=(tls_server&&) = delete;
-    ~tls_server() override = default;
+    ~tls_server() override;
 
 private:
     void start(event::fd_event_handler& handler) override;

--- a/lib/everest/io/include/everest/io/tls/tls_server.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_server.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_endpoint_base.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <memory>
+
+namespace everest::lib::io::tls {
+
+// Event-loop-driven TLS server connection: registering it with an fd_event_handler
+// drives it. The accept handshake runs on the loop (accept(0)), kicked by the
+// incoming ClientHello, so no worker thread and no TCP connect are needed.
+//
+// Single-use: a tls_server wraps exactly ONE accepted connection (injected via the
+// ctor) and does not reconnect (an accepted connection cannot be replayed). On
+// disconnect or error the owner must drop the unique_ptr<tls_server>; the error
+// path tears the connection down and does not re-open it.
+class tls_server : public tls_endpoint_base<tls_server_socket> {
+public:
+    explicit tls_server(std::unique_ptr<::tls::ServerConnection> conn);
+
+    tls_server(tls_server const&) = delete;
+    tls_server(tls_server&&) = delete;
+    tls_server& operator=(tls_server const&) = delete;
+    tls_server& operator=(tls_server&&) = delete;
+    ~tls_server() override = default;
+
+private:
+    void start(event::fd_event_handler& handler) override;
+    void stop() override;
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_server_socket.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_server_socket.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+#include <everest/io/tls/tls_socket_base.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <memory>
+
+namespace everest::lib::io::tls {
+
+// TLS server connection policy. The accepted connection is injected once via
+// open(); the event loop then drives accept(0) until handshake_complete(), then
+// tx()/rx(). Shared logic lives in tls_socket_base; this class adds the three
+// socket-base hooks and holds the accepted ServerConnection.
+class tls_server_socket : public tls_socket_base<tls_server_socket> {
+public:
+    tls_server_socket() = default;
+
+    // Inject an accepted connection (taken by value; moved into m_conn).
+    // true when a non-null connection was stored.
+    bool open(std::unique_ptr<::tls::ServerConnection> conn);
+
+    tls_server_socket(tls_server_socket const&) = delete;
+    tls_server_socket(tls_server_socket&&) = default;
+    tls_server_socket& operator=(tls_server_socket const&) = delete;
+    tls_server_socket& operator=(tls_server_socket&&) = default;
+    ~tls_server_socket() = default;
+
+    // tls_socket_base hooks (public so the base can call them without friendship).
+    ::tls::Connection* connection() const;
+    ::tls::Connection::result_t step_handshake(); // one non-blocking accept(0)
+    void reset_connection();
+
+private:
+    std::unique_ptr<::tls::ServerConnection> m_conn;
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_server_socket.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_server_socket.hpp
@@ -5,6 +5,7 @@
 #include <everest/io/tls/tls_socket_base.hpp>
 #include <everest/tls/tls.hpp>
 
+#include <functional>
 #include <memory>
 
 namespace everest::lib::io::tls {
@@ -31,6 +32,11 @@ public:
     ::tls::Connection* connection() const;
     ::tls::Connection::result_t step_handshake(); // one non-blocking accept(0)
     void reset_connection();
+
+    // Hand the connection (the fd's BIO_CLOSE owner) to a closer so the fd stays
+    // open until the closer runs; used by the endpoint to defer the close past the
+    // handler removal. No TLS shutdown is performed (the connection has faulted).
+    std::function<void()> release_closer();
 
 private:
     std::unique_ptr<::tls::ServerConnection> m_conn;

--- a/lib/everest/io/include/everest/io/tls/tls_socket_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_socket_base.hpp
@@ -41,10 +41,10 @@ public:
             return true;
         default:
             m_last_error = errno_from_result(res);
-            // reset_connection() destroys the Connection; capture its OpenSSL
-            // error text first.
             m_last_error_text = c->last_error();
-            self().reset_connection();
+            // Keep the Connection (and its fd) alive; the endpoint's fail() defers
+            // the close so the fd number stays reserved until it is unregistered.
+            m_failed = true;
             return false;
         }
     }
@@ -83,7 +83,7 @@ public:
         default:
             m_last_error = errno_from_result(res);
             m_last_error_text = c->last_error();
-            self().reset_connection();
+            m_failed = true;
             return false;
         }
     }
@@ -124,13 +124,13 @@ public:
         default:
             m_last_error = errno_from_result(res);
             m_last_error_text = c->last_error();
-            self().reset_connection();
+            m_failed = true;
             return false;
         }
     }
 
     bool is_open() const {
-        return self().connection() != nullptr;
+        return not m_failed and self().connection() != nullptr;
     }
 
     int get_fd() const {
@@ -155,6 +155,7 @@ public:
         self().reset_connection();
         m_desired = event::poll_events::read;
         m_handshake_done = false;
+        m_failed = false;
         m_last_error_text.clear();
     }
 
@@ -175,12 +176,17 @@ protected:
     void reset_error_state() {
         m_last_error = 0;
         m_last_error_text.clear();
+        m_failed = false;
     }
 
     event::poll_events m_desired{event::poll_events::read};
     int m_last_error{0};
     std::string m_last_error_text;
     bool m_handshake_done{false};
+    // Set on a terminal TLS result. The Connection is kept alive (so its fd stays
+    // open) until the endpoint's fail() defers the close; is_open() reports the
+    // socket as closed so the endpoint routes through fail().
+    bool m_failed{false};
 };
 
 } // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_socket_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_socket_base.hpp
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#pragma once
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_result.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace everest::lib::io::tls {
+
+// Shared fd_event_client policy logic for the TLS client and server sockets.
+// Derived (client/server) provides three public hooks the base calls:
+//   ::tls::Connection* connection() const;          // current connection or nullptr
+//   ::tls::Connection::result_t step_handshake();   // connect(0) or accept(0)
+//   void reset_connection();                         // release the held connection
+template <class Derived> class tls_socket_base {
+public:
+    using PayloadT = std::vector<std::uint8_t>;
+
+    bool handshake_step() {
+        auto* c = self().connection();
+        if (c == nullptr || m_handshake_done) {
+            return false;
+        }
+        using result_t = ::tls::Connection::result_t;
+        const auto res = self().step_handshake();
+        switch (res) {
+        case result_t::success:
+            m_handshake_done = true;
+            m_desired = event::poll_events::read;
+            return true;
+        case result_t::want_read:
+            m_desired = event::poll_events::read;
+            return true;
+        case result_t::want_write:
+            m_desired = event::poll_events::write;
+            return true;
+        default:
+            m_last_error = errno_from_result(res);
+            self().reset_connection();
+            return false;
+        }
+    }
+
+    bool handshake_complete() const {
+        return m_handshake_done;
+    }
+
+    bool tx(PayloadT& payload) {
+        if (payload.empty()) {
+            return true;
+        }
+        auto* c = self().connection();
+        if (c == nullptr) {
+            return false;
+        }
+        using result_t = ::tls::Connection::result_t;
+        std::size_t written = 0;
+        const auto res = c->write(reinterpret_cast<std::byte const*>(payload.data()), payload.size(), written, 0);
+        switch (res) {
+        case result_t::success:
+            payload.erase(payload.begin(), payload.begin() + static_cast<std::ptrdiff_t>(written));
+            return payload.empty();
+        case result_t::want_read:
+            if (written > 0) {
+                payload.erase(payload.begin(), payload.begin() + static_cast<std::ptrdiff_t>(written));
+            }
+            m_desired = event::poll_events::read;
+            return false;
+        case result_t::want_write:
+            if (written > 0) {
+                payload.erase(payload.begin(), payload.begin() + static_cast<std::ptrdiff_t>(written));
+            }
+            m_desired = event::poll_events::write;
+            return false;
+        default:
+            m_last_error = errno_from_result(res);
+            self().reset_connection();
+            return false;
+        }
+    }
+
+    bool rx(PayloadT& buffer) {
+        auto* c = self().connection();
+        if (c == nullptr) {
+            return false;
+        }
+        using result_t = ::tls::Connection::result_t;
+        std::byte tmp[c_read_chunk_size];
+        std::size_t n = 0;
+        const auto res = c->read(tmp, sizeof tmp, n, 0);
+        buffer.clear();
+        switch (res) {
+        case result_t::success:
+            buffer.assign(reinterpret_cast<std::uint8_t*>(tmp), reinterpret_cast<std::uint8_t*>(tmp) + n);
+            // libtls/OpenSSL can buffer several decrypted records under
+            // level-triggered epoll. Drain SSL_pending() so the whole message is
+            // delivered in one rx() call rather than one record per loop wakeup.
+            while (self().connection() != nullptr && self().connection()->pending() > 0) {
+                std::size_t more = 0;
+                const auto next = self().connection()->read(tmp, sizeof tmp, more, 0);
+                if (next != result_t::success || more == 0) {
+                    break;
+                }
+                buffer.insert(buffer.end(), reinterpret_cast<std::uint8_t*>(tmp),
+                              reinterpret_cast<std::uint8_t*>(tmp) + more);
+            }
+            m_desired = event::poll_events::read;
+            return not buffer.empty();
+        case result_t::want_read:
+            m_desired = event::poll_events::read;
+            return false;
+        case result_t::want_write:
+            m_desired = event::poll_events::write;
+            return false;
+        default:
+            m_last_error = errno_from_result(res);
+            self().reset_connection();
+            return false;
+        }
+    }
+
+    bool is_open() const {
+        return self().connection() != nullptr;
+    }
+
+    int get_fd() const {
+        auto* c = self().connection();
+        return c != nullptr ? c->socket() : -1;
+    }
+
+    int get_error() const {
+        return m_last_error;
+    }
+
+    void close() {
+        if (auto* c = self().connection()) {
+            c->shutdown(0);
+        }
+        self().reset_connection();
+        m_desired = event::poll_events::read;
+        m_handshake_done = false;
+    }
+
+    event::poll_events desired_events() const {
+        return m_desired;
+    }
+
+protected:
+    static constexpr std::size_t c_read_chunk_size = 4096;
+
+    Derived& self() {
+        return static_cast<Derived&>(*this);
+    }
+    Derived const& self() const {
+        return static_cast<Derived const&>(*this);
+    }
+
+    event::poll_events m_desired{event::poll_events::read};
+    int m_last_error{0};
+    bool m_handshake_done{false};
+};
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/include/everest/io/tls/tls_socket_base.hpp
+++ b/lib/everest/io/include/everest/io/tls/tls_socket_base.hpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace everest::lib::io::tls {
@@ -40,6 +41,9 @@ public:
             return true;
         default:
             m_last_error = errno_from_result(res);
+            // reset_connection() destroys the Connection; capture its OpenSSL
+            // error text first.
+            m_last_error_text = c->last_error();
             self().reset_connection();
             return false;
         }
@@ -78,6 +82,7 @@ public:
             return false;
         default:
             m_last_error = errno_from_result(res);
+            m_last_error_text = c->last_error();
             self().reset_connection();
             return false;
         }
@@ -118,6 +123,7 @@ public:
             return false;
         default:
             m_last_error = errno_from_result(res);
+            m_last_error_text = c->last_error();
             self().reset_connection();
             return false;
         }
@@ -136,6 +142,12 @@ public:
         return m_last_error;
     }
 
+    // OpenSSL error text captured from the Connection that the last failure
+    // destroyed; empty when no error text was reported.
+    const std::string& get_error_string() const {
+        return m_last_error_text;
+    }
+
     void close() {
         if (auto* c = self().connection()) {
             c->shutdown(0);
@@ -143,6 +155,7 @@ public:
         self().reset_connection();
         m_desired = event::poll_events::read;
         m_handshake_done = false;
+        m_last_error_text.clear();
     }
 
     event::poll_events desired_events() const {
@@ -159,8 +172,14 @@ protected:
         return static_cast<Derived const&>(*this);
     }
 
+    void reset_error_state() {
+        m_last_error = 0;
+        m_last_error_text.clear();
+    }
+
     event::poll_events m_desired{event::poll_events::read};
     int m_last_error{0};
+    std::string m_last_error_text;
     bool m_handshake_done{false};
 };
 

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -136,6 +136,28 @@ else()
     )
 endif()
 
+option(EVEREST_IO_ENABLE_TLS "Build TLS client/server adapters in everest_io (requires everest::tls)" ON)
+
+if(EVEREST_IO_ENABLE_TLS)
+    target_sources(everest_io
+        PRIVATE
+            tls/tls_server_socket.cpp
+            tls/tls_server.cpp
+            tls/tls_listener.cpp
+            tls/tls_client_socket.cpp
+            tls/tls_client.cpp
+    )
+    target_link_libraries(everest_io PRIVATE $<BUILD_INTERFACE:tls>)
+    # libtls is not installed as part of everest-core's export set, so its
+    # public include directories are propagated to in-tree consumers only via
+    # BUILD_INTERFACE. Mirrors libtls's own PUBLIC include directories.
+    target_include_directories(everest_io
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/everest/tls>
+            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/lib/everest/tls/include>
+    )
+endif()
+
 if(DISABLE_EDM)
     evc_setup_package_no_export(
         NAME everest-io

--- a/lib/everest/io/src/socket/socket.cpp
+++ b/lib/everest/io/src/socket/socket.cpp
@@ -367,6 +367,66 @@ event::unique_fd open_tcp_socket(const std::string& host, std::uint16_t port, co
     throw std::runtime_error(std::string("Could not open a socket for ") + host + ":" + std::to_string(port));
 }
 
+event::unique_fd open_tcp_server_socket(std::string const& bind_addr, std::uint16_t port, bool ipv6_only) {
+    const bool is_ipv6 = ipv6_only || (bind_addr.find(':') != std::string::npos);
+    const int family = is_ipv6 ? AF_INET6 : AF_INET;
+
+    const int raw_fd = ::socket(family, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (raw_fd < 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket socket(): ") + std::strerror(errno));
+    }
+    // Own the fd immediately so any throw below auto-closes it.
+    event::unique_fd fd(raw_fd);
+
+    const int opt = 1;
+    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) != 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket setsockopt(SO_REUSEADDR): ") +
+                                 std::strerror(errno));
+    }
+    if (::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)) != 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket setsockopt(SO_REUSEPORT): ") +
+                                 std::strerror(errno));
+    }
+
+    if (is_ipv6) {
+        const int v6only = ipv6_only ? 1 : 0;
+        if (::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) != 0) {
+            throw std::runtime_error(std::string("open_tcp_server_socket setsockopt(IPV6_V6ONLY): ") +
+                                     std::strerror(errno));
+        }
+    }
+
+    sockaddr_storage sa{};
+    socklen_t sa_len = 0;
+    if (is_ipv6) {
+        auto* sa6 = reinterpret_cast<sockaddr_in6*>(&sa);
+        sa6->sin6_family = AF_INET6;
+        sa6->sin6_port = htons(port);
+        if (::inet_pton(AF_INET6, bind_addr.c_str(), &sa6->sin6_addr) != 1) {
+            throw std::runtime_error(std::string("open_tcp_server_socket inet_pton IPv6: ") + bind_addr);
+        }
+        sa_len = sizeof(sockaddr_in6);
+    } else {
+        auto* sa4 = reinterpret_cast<sockaddr_in*>(&sa);
+        sa4->sin_family = AF_INET;
+        sa4->sin_port = htons(port);
+        if (::inet_pton(AF_INET, bind_addr.c_str(), &sa4->sin_addr) != 1) {
+            throw std::runtime_error(std::string("open_tcp_server_socket inet_pton IPv4: ") + bind_addr);
+        }
+        sa_len = sizeof(sockaddr_in);
+    }
+
+    if (::bind(fd, reinterpret_cast<sockaddr*>(&sa), sa_len) != 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket bind(): ") + std::strerror(errno));
+    }
+
+    if (::listen(fd, SOMAXCONN) != 0) {
+        throw std::runtime_error(std::string("open_tcp_server_socket listen(): ") + std::strerror(errno));
+    }
+
+    return fd;
+}
+
 #ifndef EVEREST_NO_PACKET_IGNORE_OUTGOING
 event::unique_fd open_raw_promiscuous_socket(std::string const& if_name) {
     auto const socket_fd = ::socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));

--- a/lib/everest/io/src/tcp/tcp_socket.cpp
+++ b/lib/everest/io/src/tcp/tcp_socket.cpp
@@ -97,6 +97,10 @@ void tcp_socket::close() {
     m_fd.close();
 }
 
+int tcp_socket::release() {
+    return m_fd.release();
+}
+
 bool tcp_socket::set_keep_alive(uint32_t count, uint32_t idle_s, uint32_t intval_s) {
     if (not is_open()) {
         return false;

--- a/lib/everest/io/src/tls/tls_client.cpp
+++ b/lib/everest/io/src/tls/tls_client.cpp
@@ -58,6 +58,15 @@ void tls_client::stop() {
 }
 
 tls_client::~tls_client() {
+    // Backstop for a drop while still registered (the README's "connections.clear()"
+    // teardown): remove the connection fd, tx-notify and m_connected synchronously
+    // so no this-capturing lambda is left in the handler to dispatch into a freed
+    // object. unregister_event_handler routes through unregister_events()/stop(),
+    // which also joins the worker. A no-op after an explicit unregister (m_handler
+    // is then null).
+    if (m_handler != nullptr) {
+        m_handler->unregister_event_handler(this);
+    }
     // Backstop for any path that destroys without stop(): the worker must not
     // outlive *this (it captures this and writes m_connect_ok / m_connected).
     if (m_worker.joinable()) {

--- a/lib/everest/io/src/tls/tls_client.cpp
+++ b/lib/everest/io/src/tls/tls_client.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/tls/tls_client.hpp>
+
+#include <thread>
+#include <utility>
+
+namespace everest::lib::io::tls {
+
+tls_client::tls_client(tls_client_socket::Config cfg, std::string host, std::uint16_t port, int timeout_ms) :
+    m_cfg(std::move(cfg)), m_host(std::move(host)), m_port(port), m_timeout_ms(timeout_ms) {
+}
+
+void tls_client::start(event::fd_event_handler& handler) {
+    // Fired from the connect worker. On success the fd is live: register it armed
+    // for write and drive the first handshake step (the client must send its
+    // ClientHello — a freshly connected socket has nothing to read yet).
+    handler.register_event_handler(&m_connected, [this, &handler]() {
+        if (m_connect_ok) {
+            register_connection_fd(handler, m_socket.get_fd(), event::poll_events::write);
+            drive_handshake(m_socket.get_fd());
+        } else {
+            fail(m_socket.get_error());
+        }
+    });
+
+    if (not m_socket.setup(m_cfg, m_host, m_port, m_timeout_ms)) {
+        m_connect_ok = false;
+        m_connected.notify();
+        return;
+    }
+
+    // TCP connect on the owned worker thread; TLS handshake on the loop. The
+    // worker is joined on teardown (stop()/dtor) before m_socket is closed.
+    m_worker = std::thread([this]() {
+        m_socket.connect([this](bool ok, int /*fd*/) {
+            m_connect_ok = ok;
+            m_connected.notify();
+        });
+    });
+}
+
+void tls_client::stop() {
+    // Symmetric with start(), which registered m_connected: the base's
+    // unregister_events() only removes the connection fd and tx-notify, so the
+    // client tears down its own m_connected here (m_handler is still valid).
+    if (m_handler != nullptr) {
+        m_handler->unregister_event_handler(&m_connected);
+    }
+    // Join before close(): the worker may still be inside m_socket.connect();
+    // joining here (bounded by the connect timeout) guarantees it has stopped
+    // touching m_socket before we tear it down.
+    if (m_worker.joinable()) {
+        m_worker.join();
+    }
+    m_socket.close();
+}
+
+tls_client::~tls_client() {
+    // Backstop for any path that destroys without stop(): the worker must not
+    // outlive *this (it captures this and writes m_connect_ok / m_connected).
+    if (m_worker.joinable()) {
+        m_worker.join();
+    }
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_client_socket.cpp
+++ b/lib/everest/io/src/tls/tls_client_socket.cpp
@@ -84,4 +84,14 @@ void tls_client_socket::close() {
     m_tcp.close();
 }
 
+std::function<void()> tls_client_socket::release_closer() {
+    // Post-wrap the connection's BIO owns the fd and m_tcp is already released;
+    // move the connection into a closer that drops it (SSL_free -> BIO_CLOSE) when
+    // run. m_tcp.close() is a no-op here (released) but stays defensive.
+    m_tcp.close();
+    // shared_ptr (not the move-only unique_ptr) so the closer is copy-constructible
+    // and fits std::function / the handler's task queue.
+    return [conn = std::shared_ptr<::tls::ClientConnection>(std::move(m_conn))]() mutable { conn.reset(); };
+}
+
 } // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_client_socket.cpp
+++ b/lib/everest/io/src/tls/tls_client_socket.cpp
@@ -28,8 +28,7 @@ bool tls_client_socket::setup(Config cfg, std::string const& remote_host, std::u
 }
 
 void tls_client_socket::connect(std::function<void(bool, int)> const& cb) {
-    bool wrapped = false;
-    m_tcp.connect([this, cb, &wrapped](bool ok, int fd) {
+    m_tcp.connect([this, cb](bool ok, int fd) {
         if (!ok) {
             cb(false, -1);
             return;
@@ -42,14 +41,11 @@ void tls_client_socket::connect(std::function<void(bool, int)> const& cb) {
             cb(false, -1);
             return;
         }
-        wrapped = true;
+        // After a successful wrap the connection's BIO (BIO_CLOSE) is the sole
+        // owner of the fd, so m_tcp surrenders its claim.
+        m_tcp.release();
         cb(true, m_conn->socket());
     });
-    if (wrapped) {
-        // m_tcp now owns the connected fd (assigned after the callback); the
-        // connection's BIO (BIO_CLOSE) owns it too. Drop our second owner.
-        m_tcp.release();
-    }
 }
 
 ::tls::Connection* tls_client_socket::connection() const {

--- a/lib/everest/io/src/tls/tls_client_socket.cpp
+++ b/lib/everest/io/src/tls/tls_client_socket.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/tls/tls_client_socket.hpp>
+#include <everest/io/tls/tls_result.hpp>
+
+namespace everest::lib::io::tls {
+
+namespace {
+
+bool init_client(std::unique_ptr<::tls::Client>& client, ::tls::Client::config_t const& tls_cfg) {
+    client = std::make_unique<::tls::Client>();
+    if (!client->init(tls_cfg)) {
+        client.reset();
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+bool tls_client_socket::setup(Config cfg, std::string const& remote_host, std::uint16_t remote_port, int timeout_ms) {
+    m_cfg = std::move(cfg);
+    if (!init_client(m_client, m_cfg.tls)) {
+        return false;
+    }
+    return m_tcp.setup(remote_host, remote_port, timeout_ms);
+}
+
+void tls_client_socket::connect(std::function<void(bool, int)> const& cb) {
+    bool wrapped = false;
+    m_tcp.connect([this, cb, &wrapped](bool ok, int fd) {
+        if (!ok) {
+            cb(false, -1);
+            return;
+        }
+        // Wrap the connected TCP fd but do NOT perform the TLS handshake here:
+        // the event loop drives it via handshake_step() once the fd is armed.
+        m_conn = m_client->wrap_connecting_fd(fd, m_cfg.host_for_sni.c_str());
+        if (!m_conn) {
+            m_last_error = EPROTO;
+            cb(false, -1);
+            return;
+        }
+        wrapped = true;
+        cb(true, m_conn->socket());
+    });
+    if (wrapped) {
+        // m_tcp now owns the connected fd (assigned after the callback); the
+        // connection's BIO (BIO_CLOSE) owns it too. Drop our second owner.
+        m_tcp.release();
+    }
+}
+
+::tls::Connection* tls_client_socket::connection() const {
+    return m_conn.get();
+}
+
+::tls::Connection::result_t tls_client_socket::step_handshake() {
+    return m_conn->connect(0);
+}
+
+void tls_client_socket::reset_connection() {
+    m_conn.reset();
+}
+
+int tls_client_socket::get_fd() const {
+    if (m_conn) {
+        return m_conn->socket();
+    }
+    return m_tcp.get_fd();
+}
+
+int tls_client_socket::get_error() const {
+    if (m_last_error != 0) {
+        return m_last_error;
+    }
+    if (!m_conn) {
+        return m_tcp.get_error();
+    }
+    return 0;
+}
+
+void tls_client_socket::close() {
+    // Base close() shuts down + releases the connection and resets handshake state
+    // (via the connection()/reset_connection() hooks); this adds the TCP fd.
+    tls_socket_base::close();
+    m_tcp.close();
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_listener.cpp
+++ b/lib/everest/io/src/tls/tls_listener.cpp
@@ -78,8 +78,6 @@ event::sync_status tls_listener::sync() {
 
     const std::uint16_t peer_port = port_from_storage(peer);
 
-    // wrap_accepted_fd's key-logging path runs std::stoul(service); an empty string would throw
-    // std::invalid_argument and kill the accept loop, so always pass a numeric service string.
     const std::string svc = std::to_string(peer_port);
     auto raw_conn = m_server.wrap_accepted_fd(accepted, ip_buf, svc.c_str());
     if (!raw_conn) {

--- a/lib/everest/io/src/tls/tls_listener.cpp
+++ b/lib/everest/io/src/tls/tls_listener.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/socket/socket.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstdint>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace everest::lib::io::tls {
+
+namespace {
+
+std::uint16_t port_from_storage(const sockaddr_storage& ss) {
+    if (ss.ss_family == AF_INET6) {
+        return ntohs(reinterpret_cast<const sockaddr_in6*>(&ss)->sin6_port);
+    }
+    if (ss.ss_family == AF_INET) {
+        return ntohs(reinterpret_cast<const sockaddr_in*>(&ss)->sin_port);
+    }
+    return 0;
+}
+
+} // namespace
+
+tls_listener::tls_listener(Config cfg) {
+    m_listen_fd = socket::open_tcp_server_socket(cfg.bind_addr, cfg.bind_port, cfg.ipv6_only);
+    const int fd = static_cast<int>(m_listen_fd);
+
+    sockaddr_storage bound{};
+    socklen_t bound_len = sizeof(bound);
+    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&bound), &bound_len) == 0) {
+        m_listen_port = port_from_storage(bound);
+    }
+
+    // Hand the listen fd to the libtls Server so wrap_accepted_fd works without the
+    // Server attempting its own bind/listen. The Server borrows the fd number only;
+    // it does NOT take ownership (it never runs its blocking serve loop here, which
+    // is the only path that would close it). m_listen_fd (unique_fd) stays the sole
+    // owner, so there is no double-close on teardown.
+    cfg.tls.socket = fd;
+    const auto state = m_server.init(cfg.tls, nullptr);
+    if (state == ::tls::Server::state_t::init_needed) {
+        throw std::runtime_error("tls_listener: tls::Server::init failed");
+    }
+}
+
+event::sync_status tls_listener::sync() {
+    sockaddr_storage peer{};
+    socklen_t peer_len = sizeof(peer);
+
+    // SOCK_NONBLOCK is essential: the handshake is stepped non-blockingly
+    // (accept(0)) on the loop; a blocking socket would stall SSL_accept (and the
+    // whole loop) until the peer sends data.
+    const int accepted = ::accept4(static_cast<int>(m_listen_fd), reinterpret_cast<sockaddr*>(&peer), &peer_len,
+                                   SOCK_CLOEXEC | SOCK_NONBLOCK);
+
+    if (accepted < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+            return event::sync_status::ok;
+        }
+        return event::sync_status::error;
+    }
+
+    char ip_buf[NI_MAXHOST] = {};
+    if (::getnameinfo(reinterpret_cast<sockaddr*>(&peer), peer_len, ip_buf, sizeof(ip_buf), nullptr, 0,
+                      NI_NUMERICHOST) != 0) {
+        // Peer IP is informational only (never read by wrap_accepted_fd); leave ip_buf empty.
+        ip_buf[0] = '\0';
+    }
+
+    const std::uint16_t peer_port = port_from_storage(peer);
+
+    // wrap_accepted_fd's key-logging path runs std::stoul(service); an empty string would throw
+    // std::invalid_argument and kill the accept loop, so always pass a numeric service string.
+    const std::string svc = std::to_string(peer_port);
+    auto raw_conn = m_server.wrap_accepted_fd(accepted, ip_buf, svc.c_str());
+    if (!raw_conn) {
+        ::close(accepted);
+        return event::sync_status::error;
+    }
+
+    if (m_cb) {
+        auto srv = std::make_unique<tls_server>(std::move(raw_conn));
+        m_cb(std::move(srv), std::string(ip_buf), peer_port);
+    }
+
+    return event::sync_status::ok;
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_server.cpp
+++ b/lib/everest/io/src/tls/tls_server.cpp
@@ -22,4 +22,14 @@ void tls_server::stop() {
     m_socket.close();
 }
 
+tls_server::~tls_server() {
+    // Backstop for a drop while still registered (the README's "connections.clear()"
+    // teardown): remove the connection fd and tx-notify synchronously so no
+    // this-capturing lambda is left in the handler. A no-op after an explicit
+    // unregister (m_handler is then null).
+    if (m_handler != nullptr) {
+        m_handler->unregister_event_handler(this);
+    }
+}
+
 } // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_server.cpp
+++ b/lib/everest/io/src/tls/tls_server.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/tls/tls_server.hpp>
+
+#include <utility>
+
+namespace everest::lib::io::tls {
+
+tls_server::tls_server(std::unique_ptr<::tls::ServerConnection> conn) {
+    m_socket.open(std::move(conn));
+}
+
+void tls_server::start(event::fd_event_handler& handler) {
+    // The server is kicked by the incoming ClientHello: arm the connection fd
+    // for read and let the dispatch lambda drive the accept(0) handshake once
+    // bytes arrive. No worker thread and no TCP connect are needed.
+    register_connection_fd(handler, m_socket.get_fd(), event::poll_events::read);
+}
+
+void tls_server::stop() {
+    m_socket.close();
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_server_socket.cpp
+++ b/lib/everest/io/src/tls/tls_server_socket.cpp
@@ -27,4 +27,12 @@ void tls_server_socket::reset_connection() {
     m_conn.reset();
 }
 
+std::function<void()> tls_server_socket::release_closer() {
+    // Move the accepted connection into a closer that drops it (SSL_free ->
+    // BIO_CLOSE) when run, keeping the fd open until then. shared_ptr (not the
+    // move-only unique_ptr) so the closer is copy-constructible and fits
+    // std::function / the handler's task queue.
+    return [conn = std::shared_ptr<::tls::ServerConnection>(std::move(m_conn))]() mutable { conn.reset(); };
+}
+
 } // namespace everest::lib::io::tls

--- a/lib/everest/io/src/tls/tls_server_socket.cpp
+++ b/lib/everest/io/src/tls/tls_server_socket.cpp
@@ -11,7 +11,7 @@ bool tls_server_socket::open(std::unique_ptr<::tls::ServerConnection> conn) {
     m_conn = std::move(conn);
     m_handshake_done = false;
     m_desired = event::poll_events::read;
-    m_last_error = 0;
+    reset_error_state();
     return static_cast<bool>(m_conn);
 }
 

--- a/lib/everest/io/src/tls/tls_server_socket.cpp
+++ b/lib/everest/io/src/tls/tls_server_socket.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/tls/tls_server_socket.hpp>
+
+#include <utility>
+
+namespace everest::lib::io::tls {
+
+bool tls_server_socket::open(std::unique_ptr<::tls::ServerConnection> conn) {
+    m_conn = std::move(conn);
+    m_handshake_done = false;
+    m_desired = event::poll_events::read;
+    m_last_error = 0;
+    return static_cast<bool>(m_conn);
+}
+
+::tls::Connection* tls_server_socket::connection() const {
+    return m_conn.get();
+}
+
+::tls::Connection::result_t tls_server_socket::step_handshake() {
+    return m_conn->accept(0);
+}
+
+void tls_server_socket::reset_connection() {
+    m_conn.reset();
+}
+
+} // namespace everest::lib::io::tls

--- a/lib/everest/io/test/CMakeLists.txt
+++ b/lib/everest/io/test/CMakeLists.txt
@@ -61,3 +61,8 @@ add_test(
     COMMAND everest_io_tls_test
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib/everest/tls/tests
 )
+
+# Both this binary and libtls's tls_test regenerate the PKI fixture via
+# ./pki.sh in the same working directory; serialize them under ctest so one
+# does not regenerate certs mid-handshake of the other.
+set_tests_properties(everest_io_tls_test PROPERTIES RESOURCE_LOCK tls_pki)

--- a/lib/everest/io/test/CMakeLists.txt
+++ b/lib/everest/io/test/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_executable(everest_io_tests
   endpoint_test.cpp
+  fd_event_client_alias_test.cpp
+  socket_test.cpp
   udp_client_v6_test.cpp
   udp_unconnected_socket_test.cpp
   udp_dualstack_server_socket_test.cpp
@@ -14,3 +16,48 @@ target_link_libraries(everest_io_tests
 
 include(GoogleTest)
 gtest_discover_tests(everest_io_tests TEST_PREFIX "io.")
+
+if(NOT EVEREST_IO_ENABLE_TLS)
+    return()
+endif()
+
+find_package(OpenSSL 3 REQUIRED)
+
+# The alias regression test asserts the tls_client alias too; that header pulls
+# in OpenSSL transitively. Make everest_io_tests aware of TLS and able to find
+# the OpenSSL headers so the guarded static_assert compiles when TLS is on.
+target_compile_definitions(everest_io_tests PRIVATE EVEREST_IO_ENABLE_TLS)
+target_link_libraries(everest_io_tests
+    PRIVATE
+        OpenSSL::SSL
+        OpenSSL::Crypto
+)
+
+add_executable(everest_io_tls_test
+    tls_test_main.cpp
+    tls_server_socket_test.cpp
+    tls_listener_test.cpp
+    tls_client_socket_test.cpp
+    tls_e2e_test.cpp
+)
+
+target_link_libraries(everest_io_tls_test
+    PRIVATE
+        GTest::gtest
+        everest::io
+        OpenSSL::SSL
+        OpenSSL::Crypto
+)
+
+# Reuse existing libtls test fixtures (server_chain.pem etc) by adding the
+# libtls test dir to the test binary's working data path. Existing libtls
+# pki cookbook lives at lib/everest/tls/tests/pki/. The custom main in
+# tls_test_main.cpp invokes ./pki.sh at startup so this binary does not
+# depend on libtls's tls_test having run first under ctest.
+add_dependencies(everest_io_tls_test tls_test_files_target)
+
+add_test(
+    NAME everest_io_tls_test
+    COMMAND everest_io_tls_test
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib/everest/tls/tests
+)

--- a/lib/everest/io/test/fd_event_client_alias_test.cpp
+++ b/lib/everest/io/test/fd_event_client_alias_test.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// Regression gate for fd_event_client: every existing client alias must still
+// resolve unchanged, and a client (tcp_client) must construct via the plain
+// synchronous open() path with no deferral.
+
+#include <everest/io/raw/raw_client.hpp>
+#include <everest/io/tcp/tcp_client.hpp>
+#include <everest/io/tun_tap/tap_client.hpp>
+#include <everest/io/udp/udp_client.hpp>
+#include <everest/io/udp/udp_unconnected_client.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <type_traits>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+// The existing aliases must remain valid types. A type that fails to resolve
+// would not even name here.
+static_assert(std::is_class_v<everest::lib::io::tcp::tcp_client>, "tcp_client alias must resolve");
+static_assert(std::is_class_v<everest::lib::io::udp::udp_client>, "udp_client alias must resolve");
+static_assert(std::is_class_v<everest::lib::io::udp::udp_unconnected_client>,
+              "udp_unconnected_client alias must resolve");
+static_assert(std::is_class_v<everest::lib::io::raw::raw_client>, "raw_client alias must resolve");
+static_assert(std::is_class_v<everest::lib::io::tun_tap::tap_client>, "tap_client alias must resolve");
+
+TEST(fd_event_client_alias, tcp_client_constructs_hookless_path_unchanged) {
+    // A loopback listener gives tcp_socket's async setup()/connect() a real peer.
+    int srv = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(srv, 0);
+    sockaddr_in sa{};
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    sa.sin_port = 0;
+    ASSERT_EQ(::bind(srv, reinterpret_cast<sockaddr*>(&sa), sizeof(sa)), 0);
+    ASSERT_EQ(::listen(srv, 1), 0);
+    socklen_t len = sizeof(sa);
+    ASSERT_EQ(::getsockname(srv, reinterpret_cast<sockaddr*>(&sa), &len), 0);
+    const std::uint16_t port = ntohs(sa.sin_port);
+
+    // Accept the connection so the async connect() completes.
+    std::atomic<bool> accepted{false};
+    std::thread accept_thread([&]() {
+        int c = ::accept(srv, nullptr, nullptr);
+        if (c >= 0) {
+            accepted = true;
+            std::this_thread::sleep_for(200ms);
+            ::close(c);
+        }
+    });
+
+    everest::lib::io::tcp::tcp_client client("127.0.0.1", port, 1000);
+
+    // The ready action fires via the synchronous open() path with no deferral.
+    std::atomic<bool> ready{false};
+    client.set_on_ready_action([&]() { ready = true; });
+
+    EXPECT_GE(client.get_poll_fd(), 0);
+
+    auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline && not ready.load()) {
+        client.sync(100ms);
+    }
+
+    EXPECT_TRUE(ready.load()) << "hookless tcp_client never reached ready";
+    auto const& raw = client.get_raw_handler();
+    ASSERT_NE(raw, nullptr);
+    EXPECT_GE(raw->get_fd(), 0);
+
+    if (accept_thread.joinable()) {
+        accept_thread.join();
+    }
+    ::close(srv);
+}

--- a/lib/everest/io/test/socket_test.cpp
+++ b/lib/everest/io/test/socket_test.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/socket/socket.hpp>
+
+#include <cstdint>
+#include <string>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <gtest/gtest.h>
+
+using everest::lib::io::socket::open_tcp_server_socket;
+
+namespace {
+
+std::uint16_t bound_port(int fd) {
+    sockaddr_storage ss{};
+    socklen_t len = sizeof(ss);
+    EXPECT_EQ(::getsockname(fd, reinterpret_cast<sockaddr*>(&ss), &len), 0);
+    return ntohs(ss.ss_family == AF_INET6 ? reinterpret_cast<sockaddr_in6*>(&ss)->sin6_port
+                                          : reinterpret_cast<sockaddr_in*>(&ss)->sin_port);
+}
+
+} // namespace
+
+TEST(open_tcp_server_socket_test, OpenTcpServerSocketV4) {
+    auto fd = open_tcp_server_socket("127.0.0.1", 0, false);
+    ASSERT_GE(static_cast<int>(fd), 0);
+    EXPECT_NE(bound_port(fd), 0);
+}
+
+TEST(open_tcp_server_socket_test, OpenTcpServerSocketV6) {
+    auto fd = open_tcp_server_socket("::1", 0, true);
+    ASSERT_GE(static_cast<int>(fd), 0);
+    EXPECT_NE(bound_port(fd), 0);
+}
+
+TEST(open_tcp_server_socket_test, OpenTcpServerSocketBadAddress) {
+    EXPECT_THROW(open_tcp_server_socket("not.an.ip", 0, false), std::runtime_error);
+}

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Pionix GmbH and Contributors to EVerest
 
+#include "tls_test_common.hpp"
+
 #include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/tls/tls_client.hpp>
 #include <everest/io/tls/tls_client_socket.hpp>
@@ -24,6 +26,8 @@
 using namespace std::chrono_literals;
 
 namespace {
+
+namespace test = everest::lib::io::test;
 
 /// Payload size that exceeds a single 4096-byte TLS-record read so the
 /// client-side rx() must drain SSL_pending() records in one call.
@@ -59,33 +63,17 @@ int make_listen_socket(uint16_t& bound_port) {
 
 /// Configure a tls::Server matching the test PKI on an already-listening socket.
 tls::Server::config_t make_server_config(int listen_fd, std::string const& port_str) {
-    tls::Server::config_t scfg;
-    scfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
-    scfg.ciphersuites = "";
-    auto& chain = scfg.chains.emplace_back();
-    chain.certificate_chain_file = "server_chain.pem";
-    chain.private_key_file = "server_priv.pem";
-    chain.trust_anchor_file = "server_root_cert.pem";
-    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
+    auto scfg = test::server_test_config();
     scfg.host = "127.0.0.1";
     scfg.service = port_str.c_str();
     scfg.ipv6_only = false;
-    scfg.verify_client = false;
-    scfg.io_timeout_ms = 1000;
     scfg.socket = listen_fd; // bypass init_socket()
     return scfg;
 }
 
 /// Build the client Config shared by the tests.
 everest::lib::io::tls::tls_client_socket::Config make_client_config() {
-    everest::lib::io::tls::tls_client_socket::Config cfg;
-    cfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
-    cfg.tls.ciphersuites = "";
-    cfg.tls.verify_locations_file = "server_root_cert.pem";
-    cfg.tls.io_timeout_ms = 1000;
-    cfg.tls.verify_server = true;
-    cfg.host_for_sni = "localhost";
-    return cfg;
+    return test::client_test_config(1000, "localhost");
 }
 
 } // namespace
@@ -229,12 +217,8 @@ TEST(TlsClient, HandshakeAndExchange) {
         });
     ASSERT_TRUE(ev.register_event_handler(&client));
 
-    const auto deadline = std::chrono::steady_clock::now() + 5s;
-    while (running && std::chrono::steady_clock::now() < deadline) {
-        ev.poll(50ms);
-        ev.run_actions();
-    }
-    running = false;
+    test::pump_until(
+        ev, [&] { return !running; }, 5s);
 
     server_thread.join();
     ::close(listen_fd);

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -174,9 +174,9 @@ struct testable_client_socket : tls_client_socket {
 };
 } // namespace everest::lib::io::tls
 
-// After the async TCP connect + fd wrap, connect() releases m_tcp once it
-// returns; the connection owns the fd, m_tcp must have surrendered it. This
-// exercises the UNCHANGED synchronous tls_client_socket::connect() wrap path.
+// After connect() wraps the connected TCP fd, the connection's BIO is the
+// fd's sole owner: m_tcp must have surrendered it (outcome, not timing), or
+// teardown double-closes.
 TEST(tls_client_socket, fd_ownership_released_after_async_wrap) {
     uint16_t bound_port = 0;
     int listen_fd = make_listen_socket(bound_port);
@@ -201,7 +201,7 @@ TEST(tls_client_socket, fd_ownership_released_after_async_wrap) {
     });
 
     bool ok = false;
-    sock.connect([&](bool o, int /*fd*/) { ok = o; }); // synchronous; returns AFTER release
+    sock.connect([&](bool o, int /*fd*/) { ok = o; }); // synchronous
     const int tcp_fd_after = sock.m_tcp.get_fd();
 
     // Join before asserting so a fatal ASSERT cannot return with the thread

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -102,8 +102,7 @@ int start_nonblocking_connect(uint16_t port) {
 /// nothing within the window.
 bool connect_completed(int fd, int wait_ms) {
     pollfd pfd{fd, POLLOUT, 0};
-    return ::poll(&pfd, 1, wait_ms) == 1 && (pfd.revents & POLLOUT) != 0 &&
-           (pfd.revents & (POLLERR | POLLHUP)) == 0;
+    return ::poll(&pfd, 1, wait_ms) == 1 && (pfd.revents & POLLOUT) != 0 && (pfd.revents & (POLLERR | POLLHUP)) == 0;
 }
 
 /// A 127.0.0.1 listen socket whose accept queue is deliberately saturated:

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -98,8 +98,8 @@ int start_nonblocking_connect(uint16_t port) {
 }
 
 /// True if the pending connect on fd completed cleanly within wait_ms (POLLOUT
-/// without POLLERR/POLLHUP). A connect whose SYN was dropped stays in SYN_SENT
-/// (first retransmit is ~1 s out) and reports nothing within the window.
+/// without POLLERR/POLLHUP). A connect the kernel never completes reports
+/// nothing within the window.
 bool connect_completed(int fd, int wait_ms) {
     pollfd pfd{fd, POLLOUT, 0};
     return ::poll(&pfd, 1, wait_ms) == 1 && (pfd.revents & POLLOUT) != 0 &&
@@ -108,12 +108,12 @@ bool connect_completed(int fd, int wait_ms) {
 
 /// A 127.0.0.1 listen socket whose accept queue is deliberately saturated:
 /// listen(fd, 1), never accept, and raw pre-connects issued until one no
-/// longer completes. Once the queue is full the kernel drops further SYNs
-/// (tcp_abort_on_overflow=0 default), so any later connect to port() stalls
-/// in TCP SYN retry — a deterministic loopback stand-in for an unreachable
-/// host. The stalled final pre-connect doubles as the saturation probe. All
-/// fds (listener + pre-connect sockets) stay open until destruction so the
-/// block holds for the object's whole lifetime.
+/// longer completes. With the queue full (and default syncookies) the kernel
+/// no longer completes new handshakes, so any later connect to port() stays
+/// pending until the caller's timeout — a deterministic loopback stand-in for
+/// an unreachable host. The stalled final pre-connect doubles as the
+/// saturation probe. All fds (listener + pre-connect sockets) stay open until
+/// destruction so the block holds for the object's whole lifetime.
 class saturated_loopback_port {
 public:
     saturated_loopback_port() {
@@ -156,6 +156,7 @@ public:
     }
 
 private:
+    // ~3 connects saturate in practice on Linux; 8 is headroom, not a tuned value.
     static constexpr int max_pre_connects = 8;
     int m_listen_fd{-1};
     uint16_t m_port{0};
@@ -320,16 +321,17 @@ TEST(TlsClient, HandshakeAndExchange) {
 
 // Teardown while the TCP connect is still pending. The client targets a
 // loopback port whose accept queue is saturated (saturated_loopback_port), so
-// its SYNs are dropped and the connect worker is still blocked inside
-// m_socket.connect() when the client is unregistered and destroyed. Teardown
-// (stop()/dtor) must join the worker before tearing down m_socket, so the
-// worker cannot touch a freed socket (no use-after-free) and cannot outlive
-// *this. Under ThreadSanitizer the prior detached-worker race would be flagged
-// directly; without tsan the test pins that teardown completes cleanly with
-// the connect deterministically pending: it returns true, the on-ready action
-// never fired (the connect never completed — the canary that the saturation
-// held), and the whole sequence finishes promptly (bounded by the connect
-// timeout, asserted well below 5 s) with the loop healthy afterward.
+// the kernel never completes the handshake and the connect worker is still
+// blocked inside m_socket.connect() when the client is unregistered and
+// destroyed. Teardown (stop()/dtor) must join the worker before tearing down
+// m_socket, so the worker cannot touch a freed socket (no use-after-free) and
+// cannot outlive *this. That joined-worker/no-UAF invariant is enforced only
+// under ThreadSanitizer, which flags the detached-worker race directly; the
+// asserts below would all also pass with a detached worker. Without tsan this
+// is a teardown smoke/liveness test on a deterministically pending connect:
+// teardown returns true, the on-ready action never fired (the connect never
+// completed — the canary that the saturation held), and the whole sequence
+// finishes promptly with the loop healthy afterward.
 TEST(TlsClient, teardown_during_pending_connect_is_clean) {
     saturated_loopback_port blocked;
     ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
@@ -344,8 +346,8 @@ TEST(TlsClient, teardown_during_pending_connect_is_clean) {
                                                  connect_timeout_ms);
         client.set_on_ready_action([&ready_fired]() { ready_fired = true; });
         ASSERT_TRUE(ev.register_event_handler(&client));
-        // Pump the loop so the connect worker is mid-flight (blocked in TCP
-        // SYN retry against the saturated port) before teardown.
+        // Pump the loop so the connect worker is mid-flight (blocked on the
+        // never-completing connect to the saturated port) before teardown.
         for (int i = 0; i < 3; ++i) {
             ev.poll(50ms);
             ev.run_actions();

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_client.hpp>
+#include <everest/io/tls/tls_client_socket.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+/// Payload size that exceeds a single 4096-byte TLS-record read so the
+/// client-side rx() must drain SSL_pending() records in one call.
+constexpr std::size_t kLargePayload = 10000;
+
+/// Open an ephemeral 127.0.0.1 listen socket and return its fd + bound port.
+int make_listen_socket(uint16_t& bound_port) {
+    int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd < 0) {
+        return -1;
+    }
+    int opt = 1;
+    ::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0; // ephemeral
+    if (::bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 || ::listen(listen_fd, 1) != 0) {
+        ::close(listen_fd);
+        return -1;
+    }
+
+    sockaddr_in bound{};
+    socklen_t bound_len = sizeof(bound);
+    if (::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound), &bound_len) != 0) {
+        ::close(listen_fd);
+        return -1;
+    }
+    bound_port = ntohs(bound.sin_port);
+    return listen_fd;
+}
+
+/// Configure a tls::Server matching the test PKI on an already-listening socket.
+tls::Server::config_t make_server_config(int listen_fd, std::string const& port_str) {
+    tls::Server::config_t scfg;
+    scfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    scfg.ciphersuites = "";
+    auto& chain = scfg.chains.emplace_back();
+    chain.certificate_chain_file = "server_chain.pem";
+    chain.private_key_file = "server_priv.pem";
+    chain.trust_anchor_file = "server_root_cert.pem";
+    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
+    scfg.host = "127.0.0.1";
+    scfg.service = port_str.c_str();
+    scfg.ipv6_only = false;
+    scfg.verify_client = false;
+    scfg.io_timeout_ms = 1000;
+    scfg.socket = listen_fd; // bypass init_socket()
+    return scfg;
+}
+
+/// Build the client Config shared by the tests.
+everest::lib::io::tls::tls_client_socket::Config make_client_config() {
+    everest::lib::io::tls::tls_client_socket::Config cfg;
+    cfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    cfg.tls.ciphersuites = "";
+    cfg.tls.verify_locations_file = "server_root_cert.pem";
+    cfg.tls.io_timeout_ms = 1000;
+    cfg.tls.verify_server = true;
+    cfg.host_for_sni = "localhost";
+    return cfg;
+}
+
+} // namespace
+
+namespace everest::lib::io::tls {
+// Test seam (no friendship): re-expose the otherwise-internal tcp_socket so the
+// ownership-surrender checks below can confirm m_tcp released its fd to the BIO.
+struct testable_client_socket : tls_client_socket {
+    using tls_client_socket::m_tcp;
+};
+} // namespace everest::lib::io::tls
+
+// After the async TCP connect + fd wrap, connect() releases m_tcp once it
+// returns; the connection owns the fd, m_tcp must have surrendered it. This
+// exercises the UNCHANGED synchronous tls_client_socket::connect() wrap path.
+TEST(tls_client_socket, fd_ownership_released_after_async_wrap) {
+    uint16_t bound_port = 0;
+    int listen_fd = make_listen_socket(bound_port);
+    ASSERT_GE(listen_fd, 0);
+
+    everest::lib::io::tls::testable_client_socket sock;
+    auto cfg = make_client_config();
+    // setup() does no network I/O, so assert it before spawning the server
+    // thread (no joinable thread is live yet if it fails).
+    ASSERT_TRUE(sock.setup(std::move(cfg), "127.0.0.1", bound_port, 2000));
+
+    // connect() only wraps the TCP fd (no TLS handshake), so the server thread
+    // just needs to accept the TCP connection and exit. accept() is blocking;
+    // the client's TCP connect unblocks it.
+    std::thread server_thread([&]() {
+        sockaddr peer{};
+        socklen_t peer_len = sizeof(peer);
+        int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+        if (accepted_fd >= 0) {
+            ::close(accepted_fd);
+        }
+    });
+
+    bool ok = false;
+    sock.connect([&](bool o, int /*fd*/) { ok = o; }); // synchronous; returns AFTER release
+    const int tcp_fd_after = sock.m_tcp.get_fd();
+
+    // Join before asserting so a fatal ASSERT cannot return with the thread
+    // still joinable (std::terminate). connect() drove the TCP connect, so the
+    // server's accept() has returned and the thread is exiting.
+    sock.close();
+    server_thread.join();
+    ::close(listen_fd);
+
+    ASSERT_TRUE(ok) << "TCP connect / fd wrap failed";
+    EXPECT_EQ(tcp_fd_after, everest::lib::io::event::unique_fd::NO_DESCRIPTOR_SENTINEL)
+        << "m_tcp still owns the fd after async wrap -> double-close on teardown";
+}
+
+// tls_client (the loop-driven register-interface class): register with an
+// fd_event_handler, drive the loop against a background raw tls::Server. The
+// on-ready action must fire after the handshake; a small tx request must elicit
+// a > 4096-byte rx reply that rx() drains via SSL_pending() in one delivery.
+TEST(TlsClient, HandshakeAndExchange) {
+    uint16_t bound_port = 0;
+    int listen_fd = make_listen_socket(bound_port);
+    ASSERT_GE(listen_fd, 0);
+    const std::string port_str = std::to_string(bound_port);
+
+    tls::Server server;
+    const auto state = server.init(make_server_config(listen_fd, port_str), nullptr);
+    ASSERT_NE(state, tls::Server::state_t::init_needed)
+        << "tls::Server::init failed — check that server_chain.pem etc. exist "
+           "in the working directory (lib/everest/tls/tests in the build tree).";
+
+    // Background server thread: accept, handshake, read the small request, reply
+    // with a > 4096-byte payload so the client rx() must drain SSL_pending().
+    std::atomic<bool> server_ok{false};
+    std::string server_error;
+    std::thread server_thread([&]() {
+        sockaddr peer{};
+        socklen_t peer_len = sizeof(peer);
+        int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+        if (accepted_fd < 0) {
+            server_error = "accept failed";
+            return;
+        }
+
+        char ip_buf[NI_MAXHOST] = "127.0.0.1";
+        char svc_buf[NI_MAXSERV] = "0";
+        ::getnameinfo(&peer, peer_len, ip_buf, sizeof ip_buf, svc_buf, sizeof svc_buf, NI_NUMERICHOST | NI_NUMERICSERV);
+
+        auto conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (!conn) {
+            server_error = "wrap_accepted_fd returned nullptr";
+            return;
+        }
+        if (conn->accept(2000) != tls::Connection::result_t::success) {
+            server_error = "server TLS handshake failed";
+            return;
+        }
+
+        std::byte buf[64]{};
+        std::size_t nread = 0;
+        if (conn->read(buf, sizeof buf, nread, 2000) != tls::Connection::result_t::success) {
+            server_error = "server read failed";
+            return;
+        }
+
+        std::vector<uint8_t> reply(kLargePayload);
+        for (std::size_t i = 0; i < reply.size(); ++i) {
+            reply[i] = static_cast<uint8_t>(i & 0xFF);
+        }
+        std::size_t written = 0;
+        if (conn->write(reinterpret_cast<const std::byte*>(reply.data()), reply.size(), written, 2000) !=
+                tls::Connection::result_t::success ||
+            written != reply.size()) {
+            server_error = "server write failed";
+            return;
+        }
+
+        conn->shutdown(0);
+        server_ok = true;
+    });
+
+    // Client side: construct, attach handlers, register on the loop and drive it.
+    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
+
+    everest::lib::io::event::fd_event_handler ev;
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> ready_fired{false};
+    std::vector<std::uint8_t> rx_buf;
+
+    client.set_on_ready_action([&client, &ready_fired]() {
+        ready_fired = true;
+        everest::lib::io::tls::tls_client_socket::PayloadT msg = {'h', 'i'};
+        client.tx(msg);
+    });
+    client.set_rx_handler(
+        [&rx_buf, &running](everest::lib::io::tls::tls_client_socket::PayloadT const& payload, auto&) {
+            rx_buf.insert(rx_buf.end(), payload.begin(), payload.end());
+            if (rx_buf.size() >= kLargePayload) {
+                running = false;
+            }
+        });
+    ASSERT_TRUE(ev.register_event_handler(&client));
+
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (running && std::chrono::steady_clock::now() < deadline) {
+        ev.poll(50ms);
+        ev.run_actions();
+    }
+    running = false;
+
+    server_thread.join();
+    ::close(listen_fd);
+
+    EXPECT_TRUE(ready_fired) << "on-ready action did not fire after handshake";
+    ASSERT_EQ(rx_buf.size(), kLargePayload) << "rx() did not drain all buffered TLS records in one call";
+    for (std::size_t i = 0; i < rx_buf.size(); ++i) {
+        ASSERT_EQ(rx_buf[i], static_cast<uint8_t>(i & 0xFF)) << "payload corruption at index " << i;
+    }
+    EXPECT_TRUE(server_ok) << "Server error: " << server_error;
+}
+
+// Teardown while the TCP connect is still pending. The client targets a
+// non-routable TEST-NET-2 address so the connect never resolves within the
+// test window; the connect worker is still blocked inside m_socket.connect()
+// when the client is unregistered and destroyed. Destruction must join the
+// worker before tearing down m_socket, so the worker cannot touch a freed
+// socket (no use-after-free) and cannot outlive *this. Under ThreadSanitizer
+// this would flag the prior detached-worker race directly; without tsan the
+// test pins the deterministic invariant that destruction blocks until the
+// worker has joined: with the connect still pending (bounded by the connect
+// timeout), tearing down must not return before the worker stops touching the
+// socket. The old detached-worker path returned immediately while the worker
+// kept running; the joined path returns only after the worker is done.
+TEST(TlsClient, teardown_during_pending_connect_is_clean) {
+    everest::lib::io::event::fd_event_handler ev;
+    constexpr int connect_timeout_ms = 500;
+    std::chrono::steady_clock::time_point teardown_start{};
+    {
+        everest::lib::io::tls::tls_client client(make_client_config(), std::string("198.51.100.1"), 4433,
+                                                 connect_timeout_ms);
+        ASSERT_TRUE(ev.register_event_handler(&client));
+        // Pump the loop so the connect worker is mid-flight (blocked inside
+        // m_socket.connect() on the unreachable host) before teardown.
+        for (int i = 0; i < 3; ++i) {
+            ev.poll(50ms);
+            ev.run_actions();
+        }
+        // Start the clock just before teardown begins: unregister runs stop()
+        // and the closing brace runs the destructor — both must wait for the
+        // worker to join while the connect is still pending.
+        teardown_start = std::chrono::steady_clock::now();
+        ev.unregister_event_handler(&client);
+        // client destroyed at the closing brace below, connect still pending —
+        // teardown must join the worker, not return into a UAF window.
+    }
+    const auto teardown_elapsed = std::chrono::steady_clock::now() - teardown_start;
+
+    // The connect worker is blocked inside m_socket.connect() on the unreachable
+    // host for ~connect_timeout_ms; a joined teardown cannot return until that
+    // blocking connect finishes. The old detached-worker path returned at once
+    // (the worker raced on free'd state). Assert teardown actually waited for the
+    // worker, i.e. it blocked for a meaningful fraction of the connect timeout.
+    EXPECT_GE(teardown_elapsed, std::chrono::milliseconds(connect_timeout_ms / 2))
+        << "teardown returned before the pending connect worker joined "
+           "(detached/non-joined worker can outlive the client and touch freed state)";
+
+    // Loop stays healthy after teardown; no crash/hang.
+    for (int i = 0; i < 3; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+    SUCCEED();
+}
+
+// Registering the same client twice without an intervening unregister must be
+// rejected, not re-run start(). fd_event_handler forwards an interface register
+// straight to register_events() with no interface-level dedup, so a second
+// register would call start() again and move-assign a std::thread onto the
+// still-joinable connect worker -> std::terminate. The register_events() guard
+// makes the second register a clean no-op returning false.
+TEST(TlsClient, double_register_is_rejected_not_fatal) {
+    everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::tls_client client(make_client_config(), std::string("198.51.100.1"), 4433, 500);
+
+    ASSERT_TRUE(ev.register_event_handler(&client)) << "first register should succeed and start the worker";
+    // Second register without an intervening unregister: must return false and
+    // must NOT re-enter start() (which would std::terminate by move-assigning
+    // onto the live worker).
+    EXPECT_FALSE(ev.register_event_handler(&client)) << "double register must be rejected, not re-start the endpoint";
+
+    // Clean teardown joins the worker; the loop stays healthy afterward.
+    ev.unregister_event_handler(&client);
+    for (int i = 0; i < 3; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+    SUCCEED();
+}

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -171,6 +171,15 @@ namespace everest::lib::io::tls {
 struct testable_client_socket : tls_client_socket {
     using tls_client_socket::m_tcp;
 };
+
+// Test seam: re-expose the endpoint's registered fds and socket so the teardown
+// tests can confirm the handler entries are gone and the connection state.
+struct testable_client : tls_client {
+    using tls_client::tls_client;
+    using tls_endpoint_base<tls_client_socket>::m_fd;
+    using tls_endpoint_base<tls_client_socket>::m_socket;
+    using tls_endpoint_base<tls_client_socket>::m_tx_notify;
+};
 } // namespace everest::lib::io::tls
 
 // After connect() wraps the connected TCP fd, the connection's BIO is the
@@ -282,9 +291,10 @@ TEST(TlsClient, HandshakeAndExchange) {
     });
 
     // Client side: construct, attach handlers, register on the loop and drive it.
-    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
-
+    // The handler must outlive the endpoint (the client dtor unregisters from the
+    // handler), so declare it first.
     everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
 
     std::atomic<bool> running{true};
     std::atomic<bool> ready_fired{false};
@@ -418,8 +428,10 @@ TEST(TlsClient, poll_error_delivers_nonzero_code) {
         conn.reset();
     });
 
-    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
+    // The handler must outlive the endpoint (the client dtor unregisters from the
+    // handler), so declare it first.
     everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
 
     std::atomic<bool> got_error{false};
     std::atomic<int> err_code{-1};
@@ -441,6 +453,84 @@ TEST(TlsClient, poll_error_delivers_nonzero_code) {
 
     ASSERT_TRUE(got_error) << "error handler never fired after a peer RST";
     EXPECT_NE(err_code.load(), 0) << "error handler received code 0 on the poll-error (RST) path";
+}
+
+// P2: dropping a still-registered endpoint (the README's documented teardown,
+// "connections.clear()") must not leave its this-capturing lambdas registered
+// in the handler. The destructor must unregister the connection fd and the
+// tx-notify eventfd; otherwise the handler keeps stale entries referencing a
+// freed object. After the drop, re-registering those fd numbers must succeed
+// (a stale entry makes the map's exists() guard reject the register).
+TEST(TlsClient, drop_registered_endpoint_unregisters_fds) {
+    uint16_t bound_port = 0;
+    int listen_fd = make_listen_socket(bound_port);
+    ASSERT_GE(listen_fd, 0);
+    const std::string port_str = std::to_string(bound_port);
+
+    tls::Server server;
+    ASSERT_NE(server.init(make_server_config(listen_fd, port_str), nullptr), tls::Server::state_t::init_needed);
+
+    // Server: accept + handshake, then hold the connection open until released so
+    // the client stays live while it is dropped.
+    std::atomic<bool> release_server{false};
+    std::thread server_thread([&]() {
+        sockaddr peer{};
+        socklen_t peer_len = sizeof(peer);
+        int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+        if (accepted_fd < 0) {
+            return;
+        }
+        char ip_buf[NI_MAXHOST] = "127.0.0.1";
+        char svc_buf[NI_MAXSERV] = "0";
+        ::getnameinfo(&peer, peer_len, ip_buf, sizeof ip_buf, svc_buf, sizeof svc_buf, NI_NUMERICHOST | NI_NUMERICSERV);
+        auto conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (!conn) {
+            ::close(accepted_fd);
+            return;
+        }
+        if (conn->accept(2000) != tls::Connection::result_t::success) {
+            return;
+        }
+        while (!release_server.load()) {
+            std::this_thread::sleep_for(10ms);
+        }
+        conn->shutdown(0);
+    });
+
+    everest::lib::io::event::fd_event_handler ev;
+    int conn_fd = -1;
+    int notify_fd = -1;
+    {
+        everest::lib::io::tls::testable_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
+        std::atomic<bool> ready{false};
+        client.set_on_ready_action([&ready]() { ready = true; });
+        ASSERT_TRUE(ev.register_event_handler(&client));
+        test::pump_until(
+            ev, [&] { return ready.load(); }, 5s);
+        ASSERT_TRUE(ready) << "handshake did not complete before the drop";
+        conn_fd = client.m_fd;
+        notify_fd = client.m_tx_notify.get_raw_fd();
+        ASSERT_GE(conn_fd, 0);
+        ASSERT_GE(notify_fd, 0);
+        // Drop WITHOUT unregister at the closing brace.
+    }
+
+    // Nothing here opens new fds, so conn_fd / notify_fd stay closed-but-unclaimed;
+    // driving the loop after the drop must not crash.
+    for (int i = 0; i < 5; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+
+    auto noop = [](auto&&) {};
+    EXPECT_TRUE(ev.register_event_handler(conn_fd, noop, everest::lib::io::event::poll_events::read))
+        << "connection fd still registered after dropping the endpoint";
+    EXPECT_TRUE(ev.register_event_handler(notify_fd, noop, everest::lib::io::event::poll_events::read))
+        << "tx-notify fd still registered after dropping the endpoint";
+
+    release_server = true;
+    server_thread.join();
+    ::close(listen_fd);
 }
 
 // Registering the same client twice without an intervening unregister must be

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -13,10 +13,12 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <cstring>
 #include <string>
@@ -75,6 +77,91 @@ tls::Server::config_t make_server_config(int listen_fd, std::string const& port_
 everest::lib::io::tls::tls_client_socket::Config make_client_config() {
     return test::client_test_config(1000, "localhost");
 }
+
+/// Open a raw non-blocking IPv4 socket and start a connect to 127.0.0.1:port.
+/// Returns the fd with the connect completed or in flight, or -1 on a hard
+/// socket()/connect() failure.
+int start_nonblocking_connect(uint16_t port) {
+    int fd = ::socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = htons(port);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0 && errno != EINPROGRESS) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+/// True if the pending connect on fd completed cleanly within wait_ms (POLLOUT
+/// without POLLERR/POLLHUP). A connect whose SYN was dropped stays in SYN_SENT
+/// (first retransmit is ~1 s out) and reports nothing within the window.
+bool connect_completed(int fd, int wait_ms) {
+    pollfd pfd{fd, POLLOUT, 0};
+    return ::poll(&pfd, 1, wait_ms) == 1 && (pfd.revents & POLLOUT) != 0 &&
+           (pfd.revents & (POLLERR | POLLHUP)) == 0;
+}
+
+/// A 127.0.0.1 listen socket whose accept queue is deliberately saturated:
+/// listen(fd, 1), never accept, and raw pre-connects issued until one no
+/// longer completes. Once the queue is full the kernel drops further SYNs
+/// (tcp_abort_on_overflow=0 default), so any later connect to port() stalls
+/// in TCP SYN retry — a deterministic loopback stand-in for an unreachable
+/// host. The stalled final pre-connect doubles as the saturation probe. All
+/// fds (listener + pre-connect sockets) stay open until destruction so the
+/// block holds for the object's whole lifetime.
+class saturated_loopback_port {
+public:
+    saturated_loopback_port() {
+        m_listen_fd = make_listen_socket(m_port);
+        if (m_listen_fd < 0) {
+            return;
+        }
+        // Linux admits roughly backlog+1 queued connections for listen(fd, 1);
+        // keep connecting until one stalls (capped as a safety margin).
+        for (int i = 0; i < max_pre_connects; ++i) {
+            const int fd = start_nonblocking_connect(m_port);
+            if (fd < 0) {
+                return;
+            }
+            m_fds.push_back(fd);
+            if (!connect_completed(fd, 200)) {
+                m_saturated = true;
+                return;
+            }
+        }
+    }
+
+    saturated_loopback_port(saturated_loopback_port const&) = delete;
+    saturated_loopback_port& operator=(saturated_loopback_port const&) = delete;
+
+    ~saturated_loopback_port() {
+        for (int fd : m_fds) {
+            ::close(fd);
+        }
+        if (m_listen_fd >= 0) {
+            ::close(m_listen_fd);
+        }
+    }
+
+    bool saturated() const {
+        return m_saturated;
+    }
+    uint16_t port() const {
+        return m_port;
+    }
+
+private:
+    static constexpr int max_pre_connects = 8;
+    int m_listen_fd{-1};
+    uint16_t m_port{0};
+    std::vector<int> m_fds;
+    bool m_saturated{false};
+};
 
 } // namespace
 
@@ -232,49 +319,46 @@ TEST(TlsClient, HandshakeAndExchange) {
 }
 
 // Teardown while the TCP connect is still pending. The client targets a
-// non-routable TEST-NET-2 address so the connect never resolves within the
-// test window; the connect worker is still blocked inside m_socket.connect()
-// when the client is unregistered and destroyed. Destruction must join the
-// worker before tearing down m_socket, so the worker cannot touch a freed
-// socket (no use-after-free) and cannot outlive *this. Under ThreadSanitizer
-// this would flag the prior detached-worker race directly; without tsan the
-// test pins the deterministic invariant that destruction blocks until the
-// worker has joined: with the connect still pending (bounded by the connect
-// timeout), tearing down must not return before the worker stops touching the
-// socket. The old detached-worker path returned immediately while the worker
-// kept running; the joined path returns only after the worker is done.
+// loopback port whose accept queue is saturated (saturated_loopback_port), so
+// its SYNs are dropped and the connect worker is still blocked inside
+// m_socket.connect() when the client is unregistered and destroyed. Teardown
+// (stop()/dtor) must join the worker before tearing down m_socket, so the
+// worker cannot touch a freed socket (no use-after-free) and cannot outlive
+// *this. Under ThreadSanitizer the prior detached-worker race would be flagged
+// directly; without tsan the test pins that teardown completes cleanly with
+// the connect deterministically pending: it returns true, the on-ready action
+// never fired (the connect never completed — the canary that the saturation
+// held), and the whole sequence finishes promptly (bounded by the connect
+// timeout, asserted well below 5 s) with the loop healthy afterward.
 TEST(TlsClient, teardown_during_pending_connect_is_clean) {
+    saturated_loopback_port blocked;
+    ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
+
     everest::lib::io::event::fd_event_handler ev;
-    constexpr int connect_timeout_ms = 500;
-    std::chrono::steady_clock::time_point teardown_start{};
+    constexpr int connect_timeout_ms = 300;
+    std::atomic<bool> ready_fired{false};
+    bool unregistered = false;
+    const auto start = std::chrono::steady_clock::now();
     {
-        everest::lib::io::tls::tls_client client(make_client_config(), std::string("198.51.100.1"), 4433,
+        everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), blocked.port(),
                                                  connect_timeout_ms);
+        client.set_on_ready_action([&ready_fired]() { ready_fired = true; });
         ASSERT_TRUE(ev.register_event_handler(&client));
-        // Pump the loop so the connect worker is mid-flight (blocked inside
-        // m_socket.connect() on the unreachable host) before teardown.
+        // Pump the loop so the connect worker is mid-flight (blocked in TCP
+        // SYN retry against the saturated port) before teardown.
         for (int i = 0; i < 3; ++i) {
             ev.poll(50ms);
             ev.run_actions();
         }
-        // Start the clock just before teardown begins: unregister runs stop()
-        // and the closing brace runs the destructor — both must wait for the
-        // worker to join while the connect is still pending.
-        teardown_start = std::chrono::steady_clock::now();
-        ev.unregister_event_handler(&client);
+        unregistered = ev.unregister_event_handler(&client);
         // client destroyed at the closing brace below, connect still pending —
         // teardown must join the worker, not return into a UAF window.
     }
-    const auto teardown_elapsed = std::chrono::steady_clock::now() - teardown_start;
+    const auto elapsed = std::chrono::steady_clock::now() - start;
 
-    // The connect worker is blocked inside m_socket.connect() on the unreachable
-    // host for ~connect_timeout_ms; a joined teardown cannot return until that
-    // blocking connect finishes. The old detached-worker path returned at once
-    // (the worker raced on free'd state). Assert teardown actually waited for the
-    // worker, i.e. it blocked for a meaningful fraction of the connect timeout.
-    EXPECT_GE(teardown_elapsed, std::chrono::milliseconds(connect_timeout_ms / 2))
-        << "teardown returned before the pending connect worker joined "
-           "(detached/non-joined worker can outlive the client and touch freed state)";
+    EXPECT_TRUE(unregistered) << "unregister of the pending-connect client failed";
+    EXPECT_FALSE(ready_fired) << "on-ready fired — the connect completed, so the backlog saturation did not hold";
+    EXPECT_LT(elapsed, 5s) << "teardown of a pending connect must be bounded by the connect timeout";
 
     // Loop stays healthy after teardown; no crash/hang.
     for (int i = 0; i < 3; ++i) {
@@ -291,8 +375,11 @@ TEST(TlsClient, teardown_during_pending_connect_is_clean) {
 // still-joinable connect worker -> std::terminate. The register_events() guard
 // makes the second register a clean no-op returning false.
 TEST(TlsClient, double_register_is_rejected_not_fatal) {
+    saturated_loopback_port blocked;
+    ASSERT_TRUE(blocked.saturated()) << "could not saturate the loopback accept queue";
+
     everest::lib::io::event::fd_event_handler ev;
-    everest::lib::io::tls::tls_client client(make_client_config(), std::string("198.51.100.1"), 4433, 500);
+    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), blocked.port(), 300);
 
     ASSERT_TRUE(ev.register_event_handler(&client)) << "first register should succeed and start the worker";
     // Second register without an intervening unregister: must return false and

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -11,6 +11,7 @@
 #include <gtest/gtest.h>
 
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <poll.h>
@@ -529,6 +530,109 @@ TEST(TlsClient, drop_registered_endpoint_unregisters_fds) {
         << "tx-notify fd still registered after dropping the endpoint";
 
     release_server = true;
+    server_thread.join();
+    ::close(listen_fd);
+}
+
+// P3: fail() closes the connection fd but defers the handler removal by fd
+// number to run_actions(). If the close were synchronous, the fd number frees
+// while the deferred remove is still pending, so an accept in the same poll
+// batch could recycle it and the stale remove-by-number would then strand the
+// new connection. The fix keeps the fd number reserved until AFTER the handler
+// entry is removed: the close must be deferred alongside the removal, not run
+// synchronously inside the dispatch pass. Assert the fd is still open right
+// after fail() runs (before run_actions) and closed only afterwards.
+TEST(TlsClient, fail_defers_fd_close_until_after_unregister) {
+    uint16_t bound_port = 0;
+    int listen_fd = make_listen_socket(bound_port);
+    ASSERT_GE(listen_fd, 0);
+    const std::string port_str = std::to_string(bound_port);
+
+    tls::Server server;
+    ASSERT_NE(server.init(make_server_config(listen_fd, port_str), nullptr), tls::Server::state_t::init_needed);
+
+    // Server: accept + handshake + read the ping, then RST on demand so the test
+    // controls when the client's fail() path runs.
+    std::atomic<bool> release_rst{false};
+    std::thread server_thread([&]() {
+        sockaddr peer{};
+        socklen_t peer_len = sizeof(peer);
+        int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+        if (accepted_fd < 0) {
+            return;
+        }
+        char ip_buf[NI_MAXHOST] = "127.0.0.1";
+        char svc_buf[NI_MAXSERV] = "0";
+        ::getnameinfo(&peer, peer_len, ip_buf, sizeof ip_buf, svc_buf, sizeof svc_buf, NI_NUMERICHOST | NI_NUMERICSERV);
+        auto conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (!conn) {
+            ::close(accepted_fd);
+            return;
+        }
+        if (conn->accept(2000) != tls::Connection::result_t::success) {
+            return;
+        }
+        std::byte buf[64]{};
+        std::size_t nread = 0;
+        (void)conn->read(buf, sizeof buf, nread, 2000);
+        while (!release_rst.load()) {
+            std::this_thread::sleep_for(10ms);
+        }
+        struct linger lo {
+            1, 0
+        };
+        ::setsockopt(accepted_fd, SOL_SOCKET, SO_LINGER, &lo, sizeof(lo));
+        conn.reset();
+    });
+
+    // Handler must outlive the endpoint.
+    everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::testable_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
+
+    std::atomic<bool> ready{false};
+    std::atomic<bool> got_error{false};
+    client.set_on_ready_action([&client, &ready]() {
+        everest::lib::io::tls::tls_client_socket::PayloadT msg = {'p', 'i', 'n', 'g'};
+        client.tx(msg);
+        ready = true;
+    });
+    client.set_error_handler([&got_error](int, std::string const&) { got_error = true; });
+    ASSERT_TRUE(ev.register_event_handler(&client));
+
+    // Drive to ready and capture the live connection fd (fail() will reset m_fd
+    // to -1 as it hands the fd off to the deferred teardown).
+    test::pump_until(
+        ev, [&] { return ready.load(); }, 5s);
+    ASSERT_TRUE(ready) << "handshake did not complete";
+    const int conn_fd = client.m_fd;
+    ASSERT_GE(conn_fd, 0);
+
+    // Trigger the RST and stop the loop on the exact poll that fires the error,
+    // before run_actions() drains the deferred teardown.
+    release_rst = true;
+    bool checked_open = false;
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline && !checked_open) {
+        ev.poll(50ms);
+        if (got_error.load()) {
+            // fail() has run in this dispatch pass. The fd must still be open: a
+            // synchronous close would have freed the number before the deferred
+            // remove_event_handler(fd) runs.
+            EXPECT_NE(::fcntl(conn_fd, F_GETFD), -1)
+                << "connection fd was closed synchronously in fail() (recycle race window)";
+            checked_open = true;
+        }
+        ev.run_actions();
+    }
+    ASSERT_TRUE(checked_open) << "error path never ran";
+
+    // After the deferred teardown ran, the fd is closed and its handler entry is
+    // gone (its number is re-registerable).
+    EXPECT_EQ(::fcntl(conn_fd, F_GETFD), -1) << "connection fd still open after run_actions()";
+    auto noop = [](auto&&) {};
+    EXPECT_TRUE(ev.register_event_handler(conn_fd, noop, everest::lib::io::event::poll_events::read))
+        << "connection fd still registered after the deferred teardown";
+
     server_thread.join();
     ::close(listen_fd);
 }

--- a/lib/everest/io/test/tls_client_socket_test.cpp
+++ b/lib/everest/io/test/tls_client_socket_test.cpp
@@ -369,6 +369,80 @@ TEST(TlsClient, teardown_during_pending_connect_is_clean) {
     SUCCEED();
 }
 
+// P1: an EPOLLERR/EPOLLHUP on a live, post-handshake connection with no prior
+// TLS-op failure must deliver a NONZERO error code. A peer RST (SO_LINGER{1,0}
+// + close) after the handshake makes epoll report error/hungup while the socket
+// still holds a live connection and m_last_error is 0, so get_error() resolves
+// to 0. Every shipped example ignores the callback via `if (err != 0)`, so a 0
+// code silently strands the endpoint. The handler must observe a nonzero code.
+TEST(TlsClient, poll_error_delivers_nonzero_code) {
+    uint16_t bound_port = 0;
+    int listen_fd = make_listen_socket(bound_port);
+    ASSERT_GE(listen_fd, 0);
+    const std::string port_str = std::to_string(bound_port);
+
+    tls::Server server;
+    const auto state = server.init(make_server_config(listen_fd, port_str), nullptr);
+    ASSERT_NE(state, tls::Server::state_t::init_needed);
+
+    // Background server: accept, complete the handshake, read the client ping so
+    // the client is fully handshaked and armed for read, then RST.
+    std::thread server_thread([&]() {
+        sockaddr peer{};
+        socklen_t peer_len = sizeof(peer);
+        int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+        if (accepted_fd < 0) {
+            return;
+        }
+        char ip_buf[NI_MAXHOST] = "127.0.0.1";
+        char svc_buf[NI_MAXSERV] = "0";
+        ::getnameinfo(&peer, peer_len, ip_buf, sizeof ip_buf, svc_buf, sizeof svc_buf, NI_NUMERICHOST | NI_NUMERICSERV);
+        auto conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (!conn) {
+            ::close(accepted_fd);
+            return;
+        }
+        if (conn->accept(2000) != tls::Connection::result_t::success) {
+            return;
+        }
+        std::byte buf[64]{};
+        std::size_t nread = 0;
+        (void)conn->read(buf, sizeof buf, nread, 2000);
+        // Zero-linger close discards the send queue and emits a RST instead of a
+        // graceful close_notify/FIN: the client sees EPOLLERR/EPOLLHUP with no
+        // readable TLS record. The BIO (BIO_CLOSE) closes accepted_fd on reset.
+        struct linger lo {
+            1, 0
+        };
+        ::setsockopt(accepted_fd, SOL_SOCKET, SO_LINGER, &lo, sizeof(lo));
+        conn.reset();
+    });
+
+    everest::lib::io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), bound_port, 2000);
+    everest::lib::io::event::fd_event_handler ev;
+
+    std::atomic<bool> got_error{false};
+    std::atomic<int> err_code{-1};
+    client.set_on_ready_action([&client]() {
+        everest::lib::io::tls::tls_client_socket::PayloadT msg = {'p', 'i', 'n', 'g'};
+        client.tx(msg);
+    });
+    client.set_error_handler([&](int err, std::string const&) {
+        err_code = err;
+        got_error = true;
+    });
+    ASSERT_TRUE(ev.register_event_handler(&client));
+
+    test::pump_until(
+        ev, [&] { return got_error.load(); }, 5s);
+
+    server_thread.join();
+    ::close(listen_fd);
+
+    ASSERT_TRUE(got_error) << "error handler never fired after a peer RST";
+    EXPECT_NE(err_code.load(), 0) << "error handler received code 0 on the poll-error (RST) path";
+}
+
 // Registering the same client twice without an intervening unregister must be
 // rejected, not re-run start(). fd_event_handler forwards an interface register
 // straight to register_events() with no interface-level dedup, so a second

--- a/lib/everest/io/test/tls_e2e_test.cpp
+++ b/lib/everest/io/test/tls_e2e_test.cpp
@@ -331,6 +331,59 @@ TEST(TlsE2E, ServerCloseTearsDownClientWithoutCrash) {
     }
 }
 
+// A payload enqueued via tx() right after register_event_handler() returns —
+// before the TCP connect has yielded a connection fd, let alone before the
+// handshake completed — must be held and flushed once the handshake finishes.
+// The eventfd tx-notify fired while m_fd was still -1, so the flush depends on
+// the handshake-completion path re-arming POLLOUT for the queued payload.
+TEST(TlsE2E, tx_queued_before_handshake_is_flushed_after_ready) {
+    io::tls::tls_listener listener(make_listener_config());
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+
+    io::event::fd_event_handler ev;
+
+    std::unique_ptr<io::tls::tls_server> server_conn;
+    listener.set_accept_callback(
+        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
+            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+                self.tx(payload); // echo
+            });
+            ev.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+
+    io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> running{true};
+    const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+    std::vector<std::uint8_t> echo;
+
+    client.set_rx_handler([&echo, &ping, &running](tls_payload const& payload, auto&) {
+        echo.insert(echo.end(), payload.begin(), payload.end());
+        if (echo.size() >= ping.size()) {
+            running = false;
+        }
+    });
+    ev.register_event_handler(&client);
+
+    // Send BEFORE the handshake (or even the TCP connect) has completed: no
+    // on-ready action involved. The payload must be queued and flushed later.
+    tls_payload msg(ping.begin(), ping.end());
+    ASSERT_TRUE(client.tx(msg)) << "tx() rejected a payload queued before the handshake";
+
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (running && std::chrono::steady_clock::now() < deadline) {
+        ev.poll(50ms);
+        ev.run_actions();
+    }
+    running = false;
+
+    ASSERT_EQ(echo.size(), ping.size()) << "payload queued before the handshake was never flushed within 5 seconds";
+    EXPECT_EQ(echo, ping) << "echoed payload differs from sent payload";
+}
+
 // Explicit unregister of a tls_client must run the client stop() hook so the
 // m_connected event it registered in start() is torn down alongside the base
 // connection fd / tx-notify. Regression guard for the register/unregister

--- a/lib/everest/io/test/tls_e2e_test.cpp
+++ b/lib/everest/io/test/tls_e2e_test.cpp
@@ -224,10 +224,14 @@ TEST(TlsE2E, WrongHostnameVerificationFails) {
     std::atomic<bool> got_error{false};
     std::atomic<bool> got_echo{false};
     const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+    // The handler runs on the loop thread, same thread as the assertions below,
+    // so a plain string capture is safe.
+    std::string error_text;
 
-    client.set_error_handler([&got_error, &running](int err, std::string const& /*msg*/) {
+    client.set_error_handler([&got_error, &running, &error_text](int err, std::string const& msg) {
         if (err != 0) {
             got_error = true;
+            error_text = msg;
             running = false;
         }
     });
@@ -253,6 +257,7 @@ TEST(TlsE2E, WrongHostnameVerificationFails) {
 
     EXPECT_FALSE(got_echo) << "round-trip completed despite a hostname mismatch";
     EXPECT_TRUE(got_error) << "client error handler did not fire on a hostname mismatch within 3 seconds";
+    EXPECT_FALSE(error_text.empty()) << "error handler received an empty string instead of the OpenSSL error text";
 }
 
 // Steady-state teardown: after a successful handshake and round-trip the server

--- a/lib/everest/io/test/tls_e2e_test.cpp
+++ b/lib/everest/io/test/tls_e2e_test.cpp
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// End-to-end test: a tls_listener (server) AND a tls_client (the alias) driven
+// on the SAME single fd_event_handler loop, on one thread. The client's TCP
+// connect runs on a detached worker thread; the listen backlog buffers the SYN
+// so the loop accepts it once polling starts. Both TLS handshakes are then
+// driven on the one loop (nested fd_event_sync_interface model). This exercises
+// the full > 4096-byte drain path and RFC-6125 hostname verification.
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_client.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+namespace io = everest::lib::io;
+
+using tls_payload = io::tls::tls_client_socket::PayloadT;
+
+/// Payload larger than a single 4096-byte TLS record so the rx() path must
+/// drain SSL_pending() to return the whole message.
+constexpr std::size_t kLargePayload = 10000;
+
+/// Build a > 4096-byte patterned payload for round-trip verification.
+std::vector<std::uint8_t> make_large_payload() {
+    std::vector<std::uint8_t> payload(kLargePayload);
+    for (std::size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<std::uint8_t>((i * 31 + 7) & 0xFF);
+    }
+    return payload;
+}
+
+/// Populate a tls_listener::Config with the test PKI and an ephemeral bind on
+/// 127.0.0.1. Mirrors the listener config used in tls_listener_test.cpp.
+io::tls::tls_listener::Config make_listener_config() {
+    io::tls::tls_listener::Config lcfg;
+    lcfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    lcfg.tls.ciphersuites = "";
+    auto& chain = lcfg.tls.chains.emplace_back();
+    chain.certificate_chain_file = "server_chain.pem";
+    chain.private_key_file = "server_priv.pem";
+    chain.trust_anchor_file = "server_root_cert.pem";
+    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
+    lcfg.tls.verify_client = false;
+    lcfg.tls.io_timeout_ms = 1000;
+    lcfg.bind_addr = "127.0.0.1";
+    lcfg.bind_port = 0;
+    lcfg.ipv6_only = false;
+    return lcfg;
+}
+
+/// Base client config that trusts the test server root so chain validation
+/// passes. Hostname verification is left off by default (opt in per test).
+io::tls::tls_client_socket::Config make_client_config() {
+    io::tls::tls_client_socket::Config cfg;
+    cfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    cfg.tls.ciphersuites = "";
+    cfg.tls.verify_locations_file = "server_root_cert.pem";
+    cfg.tls.io_timeout_ms = 2000;
+    cfg.tls.verify_server = true;
+    return cfg;
+}
+
+} // namespace
+
+// A tls_listener (server) and a tls_client (the alias) share one
+// fd_event_handler on one thread. The client sends a > 4096-byte payload, the
+// server echoes it, and the loop drives both TLS handshakes plus the round-trip.
+// Asserts the FULL payload round-trips intact (size + byte content).
+TEST(TlsE2E, RoundTripLargePayloadSingleLoop) {
+    io::tls::tls_listener listener(make_listener_config());
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+
+    io::event::fd_event_handler ev;
+
+    // The yielded tls_server must outlive the accept callback; the loop drives
+    // its handshake/rx/tx after register_event_handler().
+    std::unique_ptr<io::tls::tls_server> server_conn;
+    listener.set_accept_callback(
+        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
+            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+                self.tx(payload); // echo
+            });
+            ev.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+
+    const auto expected = make_large_payload();
+
+    io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> running{true};
+    std::vector<std::uint8_t> echo;
+    echo.reserve(kLargePayload);
+
+    client.set_on_ready_action([&client, &expected]() {
+        tls_payload msg(expected.begin(), expected.end());
+        client.tx(msg);
+    });
+    client.set_rx_handler([&echo, &running](tls_payload const& payload, auto&) {
+        echo.insert(echo.end(), payload.begin(), payload.end());
+        if (echo.size() >= kLargePayload) {
+            running = false;
+        }
+    });
+    ev.register_event_handler(&client);
+
+    // Timed poll so the deadline is checked every tick even with no events; a
+    // stall fails the test deterministically rather than hanging.
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (running && std::chrono::steady_clock::now() < deadline) {
+        ev.poll(50ms);
+        ev.run_actions();
+    }
+    running = false;
+
+    ASSERT_EQ(echo.size(), kLargePayload) << "round-trip did not complete within 5 seconds (drain or echo failed)";
+    EXPECT_EQ(echo, expected) << "echoed payload differs from sent payload";
+}
+
+// Hostname verification SUCCESS: verify_subject_name=true with host_for_sni
+// "localhost". The server leaf cert carries a DNS:localhost SAN, so RFC-6125
+// verification passes even though the TCP connect target is the 127.0.0.1
+// literal (SNI is the matched name, not the connect target). Round-trip
+// completes.
+TEST(TlsE2E, HostnameVerificationSucceeds) {
+    io::tls::tls_listener listener(make_listener_config());
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+
+    io::event::fd_event_handler ev;
+
+    std::unique_ptr<io::tls::tls_server> server_conn;
+    listener.set_accept_callback(
+        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
+            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+                self.tx(payload); // echo
+            });
+            ev.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+
+    auto cfg = make_client_config();
+    cfg.tls.verify_subject_name = true;
+    cfg.host_for_sni = "localhost";
+
+    io::tls::tls_client client(cfg, std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> got_echo{false};
+    const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+    std::vector<std::uint8_t> echo;
+
+    client.set_on_ready_action([&client, &ping]() {
+        tls_payload msg(ping.begin(), ping.end());
+        client.tx(msg);
+    });
+    client.set_rx_handler([&echo, &ping, &got_echo, &running](tls_payload const& payload, auto&) {
+        echo.insert(echo.end(), payload.begin(), payload.end());
+        if (echo.size() >= ping.size()) {
+            got_echo = true;
+            running = false;
+        }
+    });
+    ev.register_event_handler(&client);
+
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (running && std::chrono::steady_clock::now() < deadline) {
+        ev.poll(50ms);
+        ev.run_actions();
+    }
+    running = false;
+
+    EXPECT_TRUE(got_echo) << "round-trip did not complete with verify_subject_name + correct SNI within 5 seconds";
+    EXPECT_EQ(echo, ping) << "echoed payload differs from sent payload";
+}
+
+// Hostname verification FAILURE: verify_subject_name=true with a host_for_sni
+// that does NOT match any SAN on the server leaf cert. The TLS handshake must
+// fail verification; success here is observing the client error (no hang). The
+// round-trip must NOT complete.
+TEST(TlsE2E, WrongHostnameVerificationFails) {
+    io::tls::tls_listener listener(make_listener_config());
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+
+    io::event::fd_event_handler ev;
+
+    std::unique_ptr<io::tls::tls_server> server_conn;
+    listener.set_accept_callback(
+        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
+            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+                self.tx(payload); // echo
+            });
+            ev.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+
+    auto cfg = make_client_config();
+    cfg.tls.verify_subject_name = true;
+    cfg.host_for_sni = "wrong.example";
+
+    io::tls::tls_client client(cfg, std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> got_error{false};
+    std::atomic<bool> got_echo{false};
+    const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+
+    client.set_error_handler([&got_error, &running](int err, std::string const& /*msg*/) {
+        if (err != 0) {
+            got_error = true;
+            running = false;
+        }
+    });
+    client.set_on_ready_action([&client, &ping]() {
+        // Should never fire: the handshake fails verification before ready.
+        tls_payload msg(ping.begin(), ping.end());
+        client.tx(msg);
+    });
+    client.set_rx_handler([&got_echo, &running](tls_payload const& /*payload*/, auto&) {
+        got_echo = true;
+        running = false;
+    });
+    ev.register_event_handler(&client);
+
+    // Short deadline: a hostname mismatch must surface as an error promptly, not
+    // hang. Success = error observed (or, at minimum, no round-trip completes).
+    const auto deadline = std::chrono::steady_clock::now() + 3s;
+    while (running && std::chrono::steady_clock::now() < deadline) {
+        ev.poll(50ms);
+        ev.run_actions();
+    }
+    running = false;
+
+    EXPECT_FALSE(got_echo) << "round-trip completed despite a hostname mismatch";
+    EXPECT_TRUE(got_error) << "client error handler did not fire on a hostname mismatch within 3 seconds";
+}
+
+// Steady-state teardown: after a successful handshake and round-trip the server
+// drops its connection. The client's next rx fails inside the connection-fd
+// dispatch lambda, which calls fail(). fail() must NOT remove its own fd
+// synchronously from inside that dispatch pass (that would erase the
+// std::function currently executing and resize the pollfds mid-iteration).
+// Removal is deferred to run_actions(). Success = the error handler fires and
+// the loop keeps running without crashing after teardown.
+TEST(TlsE2E, ServerCloseTearsDownClientWithoutCrash) {
+    io::tls::tls_listener listener(make_listener_config());
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+
+    io::event::fd_event_handler ev;
+
+    std::unique_ptr<io::tls::tls_server> server_conn;
+    listener.set_accept_callback(
+        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
+            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+                self.tx(payload); // echo, then the test drops the server below
+            });
+            ev.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+
+    io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), port, 2000);
+
+    std::atomic<bool> running{true};
+    std::atomic<bool> got_error{false};
+    std::atomic<bool> got_echo{false};
+    const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
+
+    client.set_on_ready_action([&client, &ping]() {
+        tls_payload msg(ping.begin(), ping.end());
+        client.tx(msg);
+    });
+    client.set_rx_handler([&got_echo](tls_payload const& /*payload*/, auto&) { got_echo = true; });
+    client.set_error_handler([&got_error](int err, std::string const& /*msg*/) {
+        if (err != 0) {
+            got_error = true;
+        }
+    });
+    ev.register_event_handler(&client);
+
+    // Phase 1: drive the handshake + round-trip, then tear down the server so the
+    // client observes a peer close on its next rx.
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    bool dropped = false;
+    while (running && std::chrono::steady_clock::now() < deadline) {
+        ev.poll(50ms);
+        ev.run_actions();
+        if (got_echo && not dropped) {
+            // Drop the server connection: closes the peer fd so the client rx
+            // fails and routes through fail() on its next loop wakeup.
+            ev.unregister_event_handler(server_conn.get());
+            server_conn.reset();
+            dropped = true;
+        }
+        if (got_error) {
+            running = false;
+        }
+    }
+    running = false;
+
+    EXPECT_TRUE(got_echo) << "round-trip did not complete before the server was dropped";
+    EXPECT_TRUE(got_error) << "client error handler did not fire after the server closed within 5 seconds";
+
+    // Keep polling after teardown: a synchronous fd removal from inside the
+    // dispatch pass would have corrupted the handler state; a deferred removal
+    // leaves the loop healthy. No crash here is the assertion.
+    for (int i = 0; i < 5; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+}
+
+// Explicit unregister of a tls_client must run the client stop() hook so the
+// m_connected event it registered in start() is torn down alongside the base
+// connection fd / tx-notify. Regression guard for the register/unregister
+// symmetry fix: the client is registered, driven to ready, then unregistered,
+// and the handler is left to poll on. A clean unregister return plus a healthy
+// post-teardown loop is the assertion.
+TEST(TlsE2E, UnregisterClientRunsStopHook) {
+    io::tls::tls_listener listener(make_listener_config());
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+
+    io::event::fd_event_handler ev;
+
+    std::unique_ptr<io::tls::tls_server> server_conn;
+    listener.set_accept_callback(
+        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
+            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+                self.tx(payload); // echo
+            });
+            ev.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+    ASSERT_TRUE(ev.register_event_handler(&listener));
+
+    {
+        io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), port, 2000);
+
+        std::atomic<bool> ready{false};
+        client.set_on_ready_action([&ready]() { ready = true; });
+        ASSERT_TRUE(ev.register_event_handler(&client));
+
+        // Drive until the client's handshake completes (its on-ready fires).
+        const auto deadline = std::chrono::steady_clock::now() + 5s;
+        while (not ready && std::chrono::steady_clock::now() < deadline) {
+            ev.poll(50ms);
+            ev.run_actions();
+        }
+        ASSERT_TRUE(ready) << "client handshake did not complete within 5 seconds";
+
+        // Explicit teardown: must remove the connection fd, tx-notify, AND the
+        // m_connected event the client registered in start().
+        EXPECT_TRUE(ev.unregister_event_handler(&client))
+            << "unregistering the client did not cleanly remove its handler entries";
+    } // client destroyed here, while ev outlives it.
+
+    // The handler outlives the client: it must hold no leftover handler that
+    // references the destroyed client. Polling stays healthy. No crash here is
+    // the assertion.
+    for (int i = 0; i < 5; ++i) {
+        ev.poll(10ms);
+        ev.run_actions();
+    }
+}

--- a/lib/everest/io/test/tls_e2e_test.cpp
+++ b/lib/everest/io/test/tls_e2e_test.cpp
@@ -8,6 +8,8 @@
 // driven on the one loop (nested fd_event_sync_interface model). This exercises
 // the full > 4096-byte drain path and RFC-6125 hostname verification.
 
+#include "tls_test_common.hpp"
+
 #include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/tls/tls_client.hpp>
 #include <everest/io/tls/tls_listener.hpp>
@@ -28,6 +30,7 @@ using namespace std::chrono_literals;
 namespace {
 
 namespace io = everest::lib::io;
+namespace test = everest::lib::io::test;
 
 using tls_payload = io::tls::tls_client_socket::PayloadT;
 
@@ -44,37 +47,6 @@ std::vector<std::uint8_t> make_large_payload() {
     return payload;
 }
 
-/// Populate a tls_listener::Config with the test PKI and an ephemeral bind on
-/// 127.0.0.1. Mirrors the listener config used in tls_listener_test.cpp.
-io::tls::tls_listener::Config make_listener_config() {
-    io::tls::tls_listener::Config lcfg;
-    lcfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
-    lcfg.tls.ciphersuites = "";
-    auto& chain = lcfg.tls.chains.emplace_back();
-    chain.certificate_chain_file = "server_chain.pem";
-    chain.private_key_file = "server_priv.pem";
-    chain.trust_anchor_file = "server_root_cert.pem";
-    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
-    lcfg.tls.verify_client = false;
-    lcfg.tls.io_timeout_ms = 1000;
-    lcfg.bind_addr = "127.0.0.1";
-    lcfg.bind_port = 0;
-    lcfg.ipv6_only = false;
-    return lcfg;
-}
-
-/// Base client config that trusts the test server root so chain validation
-/// passes. Hostname verification is left off by default (opt in per test).
-io::tls::tls_client_socket::Config make_client_config() {
-    io::tls::tls_client_socket::Config cfg;
-    cfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
-    cfg.tls.ciphersuites = "";
-    cfg.tls.verify_locations_file = "server_root_cert.pem";
-    cfg.tls.io_timeout_ms = 2000;
-    cfg.tls.verify_server = true;
-    return cfg;
-}
-
 } // namespace
 
 // A tls_listener (server) and a tls_client (the alias) share one
@@ -82,28 +54,15 @@ io::tls::tls_client_socket::Config make_client_config() {
 // server echoes it, and the loop drives both TLS handshakes plus the round-trip.
 // Asserts the FULL payload round-trips intact (size + byte content).
 TEST(TlsE2E, RoundTripLargePayloadSingleLoop) {
-    io::tls::tls_listener listener(make_listener_config());
-    const auto port = listener.listen_port();
-    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
-
     io::event::fd_event_handler ev;
-
-    // The yielded tls_server must outlive the accept callback; the loop drives
-    // its handshake/rx/tx after register_event_handler().
-    std::unique_ptr<io::tls::tls_server> server_conn;
-    listener.set_accept_callback(
-        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
-            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
-                self.tx(payload); // echo
-            });
-            ev.register_event_handler(srv.get());
-            server_conn = std::move(srv);
-        });
-    ASSERT_TRUE(ev.register_event_handler(&listener));
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
 
     const auto expected = make_large_payload();
 
-    io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), port, 2000);
+    io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
 
     std::atomic<bool> running{true};
     std::vector<std::uint8_t> echo;
@@ -121,14 +80,8 @@ TEST(TlsE2E, RoundTripLargePayloadSingleLoop) {
     });
     ev.register_event_handler(&client);
 
-    // Timed poll so the deadline is checked every tick even with no events; a
-    // stall fails the test deterministically rather than hanging.
-    const auto deadline = std::chrono::steady_clock::now() + 5s;
-    while (running && std::chrono::steady_clock::now() < deadline) {
-        ev.poll(50ms);
-        ev.run_actions();
-    }
-    running = false;
+    test::pump_until(
+        ev, [&] { return !running; }, 5s);
 
     ASSERT_EQ(echo.size(), kLargePayload) << "round-trip did not complete within 5 seconds (drain or echo failed)";
     EXPECT_EQ(echo, expected) << "echoed payload differs from sent payload";
@@ -140,26 +93,14 @@ TEST(TlsE2E, RoundTripLargePayloadSingleLoop) {
 // literal (SNI is the matched name, not the connect target). Round-trip
 // completes.
 TEST(TlsE2E, HostnameVerificationSucceeds) {
-    io::tls::tls_listener listener(make_listener_config());
-    const auto port = listener.listen_port();
-    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
-
     io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
 
-    std::unique_ptr<io::tls::tls_server> server_conn;
-    listener.set_accept_callback(
-        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
-            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
-                self.tx(payload); // echo
-            });
-            ev.register_event_handler(srv.get());
-            server_conn = std::move(srv);
-        });
-    ASSERT_TRUE(ev.register_event_handler(&listener));
-
-    auto cfg = make_client_config();
+    auto cfg = test::client_test_config(2000, "localhost");
     cfg.tls.verify_subject_name = true;
-    cfg.host_for_sni = "localhost";
 
     io::tls::tls_client client(cfg, std::string("127.0.0.1"), port, 2000);
 
@@ -181,12 +122,8 @@ TEST(TlsE2E, HostnameVerificationSucceeds) {
     });
     ev.register_event_handler(&client);
 
-    const auto deadline = std::chrono::steady_clock::now() + 5s;
-    while (running && std::chrono::steady_clock::now() < deadline) {
-        ev.poll(50ms);
-        ev.run_actions();
-    }
-    running = false;
+    test::pump_until(
+        ev, [&] { return !running; }, 5s);
 
     EXPECT_TRUE(got_echo) << "round-trip did not complete with verify_subject_name + correct SNI within 5 seconds";
     EXPECT_EQ(echo, ping) << "echoed payload differs from sent payload";
@@ -197,26 +134,14 @@ TEST(TlsE2E, HostnameVerificationSucceeds) {
 // fail verification; success here is observing the client error (no hang). The
 // round-trip must NOT complete.
 TEST(TlsE2E, WrongHostnameVerificationFails) {
-    io::tls::tls_listener listener(make_listener_config());
-    const auto port = listener.listen_port();
-    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
-
     io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
 
-    std::unique_ptr<io::tls::tls_server> server_conn;
-    listener.set_accept_callback(
-        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
-            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
-                self.tx(payload); // echo
-            });
-            ev.register_event_handler(srv.get());
-            server_conn = std::move(srv);
-        });
-    ASSERT_TRUE(ev.register_event_handler(&listener));
-
-    auto cfg = make_client_config();
+    auto cfg = test::client_test_config(2000, "wrong.example");
     cfg.tls.verify_subject_name = true;
-    cfg.host_for_sni = "wrong.example";
 
     io::tls::tls_client client(cfg, std::string("127.0.0.1"), port, 2000);
 
@@ -248,12 +173,8 @@ TEST(TlsE2E, WrongHostnameVerificationFails) {
 
     // Short deadline: a hostname mismatch must surface as an error promptly, not
     // hang. Success = error observed (or, at minimum, no round-trip completes).
-    const auto deadline = std::chrono::steady_clock::now() + 3s;
-    while (running && std::chrono::steady_clock::now() < deadline) {
-        ev.poll(50ms);
-        ev.run_actions();
-    }
-    running = false;
+    test::pump_until(
+        ev, [&] { return !running; }, 3s);
 
     EXPECT_FALSE(got_echo) << "round-trip completed despite a hostname mismatch";
     EXPECT_TRUE(got_error) << "client error handler did not fire on a hostname mismatch within 3 seconds";
@@ -268,26 +189,14 @@ TEST(TlsE2E, WrongHostnameVerificationFails) {
 // Removal is deferred to run_actions(). Success = the error handler fires and
 // the loop keeps running without crashing after teardown.
 TEST(TlsE2E, ServerCloseTearsDownClientWithoutCrash) {
-    io::tls::tls_listener listener(make_listener_config());
-    const auto port = listener.listen_port();
-    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
-
     io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
 
-    std::unique_ptr<io::tls::tls_server> server_conn;
-    listener.set_accept_callback(
-        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
-            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
-                self.tx(payload); // echo, then the test drops the server below
-            });
-            ev.register_event_handler(srv.get());
-            server_conn = std::move(srv);
-        });
-    ASSERT_TRUE(ev.register_event_handler(&listener));
+    io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
 
-    io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), port, 2000);
-
-    std::atomic<bool> running{true};
     std::atomic<bool> got_error{false};
     std::atomic<bool> got_echo{false};
     const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
@@ -306,23 +215,20 @@ TEST(TlsE2E, ServerCloseTearsDownClientWithoutCrash) {
 
     // Phase 1: drive the handshake + round-trip, then tear down the server so the
     // client observes a peer close on its next rx.
-    const auto deadline = std::chrono::steady_clock::now() + 5s;
     bool dropped = false;
-    while (running && std::chrono::steady_clock::now() < deadline) {
-        ev.poll(50ms);
-        ev.run_actions();
-        if (got_echo && not dropped) {
-            // Drop the server connection: closes the peer fd so the client rx
-            // fails and routes through fail() on its next loop wakeup.
-            ev.unregister_event_handler(server_conn.get());
-            server_conn.reset();
-            dropped = true;
-        }
-        if (got_error) {
-            running = false;
-        }
-    }
-    running = false;
+    test::pump_until(
+        ev,
+        [&] {
+            if (got_echo && not dropped) {
+                // Drop the server connection: closes the peer fd so the client rx
+                // fails and routes through fail() on its next loop wakeup.
+                ev.unregister_event_handler(rig.server_conn.get());
+                rig.server_conn.reset();
+                dropped = true;
+            }
+            return got_error.load();
+        },
+        5s);
 
     EXPECT_TRUE(got_echo) << "round-trip did not complete before the server was dropped";
     EXPECT_TRUE(got_error) << "client error handler did not fire after the server closed within 5 seconds";
@@ -342,24 +248,13 @@ TEST(TlsE2E, ServerCloseTearsDownClientWithoutCrash) {
 // The eventfd tx-notify fired while m_fd was still -1, so the flush depends on
 // the handshake-completion path re-arming POLLOUT for the queued payload.
 TEST(TlsE2E, tx_queued_before_handshake_is_flushed_after_ready) {
-    io::tls::tls_listener listener(make_listener_config());
-    const auto port = listener.listen_port();
-    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
-
     io::event::fd_event_handler ev;
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
 
-    std::unique_ptr<io::tls::tls_server> server_conn;
-    listener.set_accept_callback(
-        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
-            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
-                self.tx(payload); // echo
-            });
-            ev.register_event_handler(srv.get());
-            server_conn = std::move(srv);
-        });
-    ASSERT_TRUE(ev.register_event_handler(&listener));
-
-    io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), port, 2000);
+    io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
 
     std::atomic<bool> running{true};
     const std::vector<std::uint8_t> ping = {'p', 'i', 'n', 'g'};
@@ -378,12 +273,8 @@ TEST(TlsE2E, tx_queued_before_handshake_is_flushed_after_ready) {
     tls_payload msg(ping.begin(), ping.end());
     ASSERT_TRUE(client.tx(msg)) << "tx() rejected a payload queued before the handshake";
 
-    const auto deadline = std::chrono::steady_clock::now() + 5s;
-    while (running && std::chrono::steady_clock::now() < deadline) {
-        ev.poll(50ms);
-        ev.run_actions();
-    }
-    running = false;
+    test::pump_until(
+        ev, [&] { return !running; }, 5s);
 
     ASSERT_EQ(echo.size(), ping.size()) << "payload queued before the handshake was never flushed within 5 seconds";
     EXPECT_EQ(echo, ping) << "echoed payload differs from sent payload";
@@ -396,36 +287,22 @@ TEST(TlsE2E, tx_queued_before_handshake_is_flushed_after_ready) {
 // and the handler is left to poll on. A clean unregister return plus a healthy
 // post-teardown loop is the assertion.
 TEST(TlsE2E, UnregisterClientRunsStopHook) {
-    io::tls::tls_listener listener(make_listener_config());
-    const auto port = listener.listen_port();
-    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
-
     io::event::fd_event_handler ev;
-
-    std::unique_ptr<io::tls::tls_server> server_conn;
-    listener.set_accept_callback(
-        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
-            srv->set_rx_handler([](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
-                self.tx(payload); // echo
-            });
-            ev.register_event_handler(srv.get());
-            server_conn = std::move(srv);
-        });
-    ASSERT_TRUE(ev.register_event_handler(&listener));
+    auto rig = test::make_echo_listener(ev);
+    const auto port = rig.port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+    ASSERT_TRUE(rig.registered);
 
     {
-        io::tls::tls_client client(make_client_config(), std::string("127.0.0.1"), port, 2000);
+        io::tls::tls_client client(test::client_test_config(), std::string("127.0.0.1"), port, 2000);
 
         std::atomic<bool> ready{false};
         client.set_on_ready_action([&ready]() { ready = true; });
         ASSERT_TRUE(ev.register_event_handler(&client));
 
         // Drive until the client's handshake completes (its on-ready fires).
-        const auto deadline = std::chrono::steady_clock::now() + 5s;
-        while (not ready && std::chrono::steady_clock::now() < deadline) {
-            ev.poll(50ms);
-            ev.run_actions();
-        }
+        test::pump_until(
+            ev, [&] { return ready.load(); }, 5s);
         ASSERT_TRUE(ready) << "client handshake did not complete within 5 seconds";
 
         // Explicit teardown: must remove the connection fd, tx-notify, AND the

--- a/lib/everest/io/test/tls_listener_test.cpp
+++ b/lib/everest/io/test/tls_listener_test.cpp
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+namespace io = everest::lib::io;
+
+/// Bytes the client sends and expects echoed back through the server.
+const std::vector<std::uint8_t> kPayload = {'p', 'i', 'n', 'g'};
+
+/// Populate a tls_listener::Config with the test PKI and the given bind target.
+io::tls::tls_listener::Config make_listener_config(std::string bind_addr, bool ipv6_only) {
+    io::tls::tls_listener::Config lcfg;
+    lcfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    lcfg.tls.ciphersuites = "";
+    auto& chain = lcfg.tls.chains.emplace_back();
+    chain.certificate_chain_file = "server_chain.pem";
+    chain.private_key_file = "server_priv.pem";
+    chain.trust_anchor_file = "server_root_cert.pem";
+    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
+    lcfg.tls.verify_client = false;
+    lcfg.tls.io_timeout_ms = 1000;
+    lcfg.bind_addr = std::move(bind_addr);
+    lcfg.bind_port = 0;
+    lcfg.ipv6_only = ipv6_only;
+    return lcfg;
+}
+
+/// Blocking TLS client: connect, write kPayload, read the echo, verify it.
+/// Runs on a background thread while the main thread drives the event loop.
+void run_blocking_client(std::string const& host, std::uint16_t port, std::atomic<bool>& client_ok,
+                         std::string& client_error) {
+    tls::Client client;
+    tls::Client::config_t ccfg;
+    ccfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    ccfg.verify_locations_file = "server_root_cert.pem";
+    ccfg.io_timeout_ms = 2000;
+    ccfg.verify_server = true;
+    if (!client.init(ccfg)) {
+        client_error = "client.init failed";
+        return;
+    }
+
+    const std::string port_str = std::to_string(port);
+    auto conn = client.connect(host.c_str(), port_str.c_str(), false, 2000);
+    if (!conn) {
+        client_error = "client.connect returned nullptr";
+        return;
+    }
+    if (conn->connect() != tls::Connection::result_t::success) {
+        client_error = "TLS handshake failed on client side";
+        return;
+    }
+
+    std::size_t written = 0;
+    if (conn->write(reinterpret_cast<const std::byte*>(kPayload.data()), kPayload.size(), written, 2000) !=
+            tls::Connection::result_t::success ||
+        written != kPayload.size()) {
+        client_error = "client write failed";
+        return;
+    }
+
+    std::vector<std::uint8_t> echo;
+    echo.reserve(kPayload.size());
+    while (echo.size() < kPayload.size()) {
+        std::byte buf[256]{};
+        std::size_t nread = 0;
+        if (conn->read(buf, sizeof buf, nread, 2000) != tls::Connection::result_t::success) {
+            client_error = "client read failed";
+            return;
+        }
+        echo.insert(echo.end(), reinterpret_cast<std::uint8_t*>(buf), reinterpret_cast<std::uint8_t*>(buf) + nread);
+    }
+
+    if (echo != kPayload) {
+        client_error = "client echo mismatch";
+        return;
+    }
+
+    conn->shutdown();
+    client_ok = true;
+}
+
+/// Drive a real TLS round-trip through the listener bound to bind_addr.
+///
+/// A blocking TLS client (on a worker thread) connects, sends kPayload and
+/// expects it echoed back. The listener accepts the connection, the accept
+/// callback echoes received bytes and registers the yielded tls_server with the
+/// same fd_event_handler. The main thread polls the loop until the server-side
+/// rx fires AND the client confirms the round-trip, or the 5s deadline expires.
+void run_round_trip(std::string const& bind_addr, bool ipv6_only) {
+    io::tls::tls_listener listener(make_listener_config(bind_addr, ipv6_only));
+
+    const auto port = listener.listen_port();
+    ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
+
+    io::event::fd_event_handler handler;
+
+    std::atomic<bool> server_rx_fired{false};
+    std::atomic<std::uint16_t> captured_peer_port{0};
+    // The yielded tls_server must outlive the accept callback; the loop drives
+    // its handshake/rx/tx after register_event_handler().
+    std::unique_ptr<io::tls::tls_server> server_conn;
+
+    listener.set_accept_callback(
+        [&](std::unique_ptr<io::tls::tls_server> srv, std::string /*ip*/, std::uint16_t peer_port) {
+            captured_peer_port = peer_port;
+            srv->set_rx_handler([&server_rx_fired](io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+                server_rx_fired = true;
+                self.tx(payload); // echo
+            });
+            handler.register_event_handler(srv.get());
+            server_conn = std::move(srv);
+        });
+
+    ASSERT_TRUE(handler.register_event_handler(&listener));
+
+    std::atomic<bool> client_ok{false};
+    std::string client_error;
+    std::thread client_thread([&]() { run_blocking_client(bind_addr, port, client_ok, client_error); });
+
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while ((!server_rx_fired || !client_ok) && std::chrono::steady_clock::now() < deadline) {
+        handler.poll(50ms);
+    }
+
+    client_thread.join();
+
+    EXPECT_TRUE(server_rx_fired) << "server-side rx handler did not fire within 5 seconds";
+    EXPECT_TRUE(client_ok) << "client round-trip did not complete: " << client_error;
+    EXPECT_GT(captured_peer_port.load(), 0u) << "peer_port not extracted from sockaddr_storage";
+}
+
+} // namespace
+
+TEST(TlsListener, AcceptCallbackFires) {
+    run_round_trip("127.0.0.1", false);
+}
+
+TEST(TlsListener, AcceptCallbackFiresIPv6) {
+    run_round_trip("::1", true);
+}

--- a/lib/everest/io/test/tls_listener_test.cpp
+++ b/lib/everest/io/test/tls_listener_test.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Pionix GmbH and Contributors to EVerest
 
+#include "tls_test_common.hpp"
+
 #include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/tls/tls_listener.hpp>
 #include <everest/io/tls/tls_server.hpp>
 #include <everest/io/tls/tls_server_socket.hpp>
-#include <everest/tls/tls.hpp>
 
 #include <gtest/gtest.h>
 
@@ -22,92 +23,20 @@ using namespace std::chrono_literals;
 namespace {
 
 namespace io = everest::lib::io;
+namespace test = everest::lib::io::test;
 
 /// Bytes the client sends and expects echoed back through the server.
 const std::vector<std::uint8_t> kPayload = {'p', 'i', 'n', 'g'};
-
-/// Populate a tls_listener::Config with the test PKI and the given bind target.
-io::tls::tls_listener::Config make_listener_config(std::string bind_addr, bool ipv6_only) {
-    io::tls::tls_listener::Config lcfg;
-    lcfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
-    lcfg.tls.ciphersuites = "";
-    auto& chain = lcfg.tls.chains.emplace_back();
-    chain.certificate_chain_file = "server_chain.pem";
-    chain.private_key_file = "server_priv.pem";
-    chain.trust_anchor_file = "server_root_cert.pem";
-    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
-    lcfg.tls.verify_client = false;
-    lcfg.tls.io_timeout_ms = 1000;
-    lcfg.bind_addr = std::move(bind_addr);
-    lcfg.bind_port = 0;
-    lcfg.ipv6_only = ipv6_only;
-    return lcfg;
-}
-
-/// Blocking TLS client: connect, write kPayload, read the echo, verify it.
-/// Runs on a background thread while the main thread drives the event loop.
-void run_blocking_client(std::string const& host, std::uint16_t port, std::atomic<bool>& client_ok,
-                         std::string& client_error) {
-    tls::Client client;
-    tls::Client::config_t ccfg;
-    ccfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
-    ccfg.verify_locations_file = "server_root_cert.pem";
-    ccfg.io_timeout_ms = 2000;
-    ccfg.verify_server = true;
-    if (!client.init(ccfg)) {
-        client_error = "client.init failed";
-        return;
-    }
-
-    const std::string port_str = std::to_string(port);
-    auto conn = client.connect(host.c_str(), port_str.c_str(), false, 2000);
-    if (!conn) {
-        client_error = "client.connect returned nullptr";
-        return;
-    }
-    if (conn->connect() != tls::Connection::result_t::success) {
-        client_error = "TLS handshake failed on client side";
-        return;
-    }
-
-    std::size_t written = 0;
-    if (conn->write(reinterpret_cast<const std::byte*>(kPayload.data()), kPayload.size(), written, 2000) !=
-            tls::Connection::result_t::success ||
-        written != kPayload.size()) {
-        client_error = "client write failed";
-        return;
-    }
-
-    std::vector<std::uint8_t> echo;
-    echo.reserve(kPayload.size());
-    while (echo.size() < kPayload.size()) {
-        std::byte buf[256]{};
-        std::size_t nread = 0;
-        if (conn->read(buf, sizeof buf, nread, 2000) != tls::Connection::result_t::success) {
-            client_error = "client read failed";
-            return;
-        }
-        echo.insert(echo.end(), reinterpret_cast<std::uint8_t*>(buf), reinterpret_cast<std::uint8_t*>(buf) + nread);
-    }
-
-    if (echo != kPayload) {
-        client_error = "client echo mismatch";
-        return;
-    }
-
-    conn->shutdown();
-    client_ok = true;
-}
 
 /// Drive a real TLS round-trip through the listener bound to bind_addr.
 ///
 /// A blocking TLS client (on a worker thread) connects, sends kPayload and
 /// expects it echoed back. The listener accepts the connection, the accept
 /// callback echoes received bytes and registers the yielded tls_server with the
-/// same fd_event_handler. The main thread polls the loop until the server-side
+/// same fd_event_handler. The main thread pumps the loop until the server-side
 /// rx fires AND the client confirms the round-trip, or the 5s deadline expires.
 void run_round_trip(std::string const& bind_addr, bool ipv6_only) {
-    io::tls::tls_listener listener(make_listener_config(bind_addr, ipv6_only));
+    io::tls::tls_listener listener(test::listener_test_config(bind_addr, ipv6_only));
 
     const auto port = listener.listen_port();
     ASSERT_GT(port, 0u) << "listener bound to port 0 unexpectedly";
@@ -135,12 +64,11 @@ void run_round_trip(std::string const& bind_addr, bool ipv6_only) {
 
     std::atomic<bool> client_ok{false};
     std::string client_error;
-    std::thread client_thread([&]() { run_blocking_client(bind_addr, port, client_ok, client_error); });
+    std::thread client_thread(
+        [&]() { test::run_blocking_echo_client(bind_addr, port, kPayload, client_ok, client_error); });
 
-    const auto deadline = std::chrono::steady_clock::now() + 5s;
-    while ((!server_rx_fired || !client_ok) && std::chrono::steady_clock::now() < deadline) {
-        handler.poll(50ms);
-    }
+    test::pump_until(
+        handler, [&] { return server_rx_fired && client_ok; }, 5s);
 
     client_thread.join();
 

--- a/lib/everest/io/test/tls_server_socket_test.cpp
+++ b/lib/everest/io/test/tls_server_socket_test.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Pionix GmbH and Contributors to EVerest
 
+#include "tls_test_common.hpp"
+
 #include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/tls/tls_server.hpp>
 #include <everest/io/tls/tls_server_socket.hpp>
@@ -25,6 +27,8 @@
 using namespace std::chrono_literals;
 
 namespace {
+
+namespace test = everest::lib::io::test;
 
 /// Payload size that exceeds a single 4096-byte TLS-record read so the
 /// server-side rx() must drain SSL_pending() records in one call.
@@ -62,19 +66,10 @@ TEST(TlsServer, HandshakeAndExchange) {
     // -----------------------------------------------------------------------
     // 2. Configure tls::Server and initialise TLS (socket provided externally)
     // -----------------------------------------------------------------------
-    tls::Server::config_t cfg;
-    cfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
-    cfg.ciphersuites = "";
-    auto& chain = cfg.chains.emplace_back();
-    chain.certificate_chain_file = "server_chain.pem";
-    chain.private_key_file = "server_priv.pem";
-    chain.trust_anchor_file = "server_root_cert.pem";
-    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
+    auto cfg = test::server_test_config();
     cfg.host = "127.0.0.1";
     cfg.service = port_str.c_str();
     cfg.ipv6_only = false;
-    cfg.verify_client = false;
-    cfg.io_timeout_ms = 1000;
     cfg.socket = listen_fd; // bypass init_socket()
 
     tls::Server server;
@@ -86,57 +81,14 @@ TEST(TlsServer, HandshakeAndExchange) {
     // -----------------------------------------------------------------------
     // 3. Background TLS client: connect, write large payload, read echo back
     // -----------------------------------------------------------------------
+    std::vector<uint8_t> msg(kLargePayload);
+    for (std::size_t i = 0; i < msg.size(); ++i) {
+        msg[i] = static_cast<uint8_t>(i & 0xFF);
+    }
     std::atomic<bool> client_ok{false};
     std::string client_error;
-    std::thread client_thread([&]() {
-        tls::Client client;
-        tls::Client::config_t ccfg;
-        ccfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
-        ccfg.verify_locations_file = "server_root_cert.pem";
-        ccfg.io_timeout_ms = 2000;
-        ccfg.verify_server = true;
-        if (!client.init(ccfg)) {
-            client_error = "client.init failed";
-            return;
-        }
-        auto conn = client.connect("127.0.0.1", port_str.c_str(), false, 2000);
-        if (!conn) {
-            client_error = "client.connect returned nullptr";
-            return;
-        }
-        if (conn->connect() != tls::Connection::result_t::success) {
-            client_error = "TLS handshake failed on client side";
-            return;
-        }
-        std::vector<uint8_t> msg(kLargePayload);
-        for (std::size_t i = 0; i < msg.size(); ++i) {
-            msg[i] = static_cast<uint8_t>(i & 0xFF);
-        }
-        std::size_t written = 0;
-        if (conn->write(reinterpret_cast<const std::byte*>(msg.data()), msg.size(), written, 2000) !=
-                tls::Connection::result_t::success ||
-            written != msg.size()) {
-            client_error = "client write failed";
-            return;
-        }
-        std::vector<uint8_t> echo;
-        echo.reserve(msg.size());
-        while (echo.size() < msg.size()) {
-            std::byte buf[8192]{};
-            std::size_t nread = 0;
-            if (conn->read(buf, sizeof buf, nread, 2000) != tls::Connection::result_t::success) {
-                client_error = "client read failed";
-                return;
-            }
-            echo.insert(echo.end(), reinterpret_cast<uint8_t*>(buf), reinterpret_cast<uint8_t*>(buf) + nread);
-        }
-        if (echo != msg) {
-            client_error = "client echo mismatch";
-            return;
-        }
-        conn->shutdown();
-        client_ok = true;
-    });
+    std::thread client_thread(
+        [&]() { test::run_blocking_echo_client("127.0.0.1", port, msg, client_ok, client_error); });
 
     // -----------------------------------------------------------------------
     // 4. Server side: accept raw TCP fd, wrap, construct tls_server.
@@ -174,11 +126,8 @@ TEST(TlsServer, HandshakeAndExchange) {
     // Drive the loop until the client confirms the full echo round-trip (it
     // verifies the payload itself), or the deadline expires. Stopping when the
     // server merely RECEIVES would race the not-yet-drained echo write.
-    const auto deadline = std::chrono::steady_clock::now() + 5s;
-    while (not client_ok && std::chrono::steady_clock::now() < deadline) {
-        ev.poll(50ms);
-        ev.run_actions();
-    }
+    test::pump_until(
+        ev, [&] { return client_ok.load(); }, 5s);
 
     client_thread.join();
     ::close(listen_fd);

--- a/lib/everest/io/test/tls_server_socket_test.cpp
+++ b/lib/everest/io/test/tls_server_socket_test.cpp
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+/// Payload size that exceeds a single 4096-byte TLS-record read so the
+/// server-side rx() must drain SSL_pending() records in one call.
+constexpr std::size_t kLargePayload = 10000;
+
+} // namespace
+
+// tls_server (the loop-driven register-interface class): wrap an accepted fd,
+// construct a tls_server, register it with an fd_event_handler and drive the
+// loop. The handshake runs on the loop via accept(0); a > 4096-byte client
+// payload must arrive in one rx() (SSL_pending drain) and be echoed back.
+TEST(TlsServer, HandshakeAndExchange) {
+    // -----------------------------------------------------------------------
+    // 1. Create ephemeral listen socket
+    // -----------------------------------------------------------------------
+    int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0);
+
+    int opt = 1;
+    ::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0; // ephemeral
+    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)), 0);
+    ASSERT_EQ(::listen(listen_fd, 1), 0);
+
+    sockaddr_in bound{};
+    socklen_t bound_len = sizeof(bound);
+    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound), &bound_len), 0);
+    const uint16_t port = ntohs(bound.sin_port);
+    const std::string port_str = std::to_string(port);
+
+    // -----------------------------------------------------------------------
+    // 2. Configure tls::Server and initialise TLS (socket provided externally)
+    // -----------------------------------------------------------------------
+    tls::Server::config_t cfg;
+    cfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    cfg.ciphersuites = "";
+    auto& chain = cfg.chains.emplace_back();
+    chain.certificate_chain_file = "server_chain.pem";
+    chain.private_key_file = "server_priv.pem";
+    chain.trust_anchor_file = "server_root_cert.pem";
+    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
+    cfg.host = "127.0.0.1";
+    cfg.service = port_str.c_str();
+    cfg.ipv6_only = false;
+    cfg.verify_client = false;
+    cfg.io_timeout_ms = 1000;
+    cfg.socket = listen_fd; // bypass init_socket()
+
+    tls::Server server;
+    const auto state = server.init(cfg, nullptr);
+    ASSERT_NE(state, tls::Server::state_t::init_needed)
+        << "tls::Server::init failed — check that server_chain.pem etc. exist "
+           "in the working directory (lib/everest/tls/tests in the build tree).";
+
+    // -----------------------------------------------------------------------
+    // 3. Background TLS client: connect, write large payload, read echo back
+    // -----------------------------------------------------------------------
+    std::atomic<bool> client_ok{false};
+    std::string client_error;
+    std::thread client_thread([&]() {
+        tls::Client client;
+        tls::Client::config_t ccfg;
+        ccfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+        ccfg.verify_locations_file = "server_root_cert.pem";
+        ccfg.io_timeout_ms = 2000;
+        ccfg.verify_server = true;
+        if (!client.init(ccfg)) {
+            client_error = "client.init failed";
+            return;
+        }
+        auto conn = client.connect("127.0.0.1", port_str.c_str(), false, 2000);
+        if (!conn) {
+            client_error = "client.connect returned nullptr";
+            return;
+        }
+        if (conn->connect() != tls::Connection::result_t::success) {
+            client_error = "TLS handshake failed on client side";
+            return;
+        }
+        std::vector<uint8_t> msg(kLargePayload);
+        for (std::size_t i = 0; i < msg.size(); ++i) {
+            msg[i] = static_cast<uint8_t>(i & 0xFF);
+        }
+        std::size_t written = 0;
+        if (conn->write(reinterpret_cast<const std::byte*>(msg.data()), msg.size(), written, 2000) !=
+                tls::Connection::result_t::success ||
+            written != msg.size()) {
+            client_error = "client write failed";
+            return;
+        }
+        std::vector<uint8_t> echo;
+        echo.reserve(msg.size());
+        while (echo.size() < msg.size()) {
+            std::byte buf[8192]{};
+            std::size_t nread = 0;
+            if (conn->read(buf, sizeof buf, nread, 2000) != tls::Connection::result_t::success) {
+                client_error = "client read failed";
+                return;
+            }
+            echo.insert(echo.end(), reinterpret_cast<uint8_t*>(buf), reinterpret_cast<uint8_t*>(buf) + nread);
+        }
+        if (echo != msg) {
+            client_error = "client echo mismatch";
+            return;
+        }
+        conn->shutdown();
+        client_ok = true;
+    });
+
+    // -----------------------------------------------------------------------
+    // 4. Server side: accept raw TCP fd, wrap, construct tls_server.
+    // -----------------------------------------------------------------------
+    sockaddr peer{};
+    socklen_t peer_len = sizeof(peer);
+    int accepted_fd = ::accept(listen_fd, &peer, &peer_len);
+    ASSERT_GE(accepted_fd, 0);
+
+    char ip_buf[NI_MAXHOST] = "127.0.0.1";
+    char svc_buf[NI_MAXSERV] = "0";
+    ::getnameinfo(&peer, peer_len, ip_buf, sizeof ip_buf, svc_buf, sizeof svc_buf, NI_NUMERICHOST | NI_NUMERICSERV);
+
+    auto conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+    ASSERT_TRUE(conn) << "wrap_accepted_fd returned nullptr";
+
+    everest::lib::io::tls::tls_server srv(std::move(conn));
+
+    // -----------------------------------------------------------------------
+    // 5. Drive the loop: handshake (accept(0)) + large rx drain + tx echo.
+    // -----------------------------------------------------------------------
+    everest::lib::io::event::fd_event_handler ev;
+
+    std::atomic<bool> rx_fired{false};
+    std::vector<std::uint8_t> in_buf;
+
+    srv.set_rx_handler(
+        [&in_buf, &rx_fired](everest::lib::io::tls::tls_server_socket::PayloadT const& payload, auto& self) {
+            rx_fired = true;
+            in_buf.insert(in_buf.end(), payload.begin(), payload.end());
+            self.tx(payload); // echo
+        });
+    ASSERT_TRUE(ev.register_event_handler(&srv));
+
+    // Drive the loop until the client confirms the full echo round-trip (it
+    // verifies the payload itself), or the deadline expires. Stopping when the
+    // server merely RECEIVES would race the not-yet-drained echo write.
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (not client_ok && std::chrono::steady_clock::now() < deadline) {
+        ev.poll(50ms);
+        ev.run_actions();
+    }
+
+    client_thread.join();
+    ::close(listen_fd);
+
+    EXPECT_TRUE(rx_fired) << "server-side rx handler did not fire";
+    ASSERT_EQ(in_buf.size(), kLargePayload) << "rx() did not drain all buffered TLS records in one call";
+    for (std::size_t i = 0; i < in_buf.size(); ++i) {
+        ASSERT_EQ(in_buf[i], static_cast<uint8_t>(i & 0xFF)) << "payload corruption at index " << i;
+    }
+    EXPECT_TRUE(client_ok) << "Client error: " << client_error;
+}

--- a/lib/everest/io/test/tls_server_socket_test.cpp
+++ b/lib/everest/io/test/tls_server_socket_test.cpp
@@ -105,12 +105,13 @@ TEST(TlsServer, HandshakeAndExchange) {
     auto conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
     ASSERT_TRUE(conn) << "wrap_accepted_fd returned nullptr";
 
-    everest::lib::io::tls::tls_server srv(std::move(conn));
-
     // -----------------------------------------------------------------------
     // 5. Drive the loop: handshake (accept(0)) + large rx drain + tx echo.
     // -----------------------------------------------------------------------
+    // The handler must outlive the endpoint (its dtor unregisters from the
+    // handler), so declare it first.
     everest::lib::io::event::fd_event_handler ev;
+    everest::lib::io::tls::tls_server srv(std::move(conn));
 
     std::atomic<bool> rx_fired{false};
     std::vector<std::uint8_t> in_buf;

--- a/lib/everest/io/test/tls_test_common.hpp
+++ b/lib/everest/io/test/tls_test_common.hpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// Shared helpers for the everest_io_tls_test binary. All four TLS test TUs
+// compile into this one executable, so everything here is inline/header-only.
+//
+// The PKI fixture files (server_chain.pem, server_priv.pem, ...) are resolved
+// relative to the working directory, which ctest pins to
+// build/lib/everest/tls/tests — always run this binary via ctest.
+//
+// Naming note: inside everest::lib::io::test an unqualified `tls::` finds the
+// sibling everest::lib::io::tls namespace; the libtls types are reached via the
+// fully qualified `::tls::`.
+
+#pragma once
+
+#include <everest/io/event/fd_event_handler.hpp>
+#include <everest/io/tls/tls_client_socket.hpp>
+#include <everest/io/tls/tls_listener.hpp>
+#include <everest/io/tls/tls_server.hpp>
+#include <everest/io/tls/tls_server_socket.hpp>
+#include <everest/tls/tls.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace everest::lib::io::test {
+
+/// Server-side chain/cipher core matching the test PKI: TLS 1.2 with the
+/// ECDSA test chain, TLS 1.3 disabled (empty ciphersuites), no client
+/// verification. Callers add transport specifics (host/service/socket for a
+/// raw ::tls::Server, or wrap via listener_test_config()).
+inline ::tls::Server::config_t server_test_config() {
+    ::tls::Server::config_t scfg;
+    scfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    scfg.ciphersuites = "";
+    auto& chain = scfg.chains.emplace_back();
+    chain.certificate_chain_file = "server_chain.pem";
+    chain.private_key_file = "server_priv.pem";
+    chain.trust_anchor_file = "server_root_cert.pem";
+    chain.ocsp_response_files = {"ocsp_response.der", "ocsp_response.der"};
+    scfg.verify_client = false;
+    scfg.io_timeout_ms = 1000;
+    return scfg;
+}
+
+/// tls_listener::Config on the test PKI with an ephemeral port on bind_addr.
+inline tls::tls_listener::Config listener_test_config(std::string bind_addr = "127.0.0.1", bool ipv6_only = false) {
+    tls::tls_listener::Config lcfg;
+    lcfg.tls = server_test_config();
+    lcfg.bind_addr = std::move(bind_addr);
+    lcfg.bind_port = 0;
+    lcfg.ipv6_only = ipv6_only;
+    return lcfg;
+}
+
+/// Client config trusting the test server root so chain validation passes.
+/// TLS 1.3 is disabled (empty ciphersuites) to match server_test_config().
+/// Hostname verification is left off; tests opt in via verify_subject_name.
+inline tls::tls_client_socket::Config client_test_config(std::int32_t io_timeout_ms = 2000,
+                                                         std::string host_for_sni = {}) {
+    tls::tls_client_socket::Config cfg;
+    cfg.tls.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    cfg.tls.ciphersuites = "";
+    cfg.tls.verify_locations_file = "server_root_cert.pem";
+    cfg.tls.io_timeout_ms = io_timeout_ms;
+    cfg.tls.verify_server = true;
+    cfg.host_for_sni = std::move(host_for_sni);
+    return cfg;
+}
+
+/// Drive the event loop — poll(50ms) + run_actions() per tick — until done()
+/// returns true or the budget expires. The timed poll guarantees the deadline
+/// is re-checked every tick even with no events, so a stall fails the test
+/// deterministically instead of hanging. Returns whether done() was satisfied.
+template <class Predicate>
+inline bool pump_until(event::fd_event_handler& ev, Predicate&& done, std::chrono::milliseconds budget) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    bool satisfied = done();
+    while (!satisfied && std::chrono::steady_clock::now() < deadline) {
+        ev.poll(std::chrono::milliseconds(50));
+        ev.run_actions();
+        satisfied = done();
+    }
+    return satisfied;
+}
+
+/// A tls_listener on the test PKI whose accept callback echoes every received
+/// payload back to the peer. The accepted tls_server is registered on the
+/// given event handler and owned by server_conn (it must outlive the accept
+/// callback; tests drop it explicitly to simulate a server-side close). Only
+/// a single accepted connection is kept — enough for these tests.
+/// Non-movable (the accept callback captures `this`); obtain instances via
+/// make_echo_listener(), which relies on guaranteed copy elision.
+struct echo_listener {
+    explicit echo_listener(event::fd_event_handler& ev, tls::tls_listener::Config cfg = listener_test_config()) :
+        listener(std::move(cfg)) {
+        listener.set_accept_callback(
+            [this, &ev](std::unique_ptr<tls::tls_server> srv, std::string /*ip*/, std::uint16_t /*peer_port*/) {
+                srv->set_rx_handler([](tls::tls_server_socket::PayloadT const& payload, auto& self) {
+                    self.tx(payload); // echo
+                });
+                ev.register_event_handler(srv.get());
+                server_conn = std::move(srv);
+            });
+        registered = ev.register_event_handler(&listener);
+    }
+
+    std::uint16_t port() const {
+        return listener.listen_port();
+    }
+
+    tls::tls_listener listener;
+    std::unique_ptr<tls::tls_server> server_conn;
+    bool registered{false};
+};
+
+inline echo_listener make_echo_listener(event::fd_event_handler& ev,
+                                        tls::tls_listener::Config cfg = listener_test_config()) {
+    return echo_listener(ev, std::move(cfg));
+}
+
+/// Blocking libtls client used as the remote peer on a worker thread while the
+/// main thread drives the event loop: connect, TLS handshake, write payload,
+/// read it echoed back, verify. Reports through client_ok / client_error.
+/// ciphersuites stays at the library default here (a TLS 1.3 offer is fine:
+/// the test servers disable TLS 1.3, so TLS 1.2 is negotiated either way).
+inline void run_blocking_echo_client(std::string const& host, std::uint16_t port,
+                                     std::vector<std::uint8_t> const& payload, std::atomic<bool>& client_ok,
+                                     std::string& client_error) {
+    ::tls::Client client;
+    ::tls::Client::config_t ccfg;
+    ccfg.cipher_list = "ECDHE-ECDSA-AES128-SHA256";
+    ccfg.verify_locations_file = "server_root_cert.pem";
+    ccfg.io_timeout_ms = 2000;
+    ccfg.verify_server = true;
+    if (!client.init(ccfg)) {
+        client_error = "client.init failed";
+        return;
+    }
+
+    const std::string port_str = std::to_string(port);
+    auto conn = client.connect(host.c_str(), port_str.c_str(), false, 2000);
+    if (!conn) {
+        client_error = "client.connect returned nullptr";
+        return;
+    }
+    if (conn->connect() != ::tls::Connection::result_t::success) {
+        client_error = "TLS handshake failed on client side";
+        return;
+    }
+
+    std::size_t written = 0;
+    if (conn->write(reinterpret_cast<const std::byte*>(payload.data()), payload.size(), written, 2000) !=
+            ::tls::Connection::result_t::success ||
+        written != payload.size()) {
+        client_error = "client write failed";
+        return;
+    }
+
+    std::vector<std::uint8_t> echo;
+    echo.reserve(payload.size());
+    while (echo.size() < payload.size()) {
+        std::byte buf[8192]{};
+        std::size_t nread = 0;
+        if (conn->read(buf, sizeof buf, nread, 2000) != ::tls::Connection::result_t::success) {
+            client_error = "client read failed";
+            return;
+        }
+        echo.insert(echo.end(), reinterpret_cast<std::uint8_t*>(buf), reinterpret_cast<std::uint8_t*>(buf) + nread);
+    }
+
+    if (echo != payload) {
+        client_error = "client echo mismatch";
+        return;
+    }
+
+    conn->shutdown();
+    client_ok = true;
+}
+
+} // namespace everest::lib::io::test

--- a/lib/everest/io/test/tls_test_main.cpp
+++ b/lib/everest/io/test/tls_test_main.cpp
@@ -10,6 +10,7 @@
 // not rely on tls_test having run first under ctest, so this binary
 // regenerates the fixtures itself.
 
+#include <csignal>
 #include <cstdlib>
 #include <iostream>
 #include <linux/limits.h>
@@ -18,6 +19,11 @@
 #include <gtest/gtest.h>
 
 int main(int argc, char** argv) {
+    // OpenSSL drives its socket BIO through write() without MSG_NOSIGNAL, so a
+    // write to a peer-reset connection raises SIGPIPE and kills the process.
+    // Every OpenSSL client must ignore it; production EVerest processes do the
+    // same. Without this the RST-teardown tests would abort on SIGPIPE.
+    std::signal(SIGPIPE, SIG_IGN);
     if (std::system("./pki.sh") != 0) {
         std::cerr << "Problem creating test certificates and keys" << std::endl;
         char buf[PATH_MAX];

--- a/lib/everest/io/test/tls_test_main.cpp
+++ b/lib/everest/io/test/tls_test_main.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+//
+// Custom GoogleTest main for everest_io_tls_test.
+//
+// The TLS tests reuse the libtls test PKI fixtures (server_chain.pem,
+// server_priv.pem, server_root_cert.pem, ocsp_response.der, ...) which are
+// produced by ./pki.sh in the libtls test build directory. libtls's own
+// tls_test binary runs ./pki.sh from its main(). everest_io_tls_test must
+// not rely on tls_test having run first under ctest, so this binary
+// regenerates the fixtures itself.
+
+#include <cstdlib>
+#include <iostream>
+#include <linux/limits.h>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+    if (std::system("./pki.sh") != 0) {
+        std::cerr << "Problem creating test certificates and keys" << std::endl;
+        char buf[PATH_MAX];
+        if (::getcwd(&buf[0], sizeof(buf)) != nullptr) {
+            std::cerr << "./pki.sh not found in " << buf << std::endl;
+        }
+        return 1;
+    }
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/lib/everest/iso15118/include/iso15118/detail/io/socket_helper.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/io/socket_helper.hpp
@@ -2,6 +2,7 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -9,9 +10,15 @@
 
 namespace iso15118::io {
 
+constexpr auto DEFAULT_SOCKET_BACKLOG = 4;
+
 bool check_and_update_interface(std::string& interface_name);
 
 bool get_first_sockaddr_in6_for_interface(const std::string& interface_name, sockaddr_in6& address);
+
+// creates an ipv6 TCP socket, sets address.sin6_port to htons(port), binds to
+// the address and starts listening; throws on any failure
+int create_tcp_listen_socket(sockaddr_in6& address, uint16_t port, int backlog);
 
 std::unique_ptr<char[]> sockaddr_in6_to_name(const sockaddr_in6&);
 

--- a/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
@@ -17,8 +17,6 @@
 
 namespace iso15118::io {
 
-static constexpr auto DEFAULT_SOCKET_BACKLOG = 4;
-
 ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& interface_name) :
     poll_manager(poll_manager_) {
     sockaddr_in6 address;
@@ -31,35 +29,7 @@ ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& 
     end_point.port = 50000;
     memcpy(&end_point.address, &address.sin6_addr, sizeof(address.sin6_addr));
 
-    fd = socket(AF_INET6, SOCK_STREAM, 0);
-    if (fd == -1) {
-        log_and_throw("Failed to create an ipv6 socket");
-    }
-
-    // before bind, set the port
-    address.sin6_port = htons(end_point.port);
-
-    int optval_tmp{1};
-    const auto set_reuseaddr = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp));
-    if (set_reuseaddr == -1) {
-        log_and_throw("setsockopt(SO_REUSEADDR) failed");
-    }
-
-    const auto set_reuseport = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &optval_tmp, sizeof(optval_tmp));
-    if (set_reuseport == -1) {
-        log_and_throw("setsockopt(SO_REUSEPORT) failed");
-    }
-
-    const auto bind_result = bind(fd, reinterpret_cast<const struct sockaddr*>(&address), sizeof(address));
-    if (bind_result == -1) {
-        const auto error = "Failed to bind ipv6 socket to interface " + interface_name;
-        log_and_throw(error.c_str());
-    }
-
-    const auto listen_result = listen(fd, DEFAULT_SOCKET_BACKLOG);
-    if (listen_result == -1) {
-        log_and_throw("Listen on socket failed");
-    }
+    fd = create_tcp_listen_socket(address, end_point.port, DEFAULT_SOCKET_BACKLOG);
 
     poll_manager.register_fd(fd, [this]() { this->handle_connect(); });
 }

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -31,7 +31,6 @@ struct SSLContext {
 
 namespace {
 
-constexpr auto DEFAULT_SOCKET_BACKLOG = 4;
 constexpr auto TLS_PORT = 50000;
 
 std::string_view result_name(tls::Connection::result_t r) {
@@ -130,34 +129,7 @@ ConnectionSSL::ConnectionSSL(PollManager& poll_manager_, const std::string& inte
 
     logf_info("Start TLS server [%s]:%" PRIu16, address_name.get(), end_point.port);
 
-    ssl->listen_fd = socket(AF_INET6, SOCK_STREAM, 0);
-    if (ssl->listen_fd == -1) {
-        log_and_throw("Failed to create an ipv6 socket");
-    }
-
-    address.sin6_port = htons(end_point.port);
-
-    int optval_tmp{1};
-    const auto set_reuseaddr = setsockopt(ssl->listen_fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp));
-    if (set_reuseaddr == -1) {
-        log_and_throw("setsockopt(SO_REUSEADDR) failed");
-    }
-
-    const auto set_reuseport = setsockopt(ssl->listen_fd, SOL_SOCKET, SO_REUSEPORT, &optval_tmp, sizeof(optval_tmp));
-    if (set_reuseport == -1) {
-        log_and_throw("setsockopt(SO_REUSEPORT) failed");
-    }
-
-    const auto bind_result = bind(ssl->listen_fd, reinterpret_cast<const struct sockaddr*>(&address), sizeof(address));
-    if (bind_result == -1) {
-        const auto error = "Failed to bind ipv6 socket to interface " + interface_name_;
-        log_and_throw(error.c_str());
-    }
-
-    const auto listen_result = listen(ssl->listen_fd, DEFAULT_SOCKET_BACKLOG);
-    if (listen_result == -1) {
-        log_and_throw("Listen on socket failed");
-    }
+    ssl->listen_fd = create_tcp_listen_socket(address, end_point.port, DEFAULT_SOCKET_BACKLOG);
 
     auto chains = build_chain_configs(ssl_config);
     auto cfg = make_tls_server_config(ssl_config, interface_name_, ssl->listen_fd, std::move(chains));

--- a/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
@@ -11,6 +11,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 #include <iso15118/detail/helper.hpp>
 
@@ -153,18 +154,22 @@ int create_tcp_listen_socket(sockaddr_in6& address, uint16_t port, int backlog) 
 
     int optval_tmp{1};
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp)) == -1) {
+        ::close(fd);
         log_and_throw("setsockopt(SO_REUSEADDR) failed");
     }
 
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &optval_tmp, sizeof(optval_tmp)) == -1) {
+        ::close(fd);
         log_and_throw("setsockopt(SO_REUSEPORT) failed");
     }
 
     if (bind(fd, reinterpret_cast<const struct sockaddr*>(&address), sizeof(address)) == -1) {
+        ::close(fd);
         log_and_throw("Failed to bind ipv6 socket");
     }
 
     if (listen(fd, backlog) == -1) {
+        ::close(fd);
         log_and_throw("Listen on socket failed");
     }
 

--- a/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
@@ -142,6 +142,35 @@ bool set_tcp_keepalive(int fd) {
     return true;
 }
 
+int create_tcp_listen_socket(sockaddr_in6& address, uint16_t port, int backlog) {
+    const auto fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd == -1) {
+        log_and_throw("Failed to create an ipv6 socket");
+    }
+
+    // before bind, set the port
+    address.sin6_port = htons(port);
+
+    int optval_tmp{1};
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval_tmp, sizeof(optval_tmp)) == -1) {
+        log_and_throw("setsockopt(SO_REUSEADDR) failed");
+    }
+
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &optval_tmp, sizeof(optval_tmp)) == -1) {
+        log_and_throw("setsockopt(SO_REUSEPORT) failed");
+    }
+
+    if (bind(fd, reinterpret_cast<const struct sockaddr*>(&address), sizeof(address)) == -1) {
+        log_and_throw("Failed to bind ipv6 socket");
+    }
+
+    if (listen(fd, backlog) == -1) {
+        log_and_throw("Listen on socket failed");
+    }
+
+    return fd;
+}
+
 std::unique_ptr<char[]> sockaddr_in6_to_name(const sockaddr_in6& address) {
     // account for ipv6 address string length plus possible scope/zone
     // identifier which seems to be an interface name, as both constants

--- a/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
@@ -10,6 +10,14 @@ target_link_libraries(test_logging
 
 catch_discover_tests(test_logging)
 
+add_executable(socket_helper_test socket_helper_test.cpp)
+target_link_libraries(socket_helper_test
+    PRIVATE
+        iso15118
+        Catch2::Catch2WithMain
+)
+catch_discover_tests(socket_helper_test)
+
 add_executable(test_sdp_server sdp_server_test.cpp)
 target_link_libraries(test_sdp_server PRIVATE iso15118 Catch2::Catch2WithMain)
 catch_discover_tests(test_sdp_server)

--- a/lib/everest/iso15118/test/iso15118/io/socket_helper_test.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/socket_helper_test.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstring>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iso15118/detail/io/socket_helper.hpp>
+
+TEST_CASE("socket_helper: create_tcp_listen_socket binds and listens") {
+    sockaddr_in6 address{};
+    address.sin6_family = AF_INET6;
+    address.sin6_addr = in6addr_loopback;
+
+    const auto fd = iso15118::io::create_tcp_listen_socket(address, /*port=*/0, /*backlog=*/4);
+    REQUIRE(fd >= 0);
+
+    sockaddr_in6 bound_address{};
+    socklen_t bound_address_len = sizeof(bound_address);
+    REQUIRE(getsockname(fd, reinterpret_cast<sockaddr*>(&bound_address), &bound_address_len) == 0);
+    REQUIRE(ntohs(bound_address.sin6_port) != 0);
+
+    // a successful loopback connect proves the socket is in listen state
+    const auto client_fd = socket(AF_INET6, SOCK_STREAM, 0);
+    REQUIRE(client_fd >= 0);
+    const auto connect_result =
+        connect(client_fd, reinterpret_cast<const sockaddr*>(&bound_address), sizeof(bound_address));
+    CHECK(connect_result == 0);
+
+    close(client_fd);
+    close(fd);
+}

--- a/lib/everest/iso15118/test/iso15118/io/socket_helper_test.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/socket_helper_test.cpp
@@ -4,11 +4,33 @@
 
 #include <cstring>
 
+#include <dirent.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <iso15118/detail/io/socket_helper.hpp>
+
+namespace {
+
+// counts entries in /proc/self/fd; the scan itself holds an fd, but since
+// both invocations scan identically, the transient cancels out on compare
+int count_open_fds() {
+    auto* dir = opendir("/proc/self/fd");
+    REQUIRE(dir != nullptr);
+
+    int count = 0;
+    while (auto* entry = readdir(dir)) {
+        if (strcmp(entry->d_name, ".") == 0 or strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+        ++count;
+    }
+    closedir(dir);
+    return count;
+}
+
+} // namespace
 
 TEST_CASE("socket_helper: create_tcp_listen_socket binds and listens") {
     sockaddr_in6 address{};
@@ -32,4 +54,17 @@ TEST_CASE("socket_helper: create_tcp_listen_socket binds and listens") {
 
     close(client_fd);
     close(fd);
+}
+
+TEST_CASE("socket_helper: create_tcp_listen_socket closes the fd when setup fails") {
+    // an AF_INET address family on an AF_INET6 socket makes bind fail deterministically
+    sockaddr_in6 address{};
+    address.sin6_family = AF_INET;
+    address.sin6_addr = in6addr_loopback;
+
+    const auto fds_before = count_open_fds();
+    REQUIRE_THROWS(iso15118::io::create_tcp_listen_socket(address, /*port=*/0, /*backlog=*/4));
+    const auto fds_after = count_open_fds();
+
+    REQUIRE(fds_after == fds_before);
 }

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -263,6 +263,13 @@ public:
     [[nodiscard]] int socket() const;
 
     /**
+     * \brief number of decrypted bytes buffered in the TLS record layer
+     * \returns bytes available to read() without a socket read, or 0 when
+     *          there is no active SSL context
+     */
+    [[nodiscard]] std::size_t pending() const;
+
+    /**
      * \brief obtain the peer certificate
      * \returns the certificate or nullptr
      * \note the certificate must not be freed
@@ -353,7 +360,8 @@ public:
  */
 class ClientConnection : public Connection {
 public:
-    ClientConnection(SslContext* ctx, int soc, const char* ip_in, const char* service_in, std::int32_t timeout_ms);
+    ClientConnection(SslContext* ctx, int soc, const char* ip_in, const char* service_in, std::int32_t timeout_ms,
+                     bool verify_subject_name);
     ClientConnection() = delete;
     ClientConnection(const ClientConnection&) = delete;
     ClientConnection(ClientConnection&&) = delete;
@@ -699,7 +707,10 @@ public:
         std::int32_t io_timeout_ms{-1};              //!< default socket timeout in milliseconds (recommend > 1 sec)
         //!< minimum TLS protocol version, e.g. TLS1_2_VERSION or TLS1_3_VERSION; 0 means use default
         int min_proto_version{0};
-        bool verify_server{true};      //!< verify the server certificate
+        bool verify_server{true}; //!< verify the server certificate
+        //!< when true, the peer certificate subject/SAN is matched against the SNI host via SSL_set1_host.
+        //!< Only enforced when verify_server is also true (peer verification must be active); ignored otherwise.
+        bool verify_subject_name{false};
         bool status_request{false};    //!< include a status request extension in the client hello
         bool status_request_v2{false}; //!< include a status request v2 extension in the client hello
         bool trusted_ca_keys{false};   //!< include a trusted ca keys extension in the client hello
@@ -710,6 +721,7 @@ public:
 private:
     std::unique_ptr<client_ctx> m_context;                      //!< opaque object data
     std::int32_t m_timeout_ms{-1};                              //!< default operation timeout
+    bool m_verify_subject_name{false};                          //!< pin SNI hostname verification on new connections
     trusted_ca_keys_t m_trusted_ca_keys;                        //!< trusted CA keys configuration data
     std::unique_ptr<ClientStatusRequestV2> m_status_request_v2; //!< status request extension handler
 
@@ -749,6 +761,24 @@ public:
     [[nodiscard]] inline ConnectionPtr connect(const char* host, const char* service, bool ipv6_only) {
         return connect(host, service, ipv6_only, m_timeout_ms);
     }
+
+    /**
+     * \brief wrap an already-connecting TCP socket as a TLS client connection
+     * \param[in] fd connected (or in-progress) TCP socket file descriptor
+     * \param[in] host_for_sni hostname used for the peer-id / SNI slot (may be nullptr)
+     * \return ConnectionPtr that owns \p fd on success; nullptr if SSL_CTX is not initialised
+     * \note Lets callers own the TCP connect path and hand the resulting fd to a
+     *       configured Client (mirror of Server::wrap_accepted_fd).
+     * \note A DNS \p host_for_sni is sent in the SNI extension; an IP literal is
+     *       not (RFC 6066 §3). When config_t::verify_subject_name is set the peer
+     *       certificate is pinned to \p host_for_sni (DNS name or IP SAN) and a
+     *       pin-install failure fails the handshake closed; otherwise verify_server
+     *       remains chain-of-trust only.
+     * \note Ownership: on success the returned ClientConnection owns \p fd and
+     *       will close it. On a nullptr return the caller still owns \p fd and
+     *       must close it; this factory does not close \p fd on failure.
+     */
+    [[nodiscard]] ConnectionPtr wrap_connecting_fd(int fd, const char* host_for_sni);
 
     /**
      * \brief the default SSL callbacks

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -138,7 +138,8 @@ public:
 protected:
     std::unique_ptr<connection_ctx> m_context; //!< opaque connection data
     state_t m_state{state_t::idle};            //!< connection state
-    std::string m_ip;                          //!< peer IP address
+    std::string m_peer_host; //!< peer host: DNS hostname or IP literal, as provided by the caller (server accept path
+                             //!< passes the peer IP; Client::wrap_connecting_fd passes host_for_sni)
     std::string m_service;                     //!< peer port
     std::int32_t m_timeout_ms;                 //!< default operation timeout
     std::string
@@ -225,10 +226,13 @@ public:
     }
 
     /**
-     * IP address of the connection's peer
+     * Host of the connection's peer, as provided by the caller: the peer IP
+     * address on the server accept path, or host_for_sni (which may be a DNS
+     * hostname) for Client::wrap_connecting_fd. The name is kept for API
+     * stability; the value is not always an IP address.
      */
     [[nodiscard]] const std::string& ip_address() const {
-        return m_ip;
+        return m_peer_host;
     }
 
     /**

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -265,6 +265,14 @@ public:
     [[nodiscard]] int socket() const;
 
     /**
+     * \brief whether the connection was fully constructed
+     * \returns true when both the SSL object and its socket BIO were allocated.
+     *          When false the internal SSL/BIO allocation failed and the socket
+     *          fd was NOT adopted by a BIO_CLOSE owner, so the caller still owns it.
+     */
+    [[nodiscard]] bool is_valid() const;
+
+    /**
      * \brief number of decrypted bytes buffered in the TLS record layer
      * \returns bytes available to read() without a socket read, or 0 when
      *          there is no active SSL context
@@ -712,6 +720,11 @@ public:
         bool verify_server{true}; //!< verify the server certificate
         //!< when true, the peer certificate subject/SAN is matched against the SNI host via SSL_set1_host.
         //!< Only enforced when verify_server is also true (peer verification must be active); ignored otherwise.
+        //!<
+        //!< WARNING: the default (false) means chain-of-trust ONLY — a certificate signed by any trusted
+        //!< CA is accepted regardless of the host it was issued for. This is deliberate for ISO 15118 EVSE
+        //!< certificates, which carry no hostname. For hostname-bearing PKIs (backends/CSMS) set this to
+        //!< true so a cert issued for another host is rejected.
         bool verify_subject_name{false};
         bool status_request{false};    //!< include a status request extension in the client hello
         bool status_request_v2{false}; //!< include a status request v2 extension in the client hello

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -138,10 +138,10 @@ public:
 protected:
     std::unique_ptr<connection_ctx> m_context; //!< opaque connection data
     state_t m_state{state_t::idle};            //!< connection state
-    std::string m_peer_host; //!< peer host, a DNS hostname or IP literal (server accept: peer IP;
+    std::string m_peer_host;                   //!< peer host, a DNS hostname or IP literal (server accept: peer IP;
                              //!< Client::connect: connect target; Client::wrap_connecting_fd: host_for_sni)
-    std::string m_service;                     //!< peer port
-    std::int32_t m_timeout_ms;                 //!< default operation timeout
+    std::string m_service;     //!< peer port
+    std::int32_t m_timeout_ms; //!< default operation timeout
     std::string
         m_last_error; //!< OpenSSL error text from the operation that closed this connection; empty on graceful close
 

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -781,7 +781,8 @@ public:
      * \brief wrap an already-connecting TCP socket as a TLS client connection
      * \param[in] fd connected (or in-progress) TCP socket file descriptor
      * \param[in] host_for_sni hostname used for the peer-id / SNI slot (may be nullptr)
-     * \return ConnectionPtr that owns \p fd on success; nullptr if SSL_CTX is not initialised
+     * \return ConnectionPtr that owns \p fd on success; nullptr if the SSL_CTX is
+     *         not initialised or internal SSL/BIO allocation fails
      * \note Lets callers own the TCP connect path and hand the resulting fd to a
      *       configured Client (mirror of Server::wrap_accepted_fd).
      * \note A DNS \p host_for_sni is sent in the SNI extension; an IP literal is

--- a/lib/everest/tls/include/everest/tls/tls.hpp
+++ b/lib/everest/tls/include/everest/tls/tls.hpp
@@ -138,8 +138,8 @@ public:
 protected:
     std::unique_ptr<connection_ctx> m_context; //!< opaque connection data
     state_t m_state{state_t::idle};            //!< connection state
-    std::string m_peer_host; //!< peer host: DNS hostname or IP literal, as provided by the caller (server accept path
-                             //!< passes the peer IP; Client::wrap_connecting_fd passes host_for_sni)
+    std::string m_peer_host; //!< peer host, a DNS hostname or IP literal (server accept: peer IP;
+                             //!< Client::connect: connect target; Client::wrap_connecting_fd: host_for_sni)
     std::string m_service;                     //!< peer port
     std::int32_t m_timeout_ms;                 //!< default operation timeout
     std::string
@@ -226,10 +226,8 @@ public:
     }
 
     /**
-     * Host of the connection's peer, as provided by the caller: the peer IP
-     * address on the server accept path, or host_for_sni (which may be a DNS
-     * hostname) for Client::wrap_connecting_fd. The name is kept for API
-     * stability; the value is not always an IP address.
+     * Host of the connection's peer: a DNS hostname or IP literal, depending
+     * on how the connection was created. The name is kept for API stability.
      */
     [[nodiscard]] const std::string& ip_address() const {
         return m_peer_host;

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -829,18 +829,23 @@ int ssl_keylog_server_index{-1};
 
 void keylog_callback(const SSL* ssl, const char* line) {
 
+    // The callback is registered CTX-wide, so it also fires for connections
+    // that skipped the per-connection key-log server (e.g. when the service
+    // string was not a valid port number) and carry no ex_data.
     auto keylog_server = static_cast<TlsKeyLoggingServer*>(SSL_get_ex_data(ssl, ssl_keylog_server_index));
 
-    std::string key_log_msg = "TLS Handshake keys on port ";
-    key_log_msg += std::to_string(keylog_server->get_port()) + ": ";
-    key_log_msg += std::string(line);
+    if (keylog_server != nullptr) {
+        std::string key_log_msg = "TLS Handshake keys on port ";
+        key_log_msg += std::to_string(keylog_server->get_port()) + ": ";
+        key_log_msg += std::string(line);
 
-    log_info(key_log_msg);
+        log_info(key_log_msg);
 
-    if (keylog_server->get_fd() != -1) {
-        const auto result = keylog_server->send(line);
-        if (result not_eq strlen(line)) {
-            log_error("key_logging_server send() failed!");
+        if (keylog_server->get_fd() != -1) {
+            const auto result = keylog_server->send(line);
+            if (result not_eq strlen(line)) {
+                log_error("key_logging_server send() failed!");
+            }
         }
     }
 

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -802,6 +802,12 @@ int Connection::socket() const {
     return m_context->soc;
 }
 
+bool Connection::is_valid() const {
+    // soc_bio is the BIO_CLOSE owner of the fd; it is null only when SSL_new or
+    // BIO_new_socket failed in the ctor, in which case the fd was never adopted.
+    return m_context != nullptr && m_context->soc_bio != nullptr;
+}
+
 std::size_t Connection::pending() const {
     return (m_context && m_context->ctx) ? static_cast<std::size_t>(SSL_pending(m_context->ctx.get())) : 0;
 }
@@ -1347,8 +1353,15 @@ Server::ConnectionPtr Server::wrap_accepted_fd(int soc, const char* ip, const ch
     if ((m_context == nullptr) || (m_context->ctx == nullptr)) {
         return nullptr;
     }
-    return std::make_unique<ServerConnection>(m_context->ctx.get(), soc, ip, service, m_timeout_ms,
-                                              m_tls_key_interface);
+    auto conn =
+        std::make_unique<ServerConnection>(m_context->ctx.get(), soc, ip, service, m_timeout_ms, m_tls_key_interface);
+    if (!conn->is_valid()) {
+        // Internal SSL/BIO allocation failed: no BIO_CLOSE owner took the fd.
+        // Return null and leave the fd to the caller, which closes it on the null
+        // path (closing here would double-close the caller's fd).
+        return nullptr;
+    }
+    return conn;
 }
 
 void Server::configure_signal_handler(int interrupt_signal) {
@@ -1655,8 +1668,16 @@ Client::ConnectionPtr Client::wrap_connecting_fd(int fd, const char* host_for_sn
     if (m_context == nullptr) {
         return nullptr;
     }
-    return std::make_unique<ClientConnection>(m_context->ctx.get(), fd, (host_for_sni != nullptr) ? host_for_sni : "",
-                                              "", m_timeout_ms, m_verify_subject_name);
+    auto conn =
+        std::make_unique<ClientConnection>(m_context->ctx.get(), fd, (host_for_sni != nullptr) ? host_for_sni : "", "",
+                                           m_timeout_ms, m_verify_subject_name);
+    if (!conn->is_valid()) {
+        // Internal SSL/BIO allocation failed: no BIO_CLOSE owner took the fd.
+        // Return null and leave the fd to the caller (tls_client_socket keeps its
+        // tcp_socket ownership on the null path and closes it there).
+        return nullptr;
+    }
+    return conn;
 }
 
 Client::override_t Client::default_overrides() {

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -726,8 +726,7 @@ struct client_ctx {
 // Connection represents a TLS connection (client and server)
 
 Connection::Connection(SslContext* ctx, int soc, const char* ip_in, const char* service_in, std::int32_t timeout_ms) :
-    m_context(std::make_unique<connection_ctx>()), m_peer_host(ip_in), m_service(service_in),
-    m_timeout_ms(timeout_ms) {
+    m_context(std::make_unique<connection_ctx>()), m_peer_host(ip_in), m_service(service_in), m_timeout_ms(timeout_ms) {
     m_context->ctx = SSL_ptr(SSL_new(ctx));
     m_context->soc = soc;
 
@@ -890,9 +889,8 @@ ServerConnection::ServerConnection(SslContext* ctx, int soc, const char* ip_in, 
                 m_keylog_server = std::make_unique<TlsKeyLoggingServer>(std::string(tls_key_interface), port);
                 SSL_set_ex_data(m_context->ctx.get(), ssl_keylog_server_index, m_keylog_server.get());
             } else {
-                log_warning(
-                    "ServerConnection: service string is not a port number; TLS key logging disabled for this "
-                    "connection");
+                log_warning("ServerConnection: service string is not a port number; TLS key logging disabled for this "
+                            "connection");
             }
         }
     }

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -35,6 +35,7 @@
 #include <openssl/ssl.h>
 #include <openssl/tls1.h>
 #include <openssl/types.h>
+#include <openssl/x509_vfy.h>
 #include <utility>
 
 #ifdef UNIT_TEST
@@ -800,6 +801,10 @@ int Connection::socket() const {
     return m_context->soc;
 }
 
+std::size_t Connection::pending() const {
+    return (m_context && m_context->ctx) ? static_cast<std::size_t>(SSL_pending(m_context->ctx.get())) : 0;
+}
+
 const Certificate* Connection::peer_certificate() const {
     assert(m_context != nullptr);
     return SSL_get0_peer_certificate(m_context->ctx.get());
@@ -913,11 +918,49 @@ void ServerConnection::wait_all_closed() {
 // ----------------------------------------------------------------------------
 // ClientConnection represents a TLS client connection
 
+namespace {
+// RFC 6066 §3 forbids literal IPv4/IPv6 addresses in the SNI extension, and
+// SSL_set1_host() expects a DNS name (IP SANs are matched via the verify param).
+// Detect a literal so SNI and DNS pinning apply only to real hostnames.
+bool is_ip_literal(const std::string& host) {
+    unsigned char buf[sizeof(struct in6_addr)];
+    return ::inet_pton(AF_INET, host.c_str(), buf) == 1 || ::inet_pton(AF_INET6, host.c_str(), buf) == 1;
+}
+} // namespace
+
 ClientConnection::ClientConnection(SslContext* ctx, int soc, const char* ip_in, const char* service_in,
-                                   std::int32_t timeout_ms) :
+                                   std::int32_t timeout_ms, bool verify_subject_name) :
     Connection(ctx, soc, ip_in, service_in, timeout_ms) {
-    if (m_context->soc_bio != nullptr) {
-        SSL_set_connect_state(m_context->ctx.get());
+    if (m_context->soc_bio == nullptr) {
+        return;
+    }
+    SSL_set_connect_state(m_context->ctx.get());
+    if (m_ip.empty()) {
+        return;
+    }
+
+    auto* const ssl = m_context->ctx.get();
+    const bool ip_literal = is_ip_literal(m_ip);
+
+    // RFC 6066 §3: the SNI extension carries DNS hostnames only, never IP literals.
+    if (!ip_literal) {
+        SSL_set_tlsext_host_name(ssl, m_ip.c_str());
+    }
+
+    if (verify_subject_name) {
+        // Pin certificate verification to the host: a DNS name via RFC-6125
+        // hostname matching, an IP literal via IP-SAN matching. If the pin cannot
+        // be installed, fault the connection so the handshake fails closed rather
+        // than silently downgrading to chain-of-trust only.
+        const int pinned = ip_literal ? X509_VERIFY_PARAM_set1_ip_asc(SSL_get0_param(ssl), m_ip.c_str())
+                                      : SSL_set1_host(ssl, m_ip.c_str());
+        if (pinned != 1) {
+            log_error(ip_literal ? "X509_VERIFY_PARAM_set1_ip_asc" : "SSL_set1_host");
+            m_state = state_t::fault;
+            return;
+        }
+        // disallow partial wildcards (e.g. "f*.example.com") in the certificate
+        SSL_set_hostflags(ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
     }
 }
 
@@ -1447,6 +1490,11 @@ bool Client::init(const config_t& cfg, const override_t& override) {
     assert(override.trusted_ca_keys_free != nullptr);
 
     m_timeout_ms = cfg.io_timeout_ms;
+    m_verify_subject_name = cfg.verify_subject_name;
+    if (cfg.verify_subject_name && !cfg.verify_server) {
+        log_warning("hostname verification (verify_subject_name) requires verify_server=true to be enforced; "
+                    "it will not reject a mismatched host otherwise");
+    }
     m_trusted_ca_keys = cfg.trusted_ca_keys_data;
     SSL_CTX* ctx = nullptr;
     Server::certificate_config_t cert_config{};
@@ -1574,12 +1622,21 @@ std::unique_ptr<ClientConnection> Client::connect(const char* host, const char* 
             }
 
             if (connected) {
-                result = std::make_unique<ClientConnection>(m_context->ctx.get(), socket, host, service, m_timeout_ms);
+                result = std::make_unique<ClientConnection>(m_context->ctx.get(), socket, host, service, m_timeout_ms,
+                                                            m_verify_subject_name);
             }
         }
     }
 
     return result;
+}
+
+Client::ConnectionPtr Client::wrap_connecting_fd(int fd, const char* host_for_sni) {
+    if (m_context == nullptr) {
+        return nullptr;
+    }
+    return std::make_unique<ClientConnection>(m_context->ctx.get(), fd, (host_for_sni != nullptr) ? host_for_sni : "",
+                                              "", m_timeout_ms, m_verify_subject_name);
 }
 
 Client::override_t Client::default_overrides() {

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -726,7 +726,8 @@ struct client_ctx {
 // Connection represents a TLS connection (client and server)
 
 Connection::Connection(SslContext* ctx, int soc, const char* ip_in, const char* service_in, std::int32_t timeout_ms) :
-    m_context(std::make_unique<connection_ctx>()), m_ip(ip_in), m_service(service_in), m_timeout_ms(timeout_ms) {
+    m_context(std::make_unique<connection_ctx>()), m_peer_host(ip_in), m_service(service_in),
+    m_timeout_ms(timeout_ms) {
     m_context->ctx = SSL_ptr(SSL_new(ctx));
     m_context->soc = soc;
 
@@ -956,16 +957,16 @@ ClientConnection::ClientConnection(SslContext* ctx, int soc, const char* ip_in, 
         return;
     }
     SSL_set_connect_state(m_context->ctx.get());
-    if (m_ip.empty()) {
+    if (m_peer_host.empty()) {
         return;
     }
 
     auto* const ssl = m_context->ctx.get();
-    const bool ip_literal = is_ip_literal(m_ip);
+    const bool ip_literal = is_ip_literal(m_peer_host);
 
     // RFC 6066 §3: the SNI extension carries DNS hostnames only, never IP literals.
     if (!ip_literal) {
-        SSL_set_tlsext_host_name(ssl, m_ip.c_str());
+        SSL_set_tlsext_host_name(ssl, m_peer_host.c_str());
     }
 
     if (verify_subject_name) {
@@ -973,8 +974,8 @@ ClientConnection::ClientConnection(SslContext* ctx, int soc, const char* ip_in, 
         // hostname matching, an IP literal via IP-SAN matching. If the pin cannot
         // be installed, fault the connection so the handshake fails closed rather
         // than silently downgrading to chain-of-trust only.
-        const int pinned = ip_literal ? X509_VERIFY_PARAM_set1_ip_asc(SSL_get0_param(ssl), m_ip.c_str())
-                                      : SSL_set1_host(ssl, m_ip.c_str());
+        const int pinned = ip_literal ? X509_VERIFY_PARAM_set1_ip_asc(SSL_get0_param(ssl), m_peer_host.c_str())
+                                      : SSL_set1_host(ssl, m_peer_host.c_str());
         if (pinned != 1) {
             log_error(ip_literal ? "X509_VERIFY_PARAM_set1_ip_asc" : "SSL_set1_host");
             m_state = state_t::fault;

--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -11,6 +11,7 @@
 #include <arpa/inet.h>
 #include <array>
 #include <cassert>
+#include <charconv>
 #include <csignal>
 #include <cstddef>
 #include <cstdint>
@@ -869,9 +870,24 @@ ServerConnection::ServerConnection(SslContext* ctx, int soc, const char* ip_in, 
         ServerTrustedCaKeys::set_data(m_context->ctx.get(), &m_tck_data);
 
         if (tls_key_interface != nullptr) {
-            const auto port = std::stoul(service_in);
-            m_keylog_server = std::make_unique<TlsKeyLoggingServer>(std::string(tls_key_interface), port);
-            SSL_set_ex_data(m_context->ctx.get(), ssl_keylog_server_index, m_keylog_server.get());
+            // The service string comes from the accept path and may be empty or
+            // non-numeric; parse it without throwing and only enable key logging
+            // when it is a valid port number.
+            std::uint16_t port{0};
+            bool port_valid{false};
+            if (service_in != nullptr) {
+                const char* end = service_in + std::strlen(service_in);
+                const auto [ptr, ec] = std::from_chars(service_in, end, port);
+                port_valid = (ec == std::errc{}) && (ptr == end) && (end != service_in);
+            }
+            if (port_valid) {
+                m_keylog_server = std::make_unique<TlsKeyLoggingServer>(std::string(tls_key_interface), port);
+                SSL_set_ex_data(m_context->ctx.get(), ssl_keylog_server_index, m_keylog_server.get());
+            } else {
+                log_warning(
+                    "ServerConnection: service string is not a port number; TLS key logging disabled for this "
+                    "connection");
+            }
         }
     }
 }

--- a/lib/everest/tls/tests/CMakeLists.txt
+++ b/lib/everest/tls/tests/CMakeLists.txt
@@ -165,4 +165,7 @@ target_link_libraries(${TLS_PATCH_NAME}
 )
 
 add_test(${TLS_GTEST_NAME} ${TLS_GTEST_NAME})
+# Serialize with everest_io_tls_test: both regenerate the PKI fixture via
+# ./pki.sh in this directory at startup.
+set_tests_properties(${TLS_GTEST_NAME} PROPERTIES RESOURCE_LOCK tls_pki)
 ev_register_test_target(${TLS_GTEST_NAME})

--- a/lib/everest/tls/tests/CMakeLists.txt
+++ b/lib/everest/tls/tests/CMakeLists.txt
@@ -8,10 +8,16 @@ set(TLS_TEST_FILES
         pki-tpm.sh
 )
 
+set(TLS_TEST_FILE_SOURCES "")
+foreach(_tls_test_file ${TLS_TEST_FILES})
+    list(APPEND TLS_TEST_FILE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pki/${_tls_test_file})
+endforeach()
+
 add_custom_command(
     OUTPUT ${TLS_TEST_FILES}
     COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/pki
     COMMAND cd pki && cp ${TLS_TEST_FILES} ${CMAKE_CURRENT_BINARY_DIR}/
+    DEPENDS ${TLS_TEST_FILE_SOURCES}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -40,6 +46,7 @@ target_sources(${TLS_GTEST_NAME} PRIVATE
     tls_test.cpp
     tls_connection_test.cpp
     tls_connection_tls13_test.cpp
+    tls_client_wrap_test.cpp
     ../extensions/helpers.cpp
     ../extensions/status_request.cpp
     ../extensions/trusted_ca_keys.cpp

--- a/lib/everest/tls/tests/pki/openssl-pki.conf
+++ b/lib/everest/tls/tests/pki/openssl-pki.conf
@@ -78,7 +78,7 @@ subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always
 keyUsage = digitalSignature, keyEncipherment, keyAgreement
 extendedKeyUsage = serverAuth, clientAuth
-subjectAltName = IP:192.168.245.1, DNS:evse.pionix.de
+subjectAltName = IP:192.168.245.1, DNS:evse.pionix.de, DNS:localhost
 
 # client section
 # ==============

--- a/lib/everest/tls/tests/tls_client_wrap_test.cpp
+++ b/lib/everest/tls/tests/tls_client_wrap_test.cpp
@@ -3,18 +3,14 @@
 
 #include "tls_connection_test.hpp"
 
-#include <arpa/inet.h>
-#include <fcntl.h>
-#include <netdb.h>
-#include <netinet/in.h>
+#include <cstring>
 #include <poll.h>
-#include <sys/socket.h>
-#include <sys/types.h>
 #include <unistd.h>
 
-// Use a distinct fixture name to avoid GTest suite-name collisions when
-// TlsTest (defined in the anonymous namespace of tls_connection_test.hpp)
-// is instantiated in multiple translation units.
+// TlsTest (named namespace tls_test, shared across translation units) already
+// hosts the connection test suite. This derived fixture exists solely to give
+// the wrap_connecting_fd cases their own GoogleTest suite name so they stay
+// separately addressable via --gtest_filter.
 struct TlsClientWrapTest : TlsTest {};
 
 // ---------------------------------------------------------------------------
@@ -26,76 +22,29 @@ struct TlsClientWrapTest : TlsTest {};
 
 TEST_F(TlsClientWrapTest, WrapConnectingFdHandshake) {
     using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
 
-    // Create a listen socket on an ephemeral port. Passed via
-    // server_config.socket so that init() skips its own bind/listen path.
-    const int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    ASSERT_GE(listen_fd, 0);
-    int reuse = 1;
-    (void)::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+    // Test-owned listen socket, passed via server_config.socket so that
+    // init() skips its own bind/listen path.
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
 
-    sockaddr_in listen_addr{};
-    listen_addr.sin_family = AF_INET;
-    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    listen_addr.sin_port = 0;
-    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)), 0);
-    ASSERT_EQ(::listen(listen_fd, 1), 0);
-
-    server_config.socket = listen_fd;
+    server_config.socket = listener.fd;
     const auto init_state = server.init(server_config, nullptr);
     ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
 
-    // Resolve the ephemeral port assigned by the kernel.
-    sockaddr_in bound_addr{};
-    socklen_t bound_len = sizeof(bound_addr);
-    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len), 0);
-    const std::uint16_t bound_port = ntohs(bound_addr.sin_port);
-
-    // Server-side thread: accept the incoming TCP connection, wrap it as a TLS
-    // server connection, and drive the server handshake to give the client a
-    // counterparty.
+    // Server-side thread: accept, wrap, and drive the server handshake to
+    // give the client a counterparty.
     std::thread server_side([&]() {
-        sockaddr_in peer_addr{};
-        socklen_t peer_len = sizeof(peer_addr);
-        const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
-        if (accepted_fd < 0) {
-            return;
-        }
-        char ip_buf[INET_ADDRSTRLEN]{};
-        char svc_buf[NI_MAXSERV]{};
-        (void)::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), svc_buf,
-                            sizeof(svc_buf), NI_NUMERICHOST | NI_NUMERICSERV);
-        auto server_conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        auto server_conn = accept_and_wrap(server, listener.fd);
         if (server_conn) {
             (void)server_conn->accept(1000);
             (void)server_conn->shutdown(1000);
         }
     });
 
-    // Client side: open a non-blocking TCP socket and call connect().
-    // Handle EINPROGRESS by polling until the socket is writable.
-    const int client_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    const int client_fd = connect_loopback_nonblocking(listener.port);
     ASSERT_GE(client_fd, 0);
-    {
-        const int flags = ::fcntl(client_fd, F_GETFL, 0);
-        ASSERT_NE(flags, -1);
-        ASSERT_EQ(::fcntl(client_fd, F_SETFL, flags | O_NONBLOCK), 0);
-    }
-
-    sockaddr_in server_addr{};
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    server_addr.sin_port = htons(bound_port);
-    const int rc = ::connect(client_fd, reinterpret_cast<sockaddr*>(&server_addr), sizeof(server_addr));
-    if (rc != 0) {
-        ASSERT_EQ(errno, EINPROGRESS);
-        pollfd pfd{client_fd, POLLOUT, 0};
-        ASSERT_GT(::poll(&pfd, 1, 2000), 0);
-        int err = 0;
-        socklen_t err_len = sizeof(err);
-        ASSERT_EQ(::getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &err_len), 0);
-        ASSERT_EQ(err, 0);
-    }
 
     // Initialise the client's SSL_CTX.
     ClientTest local_client;
@@ -106,20 +55,8 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdHandshake) {
     ASSERT_TRUE(conn);
     EXPECT_EQ(conn->socket(), client_fd);
 
-    // Drive the TLS handshake in a polling loop.
-    using result_t = tls::Connection::result_t;
-    result_t res = result_t::timeout;
-    for (int i = 0; i < 50 && res != result_t::success; ++i) {
-        res = conn->connect(1000);
-        if (res == result_t::want_read) {
-            pollfd pfd{client_fd, POLLIN, 0};
-            (void)::poll(&pfd, 1, 1000);
-        } else if (res == result_t::want_write) {
-            pollfd pfd{client_fd, POLLOUT, 0};
-            (void)::poll(&pfd, 1, 1000);
-        }
-    }
-    EXPECT_EQ(res, result_t::success);
+    const auto drive = drive_client_handshake(*conn, client_fd);
+    EXPECT_EQ(drive.result, result_t::success);
     EXPECT_NE(conn->peer_certificate(), nullptr);
 
     (void)conn->shutdown(1000);
@@ -127,7 +64,7 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdHandshake) {
     if (server_side.joinable()) {
         server_side.join();
     }
-    (void)::close(listen_fd);
+    (void)::close(listener.fd);
 }
 
 // ---------------------------------------------------------------------------
@@ -140,68 +77,25 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdHandshake) {
 
 TEST_F(TlsClientWrapTest, WrapConnectingFdVerifiesHostname) {
     using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
 
-    const int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    ASSERT_GE(listen_fd, 0);
-    int reuse = 1;
-    (void)::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
 
-    sockaddr_in listen_addr{};
-    listen_addr.sin_family = AF_INET;
-    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    listen_addr.sin_port = 0;
-    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)), 0);
-    ASSERT_EQ(::listen(listen_fd, 1), 0);
-
-    server_config.socket = listen_fd;
+    server_config.socket = listener.fd;
     const auto init_state = server.init(server_config, nullptr);
     ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
 
-    sockaddr_in bound_addr{};
-    socklen_t bound_len = sizeof(bound_addr);
-    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len), 0);
-    const std::uint16_t bound_port = ntohs(bound_addr.sin_port);
-
     std::thread server_side([&]() {
-        sockaddr_in peer_addr{};
-        socklen_t peer_len = sizeof(peer_addr);
-        const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
-        if (accepted_fd < 0) {
-            return;
-        }
-        char ip_buf[INET_ADDRSTRLEN]{};
-        char svc_buf[NI_MAXSERV]{};
-        (void)::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), svc_buf,
-                            sizeof(svc_buf), NI_NUMERICHOST | NI_NUMERICSERV);
-        auto server_conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        auto server_conn = accept_and_wrap(server, listener.fd);
         if (server_conn) {
             (void)server_conn->accept(1000);
             (void)server_conn->shutdown(1000);
         }
     });
 
-    const int client_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    const int client_fd = connect_loopback_nonblocking(listener.port);
     ASSERT_GE(client_fd, 0);
-    {
-        const int flags = ::fcntl(client_fd, F_GETFL, 0);
-        ASSERT_NE(flags, -1);
-        ASSERT_EQ(::fcntl(client_fd, F_SETFL, flags | O_NONBLOCK), 0);
-    }
-
-    sockaddr_in server_addr{};
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    server_addr.sin_port = htons(bound_port);
-    const int rc = ::connect(client_fd, reinterpret_cast<sockaddr*>(&server_addr), sizeof(server_addr));
-    if (rc != 0) {
-        ASSERT_EQ(errno, EINPROGRESS);
-        pollfd pfd{client_fd, POLLOUT, 0};
-        ASSERT_GT(::poll(&pfd, 1, 2000), 0);
-        int err = 0;
-        socklen_t err_len = sizeof(err);
-        ASSERT_EQ(::getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &err_len), 0);
-        ASSERT_EQ(err, 0);
-    }
 
     // Opt in to RFC-6125 hostname verification.
     tls::Client::config_t verify_config = client_config;
@@ -213,19 +107,8 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdVerifiesHostname) {
     auto conn = local_client.wrap_connecting_fd(client_fd, "localhost");
     ASSERT_TRUE(conn);
 
-    using result_t = tls::Connection::result_t;
-    result_t res = result_t::timeout;
-    for (int i = 0; i < 50 && res != result_t::success; ++i) {
-        res = conn->connect(1000);
-        if (res == result_t::want_read) {
-            pollfd pfd{client_fd, POLLIN, 0};
-            (void)::poll(&pfd, 1, 1000);
-        } else if (res == result_t::want_write) {
-            pollfd pfd{client_fd, POLLOUT, 0};
-            (void)::poll(&pfd, 1, 1000);
-        }
-    }
-    EXPECT_EQ(res, result_t::success);
+    const auto drive = drive_client_handshake(*conn, client_fd);
+    EXPECT_EQ(drive.result, result_t::success);
     EXPECT_NE(conn->peer_certificate(), nullptr);
 
     (void)conn->shutdown(1000);
@@ -233,7 +116,7 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdVerifiesHostname) {
     if (server_side.joinable()) {
         server_side.join();
     }
-    (void)::close(listen_fd);
+    (void)::close(listener.fd);
 }
 
 // ---------------------------------------------------------------------------
@@ -246,68 +129,25 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdVerifiesHostname) {
 
 TEST_F(TlsClientWrapTest, WrapConnectingFdRejectsWrongHostname) {
     using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
 
-    const int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    ASSERT_GE(listen_fd, 0);
-    int reuse = 1;
-    (void)::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
 
-    sockaddr_in listen_addr{};
-    listen_addr.sin_family = AF_INET;
-    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    listen_addr.sin_port = 0;
-    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)), 0);
-    ASSERT_EQ(::listen(listen_fd, 1), 0);
-
-    server_config.socket = listen_fd;
+    server_config.socket = listener.fd;
     const auto init_state = server.init(server_config, nullptr);
     ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
 
-    sockaddr_in bound_addr{};
-    socklen_t bound_len = sizeof(bound_addr);
-    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len), 0);
-    const std::uint16_t bound_port = ntohs(bound_addr.sin_port);
-
     std::thread server_side([&]() {
-        sockaddr_in peer_addr{};
-        socklen_t peer_len = sizeof(peer_addr);
-        const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
-        if (accepted_fd < 0) {
-            return;
-        }
-        char ip_buf[INET_ADDRSTRLEN]{};
-        char svc_buf[NI_MAXSERV]{};
-        (void)::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), svc_buf,
-                            sizeof(svc_buf), NI_NUMERICHOST | NI_NUMERICSERV);
-        auto server_conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        auto server_conn = accept_and_wrap(server, listener.fd);
         if (server_conn) {
             (void)server_conn->accept(1000);
             (void)server_conn->shutdown(1000);
         }
     });
 
-    const int client_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    const int client_fd = connect_loopback_nonblocking(listener.port);
     ASSERT_GE(client_fd, 0);
-    {
-        const int flags = ::fcntl(client_fd, F_GETFL, 0);
-        ASSERT_NE(flags, -1);
-        ASSERT_EQ(::fcntl(client_fd, F_SETFL, flags | O_NONBLOCK), 0);
-    }
-
-    sockaddr_in server_addr{};
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    server_addr.sin_port = htons(bound_port);
-    const int rc = ::connect(client_fd, reinterpret_cast<sockaddr*>(&server_addr), sizeof(server_addr));
-    if (rc != 0) {
-        ASSERT_EQ(errno, EINPROGRESS);
-        pollfd pfd{client_fd, POLLOUT, 0};
-        ASSERT_GT(::poll(&pfd, 1, 2000), 0);
-        int err = 0;
-        socklen_t err_len = sizeof(err);
-        ASSERT_EQ(::getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &err_len), 0);
-        ASSERT_EQ(err, 0);
-    }
 
     tls::Client::config_t verify_config = client_config;
     verify_config.verify_subject_name = true;
@@ -319,100 +159,68 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdRejectsWrongHostname) {
     auto conn = local_client.wrap_connecting_fd(client_fd, "wrong.example");
     ASSERT_TRUE(conn);
 
-    using result_t = tls::Connection::result_t;
-    result_t res = result_t::timeout;
-    for (int i = 0; i < 50 && res != result_t::success && res != result_t::closed; ++i) {
-        res = conn->connect(1000);
-        if (res == result_t::want_read) {
-            pollfd pfd{client_fd, POLLIN, 0};
-            (void)::poll(&pfd, 1, 1000);
-        } else if (res == result_t::want_write) {
-            pollfd pfd{client_fd, POLLOUT, 0};
-            (void)::poll(&pfd, 1, 1000);
-        }
-    }
+    const auto drive = drive_client_handshake(*conn, client_fd);
     // Hostname mismatch must prevent a successful handshake.
-    EXPECT_NE(res, result_t::success);
+    EXPECT_NE(drive.result, result_t::success);
 
     (void)conn->shutdown(1000);
 
     if (server_side.joinable()) {
         server_side.join();
     }
-    (void)::close(listen_fd);
+    (void)::close(listener.fd);
 }
 
 // ---------------------------------------------------------------------------
 // WrapConnectingFdNonBlocking
 //
-// Verifies non-blocking behaviour: drives the handshake with timeout_ms=0 and
-// asserts that at least one want_read or want_write was observed, confirming
-// that the SSL state machine properly surfaces I/O readiness signals.
+// Verifies non-blocking behaviour: drives the handshake with timeout_ms=0,
+// asserts that at least one want_read or want_write was observed, and then
+// completes a 4-byte echo round trip over the non-blocking read/write paths.
 
 TEST_F(TlsClientWrapTest, WrapConnectingFdNonBlocking) {
     using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
 
-    const int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    ASSERT_GE(listen_fd, 0);
-    int reuse = 1;
-    (void)::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
 
-    sockaddr_in listen_addr{};
-    listen_addr.sin_family = AF_INET;
-    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    listen_addr.sin_port = 0;
-    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)), 0);
-    ASSERT_EQ(::listen(listen_fd, 1), 0);
-
-    server_config.socket = listen_fd;
+    server_config.socket = listener.fd;
     const auto init_state = server.init(server_config, nullptr);
     ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
 
-    sockaddr_in bound_addr{};
-    socklen_t bound_len = sizeof(bound_addr);
-    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len), 0);
-    const std::uint16_t bound_port = ntohs(bound_addr.sin_port);
-
+    // Server-side thread: after the handshake, read 4 bytes and echo them
+    // back so the client's non-blocking write/read paths can be asserted.
     std::thread server_side([&]() {
-        sockaddr_in peer_addr{};
-        socklen_t peer_len = sizeof(peer_addr);
-        const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
-        if (accepted_fd < 0) {
+        auto server_conn = accept_and_wrap(server, listener.fd);
+        if (!server_conn) {
             return;
         }
-        char ip_buf[INET_ADDRSTRLEN]{};
-        char svc_buf[NI_MAXSERV]{};
-        (void)::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), svc_buf,
-                            sizeof(svc_buf), NI_NUMERICHOST | NI_NUMERICSERV);
-        auto server_conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
-        if (server_conn) {
-            (void)server_conn->accept(1000);
-            (void)server_conn->shutdown(1000);
+        if (server_conn->accept(1000) == result_t::success) {
+            std::array<std::byte, 4> buf{};
+            std::size_t total = 0;
+            int timeouts = 0;
+            while (total < buf.size() && timeouts <= 10) {
+                std::size_t got = 0;
+                const auto rres = server_conn->read(buf.data() + total, buf.size() - total, got, 1000);
+                if (rres == result_t::success) {
+                    total += got;
+                } else if (rres == result_t::timeout) {
+                    ++timeouts;
+                } else {
+                    break;
+                }
+            }
+            if (total == buf.size()) {
+                std::size_t sent = 0;
+                (void)server_conn->write(buf.data(), buf.size(), sent, 1000);
+            }
         }
+        (void)server_conn->shutdown(1000);
     });
 
-    const int client_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    const int client_fd = connect_loopback_nonblocking(listener.port);
     ASSERT_GE(client_fd, 0);
-    {
-        const int flags = ::fcntl(client_fd, F_GETFL, 0);
-        ASSERT_NE(flags, -1);
-        ASSERT_EQ(::fcntl(client_fd, F_SETFL, flags | O_NONBLOCK), 0);
-    }
-
-    sockaddr_in server_addr{};
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    server_addr.sin_port = htons(bound_port);
-    const int rc = ::connect(client_fd, reinterpret_cast<sockaddr*>(&server_addr), sizeof(server_addr));
-    if (rc != 0) {
-        ASSERT_EQ(errno, EINPROGRESS);
-        pollfd pfd{client_fd, POLLOUT, 0};
-        ASSERT_GT(::poll(&pfd, 1, 2000), 0);
-        int err = 0;
-        socklen_t err_len = sizeof(err);
-        ASSERT_EQ(::getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &err_len), 0);
-        ASSERT_EQ(err, 0);
-    }
 
     // Use timeout_ms = 0 to force purely non-blocking operation.
     tls::Client::config_t nb_config = client_config;
@@ -424,46 +232,49 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdNonBlocking) {
     auto conn = local_client.wrap_connecting_fd(client_fd, "localhost");
     ASSERT_TRUE(conn);
 
-    int saw_want_read = 0;
-    int saw_want_write = 0;
-
-    using result_t = tls::Connection::result_t;
-    result_t res = result_t::timeout;
-    for (int i = 0; i < 200 && res != result_t::success; ++i) {
-        res = conn->connect(0);
-        if (res == result_t::want_read) {
-            ++saw_want_read;
-            pollfd pfd{client_fd, POLLIN, 0};
-            (void)::poll(&pfd, 1, 500);
-        } else if (res == result_t::want_write) {
-            ++saw_want_write;
-            pollfd pfd{client_fd, POLLOUT, 0};
-            (void)::poll(&pfd, 1, 500);
-        } else if (res == result_t::closed) {
-            FAIL() << "connection closed unexpectedly during handshake";
-        }
-    }
-    ASSERT_EQ(res, result_t::success);
+    const auto drive = drive_client_handshake(*conn, client_fd, 0, 200, 500);
+    ASSERT_EQ(drive.result, result_t::success);
 
     // At least one I/O readiness signal must have been observed.
-    EXPECT_TRUE(saw_want_read > 0 || saw_want_write > 0)
+    EXPECT_TRUE(drive.want_read > 0 || drive.want_write > 0)
         << "expected at least one want_read or want_write during non-blocking handshake";
 
-    // Short bidirectional exchange — verify read/write want_* signals as
-    // regression guard for the non-blocking I/O path.
+    // Echo round trip: write "ping" and read the 4 bytes back.
     const std::array<std::byte, 4> ping{std::byte{'p'}, std::byte{'i'}, std::byte{'n'}, std::byte{'g'}};
     std::size_t written = 0;
-    for (int i = 0; i < 50 && written == 0; ++i) {
-        const auto wres = conn->write(ping.data(), ping.size(), written);
+    for (int i = 0; i < 50 && written < ping.size(); ++i) {
+        const auto wres = conn->write(ping.data(), ping.size(), written, 0);
         if (wres == result_t::want_write) {
             pollfd pfd{client_fd, POLLOUT, 0};
             (void)::poll(&pfd, 1, 100);
-        } else if (wres == result_t::success) {
+        } else if (wres == result_t::want_read) {
+            pollfd pfd{client_fd, POLLIN, 0};
+            (void)::poll(&pfd, 1, 100);
+        } else if (wres != result_t::success) {
             break;
+        }
+    }
+    ASSERT_EQ(written, ping.size());
+
+    std::array<std::byte, 4> echo{};
+    std::size_t echoed = 0;
+    for (int i = 0; i < 50 && echoed < echo.size(); ++i) {
+        std::size_t got = 0;
+        const auto rres = conn->read(echo.data() + echoed, echo.size() - echoed, got, 0);
+        if (rres == result_t::success) {
+            echoed += got;
+        } else if (rres == result_t::want_read) {
+            pollfd pfd{client_fd, POLLIN, 0};
+            (void)::poll(&pfd, 1, 500);
+        } else if (rres == result_t::want_write) {
+            pollfd pfd{client_fd, POLLOUT, 0};
+            (void)::poll(&pfd, 1, 500);
         } else {
             break;
         }
     }
+    ASSERT_EQ(echoed, echo.size());
+    EXPECT_EQ(std::memcmp(echo.data(), ping.data(), ping.size()), 0);
 
     // Drain the shutdown cleanly.
     result_t sr = result_t::timeout;
@@ -481,5 +292,5 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdNonBlocking) {
     if (server_side.joinable()) {
         server_side.join();
     }
-    (void)::close(listen_fd);
+    (void)::close(listener.fd);
 }

--- a/lib/everest/tls/tests/tls_client_wrap_test.cpp
+++ b/lib/everest/tls/tests/tls_client_wrap_test.cpp
@@ -177,10 +177,14 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdRejectsWrongHostname) {
 // With TLS key logging enabled the server resolves the key-log port from the
 // service string passed to wrap_accepted_fd. A non-numeric service string
 // (empty or garbage) must not throw out of the ServerConnection constructor;
-// the connection stays usable and only the key logging is skipped.
+// the connection stays usable and only the key logging is skipped. The CTX-wide
+// keylog callback still fires during the handshake even though such a
+// connection carries no per-connection key-log server, so the handshake is
+// driven to completion to prove the skip path is safe end to end.
 
 TEST_F(TlsClientWrapTest, WrapAcceptedFdToleratesNonNumericService) {
     using state_t = tls::Server::state_t;
+    using result_t = tls::Connection::result_t;
 
     const auto listener = make_loopback_listener();
     ASSERT_GE(listener.fd, 0);
@@ -191,7 +195,9 @@ TEST_F(TlsClientWrapTest, WrapAcceptedFdToleratesNonNumericService) {
     const auto init_state = server.init(server_config, nullptr);
     ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
 
-    for (const char* service : {"", "not-a-port"}) {
+    // Empty service string: wrap must not throw, and the connection must stay
+    // usable - the handshake completes on both ends with key logging skipped.
+    {
         const int client_fd = connect_loopback_nonblocking(listener.port);
         ASSERT_GE(client_fd, 0);
 
@@ -199,9 +205,42 @@ TEST_F(TlsClientWrapTest, WrapAcceptedFdToleratesNonNumericService) {
         ASSERT_GE(accepted_fd, 0);
 
         tls::Server::ConnectionPtr conn;
-        ASSERT_NO_THROW(conn = server.wrap_accepted_fd(accepted_fd, "::1", service))
-            << "service string: \"" << service << "\"";
-        EXPECT_TRUE(conn) << "service string: \"" << service << "\"";
+        ASSERT_NO_THROW(conn = server.wrap_accepted_fd(accepted_fd, "::1", ""));
+        ASSERT_TRUE(conn);
+
+        auto server_result = result_t::timeout;
+        std::thread server_side([&]() {
+            server_result = conn->accept(1000);
+            (void)conn->shutdown(1000);
+        });
+
+        client.init(client_config);
+        auto client_conn = client.wrap_connecting_fd(client_fd, "localhost");
+        ASSERT_TRUE(client_conn);
+
+        const auto drive = drive_client_handshake(*client_conn, client_fd);
+        EXPECT_EQ(drive.result, result_t::success);
+
+        (void)client_conn->shutdown(1000);
+
+        if (server_side.joinable()) {
+            server_side.join();
+        }
+        EXPECT_EQ(server_result, result_t::success);
+    }
+
+    // Garbage service string: the wrap itself must not throw and must yield a
+    // usable, non-null connection.
+    {
+        const int client_fd = connect_loopback_nonblocking(listener.port);
+        ASSERT_GE(client_fd, 0);
+
+        const int accepted_fd = ::accept(listener.fd, nullptr, nullptr);
+        ASSERT_GE(accepted_fd, 0);
+
+        tls::Server::ConnectionPtr conn;
+        ASSERT_NO_THROW(conn = server.wrap_accepted_fd(accepted_fd, "::1", "not-a-port"));
+        EXPECT_TRUE(conn);
 
         // The wrapped connection owns accepted_fd; only the client fd needs
         // explicit cleanup.

--- a/lib/everest/tls/tests/tls_client_wrap_test.cpp
+++ b/lib/everest/tls/tests/tls_client_wrap_test.cpp
@@ -172,6 +172,46 @@ TEST_F(TlsClientWrapTest, WrapConnectingFdRejectsWrongHostname) {
 }
 
 // ---------------------------------------------------------------------------
+// WrapAcceptedFdToleratesNonNumericService
+//
+// With TLS key logging enabled the server resolves the key-log port from the
+// service string passed to wrap_accepted_fd. A non-numeric service string
+// (empty or garbage) must not throw out of the ServerConnection constructor;
+// the connection stays usable and only the key logging is skipped.
+
+TEST_F(TlsClientWrapTest, WrapAcceptedFdToleratesNonNumericService) {
+    using state_t = tls::Server::state_t;
+
+    const auto listener = make_loopback_listener();
+    ASSERT_GE(listener.fd, 0);
+
+    server_config.socket = listener.fd;
+    server_config.tls_key_logging = true;
+    server_config.tls_key_logging_path = ::testing::TempDir();
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    for (const char* service : {"", "not-a-port"}) {
+        const int client_fd = connect_loopback_nonblocking(listener.port);
+        ASSERT_GE(client_fd, 0);
+
+        const int accepted_fd = ::accept(listener.fd, nullptr, nullptr);
+        ASSERT_GE(accepted_fd, 0);
+
+        tls::Server::ConnectionPtr conn;
+        ASSERT_NO_THROW(conn = server.wrap_accepted_fd(accepted_fd, "::1", service))
+            << "service string: \"" << service << "\"";
+        EXPECT_TRUE(conn) << "service string: \"" << service << "\"";
+
+        // The wrapped connection owns accepted_fd; only the client fd needs
+        // explicit cleanup.
+        (void)::close(client_fd);
+    }
+
+    (void)::close(listener.fd);
+}
+
+// ---------------------------------------------------------------------------
 // WrapConnectingFdNonBlocking
 //
 // Verifies non-blocking behaviour: drives the handshake with timeout_ms=0,

--- a/lib/everest/tls/tests/tls_client_wrap_test.cpp
+++ b/lib/everest/tls/tests/tls_client_wrap_test.cpp
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Pionix GmbH and Contributors to EVerest
+
+#include "tls_connection_test.hpp"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// Use a distinct fixture name to avoid GTest suite-name collisions when
+// TlsTest (defined in the anonymous namespace of tls_connection_test.hpp)
+// is instantiated in multiple translation units.
+struct TlsClientWrapTest : TlsTest {};
+
+// ---------------------------------------------------------------------------
+// WrapConnectingFdHandshake
+//
+// Verifies that Client::wrap_connecting_fd hands a caller-owned, already-
+// connecting TCP socket to an initialised Client and that the resulting
+// ClientConnection completes a full TLS handshake against a local server.
+
+TEST_F(TlsClientWrapTest, WrapConnectingFdHandshake) {
+    using state_t = tls::Server::state_t;
+
+    // Create a listen socket on an ephemeral port. Passed via
+    // server_config.socket so that init() skips its own bind/listen path.
+    const int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0);
+    int reuse = 1;
+    (void)::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    sockaddr_in listen_addr{};
+    listen_addr.sin_family = AF_INET;
+    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    listen_addr.sin_port = 0;
+    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)), 0);
+    ASSERT_EQ(::listen(listen_fd, 1), 0);
+
+    server_config.socket = listen_fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    // Resolve the ephemeral port assigned by the kernel.
+    sockaddr_in bound_addr{};
+    socklen_t bound_len = sizeof(bound_addr);
+    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len), 0);
+    const std::uint16_t bound_port = ntohs(bound_addr.sin_port);
+
+    // Server-side thread: accept the incoming TCP connection, wrap it as a TLS
+    // server connection, and drive the server handshake to give the client a
+    // counterparty.
+    std::thread server_side([&]() {
+        sockaddr_in peer_addr{};
+        socklen_t peer_len = sizeof(peer_addr);
+        const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
+        if (accepted_fd < 0) {
+            return;
+        }
+        char ip_buf[INET_ADDRSTRLEN]{};
+        char svc_buf[NI_MAXSERV]{};
+        (void)::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), svc_buf,
+                            sizeof(svc_buf), NI_NUMERICHOST | NI_NUMERICSERV);
+        auto server_conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (server_conn) {
+            (void)server_conn->accept(1000);
+            (void)server_conn->shutdown(1000);
+        }
+    });
+
+    // Client side: open a non-blocking TCP socket and call connect().
+    // Handle EINPROGRESS by polling until the socket is writable.
+    const int client_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(client_fd, 0);
+    {
+        const int flags = ::fcntl(client_fd, F_GETFL, 0);
+        ASSERT_NE(flags, -1);
+        ASSERT_EQ(::fcntl(client_fd, F_SETFL, flags | O_NONBLOCK), 0);
+    }
+
+    sockaddr_in server_addr{};
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    server_addr.sin_port = htons(bound_port);
+    const int rc = ::connect(client_fd, reinterpret_cast<sockaddr*>(&server_addr), sizeof(server_addr));
+    if (rc != 0) {
+        ASSERT_EQ(errno, EINPROGRESS);
+        pollfd pfd{client_fd, POLLOUT, 0};
+        ASSERT_GT(::poll(&pfd, 1, 2000), 0);
+        int err = 0;
+        socklen_t err_len = sizeof(err);
+        ASSERT_EQ(::getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &err_len), 0);
+        ASSERT_EQ(err, 0);
+    }
+
+    // Initialise the client's SSL_CTX.
+    ClientTest local_client;
+    local_client.init(client_config);
+
+    // Hand the already-connecting fd to the factory under test.
+    auto conn = local_client.wrap_connecting_fd(client_fd, "localhost");
+    ASSERT_TRUE(conn);
+    EXPECT_EQ(conn->socket(), client_fd);
+
+    // Drive the TLS handshake in a polling loop.
+    using result_t = tls::Connection::result_t;
+    result_t res = result_t::timeout;
+    for (int i = 0; i < 50 && res != result_t::success; ++i) {
+        res = conn->connect(1000);
+        if (res == result_t::want_read) {
+            pollfd pfd{client_fd, POLLIN, 0};
+            (void)::poll(&pfd, 1, 1000);
+        } else if (res == result_t::want_write) {
+            pollfd pfd{client_fd, POLLOUT, 0};
+            (void)::poll(&pfd, 1, 1000);
+        }
+    }
+    EXPECT_EQ(res, result_t::success);
+    EXPECT_NE(conn->peer_certificate(), nullptr);
+
+    (void)conn->shutdown(1000);
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    (void)::close(listen_fd);
+}
+
+// ---------------------------------------------------------------------------
+// WrapConnectingFdVerifiesHostname
+//
+// With verify_subject_name = true the client pins RFC-6125 hostname
+// verification (SSL_set1_host) to the SNI host. The PKI server leaf carries
+// DNS:localhost, so connecting with host "localhost" must complete the
+// handshake and present a peer certificate.
+
+TEST_F(TlsClientWrapTest, WrapConnectingFdVerifiesHostname) {
+    using state_t = tls::Server::state_t;
+
+    const int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0);
+    int reuse = 1;
+    (void)::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    sockaddr_in listen_addr{};
+    listen_addr.sin_family = AF_INET;
+    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    listen_addr.sin_port = 0;
+    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)), 0);
+    ASSERT_EQ(::listen(listen_fd, 1), 0);
+
+    server_config.socket = listen_fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    sockaddr_in bound_addr{};
+    socklen_t bound_len = sizeof(bound_addr);
+    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len), 0);
+    const std::uint16_t bound_port = ntohs(bound_addr.sin_port);
+
+    std::thread server_side([&]() {
+        sockaddr_in peer_addr{};
+        socklen_t peer_len = sizeof(peer_addr);
+        const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
+        if (accepted_fd < 0) {
+            return;
+        }
+        char ip_buf[INET_ADDRSTRLEN]{};
+        char svc_buf[NI_MAXSERV]{};
+        (void)::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), svc_buf,
+                            sizeof(svc_buf), NI_NUMERICHOST | NI_NUMERICSERV);
+        auto server_conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (server_conn) {
+            (void)server_conn->accept(1000);
+            (void)server_conn->shutdown(1000);
+        }
+    });
+
+    const int client_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(client_fd, 0);
+    {
+        const int flags = ::fcntl(client_fd, F_GETFL, 0);
+        ASSERT_NE(flags, -1);
+        ASSERT_EQ(::fcntl(client_fd, F_SETFL, flags | O_NONBLOCK), 0);
+    }
+
+    sockaddr_in server_addr{};
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    server_addr.sin_port = htons(bound_port);
+    const int rc = ::connect(client_fd, reinterpret_cast<sockaddr*>(&server_addr), sizeof(server_addr));
+    if (rc != 0) {
+        ASSERT_EQ(errno, EINPROGRESS);
+        pollfd pfd{client_fd, POLLOUT, 0};
+        ASSERT_GT(::poll(&pfd, 1, 2000), 0);
+        int err = 0;
+        socklen_t err_len = sizeof(err);
+        ASSERT_EQ(::getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &err_len), 0);
+        ASSERT_EQ(err, 0);
+    }
+
+    // Opt in to RFC-6125 hostname verification.
+    tls::Client::config_t verify_config = client_config;
+    verify_config.verify_subject_name = true;
+
+    ClientTest local_client;
+    local_client.init(verify_config);
+
+    auto conn = local_client.wrap_connecting_fd(client_fd, "localhost");
+    ASSERT_TRUE(conn);
+
+    using result_t = tls::Connection::result_t;
+    result_t res = result_t::timeout;
+    for (int i = 0; i < 50 && res != result_t::success; ++i) {
+        res = conn->connect(1000);
+        if (res == result_t::want_read) {
+            pollfd pfd{client_fd, POLLIN, 0};
+            (void)::poll(&pfd, 1, 1000);
+        } else if (res == result_t::want_write) {
+            pollfd pfd{client_fd, POLLOUT, 0};
+            (void)::poll(&pfd, 1, 1000);
+        }
+    }
+    EXPECT_EQ(res, result_t::success);
+    EXPECT_NE(conn->peer_certificate(), nullptr);
+
+    (void)conn->shutdown(1000);
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    (void)::close(listen_fd);
+}
+
+// ---------------------------------------------------------------------------
+// WrapConnectingFdRejectsWrongHostname
+//
+// With verify_subject_name = true the handshake must fail when the SNI host
+// does not match any subject/SAN entry of the server leaf certificate. The
+// server leaf has DNS:localhost (and DNS:evse.pionix.de), so "wrong.example"
+// must NOT reach result_t::success.
+
+TEST_F(TlsClientWrapTest, WrapConnectingFdRejectsWrongHostname) {
+    using state_t = tls::Server::state_t;
+
+    const int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0);
+    int reuse = 1;
+    (void)::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    sockaddr_in listen_addr{};
+    listen_addr.sin_family = AF_INET;
+    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    listen_addr.sin_port = 0;
+    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)), 0);
+    ASSERT_EQ(::listen(listen_fd, 1), 0);
+
+    server_config.socket = listen_fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    sockaddr_in bound_addr{};
+    socklen_t bound_len = sizeof(bound_addr);
+    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len), 0);
+    const std::uint16_t bound_port = ntohs(bound_addr.sin_port);
+
+    std::thread server_side([&]() {
+        sockaddr_in peer_addr{};
+        socklen_t peer_len = sizeof(peer_addr);
+        const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
+        if (accepted_fd < 0) {
+            return;
+        }
+        char ip_buf[INET_ADDRSTRLEN]{};
+        char svc_buf[NI_MAXSERV]{};
+        (void)::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), svc_buf,
+                            sizeof(svc_buf), NI_NUMERICHOST | NI_NUMERICSERV);
+        auto server_conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (server_conn) {
+            (void)server_conn->accept(1000);
+            (void)server_conn->shutdown(1000);
+        }
+    });
+
+    const int client_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(client_fd, 0);
+    {
+        const int flags = ::fcntl(client_fd, F_GETFL, 0);
+        ASSERT_NE(flags, -1);
+        ASSERT_EQ(::fcntl(client_fd, F_SETFL, flags | O_NONBLOCK), 0);
+    }
+
+    sockaddr_in server_addr{};
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    server_addr.sin_port = htons(bound_port);
+    const int rc = ::connect(client_fd, reinterpret_cast<sockaddr*>(&server_addr), sizeof(server_addr));
+    if (rc != 0) {
+        ASSERT_EQ(errno, EINPROGRESS);
+        pollfd pfd{client_fd, POLLOUT, 0};
+        ASSERT_GT(::poll(&pfd, 1, 2000), 0);
+        int err = 0;
+        socklen_t err_len = sizeof(err);
+        ASSERT_EQ(::getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &err_len), 0);
+        ASSERT_EQ(err, 0);
+    }
+
+    tls::Client::config_t verify_config = client_config;
+    verify_config.verify_subject_name = true;
+
+    ClientTest local_client;
+    local_client.init(verify_config);
+
+    // SNI host that matches no subject/SAN entry of the server leaf.
+    auto conn = local_client.wrap_connecting_fd(client_fd, "wrong.example");
+    ASSERT_TRUE(conn);
+
+    using result_t = tls::Connection::result_t;
+    result_t res = result_t::timeout;
+    for (int i = 0; i < 50 && res != result_t::success && res != result_t::closed; ++i) {
+        res = conn->connect(1000);
+        if (res == result_t::want_read) {
+            pollfd pfd{client_fd, POLLIN, 0};
+            (void)::poll(&pfd, 1, 1000);
+        } else if (res == result_t::want_write) {
+            pollfd pfd{client_fd, POLLOUT, 0};
+            (void)::poll(&pfd, 1, 1000);
+        }
+    }
+    // Hostname mismatch must prevent a successful handshake.
+    EXPECT_NE(res, result_t::success);
+
+    (void)conn->shutdown(1000);
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    (void)::close(listen_fd);
+}
+
+// ---------------------------------------------------------------------------
+// WrapConnectingFdNonBlocking
+//
+// Verifies non-blocking behaviour: drives the handshake with timeout_ms=0 and
+// asserts that at least one want_read or want_write was observed, confirming
+// that the SSL state machine properly surfaces I/O readiness signals.
+
+TEST_F(TlsClientWrapTest, WrapConnectingFdNonBlocking) {
+    using state_t = tls::Server::state_t;
+
+    const int listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(listen_fd, 0);
+    int reuse = 1;
+    (void)::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    sockaddr_in listen_addr{};
+    listen_addr.sin_family = AF_INET;
+    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    listen_addr.sin_port = 0;
+    ASSERT_EQ(::bind(listen_fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)), 0);
+    ASSERT_EQ(::listen(listen_fd, 1), 0);
+
+    server_config.socket = listen_fd;
+    const auto init_state = server.init(server_config, nullptr);
+    ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    sockaddr_in bound_addr{};
+    socklen_t bound_len = sizeof(bound_addr);
+    ASSERT_EQ(::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len), 0);
+    const std::uint16_t bound_port = ntohs(bound_addr.sin_port);
+
+    std::thread server_side([&]() {
+        sockaddr_in peer_addr{};
+        socklen_t peer_len = sizeof(peer_addr);
+        const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
+        if (accepted_fd < 0) {
+            return;
+        }
+        char ip_buf[INET_ADDRSTRLEN]{};
+        char svc_buf[NI_MAXSERV]{};
+        (void)::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), svc_buf,
+                            sizeof(svc_buf), NI_NUMERICHOST | NI_NUMERICSERV);
+        auto server_conn = server.wrap_accepted_fd(accepted_fd, ip_buf, svc_buf);
+        if (server_conn) {
+            (void)server_conn->accept(1000);
+            (void)server_conn->shutdown(1000);
+        }
+    });
+
+    const int client_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(client_fd, 0);
+    {
+        const int flags = ::fcntl(client_fd, F_GETFL, 0);
+        ASSERT_NE(flags, -1);
+        ASSERT_EQ(::fcntl(client_fd, F_SETFL, flags | O_NONBLOCK), 0);
+    }
+
+    sockaddr_in server_addr{};
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    server_addr.sin_port = htons(bound_port);
+    const int rc = ::connect(client_fd, reinterpret_cast<sockaddr*>(&server_addr), sizeof(server_addr));
+    if (rc != 0) {
+        ASSERT_EQ(errno, EINPROGRESS);
+        pollfd pfd{client_fd, POLLOUT, 0};
+        ASSERT_GT(::poll(&pfd, 1, 2000), 0);
+        int err = 0;
+        socklen_t err_len = sizeof(err);
+        ASSERT_EQ(::getsockopt(client_fd, SOL_SOCKET, SO_ERROR, &err, &err_len), 0);
+        ASSERT_EQ(err, 0);
+    }
+
+    // Use timeout_ms = 0 to force purely non-blocking operation.
+    tls::Client::config_t nb_config = client_config;
+    nb_config.io_timeout_ms = 0;
+
+    ClientTest local_client;
+    local_client.init(nb_config);
+
+    auto conn = local_client.wrap_connecting_fd(client_fd, "localhost");
+    ASSERT_TRUE(conn);
+
+    int saw_want_read = 0;
+    int saw_want_write = 0;
+
+    using result_t = tls::Connection::result_t;
+    result_t res = result_t::timeout;
+    for (int i = 0; i < 200 && res != result_t::success; ++i) {
+        res = conn->connect(0);
+        if (res == result_t::want_read) {
+            ++saw_want_read;
+            pollfd pfd{client_fd, POLLIN, 0};
+            (void)::poll(&pfd, 1, 500);
+        } else if (res == result_t::want_write) {
+            ++saw_want_write;
+            pollfd pfd{client_fd, POLLOUT, 0};
+            (void)::poll(&pfd, 1, 500);
+        } else if (res == result_t::closed) {
+            FAIL() << "connection closed unexpectedly during handshake";
+        }
+    }
+    ASSERT_EQ(res, result_t::success);
+
+    // At least one I/O readiness signal must have been observed.
+    EXPECT_TRUE(saw_want_read > 0 || saw_want_write > 0)
+        << "expected at least one want_read or want_write during non-blocking handshake";
+
+    // Short bidirectional exchange — verify read/write want_* signals as
+    // regression guard for the non-blocking I/O path.
+    const std::array<std::byte, 4> ping{std::byte{'p'}, std::byte{'i'}, std::byte{'n'}, std::byte{'g'}};
+    std::size_t written = 0;
+    for (int i = 0; i < 50 && written == 0; ++i) {
+        const auto wres = conn->write(ping.data(), ping.size(), written);
+        if (wres == result_t::want_write) {
+            pollfd pfd{client_fd, POLLOUT, 0};
+            (void)::poll(&pfd, 1, 100);
+        } else if (wres == result_t::success) {
+            break;
+        } else {
+            break;
+        }
+    }
+
+    // Drain the shutdown cleanly.
+    result_t sr = result_t::timeout;
+    for (int i = 0; i < 50 && sr != result_t::closed; ++i) {
+        sr = conn->shutdown(0);
+        if (sr == result_t::want_read) {
+            pollfd pfd{client_fd, POLLIN, 0};
+            (void)::poll(&pfd, 1, 200);
+        } else if (sr == result_t::want_write) {
+            pollfd pfd{client_fd, POLLOUT, 0};
+            (void)::poll(&pfd, 1, 200);
+        }
+    }
+
+    if (server_side.joinable()) {
+        server_side.join();
+    }
+    (void)::close(listen_fd);
+}

--- a/lib/everest/tls/tests/tls_connection_test.hpp
+++ b/lib/everest/tls/tests/tls_connection_test.hpp
@@ -8,14 +8,23 @@
 #include <everest/tls/openssl_util.hpp>
 
 #include <array>
+#include <cerrno>
 #include <chrono>
 #include <csignal>
+#include <cstdint>
 #include <everest/tls/tls.hpp>
 #include <gtest/gtest.h>
 #include <memory>
 #include <openssl/ssl.h>
 #include <thread>
 #include <unistd.h>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
 
 #include <everest/util/enum/EnumFlags.hpp>
 
@@ -152,6 +161,129 @@ inline void handler(tls::Server::ConnectionPtr&& con) {
 
 inline void run_server(tls::Server& server) {
     server.serve(&handler);
+}
+
+// ----------------------------------------------------------------------------
+// socket-level helpers shared by the wrap_accepted_fd / wrap_connecting_fd
+// tests. These return error values instead of using GoogleTest assertions
+// (which require a void return type); callers assert on the results.
+
+// A test-owned loopback listen socket on a kernel-assigned ephemeral port.
+// fd is -1 when any setup step failed.
+struct LoopbackListener {
+    int fd{-1};
+    std::uint16_t port{0};
+};
+
+inline LoopbackListener make_loopback_listener() {
+    LoopbackListener listener;
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return listener;
+    }
+    int reuse = 1;
+    (void)::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+
+    sockaddr_in bound{};
+    socklen_t bound_len = sizeof(bound);
+    if ((::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) || (::listen(fd, 1) != 0) ||
+        (::getsockname(fd, reinterpret_cast<sockaddr*>(&bound), &bound_len) != 0)) {
+        (void)::close(fd);
+        return listener;
+    }
+    listener.fd = fd;
+    listener.port = ntohs(bound.sin_port);
+    return listener;
+}
+
+// Accept one pending TCP connection on listen_fd, resolve the peer's numeric
+// address, and wrap the accepted fd as a server-side TLS connection.
+// Returns nullptr when accept(2), name resolution, or the wrap fails.
+inline tls::Server::ConnectionPtr accept_and_wrap(tls::Server& server, int listen_fd) {
+    sockaddr_in peer_addr{};
+    socklen_t peer_len = sizeof(peer_addr);
+    const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
+    if (accepted_fd < 0) {
+        return nullptr;
+    }
+    char ip_buf[INET_ADDRSTRLEN]{};
+    char service_buf[NI_MAXSERV]{};
+    if (::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), service_buf,
+                      sizeof(service_buf), NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
+        (void)::close(accepted_fd);
+        return nullptr;
+    }
+    return server.wrap_accepted_fd(accepted_fd, ip_buf, service_buf);
+}
+
+// Open a non-blocking TCP socket and connect it to the loopback address on
+// the given port, polling out an in-flight EINPROGRESS connect. Returns the
+// connecting fd, or -1 on failure.
+inline int connect_loopback_nonblocking(std::uint16_t port) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    const int flags = ::fcntl(fd, F_GETFL, 0);
+    if ((flags == -1) || (::fcntl(fd, F_SETFL, flags | O_NONBLOCK) != 0)) {
+        (void)::close(fd);
+        return -1;
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(port);
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+        if (errno != EINPROGRESS) {
+            (void)::close(fd);
+            return -1;
+        }
+        pollfd pfd{fd, POLLOUT, 0};
+        int err = 0;
+        socklen_t err_len = sizeof(err);
+        if ((::poll(&pfd, 1, 2000) <= 0) || (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len) != 0) ||
+            (err != 0)) {
+            (void)::close(fd);
+            return -1;
+        }
+    }
+    return fd;
+}
+
+// Outcome of drive_client_handshake: the final connect() result plus how many
+// want_read / want_write readiness signals were observed along the way.
+struct HandshakeDrive {
+    tls::Connection::result_t result{tls::Connection::result_t::timeout};
+    int want_read{0};
+    int want_write{0};
+};
+
+// Drive the client-side TLS handshake on a wrapped non-blocking fd, polling
+// for socket readiness whenever connect() reports want_read / want_write.
+// Stops early on success or closed.
+inline HandshakeDrive drive_client_handshake(tls::ClientConnection& conn, int fd, int connect_timeout_ms = 1000,
+                                             int max_attempts = 50, int poll_timeout_ms = 1000) {
+    using result_t = tls::Connection::result_t;
+    HandshakeDrive drive;
+    for (int i = 0; i < max_attempts && drive.result != result_t::success && drive.result != result_t::closed; ++i) {
+        drive.result = conn.connect(connect_timeout_ms);
+        if (drive.result == result_t::want_read) {
+            ++drive.want_read;
+            pollfd pfd{fd, POLLIN, 0};
+            (void)::poll(&pfd, 1, poll_timeout_ms);
+        } else if (drive.result == result_t::want_write) {
+            ++drive.want_write;
+            pollfd pfd{fd, POLLOUT, 0};
+            (void)::poll(&pfd, 1, poll_timeout_ms);
+        }
+    }
+    return drive;
 }
 
 class TlsTest : public testing::Test {

--- a/lib/everest/tls/tests/tls_connection_tls13_test.cpp
+++ b/lib/everest/tls/tests/tls_connection_tls13_test.cpp
@@ -3,76 +3,18 @@
 
 #include "tls_connection_test.hpp"
 
-#include <arpa/inet.h>
 #include <array>
 #include <condition_variable>
 #include <cstring>
 #include <fcntl.h>
 #include <mutex>
-#include <netdb.h>
-#include <netinet/in.h>
 #include <openssl/x509.h>
 #include <optional>
-#include <sys/socket.h>
 #include <thread>
 
 using namespace std::chrono_literals;
 
 namespace {
-
-// Test-owned loopback listen socket on an ephemeral port, for tests that
-// bypass init_socket()'s fixed-port bind by passing the fd to the Server via
-// server_config.socket. fd is -1 on failure; ASSERT_* requires a void return
-// type, so callers assert validity at the call site.
-struct LoopbackListener {
-    int fd{-1};
-    std::string service; // bound port, as a service string for Client::connect()
-};
-
-LoopbackListener make_loopback_listener() {
-    LoopbackListener listener;
-    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) {
-        return listener;
-    }
-    int reuse = 1;
-    (void)::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
-    sockaddr_in listen_addr{};
-    listen_addr.sin_family = AF_INET;
-    listen_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    listen_addr.sin_port = 0;
-    if ((::bind(fd, reinterpret_cast<sockaddr*>(&listen_addr), sizeof(listen_addr)) != 0) || (::listen(fd, 1) != 0)) {
-        (void)::close(fd);
-        return listener;
-    }
-    sockaddr_in bound_addr{};
-    socklen_t bound_len = sizeof(bound_addr);
-    if (::getsockname(fd, reinterpret_cast<sockaddr*>(&bound_addr), &bound_len) != 0) {
-        (void)::close(fd);
-        return listener;
-    }
-    listener.fd = fd;
-    listener.service = std::to_string(ntohs(bound_addr.sin_port));
-    return listener;
-}
-
-// Returns nullptr on failure; callers assert.
-tls::Server::ConnectionPtr accept_and_wrap(tls::Server& server, int listen_fd) {
-    sockaddr_in peer_addr{};
-    socklen_t peer_len = sizeof(peer_addr);
-    const int accepted_fd = ::accept(listen_fd, reinterpret_cast<sockaddr*>(&peer_addr), &peer_len);
-    if (accepted_fd < 0) {
-        return nullptr;
-    }
-    char ip_buf[INET_ADDRSTRLEN]{};
-    char service_buf[NI_MAXSERV]{};
-    if (::getnameinfo(reinterpret_cast<sockaddr*>(&peer_addr), peer_len, ip_buf, sizeof(ip_buf), service_buf,
-                      sizeof(service_buf), NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
-        (void)::close(accepted_fd);
-        return nullptr;
-    }
-    return server.wrap_accepted_fd(accepted_fd, ip_buf, service_buf);
-}
 
 TEST_F(TlsTest, EnforceTls13RejectsTls12Client) {
     // Server enforces TLS 1.3; a TLS-1.2-only client must be rejected.
@@ -459,17 +401,21 @@ TEST_F(TlsTest, WrapAcceptedFdHandshake) {
     const auto init_state = server.init(server_config, nullptr);
     ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
 
+    const std::string bound_service = std::to_string(listener.port);
+
     // Client thread: open a TLS 1.2 connection to our listen socket.
     std::thread client_thread([&]() {
         ClientTest local_client;
         local_client.init(client_config);
-        auto conn = local_client.connect("127.0.0.1", listener.service.c_str(), false, 1000);
+        auto conn = local_client.connect("127.0.0.1", bound_service.c_str(), false, 1000);
         if (conn) {
             (void)conn->connect();
             (void)conn->shutdown();
         }
     });
 
+    // Accept the incoming TCP connection on the test-owned socket and hand
+    // the accepted fd to the factory under test.
     tls::Server::ConnectionPtr server_conn = accept_and_wrap(server, listener.fd);
     ASSERT_TRUE(server_conn);
 
@@ -570,6 +516,9 @@ TEST_F(TlsTest, LastErrorDoesNotBleedIntoGracefulClose) {
     // here on the main thread, so the bleed (if present) is on this thread.
     using state_t = tls::Server::state_t;
 
+    // Test-owned loopback listen socket on an ephemeral port (as in
+    // WrapAcceptedFdHandshake), passed to the Server via server_config.socket so
+    // init_socket() does not bind the fixture's fixed port.
     const auto listener = make_loopback_listener();
     ASSERT_GE(listener.fd, 0);
 
@@ -581,6 +530,8 @@ TEST_F(TlsTest, LastErrorDoesNotBleedIntoGracefulClose) {
     server_config.verify_locations_file = "client_root_cert.pem";
     const auto init_state = server.init(server_config, nullptr);
     ASSERT_TRUE(init_state == state_t::init_complete || init_state == state_t::init_socket);
+
+    const std::string bound_service = std::to_string(listener.port);
 
     // Spawn a TLS 1.3 client (on its own thread) presenting the given cert pair,
     // then gracefully shut down so the server observes a clean close_notify.
@@ -594,7 +545,7 @@ TEST_F(TlsTest, LastErrorDoesNotBleedIntoGracefulClose) {
             cc.certificate_chain_file = chain;
             cc.private_key_file = key;
             local_client.init(cc);
-            auto conn = local_client.connect("127.0.0.1", listener.service.c_str(), false, 1000);
+            auto conn = local_client.connect("127.0.0.1", bound_service.c_str(), false, 1000);
             if (conn) {
                 (void)conn->connect();
                 (void)conn->shutdown();


### PR DESCRIPTION
## Superseded

Closed in favor of an eight PR series that replaces this branch. The work here was one branch touching
`lib/everest/io`, `lib/everest/tls` and `lib/everest/iso15118` at once; it has been split so each piece
sits on the smallest base it needs and can be reviewed by the people who own that library.

Rooted on `main`, reviewable in parallel:

- #2558 `fix(iso15118): extract the listen socket helper` — the `lib/everest/iso15118` changes, separated
  out as requested on this PR
- #2559 `feat(tls): wrap an already connecting descriptor` — the `lib/everest/tls` changes, and the root
  of the chain below
- #2560 `fix(io): carry the connect errno and name the retry delay` — independent connect errno fix

The chain, each on the one before it:

- #2561 `fix(io): make event handler registration truthful`
- #2562 `feat(io): tri-state connection state and bounded tx buffer`
- #2563 `feat(io): event loop driven handshake phase`
- #2564 `feat(io/tls): event loop driven TLS client and server` — the direct successor to this PR
- #2565 `refactor(chargebridge): drop tx gates and recover on error` — forks off #2562, not off #2563

#2564 is not a rebase of this branch. The TLS client was rebuilt as a one line alias over the generic
event client rather than a hand written class, so the version here that was added and then deleted within
the same branch never reaches a reviewer.

Each of the eight carries the full series in its own description, with its position relative to `main`.
