### PR TITLE
fix(ocpp): reply RpcFrameworkError on orphan call

### DIFF
--- a/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
@@ -849,24 +849,31 @@ public:
             }
         }
 
-        // TODO(kai): what happens if we receive a CallResult or CallError out of order?
         if (enhanced_message.messageTypeId == MessageTypeId::CALLRESULT ||
             enhanced_message.messageTypeId == MessageTypeId::CALLERROR) {
             {
                 const std::lock_guard<std::recursive_mutex> lk(this->next_message_mutex);
                 next_message_to_send.reset();
             }
-            // we need to remove Call messages from in_flight if we receive a CallResult OR a CallError
-
-            // TODO(kai): we need to do some error handling in the CallError case
             std::unique_lock<std::recursive_mutex> lk(this->message_mutex);
             if (this->in_flight == nullptr) {
-                EVLOG_error << "Received a CALLRESULT OR CALLERROR without a message in flight, this should not happen";
+                EVLOG_error << "Received a CALLRESULT OR CALLERROR without a message in flight; "
+                               "replying with RpcFrameworkError for uid "
+                            << enhanced_message.uniqueId;
+                this->push_call_error(CallError{enhanced_message.uniqueId, "RpcFrameworkError",
+                                                "Received unsolicited CallResult/CallError", json::object()});
                 return enhanced_message;
             }
             if (this->in_flight->uniqueId() != enhanced_message.uniqueId) {
                 EVLOG_error << "Received a CALLRESULT OR CALLERROR with mismatching uid: "
                             << this->in_flight->uniqueId() << " != " << enhanced_message.uniqueId;
+                EnhancedMessage<M> stale;
+                stale.uniqueId = this->in_flight->uniqueId();
+                stale.offline = true;
+                this->in_flight->promise.set_value(stale);
+                this->reset_in_flight();
+                this->push_call_error(CallError{enhanced_message.uniqueId, "RpcFrameworkError",
+                                                "messageId does not match in-flight call", json::object()});
                 return enhanced_message;
             }
             if (enhanced_message.messageTypeId == MessageTypeId::CALLERROR) {

--- a/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/message_queue.hpp
@@ -865,13 +865,11 @@ public:
                 return enhanced_message;
             }
             if (this->in_flight->uniqueId() != enhanced_message.uniqueId) {
+                // The response is for a uid we are not waiting on: reply with a RpcFrameworkError and leave
+                // the in-flight call untouched. A mismatch must not be counted as a timeout for the in-flight
+                // call; its own timeout timer remains responsible for retry/expiry.
                 EVLOG_error << "Received a CALLRESULT OR CALLERROR with mismatching uid: "
                             << this->in_flight->uniqueId() << " != " << enhanced_message.uniqueId;
-                EnhancedMessage<M> stale;
-                stale.uniqueId = this->in_flight->uniqueId();
-                stale.offline = true;
-                this->in_flight->promise.set_value(stale);
-                this->reset_in_flight();
                 this->push_call_error(CallError{enhanced_message.uniqueId, "RpcFrameworkError",
                                                 "messageId does not match in-flight call", json::object()});
                 return enhanced_message;

--- a/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
@@ -834,9 +834,9 @@ TEST_F(MessageQueueTest, test_boot_notification_survives_when_only_message_in_no
     EXPECT_TRUE(boot_sent) << "BootNotification was dropped from the queue!";
 }
 
-// Mismatched-uid CallResult must emit a CallError(RpcFrameworkError) outbound and
-// resolve the in-flight waiter with offline=true so the caller does not stall on
-// the in-flight timeout timer.
+// A CallResult whose uid does not match the in-flight call is unsolicited: the queue must NACK it with a
+// CallError(RpcFrameworkError) and leave the in-flight call untouched, so the in-flight call still completes
+// when its own matching response arrives (its timeout timer keeps owning retry/expiry).
 TEST_F(MessageQueueTest, test_mismatching_uid_callresult_emits_rpc_framework_error) {
     EXPECT_CALL(send_callback_mock, Call(json{2, "0", "non_transactional", json{{"data", "x"}}}))
         .WillOnce(MarkAndReturn(true));
@@ -852,14 +852,21 @@ TEST_F(MessageQueueTest, test_mismatching_uid_callresult_emits_rpc_framework_err
 
     wait_for_calls(1);
 
+    // Stray CallResult for an unknown uid: NACKed outbound, in-flight call left in place.
     message_queue->receive(json::array({3, "bogus-uid", json::object()}).dump());
 
     wait_for_calls(2);
 
-    auto status = future.wait_for(std::chrono::seconds(1));
-    ASSERT_EQ(status, std::future_status::ready);
+    // The mismatch must not resolve the in-flight call.
+    EXPECT_EQ(future.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+
+    // The real response still completes the in-flight call.
+    message_queue->receive(json::array({3, "0", json::object()}).dump());
+
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(1)), std::future_status::ready);
     auto enhanced = future.get();
-    EXPECT_TRUE(enhanced.offline);
+    EXPECT_FALSE(enhanced.offline);
+    EXPECT_EQ(enhanced.uniqueId, "0");
 }
 
 // Unsolicited CallResult (no in-flight) must emit a CallError(RpcFrameworkError).
@@ -873,7 +880,8 @@ TEST_F(MessageQueueTest, test_unsolicited_callresult_emits_rpc_framework_error) 
     wait_for_calls(1);
 }
 
-// CallError variant of the mismatched-uid path: same outbound + immediate waiter resolve.
+// CallError variant of the mismatched-uid path: NACK the stray uid, leave the in-flight call untouched,
+// and confirm it still completes when its own response arrives.
 TEST_F(MessageQueueTest, test_mismatching_uid_callerror_emits_rpc_framework_error) {
     EXPECT_CALL(send_callback_mock, Call(json{2, "0", "non_transactional", json{{"data", "x"}}}))
         .WillOnce(MarkAndReturn(true));
@@ -889,13 +897,21 @@ TEST_F(MessageQueueTest, test_mismatching_uid_callerror_emits_rpc_framework_erro
 
     wait_for_calls(1);
 
+    // Stray CallError for an unknown uid: NACKed outbound, in-flight call left in place.
     message_queue->receive(json::array({4, "other-uid", "GenericError", "", json::object()}).dump());
 
     wait_for_calls(2);
 
-    auto status = future.wait_for(std::chrono::seconds(1));
-    ASSERT_EQ(status, std::future_status::ready);
-    EXPECT_TRUE(future.get().offline);
+    // The mismatch must not resolve the in-flight call.
+    EXPECT_EQ(future.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+
+    // The real response still completes the in-flight call.
+    message_queue->receive(json::array({3, "0", json::object()}).dump());
+
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(1)), std::future_status::ready);
+    auto enhanced = future.get();
+    EXPECT_FALSE(enhanced.offline);
+    EXPECT_EQ(enhanced.uniqueId, "0");
 }
 
 } // namespace ocpp

