### PR TITLE
fix(libocpp): keep blob when profile import fails

### DIFF
--- a/lib/everest/ocpp/BUILD.bazel
+++ b/lib/everest/ocpp/BUILD.bazel
@@ -2,6 +2,30 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 exports_files(["config"])
 
+# Mirrors the CMake configure_file step in lib/CMakeLists.txt that embeds the
+# canonical NetworkConfiguration_1 schema into a generated translation unit so
+# blob migration can bootstrap a per-slot component without a filesystem read.
+genrule(
+    name = "network_configuration_default_schema_cpp",
+    srcs = [
+        "lib/ocpp/v2/network_configuration_default_schema.cpp.in",
+        "config/common/component_config/standardized/NetworkConfiguration_1.json",
+    ],
+    outs = ["generated/network_configuration_default_schema.cpp"],
+    cmd = """python3 - "$(location lib/ocpp/v2/network_configuration_default_schema.cpp.in)" "$(location config/common/component_config/standardized/NetworkConfiguration_1.json)" "$@" <<'PYEOF'
+import sys
+tpl_path, json_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(tpl_path) as f:
+    tpl = f.read()
+with open(json_path) as f:
+    js = f.read()
+with open(out_path, 'w') as f:
+    f.write(tpl.replace('@OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_JSON@', js))
+PYEOF
+""",
+    visibility = ["//visibility:private"],
+)
+
 cc_library(
     name = "websocketpp_utils",
     hdrs = glob([
@@ -24,7 +48,7 @@ cc_library(
         "lib/ocpp/v16/messages/*.cpp",
         "lib/ocpp/v2/messages/*.cpp",
         "lib/ocpp/v21/messages/*.cpp",
-    ]),
+    ]) + [":network_configuration_default_schema_cpp"],
     hdrs = glob([
         "include/**/*.hpp",
     ]),

--- a/lib/everest/ocpp/include/ocpp/v2/device_model.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model.hpp
@@ -103,6 +103,8 @@ public:
                                     const AttributeEnum& attribute_enum, const std::string& value,
                                     const std::string& source, bool allow_read_only = false) override;
 
+    bool create_network_configuration_slot_from_default_schema(std::int32_t new_slot) override;
+
     SetVariableStatusEnum set_read_only_value(const Component& component_id, const Variable& variable_id,
                                               const AttributeEnum& attribute_enum, const std::string& value,
                                               const std::string& source) override;

--- a/lib/everest/ocpp/include/ocpp/v2/device_model_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model_interface.hpp
@@ -205,6 +205,13 @@ public:
     /// \brief Check data integrity of the device model
     /// \param evse_connector_structure The EVSE connector structure
     virtual void check_integrity(const std::map<std::int32_t, std::int32_t>& evse_connector_structure) = 0;
+
+    /// \brief Create a fresh NetworkConfiguration_<new_slot> from the embedded default schema.
+    /// \param new_slot  New NetworkConfiguration instance to create.
+    /// \return true on success; false on failure.
+    virtual bool create_network_configuration_slot_from_default_schema(std::int32_t /*new_slot*/) {
+        return false;
+    }
 };
 
 } // namespace v2

--- a/lib/everest/ocpp/include/ocpp/v2/device_model_storage_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model_storage_interface.hpp
@@ -98,6 +98,13 @@ public:
     /// \brief Check data integrity of the stored data:
     /// For "required" variables, assert values exist. Checks might be extended in the future.
     virtual void check_integrity() = 0;
+
+    /// \brief Create a fresh NetworkConfiguration_<new_slot> from the embedded default schema.
+    /// \param new_slot  The instance index to create.
+    /// \return true on success; false on failure.
+    virtual bool create_network_configuration_slot_from_default_schema(std::int32_t /*new_slot*/) {
+        return false;
+    }
 };
 
 } // namespace v2

--- a/lib/everest/ocpp/include/ocpp/v2/device_model_storage_sqlite.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model_storage_sqlite.hpp
@@ -78,6 +78,8 @@ public:
     std::int32_t clear_custom_variable_monitors() final;
 
     void check_integrity() final;
+
+    bool create_network_configuration_slot_from_default_schema(std::int32_t new_slot) final;
 };
 
 } // namespace v2

--- a/lib/everest/ocpp/include/ocpp/v2/init_device_model_db.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/init_device_model_db.hpp
@@ -130,6 +130,15 @@ private:
 std::map<ComponentKey, std::vector<DeviceModelVariable>>
 get_all_component_configs(const std::filesystem::path& directory);
 
+/// \brief Parse a component config JSON document into ComponentKey + variables.
+/// \throws InitDeviceModelDbError if "properties" missing.
+std::pair<ComponentKey, std::vector<DeviceModelVariable>> parse_component_config_from_json(const json& data);
+
+/// \brief Parse a component config JSON document from a string.
+/// \throws nlohmann::json::parse_error on invalid JSON; InitDeviceModelDbError if "properties" missing.
+std::pair<ComponentKey, std::vector<DeviceModelVariable>>
+parse_component_config_from_string(const std::string& json_content);
+
 class InitDeviceModelDb : public common::DatabaseHandlerCommon {
 private: // Members
     /// \brief Database path of the device model database.
@@ -360,13 +369,15 @@ private: // Functions
     std::map<ComponentKey, std::vector<DeviceModelVariable>> get_all_components_from_db();
 
     ///
-    /// \brief Remove components from db that do not exist in the component config.
+    /// \brief Warn about components that exist in the database but are not declared in the
+    ///        component config (no JSON file present on this install). The orphan rows are
+    ///        intentionally kept so per-slot components such as NetworkConfiguration_<N>
+    ///        survive missing JSON files and the legacy NetworkConnectionProfiles blob can
+    ///        still migrate into them on a later boot.
     /// \param component_config  The component config.
     /// \param db_components     The components in the database.
     ///
-    /// \throws InitDeviceModelDbError When one of the components could not be removed from the db.
-    ///
-    void remove_not_existing_components_from_db(
+    void warn_about_components_missing_from_config(
         const std::map<ComponentKey, std::vector<DeviceModelVariable>>& component_config,
         const std::map<ComponentKey, std::vector<DeviceModelVariable>>& db_components);
 

--- a/lib/everest/ocpp/include/ocpp/v2/network_configuration_default_schema.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/network_configuration_default_schema.hpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <string>
+
+namespace ocpp::v2 {
+
+/// \brief Returns the canonical NetworkConfiguration_1 JSON schema embedded at build time.
+const std::string& get_default_network_configuration_schema();
+
+} // namespace ocpp::v2

--- a/lib/everest/ocpp/lib/CMakeLists.txt
+++ b/lib/everest/ocpp/lib/CMakeLists.txt
@@ -112,6 +112,25 @@ if(LIBOCPP_ENABLE_V2)
     )
     add_subdirectory(ocpp/v2/messages)
     add_subdirectory(ocpp/v21/messages)
+
+    # Embed the canonical NetworkConfiguration_1 schema as a build-time C++ string so
+    # blob migration can bootstrap a per-slot component without a filesystem dependency.
+    set(OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_SOURCE
+        "${PROJECT_SOURCE_DIR}/config/common/component_config/standardized/NetworkConfiguration_1.json")
+    file(READ "${OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_SOURCE}"
+         OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_JSON)
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+        "${OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_SOURCE}")
+    set(OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_GENERATED
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/network_configuration_default_schema.cpp")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/ocpp/v2/network_configuration_default_schema.cpp.in"
+        "${OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_GENERATED}"
+        @ONLY)
+    target_sources(ocpp PRIVATE
+        "${OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_GENERATED}")
+    set(OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_GENERATED
+        "${OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_GENERATED}" PARENT_SCOPE)
 endif()
 
 add_subdirectory(ocpp/common/websocket)