--- a/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp
@@ -834,4 +834,68 @@ TEST_F(MessageQueueTest, test_boot_notification_survives_when_only_message_in_no
     EXPECT_TRUE(boot_sent) << "BootNotification was dropped from the queue!";
 }
 
+// Mismatched-uid CallResult must emit a CallError(RpcFrameworkError) outbound and
+// resolve the in-flight waiter with offline=true so the caller does not stall on
+// the in-flight timeout timer.
+TEST_F(MessageQueueTest, test_mismatching_uid_callresult_emits_rpc_framework_error) {
+    EXPECT_CALL(send_callback_mock, Call(json{2, "0", "non_transactional", json{{"data", "x"}}}))
+        .WillOnce(MarkAndReturn(true));
+    EXPECT_CALL(send_callback_mock, Call(json::array({4, "bogus-uid", "RpcFrameworkError",
+                                                      "messageId does not match in-flight call", json::object()})))
+        .WillOnce(MarkAndReturn(true));
+
+    Call<TestRequest> call;
+    call.msg.type = TestMessageType::NON_TRANSACTIONAL;
+    call.msg.data = "x";
+    call.uniqueId = "0";
+    auto future = message_queue->push_call_async(json(call));
+
+    wait_for_calls(1);
+
+    message_queue->receive(json::array({3, "bogus-uid", json::object()}).dump());
+
+    wait_for_calls(2);
+
+    auto status = future.wait_for(std::chrono::seconds(1));
+    ASSERT_EQ(status, std::future_status::ready);
+    auto enhanced = future.get();
+    EXPECT_TRUE(enhanced.offline);
+}
+
+// Unsolicited CallResult (no in-flight) must emit a CallError(RpcFrameworkError).
+TEST_F(MessageQueueTest, test_unsolicited_callresult_emits_rpc_framework_error) {
+    EXPECT_CALL(send_callback_mock, Call(json::array({4, "stray-uid", "RpcFrameworkError",
+                                                      "Received unsolicited CallResult/CallError", json::object()})))
+        .WillOnce(MarkAndReturn(true));
+
+    message_queue->receive(json::array({3, "stray-uid", json::object()}).dump());
+
+    wait_for_calls(1);
+}
+
+// CallError variant of the mismatched-uid path: same outbound + immediate waiter resolve.
+TEST_F(MessageQueueTest, test_mismatching_uid_callerror_emits_rpc_framework_error) {
+    EXPECT_CALL(send_callback_mock, Call(json{2, "0", "non_transactional", json{{"data", "x"}}}))
+        .WillOnce(MarkAndReturn(true));
+    EXPECT_CALL(send_callback_mock, Call(json::array({4, "other-uid", "RpcFrameworkError",
+                                                      "messageId does not match in-flight call", json::object()})))
+        .WillOnce(MarkAndReturn(true));
+
+    Call<TestRequest> call;
+    call.msg.type = TestMessageType::NON_TRANSACTIONAL;
+    call.msg.data = "x";
+    call.uniqueId = "0";
+    auto future = message_queue->push_call_async(json(call));
+
+    wait_for_calls(1);
+
+    message_queue->receive(json::array({4, "other-uid", "GenericError", "", json::object()}).dump());
+
+    wait_for_calls(2);
+
+    auto status = future.wait_for(std::chrono::seconds(1));
+    ASSERT_EQ(status, std::future_status::ready);
+    EXPECT_TRUE(future.get().offline);
+}
+
 } // namespace ocpp