--- a/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -1960,7 +1960,17 @@ void migrate_from_blob_if_needed(DeviceModelInterface& dm) {
             return;
         }
 
-        // Check if DM slots are already populated — skip migration if any slot has a configured URL.
+        auto clear_blob = [&](const char* context) {
+            const auto status = dm.set_value(ControllerComponentVariables::NetworkConnectionProfiles.component,
+                                             ControllerComponentVariables::NetworkConnectionProfiles.variable.value(),
+                                             AttributeEnum::Actual, "", "internal");
+            if (status != SetVariableStatusEnum::Accepted) {
+                EVLOG_error << "Failed to clear NetworkConnectionProfiles blob (" << context << "): set_value returned "
+                            << conversions::set_variable_status_enum_to_string(status);
+            }
+        };
+
+        // Check if DM slots are already populated. Skip migration if any slot has a configured URL.
         // A malformed token in NetworkConfigurationPriority must not abort the whole migration;
         // skip the offending entry and keep scanning the remaining slots.
         const auto priority_str =
@@ -1981,9 +1991,7 @@ void migrate_from_blob_if_needed(DeviceModelInterface& dm) {
                     EVLOG_debug << "NetworkConfiguration DM slot " << slot
                                 << " already has a URL, skipping blob migration";
                     // Clear the blob so this check does not run again
-                    dm.set_value(ControllerComponentVariables::NetworkConnectionProfiles.component,
-                                 ControllerComponentVariables::NetworkConnectionProfiles.variable.value(),
-                                 AttributeEnum::Actual, "", "internal");
+                    clear_blob("slot already populated");
                     return;
                 }
             }
@@ -1991,49 +1999,91 @@ void migrate_from_blob_if_needed(DeviceModelInterface& dm) {
 
         const auto profiles = json::parse(blob_opt.value());
         if (profiles.empty()) {
-            dm.set_value(ControllerComponentVariables::NetworkConnectionProfiles.component,
-                         ControllerComponentVariables::NetworkConnectionProfiles.variable.value(),
-                         AttributeEnum::Actual, "", "internal");
+            clear_blob("empty profiles array");
             return;
         }
 
-        // Read the global BasicAuthPassword from SecurityCtrlr so we can populate per-slot passwords
-        // during migration when the blob does not contain one (the legacy format stored it separately).
-        // Whatever the operator has put in SecurityCtrlr is treated as the source of truth — propagate
-        // it as-is, skipping only when the value would not fit the per-slot CiString<64> length cap.
+        // Read SecurityCtrlr globals (BasicAuthPassword + Identity) so we can populate per-slot
+        // fields during migration when the blob does not carry one (legacy format stored them
+        // separately). Whatever the operator has put in SecurityCtrlr is treated as the source of
+        // truth. Propagate as-is, skipping only when the value would not fit the per-slot CiString
+        // length cap.
         static constexpr std::size_t basic_auth_password_max_length = 64;
-        const auto security_ctrlr_password =
-            get_optional_value<std::string>(dm, ControllerComponentVariables::BasicAuthPassword);
-        const bool security_ctrlr_password_is_usable =
-            security_ctrlr_password.has_value() && !security_ctrlr_password->empty() &&
-            security_ctrlr_password->size() <= basic_auth_password_max_length;
-        if (security_ctrlr_password.has_value() && security_ctrlr_password->size() > basic_auth_password_max_length) {
-            EVLOG_warning << "SecurityCtrlr.BasicAuthPassword exceeds the per-slot BasicAuthPassword length limit ("
-                          << security_ctrlr_password->size() << " > " << basic_auth_password_max_length
-                          << "); not propagating to migrated slots";
-        }
+        static constexpr std::size_t identity_max_length = 48;
+
+        auto load_security_ctrlr_fallback = [&](const ComponentVariable& cv, std::size_t max_len, const char* label) {
+            auto val = get_optional_value<std::string>(dm, cv);
+            const bool usable = val.has_value() && !val->empty() && val->size() <= max_len;
+            if (val.has_value() && val->size() > max_len) {
+                EVLOG_warning << label << " exceeds the per-slot length limit (" << val->size() << " > " << max_len
+                              << "); not propagating to migrated slots";
+            }
+            return std::pair{std::move(val), usable};
+        };
+
+        const auto [security_ctrlr_password, security_ctrlr_password_is_usable] =
+            load_security_ctrlr_fallback(ControllerComponentVariables::BasicAuthPassword,
+                                         basic_auth_password_max_length, "SecurityCtrlr.BasicAuthPassword");
+        const auto [security_ctrlr_identity, security_ctrlr_identity_is_usable] = load_security_ctrlr_fallback(
+            ControllerComponentVariables::SecurityCtrlrIdentity, identity_max_length, "SecurityCtrlr.Identity");
+
+        // Some legacy blobs reference NetworkConfiguration_<N> slots that were never installed
+        // via a per-slot JSON config on this target. Probe each slot before writing and create
+        // it from the embedded default schema if missing, so the write can succeed in-place
+        // rather than reporting "UnknownComponent" and dropping the profile.
+        auto ensure_slot_exists = [&](int slot) {
+            const auto probe_cv = get_component_variable(slot, OcppCsmsUrl);
+            if (dm.get_variable_meta_data(probe_cv.component, probe_cv.variable.value()).has_value()) {
+                return true;
+            }
+            if (dm.create_network_configuration_slot_from_default_schema(slot)) {
+                EVLOG_info << "Created NetworkConfiguration_" << slot
+                           << " from embedded default schema for blob migration";
+                return true;
+            }
+            EVLOG_warning << "Could not create NetworkConfiguration_" << slot
+                          << " for blob migration; profile will not be written";
+            return false;
+        };
 
         int imported = 0;
+        int failed = 0;
         for (const auto& profile_json : profiles) {
-            const int slot = profile_json.at("configurationSlot").get<int>();
-            NetworkConnectionProfile profile = profile_json.at("connectionData");
-            if (!profile.basicAuthPassword.has_value() && security_ctrlr_password_is_usable) {
-                profile.basicAuthPassword = CiString<64>(security_ctrlr_password.value());
-            }
-            if (write_profile_to_device_model(dm, slot, profile, "internal")) {
-                ++imported;
-            } else {
-                EVLOG_warning << "Failed to import NetworkConfiguration[" << slot << "] from blob";
+            try {
+                const int slot = profile_json.at("configurationSlot").get<int>();
+                NetworkConnectionProfile profile = profile_json.at("connectionData");
+                if (!profile.basicAuthPassword.has_value() && security_ctrlr_password_is_usable) {
+                    profile.basicAuthPassword = CiString<64>(security_ctrlr_password.value());
+                }
+                if (!profile.identity.has_value() && security_ctrlr_identity_is_usable) {
+                    profile.identity = CiString<48>(security_ctrlr_identity.value());
+                }
+                if (!ensure_slot_exists(slot)) {
+                    ++failed;
+                    continue;
+                }
+                if (write_profile_to_device_model(dm, slot, profile, "internal")) {
+                    ++imported;
+                } else {
+                    ++failed;
+                    EVLOG_warning << "Failed to import NetworkConfiguration[" << slot << "] from blob";
+                }
+            } catch (const std::exception& e) {
+                ++failed;
+                EVLOG_warning << "Skipping malformed profile entry in NetworkConnectionProfiles blob: " << e.what();
             }
         }
 
-        // Clear the blob so this migration does not run again on the next boot
-        dm.set_value(ControllerComponentVariables::NetworkConnectionProfiles.component,
-                     ControllerComponentVariables::NetworkConnectionProfiles.variable.value(), AttributeEnum::Actual,
-                     "", "internal");
-
-        EVLOG_info << "Imported " << imported
-                   << " profile(s) from NetworkConnectionProfiles blob into NetworkConfiguration DM components";
+        // Clear the blob so this migration does not run again on the next boot.
+        clear_blob("post-migration");
+        if (failed == 0) {
+            EVLOG_info << "Imported " << imported
+                       << " profile(s) from NetworkConnectionProfiles blob into NetworkConfiguration DM components";
+        } else {
+            EVLOG_error << "Imported " << imported << " of " << (imported + failed)
+                        << " profile(s) from NetworkConnectionProfiles blob; the remaining " << failed
+                        << " could not be written and the blob has been cleared";
+        }
     } catch (const std::exception& e) {
         EVLOG_error << "Error importing from NetworkConnectionProfiles blob: " << e.what();
     }

--- a/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
@@ -395,6 +395,27 @@ DeviceModel::DeviceModel(std::unique_ptr<DeviceModelStorageInterface> device_mod
     this->device_model_map = this->device_model->get_device_model();
 }
 
+bool DeviceModel::create_network_configuration_slot_from_default_schema(std::int32_t new_slot) {
+    if (this->device_model == nullptr) {
+        return false;
+    }
+    if (!this->device_model->create_network_configuration_slot_from_default_schema(new_slot)) {
+        return false;
+    }
+    try {
+        // Reload the cached map so the freshly created component is visible to subsequent
+        // get_variable / set_value calls; the cache is built once at construction.
+        this->device_model_map = this->device_model->get_device_model();
+    } catch (const std::exception& e) {
+        EVLOG_error << "DeviceModel::create_network_configuration_slot_from_default_schema: storage "
+                       "committed slot "
+                    << new_slot << " but in-memory device-model reload failed (" << e.what()
+                    << "); restart required to pick up the new component";
+        throw;
+    }
+    return true;
+}
+
 SetVariableStatusEnum DeviceModel::set_read_only_value(const Component& component, const Variable& variable,
                                                        const AttributeEnum& attribute_enum, const std::string& value,
                                                        const std::string& source) {

--- a/lib/everest/ocpp/lib/ocpp/v2/device_model_storage_sqlite.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/device_model_storage_sqlite.cpp
@@ -6,6 +6,7 @@
 #include <limits>
 #include <ocpp/v2/device_model_storage_sqlite.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>
+#include <ocpp/v2/network_configuration_default_schema.hpp>
 #include <ocpp/v2/utils.hpp>
 
 using namespace everest::db;
@@ -473,6 +474,126 @@ std::int32_t DeviceModelStorageSqlite::clear_custom_variable_monitors() {
 
 void DeviceModelStorageSqlite::check_integrity() {
     // Function is now empty because checks are already done elsewhere (for example the check for 'required' variables).
+}
+
+bool DeviceModelStorageSqlite::create_network_configuration_slot_from_default_schema(std::int32_t new_slot) {
+    const std::string new_instance = std::to_string(new_slot);
+
+    // Embedded schema parse. Failure means a build defect, not a runtime data issue.
+    std::pair<ComponentKey, std::vector<DeviceModelVariable>> parsed;
+    try {
+        parsed = parse_component_config_from_string(get_default_network_configuration_schema());
+    } catch (const std::exception& e) {
+        EVLOG_critical << "create_network_configuration_slot_from_default_schema: embedded default "
+                          "schema could not be parsed (build defect): "
+                       << e.what();
+        return false;
+    }
+    const auto& variables = parsed.second;
+
+    try {
+        auto select_existing = this->db->new_statement(
+            "SELECT 1 FROM COMPONENT WHERE NAME = 'NetworkConfiguration' AND INSTANCE = @instance");
+        select_existing->bind_text("@instance", new_instance, SQLiteString::Transient);
+        if (select_existing->step() == SQLITE_ROW) {
+            EVLOG_warning << "create_network_configuration_slot_from_default_schema: slot " << new_slot
+                          << " already exists";
+            return false;
+        }
+
+        auto transaction = this->db->begin_transaction();
+
+        auto bind_opt_text = [](everest::db::sqlite::StatementInterface& stmt, const char* p,
+                                const std::optional<std::string>& v) {
+            if (v.has_value() && !v->empty()) {
+                stmt.bind_text(p, *v, SQLiteString::Transient);
+            } else {
+                stmt.bind_null(p);
+            }
+        };
+        auto bind_opt_int = [](everest::db::sqlite::StatementInterface& stmt, const char* p, const auto& v) {
+            if (v.has_value()) {
+                stmt.bind_int(p, static_cast<int>(*v));
+            } else {
+                stmt.bind_null(p);
+            }
+        };
+        auto bind_opt_double = [](everest::db::sqlite::StatementInterface& stmt, const char* p, const auto& v) {
+            if (v.has_value()) {
+                stmt.bind_double(p, static_cast<double>(*v));
+            } else {
+                stmt.bind_null(p);
+            }
+        };
+
+        auto insert_component = this->db->new_statement("INSERT INTO COMPONENT (NAME, INSTANCE, EVSE_ID, CONNECTOR_ID) "
+                                                        "VALUES ('NetworkConfiguration', @instance, NULL, NULL)");
+        insert_component->bind_text("@instance", new_instance, SQLiteString::Transient);
+        if (insert_component->step() != SQLITE_DONE) {
+            EVLOG_error << "create_network_configuration_slot_from_default_schema: insert COMPONENT failed: "
+                        << this->db->get_error_message();
+            return false;
+        }
+        const auto new_component_id = this->db->get_last_inserted_rowid();
+
+        for (const auto& variable : variables) {
+            auto insert_variable = this->db->new_statement(
+                "INSERT INTO VARIABLE (NAME, INSTANCE, COMPONENT_ID, SOURCE) VALUES (@n, @i, @cid, @src)");
+            insert_variable->bind_text("@n", variable.name, SQLiteString::Transient);
+            bind_opt_text(*insert_variable, "@i", variable.instance);
+            insert_variable->bind_int("@cid", static_cast<int>(new_component_id));
+            bind_opt_text(*insert_variable, "@src", variable.source);
+            if (insert_variable->step() != SQLITE_DONE) {
+                EVLOG_error << "create_network_configuration_slot_from_default_schema: insert VARIABLE failed: "
+                            << this->db->get_error_message();
+                return false;
+            }
+            const auto new_variable_id = this->db->get_last_inserted_rowid();
+
+            auto insert_characteristics = this->db->new_statement(
+                "INSERT INTO VARIABLE_CHARACTERISTICS "
+                "(DATATYPE_ID, VARIABLE_ID, MAX_LIMIT, MIN_LIMIT, SUPPORTS_MONITORING, UNIT, VALUES_LIST) "
+                "VALUES (@dtype, @vid, @max, @min, @supp, @unit, @vlist)");
+            insert_characteristics->bind_int("@dtype", static_cast<int>(variable.characteristics.dataType));
+            insert_characteristics->bind_int("@vid", static_cast<int>(new_variable_id));
+            bind_opt_double(*insert_characteristics, "@max", variable.characteristics.maxLimit);
+            bind_opt_double(*insert_characteristics, "@min", variable.characteristics.minLimit);
+            insert_characteristics->bind_int("@supp", variable.characteristics.supportsMonitoring ? 1 : 0);
+            bind_opt_text(*insert_characteristics, "@unit", variable.characteristics.unit);
+            bind_opt_text(*insert_characteristics, "@vlist", variable.characteristics.valuesList);
+            if (insert_characteristics->step() != SQLITE_DONE) {
+                EVLOG_error << "create_network_configuration_slot_from_default_schema: "
+                               "insert VARIABLE_CHARACTERISTICS failed: "
+                            << this->db->get_error_message();
+                return false;
+            }
+
+            for (const auto& db_attribute : variable.attributes) {
+                const auto& attribute = db_attribute.variable_attribute;
+                auto insert_attribute = this->db->new_statement(
+                    "INSERT INTO VARIABLE_ATTRIBUTE "
+                    "(VARIABLE_ID, MUTABILITY_ID, PERSISTENT, CONSTANT, TYPE_ID, VALUE_SOURCE, VALUE) "
+                    "VALUES (@vid, @mut, 1, 0, @type, 'internal', NULL)");
+                insert_attribute->bind_int("@vid", static_cast<int>(new_variable_id));
+                bind_opt_int(*insert_attribute, "@mut", attribute.mutability);
+                bind_opt_int(*insert_attribute, "@type", attribute.type);
+                if (insert_attribute->step() != SQLITE_DONE) {
+                    EVLOG_error << "create_network_configuration_slot_from_default_schema: "
+                                   "insert VARIABLE_ATTRIBUTE failed: "
+                                << this->db->get_error_message();
+                    return false;
+                }
+            }
+        }
+
+        transaction->commit();
+        EVLOG_info << "Created NetworkConfiguration_" << new_slot << " from embedded default schema ("
+                   << variables.size() << " variables)";
+        return true;
+    } catch (const std::exception& e) {
+        EVLOG_error << "create_network_configuration_slot_from_default_schema: exception: " << e.what();
+        return false;
+    }
 }
 
 } // namespace v2

--- a/lib/everest/ocpp/lib/ocpp/v2/init_device_model_db.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/init_device_model_db.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <fstream>
 #include <map>
+#include <sstream>
 #include <string>
 
 #include <everest/logging.hpp>
@@ -88,9 +89,13 @@ void InitDeviceModelDb::initialize_database(
     // Check if the config is consistent.
     check_integrity(component_configs);
 
-    // Remove components from db if they do not exist in the component config
+    // Components in the database that no longer have a matching entry in the component
+    // config (e.g. NetworkConfiguration_<N>.json was removed from the install) are kept
+    // in place and reported via a warning. Pruning these rows used to drop migration
+    // targets, so the operator could end up with a populated NetworkConnectionProfiles
+    // blob and no per-slot components to migrate it into.
     if (this->database_exists) {
-        remove_not_existing_components_from_db(component_configs, existing_components);
+        warn_about_components_missing_from_config(component_configs, existing_components);
     }
 
     // Starting a transaction makes this a lot faster (inserting all components takes a few seconds without it and a
@@ -170,18 +175,14 @@ read_component_config(const std::vector<std::filesystem::path>& components_confi
     for (const auto& path : components_config_path) {
         std::ifstream config_file(path);
         try {
-            json data = json::parse(config_file);
-            const ComponentKey p = data;
-            if (data.contains("properties")) {
-                const std::vector<DeviceModelVariable> variables = get_all_component_properties(data.at("properties"));
-                components.insert({p, variables});
-            } else {
-                EVLOG_warning << "Component " << data.at("name") << " does not contain any properties";
-                continue;
-            }
+            auto parsed = parse_component_config_from_json(json::parse(config_file));
+            components.insert({parsed.first, std::move(parsed.second)});
         } catch (const json::parse_error& e) {
             EVLOG_error << "Error while parsing config file: " << path;
             throw;
+        } catch (const InitDeviceModelDbError& e) {
+            EVLOG_warning << "Skipping component config " << path << ": " << e.what();
+            continue;
         }
     }
 
@@ -189,6 +190,20 @@ read_component_config(const std::vector<std::filesystem::path>& components_confi
 }
 
 } // namespace
+
+std::pair<ComponentKey, std::vector<DeviceModelVariable>> parse_component_config_from_json(const json& data) {
+    if (!data.contains("properties")) {
+        throw InitDeviceModelDbError("Component config has no \"properties\"");
+    }
+    const ComponentKey component_key = data;
+    auto variables = get_all_component_properties(data.at("properties"));
+    return {component_key, std::move(variables)};
+}
+
+std::pair<ComponentKey, std::vector<DeviceModelVariable>>
+parse_component_config_from_string(const std::string& json_content) {
+    return parse_component_config_from_json(json::parse(json_content));
+}
 
 std::map<ComponentKey, std::vector<DeviceModelVariable>>
 get_all_component_configs(const std::filesystem::path& directory) {
@@ -999,12 +1014,25 @@ bool component_exists_in_config(const std::map<ComponentKey, std::vector<DeviceM
 }
 } // namespace
 
-void InitDeviceModelDb::remove_not_existing_components_from_db(
+void InitDeviceModelDb::warn_about_components_missing_from_config(
     const std::map<ComponentKey, std::vector<DeviceModelVariable>>& component_config,
     const std::map<ComponentKey, std::vector<DeviceModelVariable>>& db_components) {
     for (const auto& component : db_components) {
         if (!component_exists_in_config(component_config, component.first)) {
-            remove_component_from_db(component.first);
+            std::ostringstream identifier;
+            identifier << component.first.name;
+            if (component.first.instance.has_value() && !component.first.instance.value().empty()) {
+                identifier << " (instance=" << component.first.instance.value() << ")";
+            }
+            if (component.first.evse_id.has_value()) {
+                identifier << " (evse_id=" << component.first.evse_id.value();
+                if (component.first.connector_id.has_value()) {
+                    identifier << ", connector_id=" << component.first.connector_id.value();
+                }
+                identifier << ")";
+            }
+            EVLOG_warning << "Component " << identifier.str()
+                          << " is present in the device model database but has no matching component config file";
         }
     }
 }

--- a/lib/everest/ocpp/lib/ocpp/v2/network_configuration_default_schema.cpp.in
+++ b/lib/everest/ocpp/lib/ocpp/v2/network_configuration_default_schema.cpp.in
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+//
+// AUTO-GENERATED. Do not edit by hand.
+// Source: config/common/component_config/standardized/NetworkConfiguration_1.json
+
+#include <ocpp/v2/network_configuration_default_schema.hpp>
+
+namespace ocpp::v2 {
+
+const std::string& get_default_network_configuration_schema() {
+    static const std::string schema = R"json(@OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_JSON@)json";
+    return schema;
+}
+
+} // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_init_device_model_db.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_init_device_model_db.cpp
@@ -345,22 +345,24 @@ TEST_F(InitDeviceModelDbTest, init_db) {
     // Component added
     EXPECT_TRUE(component_exists("EVSE", std::nullopt, 3, std::nullopt));
     EXPECT_TRUE(component_exists("Connector", std::nullopt, 2, 2));
-    // Component removed, variables, characteristics and attributes should also have been removed.
-    EXPECT_FALSE(component_exists("Connector", std::nullopt, 2, 1));
-    EXPECT_FALSE(variable_exists("Connector", std::nullopt, 2, 1, "AvailabilityState", std::nullopt));
-    EXPECT_FALSE(variable_exists("Connector", std::nullopt, 2, 1, "Available", std::nullopt));
-    EXPECT_FALSE(variable_exists("Connector", std::nullopt, 2, 1, "ChargeProtocol", std::nullopt));
-    EXPECT_FALSE(variable_exists("Connector", std::nullopt, 2, 1, "ConnectorType", std::nullopt));
-    EXPECT_FALSE(variable_exists("Connector", std::nullopt, 2, 1, "SupplyPhases", std::nullopt));
-    EXPECT_FALSE(attribute_exists("Connector", std::nullopt, 2, 1, "ChargeProtocol", std::nullopt, std::nullopt,
-                                  AttributeEnum::Actual));
-    EXPECT_FALSE(attribute_exists("Connector", std::nullopt, 2, 1, "ConnectorType", std::nullopt,
-                                  MutabilityEnum::ReadOnly, AttributeEnum::Actual));
-    EXPECT_FALSE(characteristics_exists("Connector", std::nullopt, 2, 1, "Available", std::nullopt, DataEnum::boolean,
-                                        std::nullopt, std::nullopt, true, std::nullopt, std::nullopt));
-    EXPECT_FALSE(characteristics_exists("Connector", std::nullopt, 2, 1, "AvailabilityState", std::nullopt,
-                                        DataEnum::OptionList, std::nullopt, std::nullopt, true, std::nullopt,
-                                        "Available,Occupied,Reserved,Unavailable,Faulted"));
+    // Component is missing from the changed config but must NOT be removed on reinit.
+    // Pruning was replaced with a warning so per-slot components (NetworkConfiguration_<N>)
+    // survive missing JSON files and blob migration retries can still complete.
+    EXPECT_TRUE(component_exists("Connector", std::nullopt, 2, 1));
+    EXPECT_TRUE(variable_exists("Connector", std::nullopt, 2, 1, "AvailabilityState", std::nullopt));
+    EXPECT_TRUE(variable_exists("Connector", std::nullopt, 2, 1, "Available", std::nullopt));
+    EXPECT_TRUE(variable_exists("Connector", std::nullopt, 2, 1, "ChargeProtocol", std::nullopt));
+    EXPECT_TRUE(variable_exists("Connector", std::nullopt, 2, 1, "ConnectorType", std::nullopt));
+    EXPECT_TRUE(variable_exists("Connector", std::nullopt, 2, 1, "SupplyPhases", std::nullopt));
+    EXPECT_TRUE(attribute_exists("Connector", std::nullopt, 2, 1, "ChargeProtocol", std::nullopt, std::nullopt,
+                                 AttributeEnum::Actual));
+    EXPECT_TRUE(attribute_exists("Connector", std::nullopt, 2, 1, "ConnectorType", std::nullopt,
+                                 MutabilityEnum::ReadOnly, AttributeEnum::Actual));
+    EXPECT_TRUE(characteristics_exists("Connector", std::nullopt, 2, 1, "Available", std::nullopt, DataEnum::boolean,
+                                       std::nullopt, std::nullopt, true, std::nullopt, std::nullopt));
+    EXPECT_TRUE(characteristics_exists("Connector", std::nullopt, 2, 1, "AvailabilityState", std::nullopt,
+                                       DataEnum::OptionList, std::nullopt, std::nullopt, true, std::nullopt,
+                                       "Available,Occupied,Reserved,Unavailable,Faulted"));
 
     // Changed supports monitoring and datatype
     EXPECT_FALSE(characteristics_exists("EVSE", std::nullopt, 2, std::nullopt, "AvailabilityState", std::nullopt,

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_network_config_sync.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_network_config_sync.cpp
@@ -4,6 +4,8 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
+#include <filesystem>
+
 #include <boost/asio/io_context.hpp>
 
 #include <component_state_manager_mock.hpp>
@@ -18,6 +20,7 @@
 #include <ocpp/common/message_queue.hpp>
 #include <ocpp/common/ocpp_logging.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/device_model_interface.hpp>
 #include <ocpp/v2/device_model_storage_sqlite.hpp>
 #include <ocpp/v2/functional_blocks/availability.hpp>
@@ -28,6 +31,7 @@
 #include <ocpp/v2/functional_blocks/security.hpp>
 #include <ocpp/v2/functional_blocks/tariff_and_cost.hpp>
 #include <ocpp/v2/functional_blocks/transaction.hpp>
+#include <ocpp/v2/init_device_model_db.hpp>
 #include <ocpp/v2/messages/Get15118EVCertificate.hpp>
 #include <ocpp/v2/messages/SetNetworkProfile.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
@@ -381,6 +385,56 @@ TEST_F(NetworkConfigSyncTest, MigrateFromBlobPreservesBlobBasicAuthPassword) {
     ASSERT_TRUE(result.has_value());
     ASSERT_TRUE(result->basicAuthPassword.has_value());
     EXPECT_EQ(result->basicAuthPassword->get(), "SlotSpecificPassword!");
+}
+
+TEST_F(NetworkConfigSyncTest, MigrateFromBlobPullsIdentityFromSecurityCtrlr) {
+    NetworkConfigurationComponentVariables::clear_slot_in_device_model(*dm, 1);
+
+    // Set a known Identity in SecurityCtrlr (the global charging-station identifier)
+    const std::string expected_identity = "CP-001-station-alpha";
+    dm->set_read_only_value(ControllerComponentVariables::SecurityCtrlrIdentity.component,
+                            ControllerComponentVariables::SecurityCtrlrIdentity.variable.value(), AttributeEnum::Actual,
+                            expected_identity, "test");
+
+    // Build a blob whose profile does NOT contain an identity (typical legacy format)
+    SetNetworkProfileRequest req;
+    req.configurationSlot = 1;
+    req.connectionData = make_basic_profile(1, "wss://id-migration.example.com/ocpp");
+    ASSERT_FALSE(req.connectionData.identity.has_value());
+
+    seed_blob(*dm, make_blob({req}));
+    NetworkConfigurationComponentVariables::migrate_from_blob_if_needed(*dm);
+
+    // After migration, the per-slot Identity must have been populated from SecurityCtrlr
+    auto result = NetworkConfigurationComponentVariables::read_profile_from_device_model(*dm, 1);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->identity.has_value())
+        << "Migration must populate per-slot Identity from SecurityCtrlr when blob has none";
+    EXPECT_EQ(result->identity->get(), expected_identity);
+}
+
+TEST_F(NetworkConfigSyncTest, MigrateFromBlobPreservesBlobIdentity) {
+    NetworkConfigurationComponentVariables::clear_slot_in_device_model(*dm, 1);
+
+    // Set a different Identity in SecurityCtrlr
+    dm->set_read_only_value(ControllerComponentVariables::SecurityCtrlrIdentity.component,
+                            ControllerComponentVariables::SecurityCtrlrIdentity.variable.value(), AttributeEnum::Actual,
+                            "global-station-identity", "test");
+
+    // Build a blob whose profile DOES contain an identity
+    SetNetworkProfileRequest req;
+    req.configurationSlot = 1;
+    req.connectionData = make_basic_profile(1, "wss://id-migration.example.com/ocpp");
+    req.connectionData.identity = CiString<48>("slot-specific-identity");
+
+    seed_blob(*dm, make_blob({req}));
+    NetworkConfigurationComponentVariables::migrate_from_blob_if_needed(*dm);
+
+    // The per-slot identity from the blob must be used, not the SecurityCtrlr identity
+    auto result = NetworkConfigurationComponentVariables::read_profile_from_device_model(*dm, 1);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->identity.has_value());
+    EXPECT_EQ(result->identity->get(), "slot-specific-identity");
 }
 
 // ---------------------------------------------------------------------------
@@ -1722,6 +1776,411 @@ TEST_F(ProvisioningSetNetworkProfileTest, HappyPathReturnsAccepted) {
     provisioning->handle_message(em);
 
     EXPECT_EQ(response.status, SetNetworkProfileStatusEnum::Accepted);
+}
+
+// ---------------------------------------------------------------------------
+// Migration survives missing NetworkConfiguration JSON files
+//
+// `InitDeviceModelDb::initialize_database` used to delete every component row
+// in the database that no longer had a matching JSON in the component config
+// directory. That pruning broke blob migration on targets where the operator
+// updated the install without re-shipping `NetworkConfiguration_<N>.json`: the
+// per-slot device-model components vanished, the blob retry never had a
+// migration target, and the operator's connection profiles became unrecoverable.
+//
+// The fix replaced the prune with a warning, so the orphan rows are preserved
+// and a later `migrate_from_blob_if_needed` can still write into the existing
+// per-slot components. The tests below exercise that behavior end-to-end with
+// an on-disk database (so `InitDeviceModelDb`'s ctor sets `database_exists`
+// via the filesystem check on the second init, without test-only hacks).
+// ---------------------------------------------------------------------------
+
+class MigrationWithoutJsonTest : public ::testing::Test {
+protected:
+    std::filesystem::path db_path;
+    std::string config_path = "./resources/example_config/v2/component_config";
+    std::string migration_files_path = "./resources/v2/device_model_migration_files";
+
+    void SetUp() override {
+        const std::string unique = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+        db_path = std::filesystem::temp_directory_path() / ("libocpp_no_prune_" + unique + ".db");
+        std::error_code ec;
+        std::filesystem::remove(db_path, ec);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove(db_path, ec);
+    }
+
+    // Return a copy of the component config map with every NetworkConfiguration
+    // entry whose instance is `instance_to_drop` removed. Simulates a target
+    // where `NetworkConfiguration_<instance>.json` was not installed.
+    static std::map<ComponentKey, std::vector<DeviceModelVariable>>
+    drop_network_configuration_instance(std::map<ComponentKey, std::vector<DeviceModelVariable>> configs,
+                                        const std::string& instance_to_drop) {
+        for (auto it = configs.begin(); it != configs.end();) {
+            const auto& key = it->first;
+            const bool is_network_config = key.name == "NetworkConfiguration";
+            const bool matches_instance = key.instance.has_value() && key.instance.value() == instance_to_drop;
+            if (is_network_config && matches_instance) {
+                it = configs.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        return configs;
+    }
+};
+
+// The first init creates NetworkConfiguration_1 and _2 from the JSON config.
+// The second init runs with a config map that lacks NetworkConfiguration_2,
+// simulating the JSON file being absent. The orphan row must NOT be removed,
+// so that a later blob migration can still write into slot 2.
+TEST_F(MigrationWithoutJsonTest, OrphanNetworkConfigurationComponentSurvivesReinit) {
+    const auto full = get_all_component_configs(config_path);
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(full, true));
+    }
+
+    // Sanity: the first init must have populated NetworkConfiguration_2 from JSON,
+    // otherwise the rest of the test is vacuous.
+    bool slot_2_in_first_init = false;
+    for (const auto& [key, _vars] : full) {
+        if (key.name == "NetworkConfiguration" && key.instance.has_value() && key.instance.value() == "2") {
+            slot_2_in_first_init = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(slot_2_in_first_init) << "Precondition: example component_config must declare NetworkConfiguration_2";
+
+    const auto reduced = drop_network_configuration_instance(full, "2");
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(reduced, false));
+    }
+
+    // Open the DB through DeviceModel and confirm slot 2 variables still resolve.
+    auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+    DeviceModel dm(std::move(storage));
+
+    const auto slot_2_url_cv = NetworkConfigurationComponentVariables::get_component_variable(
+        2, NetworkConfigurationComponentVariables::OcppCsmsUrl);
+    auto status_after_reinit =
+        dm.set_value(slot_2_url_cv.component, slot_2_url_cv.variable.value(), AttributeEnum::Actual,
+                     "wss://orphan-survived.example.com/ocpp", "test", true);
+    EXPECT_EQ(status_after_reinit, SetVariableStatusEnum::Accepted)
+        << "NetworkConfiguration_2 must still be writable after the JSON config was removed";
+}
+
+// Same scenario but exercises the full migration path: seed a legacy blob with
+// a profile for slot 2 in a fresh DB, then re-init with the reduced config (no
+// NetworkConfiguration_2.json), then run migrate_from_blob_if_needed. The
+// migration must succeed because the orphan slot 2 row was preserved.
+TEST_F(MigrationWithoutJsonTest, MigrationSucceedsWhenNetworkConfigurationJsonRemoved) {
+    const auto full = get_all_component_configs(config_path);
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(full, true));
+    }
+
+    // Seed the legacy blob and clear slot 2's defaults so the migration must
+    // actually write into the slot (rather than skipping it as already populated).
+    {
+        auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+        DeviceModel dm(std::move(storage));
+        NetworkConfigurationComponentVariables::clear_slot_in_device_model(dm, 1);
+        NetworkConfigurationComponentVariables::clear_slot_in_device_model(dm, 2);
+
+        SetNetworkProfileRequest req;
+        req.configurationSlot = 2;
+        req.connectionData = make_basic_profile(1, "wss://post-orphan.example.com/ocpp");
+        seed_blob(dm, make_blob({req}));
+    }
+
+    // Re-init the DB without NetworkConfiguration_2.json. Pre-fix this would have
+    // deleted the slot 2 component and the migration below would silently fail.
+    const auto reduced = drop_network_configuration_instance(full, "2");
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(reduced, false));
+    }
+
+    auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+    DeviceModel dm(std::move(storage));
+
+    NetworkConfigurationComponentVariables::migrate_from_blob_if_needed(dm);
+
+    auto result = NetworkConfigurationComponentVariables::read_profile_from_device_model(dm, 2);
+    ASSERT_TRUE(result.has_value())
+        << "Slot 2 must be populated after migration even though NetworkConfiguration_2.json is missing";
+    EXPECT_EQ(result->ocppCsmsUrl.get(), "wss://post-orphan.example.com/ocpp");
+    EXPECT_EQ(read_blob(dm).size(), 0u) << "Blob must be cleared once migration writes every profile into its DM slot";
+}
+
+// Drops NetworkConfiguration_1 and _2 from the reduced config but keeps the
+// previously inserted rows. Both slots must survive the reinit (one warning
+// per orphan, no deletions), and migration into both slots must complete.
+TEST_F(MigrationWithoutJsonTest, MigrationSucceedsWhenAllNetworkConfigurationJsonRemoved) {
+    const auto full = get_all_component_configs(config_path);
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(full, true));
+    }
+
+    {
+        auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+        DeviceModel dm(std::move(storage));
+        NetworkConfigurationComponentVariables::clear_slot_in_device_model(dm, 1);
+        NetworkConfigurationComponentVariables::clear_slot_in_device_model(dm, 2);
+
+        SetNetworkProfileRequest req1;
+        req1.configurationSlot = 1;
+        req1.connectionData = make_basic_profile(1, "wss://no-json-slot1.example.com/ocpp");
+
+        SetNetworkProfileRequest req2;
+        req2.configurationSlot = 2;
+        req2.connectionData = make_basic_profile(2, "wss://no-json-slot2.example.com/ocpp");
+
+        seed_blob(dm, make_blob({req1, req2}));
+    }
+
+    auto reduced = drop_network_configuration_instance(full, "1");
+    reduced = drop_network_configuration_instance(reduced, "2");
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(reduced, false));
+    }
+
+    auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+    DeviceModel dm(std::move(storage));
+
+    NetworkConfigurationComponentVariables::migrate_from_blob_if_needed(dm);
+
+    auto r1 = NetworkConfigurationComponentVariables::read_profile_from_device_model(dm, 1);
+    auto r2 = NetworkConfigurationComponentVariables::read_profile_from_device_model(dm, 2);
+    ASSERT_TRUE(r1.has_value()) << "Slot 1 must be populated even with NetworkConfiguration_1.json missing";
+    ASSERT_TRUE(r2.has_value()) << "Slot 2 must be populated even with NetworkConfiguration_2.json missing";
+    EXPECT_EQ(r1->ocppCsmsUrl.get(), "wss://no-json-slot1.example.com/ocpp");
+    EXPECT_EQ(r2->ocppCsmsUrl.get(), "wss://no-json-slot2.example.com/ocpp");
+    EXPECT_EQ(read_blob(dm).size(), 0u);
+}
+
+// Direct storage-level coverage of the create entry point: with no NetworkConfiguration
+// components in the DB at all, the new method must insert a complete COMPONENT + VARIABLE +
+// VARIABLE_CHARACTERISTICS + VARIABLE_ATTRIBUTE tree under the new instance, and the next
+// `get_device_model()` snapshot must contain a NetworkConfiguration entry at that instance.
+TEST_F(MigrationWithoutJsonTest, StorageCreatesSlotFromEmbeddedSchema) {
+    auto reduced = get_all_component_configs(config_path);
+    reduced = drop_network_configuration_instance(reduced, "1");
+    reduced = drop_network_configuration_instance(reduced, "2");
+
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(reduced, true));
+    }
+
+    DeviceModelStorageSqlite storage(db_path);
+
+    ASSERT_TRUE(storage.create_network_configuration_slot_from_default_schema(3));
+
+    // Repeat create on the same slot must be a no-op (returns false). Refuse to overwrite.
+    EXPECT_FALSE(storage.create_network_configuration_slot_from_default_schema(3));
+
+    const auto model = storage.get_device_model();
+    const VariableMap* slot_3_vars = nullptr;
+    for (const auto& [component, variables] : model) {
+        if (component.name == "NetworkConfiguration" && component.instance.has_value() &&
+            component.instance.value() == "3") {
+            slot_3_vars = &variables;
+            break;
+        }
+    }
+    ASSERT_NE(slot_3_vars, nullptr) << "Created slot must appear in the next get_device_model() snapshot";
+    EXPECT_GT(slot_3_vars->size(), 0u) << "Created slot must expose at least one variable";
+
+    // Pin embedded JSON against accidental field removal: assert the well-known per-slot variables
+    // are present by name.
+    const auto has_var_named = [&](const std::string& name) {
+        for (const auto& [variable, _] : *slot_3_vars) {
+            if (variable.name.get() == name) {
+                return true;
+            }
+        }
+        return false;
+    };
+    EXPECT_TRUE(has_var_named("OcppCsmsUrl"));
+    EXPECT_TRUE(has_var_named("SecurityProfile"));
+    EXPECT_TRUE(has_var_named("OcppInterface"));
+    EXPECT_TRUE(has_var_named("OcppTransport"));
+    EXPECT_TRUE(has_var_named("MessageTimeout"));
+    EXPECT_TRUE(has_var_named("Identity"));
+    EXPECT_TRUE(has_var_named("BasicAuthPassword"));
+}
+
+// First boot on a target that ships without any NetworkConfiguration_<N>.json. The device model
+// holds zero NetworkConfiguration components, so the clone path has no template to copy from.
+// Migration must instead create the slot from the embedded default schema.
+TEST_F(MigrationWithoutJsonTest, MigrationCreatesSlotWhenNoTemplateExists) {
+    auto reduced = get_all_component_configs(config_path);
+    reduced = drop_network_configuration_instance(reduced, "1");
+    reduced = drop_network_configuration_instance(reduced, "2");
+
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(reduced, true));
+    }
+
+    {
+        auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+        DeviceModel dm(std::move(storage));
+
+        SetNetworkProfileRequest req;
+        req.configurationSlot = 3;
+        req.connectionData = make_basic_profile(1, "wss://bootstrap.example.com/ocpp");
+        seed_blob(dm, make_blob({req}));
+    }
+
+    auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+    DeviceModel dm(std::move(storage));
+
+    // Precondition: NO NetworkConfiguration slot should resolve before migration.
+    for (int probe_slot = 1; probe_slot <= 32; ++probe_slot) {
+        const auto probe_cv = NetworkConfigurationComponentVariables::get_component_variable(
+            probe_slot, NetworkConfigurationComponentVariables::OcppCsmsUrl);
+        ASSERT_FALSE(dm.get_variable_meta_data(probe_cv.component, probe_cv.variable.value()).has_value())
+            << "Precondition: NetworkConfiguration_" << probe_slot << " must be absent before create-path migration";
+    }
+
+    NetworkConfigurationComponentVariables::migrate_from_blob_if_needed(dm);
+
+    auto result = NetworkConfigurationComponentVariables::read_profile_from_device_model(dm, 3);
+    ASSERT_TRUE(result.has_value()) << "Slot 3 must be readable after create from the embedded schema";
+    EXPECT_EQ(result->ocppCsmsUrl.get(), "wss://bootstrap.example.com/ocpp");
+    EXPECT_EQ(read_blob(dm).size(), 0u);
+}
+
+// Multi-slot create in one migration pass. Blob seeds profiles for slots 3 and 5 on a
+// target that ships without NetworkConfiguration_<N>.json. Migration must create both
+// slots from the embedded schema and populate each.
+TEST_F(MigrationWithoutJsonTest, MigrationCreatesMultipleSlotsInOnePass) {
+    auto reduced = get_all_component_configs(config_path);
+    reduced = drop_network_configuration_instance(reduced, "1");
+    reduced = drop_network_configuration_instance(reduced, "2");
+
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(reduced, true));
+    }
+
+    {
+        auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+        DeviceModel dm(std::move(storage));
+
+        SetNetworkProfileRequest req3;
+        req3.configurationSlot = 3;
+        req3.connectionData = make_basic_profile(1, "wss://multi-slot-3.example.com/ocpp");
+
+        SetNetworkProfileRequest req5;
+        req5.configurationSlot = 5;
+        req5.connectionData = make_basic_profile(1, "wss://multi-slot-5.example.com/ocpp");
+
+        seed_blob(dm, make_blob({req3, req5}));
+    }
+
+    auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+    DeviceModel dm(std::move(storage));
+
+    NetworkConfigurationComponentVariables::migrate_from_blob_if_needed(dm);
+
+    auto r3 = NetworkConfigurationComponentVariables::read_profile_from_device_model(dm, 3);
+    auto r5 = NetworkConfigurationComponentVariables::read_profile_from_device_model(dm, 5);
+    ASSERT_TRUE(r3.has_value()) << "Slot 3 must be populated after multi-slot create";
+    ASSERT_TRUE(r5.has_value()) << "Slot 5 must be populated after multi-slot create";
+    EXPECT_EQ(r3->ocppCsmsUrl.get(), "wss://multi-slot-3.example.com/ocpp");
+    EXPECT_EQ(r5->ocppCsmsUrl.get(), "wss://multi-slot-5.example.com/ocpp");
+    EXPECT_EQ(read_blob(dm).size(), 0u);
+}
+
+// SecurityCtrlr.Identity exceeds the per-slot CiString<48> length cap. Migration must skip
+// propagation (not crash) and leave the per-slot Identity unset.
+TEST_F(NetworkConfigSyncTest, MigrateFromBlobIgnoresOverlongSecurityCtrlrIdentity) {
+    NetworkConfigurationComponentVariables::clear_slot_in_device_model(*dm, 1);
+
+    // Build a 49-char Identity (per-slot cap is 48).
+    const std::string overlong_identity(49, 'X');
+    dm->set_read_only_value(ControllerComponentVariables::SecurityCtrlrIdentity.component,
+                            ControllerComponentVariables::SecurityCtrlrIdentity.variable.value(), AttributeEnum::Actual,
+                            overlong_identity, "test");
+
+    SetNetworkProfileRequest req;
+    req.configurationSlot = 1;
+    req.connectionData = make_basic_profile(1, "wss://overlong-identity.example.com/ocpp");
+    ASSERT_FALSE(req.connectionData.identity.has_value());
+
+    seed_blob(*dm, make_blob({req}));
+    NetworkConfigurationComponentVariables::migrate_from_blob_if_needed(*dm);
+
+    auto result = NetworkConfigurationComponentVariables::read_profile_from_device_model(*dm, 1);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(result->identity.has_value())
+        << "Migration must skip overflowing SecurityCtrlr.Identity (do not truncate, do not propagate)";
+    EXPECT_EQ(read_blob(*dm).size(), 0u);
+}
+
+// Malformed blob entry: the blob carries one well-formed profile and one that lacks
+// `configurationSlot`. The well-formed slot must be populated; the migration must not abort;
+// the blob must still be cleared (per the unconditional clear policy).
+TEST_F(NetworkConfigSyncTest, MigrateFromBlobSkipsMalformedProfileEntry) {
+    NetworkConfigurationComponentVariables::clear_slot_in_device_model(*dm, 1);
+
+    // Hand-craft a blob with one valid entry and one malformed (missing configurationSlot).
+    json arr = json::array();
+
+    SetNetworkProfileRequest good;
+    good.configurationSlot = 1;
+    good.connectionData = make_basic_profile(1, "wss://good.example.com/ocpp");
+    arr.push_back(json(good));
+
+    // Malformed entry: object with only connectionData, no configurationSlot field.
+    json bad;
+    bad["connectionData"] = json(make_basic_profile(1, "wss://bad.example.com/ocpp"));
+    arr.push_back(bad);
+
+    seed_blob(*dm, arr);
+    NetworkConfigurationComponentVariables::migrate_from_blob_if_needed(*dm);
+
+    auto result = NetworkConfigurationComponentVariables::read_profile_from_device_model(*dm, 1);
+    ASSERT_TRUE(result.has_value()) << "Well-formed profile must be written even when a sibling is malformed";
+    EXPECT_EQ(result->ocppCsmsUrl.get(), "wss://good.example.com/ocpp");
+    EXPECT_EQ(read_blob(*dm).size(), 0u) << "Blob must be cleared after migration even with malformed siblings";
+}
+
+// After `create_network_configuration_slot_from_default_schema` returns, the freshly created
+// component must be immediately visible to subsequent `set_value` calls without manual cache
+// reload. Pins the in-memory device-model map reload behavior.
+TEST_F(MigrationWithoutJsonTest, CreatedSlotVisibleToSetValueWithoutManualReload) {
+    auto reduced = get_all_component_configs(config_path);
+    reduced = drop_network_configuration_instance(reduced, "1");
+    reduced = drop_network_configuration_instance(reduced, "2");
+
+    {
+        InitDeviceModelDb db(db_path, migration_files_path);
+        ASSERT_NO_THROW(db.initialize_database(reduced, true));
+    }
+
+    auto storage = std::make_unique<DeviceModelStorageSqlite>(db_path);
+    DeviceModel dm(std::move(storage));
+
+    ASSERT_TRUE(dm.create_network_configuration_slot_from_default_schema(7));
+
+    const auto cv = NetworkConfigurationComponentVariables::get_component_variable(
+        7, NetworkConfigurationComponentVariables::OcppCsmsUrl);
+    const auto status = dm.set_value(cv.component, cv.variable.value(), AttributeEnum::Actual,
+                                     "wss://bootstrap-visible.example.com/ocpp", "internal");
+    EXPECT_EQ(status, SetVariableStatusEnum::Accepted)
+        << "set_value into a freshly-created slot must succeed without manual cache reload";
 }
 
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/libocpp-unittests.cmake
+++ b/lib/everest/ocpp/tests/libocpp-unittests.cmake
@@ -76,6 +76,7 @@ set(LIBOCPP_TEST_INCLUDE_V2_SOURCES ${LIBOCPP_LIB_PATH}/ocpp/v16/ocpp_enums.cpp 
                                       ${LIBOCPP_LIB_PATH}/ocpp/v2/init_device_model_db.cpp
                                       ${LIBOCPP_LIB_PATH}/ocpp/v2/device_model_storage_sqlite.cpp
                                       ${LIBOCPP_LIB_PATH}/ocpp/v2/utils.cpp
+                                      ${OCPP_NETWORK_CONFIGURATION_DEFAULT_SCHEMA_GENERATED}
 )
 
 function(add_libocpp_unittest)