### PR DESCRIPTION
## Describe your changes

When the OCPP message queue receives a `CallResult` or `CallError` whose unique id does not match the request currently in flight, it now replies to the CSMS with a `CallError(RpcFrameworkError)` instead of mishandling the frame:

- **No request in flight (unsolicited):** emit `CallError(RpcFrameworkError)` for the stray uid and return. Previously this was logged as "should not happen" and dropped without informing the CSMS.
- **A different request is in flight (uid mismatch):** emit `CallError(RpcFrameworkError)` for the stray uid and leave the in-flight request untouched. A mismatch is not treated as a timeout, so the in-flight request still completes when its own matching response arrives, and its own timeout timer stays responsible for retry/expiry. Previously the mismatched frame fell through into the response-handling path.

The behavior lives in the `CALLRESULT`/`CALLERROR` branch of `MessageQueue::receive()` in `lib/everest/ocpp/include/ocpp/common/message_queue.hpp`. Unit tests in `lib/everest/ocpp/tests/lib/ocpp/common/test_message_queue.cpp` cover the unsolicited case, and the uid-mismatch case for both `CallResult` and `CallError`: the framework error is emitted, the in-flight call is left pending, and it still completes on its real response.

Verified with the `MessageQueueTest` suite in `libocpp_unit_tests` (18/18 passing).

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