--- a/modules/EVSE/OCPP201/device_model/composed_device_model_storage.cpp
+++ b/modules/EVSE/OCPP201/device_model/composed_device_model_storage.cpp
@@ -133,6 +133,20 @@ void ComposedDeviceModelStorage::check_integrity() {
     }
 }
 
+bool ComposedDeviceModelStorage::create_network_configuration_slot_from_default_schema(std::int32_t new_slot) {
+    // NetworkConfiguration_<N> components live in the OCPP-source storage (the SQLite-backed
+    // EverestDeviceModelStorage). Without this dispatch, libocpp's blob-migration fallback hits
+    // DeviceModelStorageInterface's default virtual (returns false) and the operator's
+    // NetworkConnectionProfiles blob ends up cleared without ever populating the per-slot
+    // device-model rows on targets that ship no NetworkConfiguration_<N>.json.
+    const auto it = this->device_model_storages.find(VARIABLE_SOURCE_OCPP);
+    if (it == this->device_model_storages.end()) {
+        EVLOG_error << "OCPP device model storage not registered, cannot create NetworkConfiguration_" << new_slot;
+        return false;
+    }
+    return it->second->create_network_configuration_slot_from_default_schema(new_slot);
+}
+
 std::string module::device_model::ComposedDeviceModelStorage::get_variable_source(const ocpp::v2::Component& component,
                                                                                   const ocpp::v2::Variable& variable) {
     if (this->component_variable_source_map.find(component) == this->component_variable_source_map.end()) {

--- a/modules/EVSE/OCPP201/device_model/composed_device_model_storage.hpp
+++ b/modules/EVSE/OCPP201/device_model/composed_device_model_storage.hpp
@@ -48,6 +48,7 @@ public:
     virtual ocpp::v2::ClearMonitoringStatusEnum clear_variable_monitor(int monitor_id, bool allow_protected) override;
     virtual int32_t clear_custom_variable_monitors() override;
     virtual void check_integrity() override;
+    virtual bool create_network_configuration_slot_from_default_schema(std::int32_t new_slot) override;
 
 private:
     ///

--- a/modules/EVSE/OCPP201/device_model/everest_device_model_storage.cpp
+++ b/modules/EVSE/OCPP201/device_model/everest_device_model_storage.cpp
@@ -773,4 +773,9 @@ int32_t EverestDeviceModelStorage::clear_custom_variable_monitors() {
 
 void EverestDeviceModelStorage::check_integrity() {
 }
+
+bool EverestDeviceModelStorage::create_network_configuration_slot_from_default_schema(std::int32_t new_slot) {
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    return this->device_model_storage->create_network_configuration_slot_from_default_schema(new_slot);
+}
 } // namespace module::device_model

--- a/modules/EVSE/OCPP201/device_model/everest_device_model_storage.hpp
+++ b/modules/EVSE/OCPP201/device_model/everest_device_model_storage.hpp
@@ -47,6 +47,7 @@ public:
     virtual ocpp::v2::ClearMonitoringStatusEnum clear_variable_monitor(int monitor_id, bool allow_protected) override;
     virtual int32_t clear_custom_variable_monitors() override;
     virtual void check_integrity() override;
+    virtual bool create_network_configuration_slot_from_default_schema(std::int32_t new_slot) override;
 
     /// \brief Updates the actual value of the EVSE Power variable to the given \p total_power_active_import value
     void update_power(const int32_t evse_id, const float total_power_active_import);


### PR DESCRIPTION
If any profile in NetworkConnectionProfiles fails to write to the per-slot device-model component, do not clear the blob. The operator can retry once the device model is repaired.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

