### PR TITLE
feat(io): add kernel CAN receive filters and use the new feature in infy driver

### DIFF
--- a/config/bringup/config-bringup-infyACDC.yaml
+++ b/config/bringup/config-bringup-infyACDC.yaml
@@ -1,0 +1,19 @@
+settings:
+  mqtt_everest_prefix: everest_infy_acdc
+  controller_port: 8849
+active_modules:
+  cli:
+    connections:
+      psu:
+        - implementation_id: main
+          module_id: powersupply
+    module: BUPowerSupplyDC
+    standalone: true
+  powersupply:
+    config_module:
+      can_device: can0
+      # module_addresses: "0"
+      group_address: 0
+      device_connection_timeout_s: 15
+      controller_address: 240
+    module: InfyPower

--- a/config/bringup/config-bringup-infyDCDC.yaml
+++ b/config/bringup/config-bringup-infyDCDC.yaml
@@ -1,0 +1,19 @@
+settings:
+  mqtt_everest_prefix: everest_infy_dcdc
+  controller_port: 8850
+active_modules:
+  cli:
+    connections:
+      psu:
+        - implementation_id: main
+          module_id: powersupply
+    module: BUPowerSupplyDC
+    standalone: true
+  powersupply:
+    config_module:
+      can_device: can1
+      module_addresses: ""
+      group_address: 0
+      device_connection_timeout_s: 15
+      controller_address: 240
+    module: InfyPower

--- a/lib/everest/io/include/everest/io/can/can_recv_filter.hpp
+++ b/lib/everest/io/include/everest/io/can/can_recv_filter.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include <cstdint>
+
+namespace everest::lib::io::can {
+
+/**
+ * @brief Userspace description of a SocketCAN \c CAN_RAW_FILTER rule.
+ *
+ * Rules are applied on the raw socket via \c setsockopt(SOL_CAN_RAW, CAN_RAW_FILTER).
+ * A frame is delivered when it matches at least one rule (OR). Use \p invert on a rule
+ * to drop matching frames instead (\c CAN_INV_FILTER).
+ *
+ * \p can_id and \p can_mask are the 29-bit (EFF) or 11-bit identifier bits without
+ * \c CAN_EFF_FLAG / \c CAN_RTR_FLAG / \c CAN_ERR_FLAG. When \p extended is true,
+ * \c CAN_EFF_FLAG is added to both fields when installing the kernel filter.
+ */
+struct can_recv_filter {
+    uint32_t can_id{0};
+    uint32_t can_mask{0};
+    bool extended{true};
+    bool invert{false};
+
+    /**
+     * @brief Drop frames whose identifier matches \p id under \p mask.
+     * @param[in] id Plain CAN identifier bits (no SocketCAN flags).
+     * @param[in] mask Bits to compare; set bits are significant.
+     * @param[in] extended If true, match extended (29-bit) frames only.
+     */
+    static can_recv_filter reject_match(uint32_t id, uint32_t mask, bool extended = true);
+};
+
+} // namespace everest::lib::io::can

--- a/lib/everest/io/include/everest/io/can/socket_can_handler.hpp
+++ b/lib/everest/io/include/everest/io/can/socket_can_handler.hpp
@@ -6,8 +6,10 @@
 #pragma once
 
 #include <everest/io/can/can_payload.hpp>
+#include <everest/io/can/can_recv_filter.hpp>
 #include <everest/io/event/unique_fd.hpp>
 #include <string>
+#include <vector>
 
 namespace everest::lib::io {
 
@@ -74,12 +76,30 @@ public:
 
     /**
      * @brief Open the socket_can device.
-     * @details Sets the socket non blocking and reduces send buffer. <br>
+     * @details Sets the socket non blocking and reduces send buffer. Kernel receive
+     * filters from the last \ref set_recv_filters call or \p recv_filters are installed
+     * after bind. <br>
      * Implementation for \p ClientPolicy
      * @param[in] can_dev The device to bind the socket to.
+     * @param[in] recv_filters Optional filters applied on open (replaces stored filters).
      * @return True on success, false otherwise.
      */
-    bool open(std::string const& can_dev);
+    bool open(std::string const& can_dev, std::vector<can_recv_filter> const& recv_filters = {});
+
+    /**
+     * @brief Set kernel receive filters for this handler.
+     * @details Stored filters are applied on the next \ref open and on \ref reset via
+     * \ref fd_event_client. If the socket is already open, filters are applied immediately.
+     * An empty list clears filtering (receive all frames).
+     * @param[in] recv_filters Filter rules (OR semantics unless \p invert is set on a rule).
+     * @return True on success, false otherwise.
+     */
+    bool set_recv_filters(std::vector<can_recv_filter> const& recv_filters);
+
+    /**
+     * @brief Get the currently configured receive filters.
+     */
+    std::vector<can_recv_filter> const& get_recv_filters() const;
 
     /**
      * @brief Check if the objects owns a device
@@ -116,9 +136,11 @@ public:
 
 private:
     int open_device();
+    bool apply_recv_filters();
 
     event::unique_fd m_owned_can_fd;
     std::string m_can_dev;
+    std::vector<can_recv_filter> m_recv_filters;
 };
 } // namespace can
 } // namespace everest::lib::io

--- a/lib/everest/io/include/everest/io/event/timer_fd.hpp
+++ b/lib/everest/io/include/everest/io/event/timer_fd.hpp
@@ -57,6 +57,19 @@ public:
     bool reset();
 
     /**
+     * @brief Select one-shot or periodic mode for subsequent \ref set_timeout_ns calls.
+     * @details One-shot: \c it_value is the delay, \c it_interval is zero. Periodic (default):
+     * both \c it_value and \c it_interval use the configured timeout.
+     */
+    void set_single_shot(bool on);
+
+    /**
+     * @brief Stop the timer (no pending expiry until armed again).
+     * @return True on success, false otherwise
+     */
+    bool disarm();
+
+    /**
      * @name Configuring the notification timeout
      * This set of functions allows to set the time after which the timer file fire
      * @{
@@ -96,6 +109,7 @@ public:
 private:
     unique_fd m_fd;
     long long m_to_ns{0};
+    bool m_single_shot{false};
 };
 
 } // namespace everest::lib::io::event

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(everest_io
         event/event_fd.cpp
         event/timer_fd.cpp
         can/socket_can_handler.cpp
+        can/can_recv_filter.cpp
         can/can_payload.cpp
         socket/socket.cpp
         utilities/generic_error_state.cpp

--- a/lib/everest/io/src/can/can_recv_filter.cpp
+++ b/lib/everest/io/src/can/can_recv_filter.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/can/can_recv_filter.hpp>
+
+namespace everest::lib::io::can {
+
+can_recv_filter can_recv_filter::reject_match(uint32_t id, uint32_t mask, bool extended) {
+    return can_recv_filter{id, mask, extended, true};
+}
+
+} // namespace everest::lib::io::can

--- a/lib/everest/io/src/can/socket_can_handler.cpp
+++ b/lib/everest/io/src/can/socket_can_handler.cpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 #include <algorithm>
+#include <everest/io/can/can_recv_filter.hpp>
 #include <everest/io/can/socket_can_handler.hpp>
 #include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/event/unique_fd.hpp>
@@ -20,6 +21,29 @@
 #include <net/if.h>
 
 namespace everest::lib::io::can {
+
+namespace {
+
+canid_t to_linux_can_id(can_recv_filter const& filter) {
+    auto id = filter.can_id & CAN_EFF_MASK;
+    if (filter.extended) {
+        id |= CAN_EFF_FLAG;
+    }
+    if (filter.invert) {
+        id |= CAN_INV_FILTER;
+    }
+    return id;
+}
+
+canid_t to_linux_can_mask(can_recv_filter const& filter) {
+    auto mask = filter.can_mask & CAN_EFF_MASK;
+    if (filter.extended) {
+        mask |= CAN_EFF_FLAG;
+    }
+    return mask;
+}
+
+} // namespace
 
 bool socket_can_handler::data_valid(can_payload const& payload) {
     return payload.size() <= CAN_MAX_DLEN;
@@ -86,7 +110,7 @@ bool socket_can_handler::rx(can_dataset& data) {
     return status == 0;
 }
 
-bool socket_can_handler::open(std::string const& can_device) {
+bool socket_can_handler::open(std::string const& can_device, std::vector<can_recv_filter> const& recv_filters) {
     // IFNAMSIZ is the size of the buffer to write the name to.
     // This situation is special concerning null termination,
     // The name can occupy the fill buffer. If it does not, nulltermination is necessary
@@ -95,8 +119,41 @@ bool socket_can_handler::open(std::string const& can_device) {
     if (can_device.size() >= IFNAMSIZ) {
         return false;
     }
+    m_recv_filters = recv_filters;
     m_can_dev = can_device;
     return open_device() == 0;
+}
+
+bool socket_can_handler::set_recv_filters(std::vector<can_recv_filter> const& recv_filters) {
+    m_recv_filters = recv_filters;
+    if (!is_open()) {
+        return true;
+    }
+    return apply_recv_filters();
+}
+
+std::vector<can_recv_filter> const& socket_can_handler::get_recv_filters() const {
+    return m_recv_filters;
+}
+
+bool socket_can_handler::apply_recv_filters() {
+    if (!is_open()) {
+        return false;
+    }
+
+    if (m_recv_filters.empty()) {
+        can_filter accept_all{};
+        return ::setsockopt(m_owned_can_fd, SOL_CAN_RAW, CAN_RAW_FILTER, &accept_all, sizeof(accept_all)) == 0;
+    }
+
+    std::vector<can_filter> linux_filters;
+    linux_filters.reserve(m_recv_filters.size());
+    for (auto const& filter : m_recv_filters) {
+        linux_filters.push_back({to_linux_can_id(filter), to_linux_can_mask(filter)});
+    }
+
+    return ::setsockopt(m_owned_can_fd, SOL_CAN_RAW, CAN_RAW_FILTER, linux_filters.data(),
+                        linux_filters.size() * sizeof(can_filter)) == 0;
 }
 
 int socket_can_handler::open_device() {
@@ -129,6 +186,12 @@ int socket_can_handler::open_device() {
     socket::set_non_blocking(can_fd);
     socket::set_socket_send_buffer_to_min(can_fd);
     m_owned_can_fd = std::move(can_fd);
+
+    if (!apply_recv_filters()) {
+        m_owned_can_fd.close();
+        return errno != 0 ? errno : EINVAL;
+    }
+
     return 0;
 }
 

--- a/lib/everest/io/src/event/timer_fd.cpp
+++ b/lib/everest/io/src/event/timer_fd.cpp
@@ -36,6 +36,15 @@ bool timer_fd::reset() {
     return set_timeout_ns(m_to_ns);
 }
 
+void timer_fd::set_single_shot(bool on) {
+    m_single_shot = on;
+}
+
+bool timer_fd::disarm() {
+    struct itimerspec timer {};
+    return ::timerfd_settime(m_fd, 0, &timer, nullptr) == 0;
+}
+
 bool timer_fd::set_timeout_ms(long long to) {
     return set_timeout_ns(1000 * 1000 * to);
 }
@@ -46,16 +55,21 @@ bool timer_fd::set_timeout_us(long long to) {
 
 bool timer_fd::set_timeout_ns(long long to) {
     m_to_ns = to;
-    struct itimerspec timer;
-    auto sec = to / 1000000000;
-    auto nano = to % 1000000000;
+    struct itimerspec timer {};
+    auto const sec = to / 1000000000LL;
+    auto const nano = to % 1000000000LL;
 
-    timer.it_interval.tv_nsec = nano;
-    timer.it_interval.tv_sec = sec;
-    timer.it_value.tv_nsec = nano;
     timer.it_value.tv_sec = sec;
+    timer.it_value.tv_nsec = nano;
+    if (m_single_shot) {
+        timer.it_interval.tv_sec = 0;
+        timer.it_interval.tv_nsec = 0;
+    } else {
+        timer.it_interval.tv_sec = sec;
+        timer.it_interval.tv_nsec = nano;
+    }
 
-    return timerfd_settime(m_fd, 0, &timer, NULL) == 0;
+    return ::timerfd_settime(m_fd, 0, &timer, nullptr) == 0;
 }
 
 } // namespace everest::lib::io::event

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/CanBus.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/CanBus.cpp
@@ -17,14 +17,23 @@
 #include <vector>
 
 #include "CanBus.hpp"
+#include <everest/io/can/can_recv_filter.hpp>
 #include <everest/logging.hpp>
 
 using namespace std::chrono_literals;
 
 namespace {
-// Timer configuration constants
 constexpr auto CAN_RECOVERY_TIMER_INTERVAL = 1000ms;
 constexpr auto CAN_POLL_STATUS_TIMER_INTERVAL = 1000ms;
+// InfyPower protocol: space controller commands 50–200 ms apart.
+constexpr auto CAN_PACE_TX_INTERVAL = 50ms;
+
+constexpr uint32_t INFY_INNER_FRAME_ID = 0x0757F800;
+constexpr uint32_t INFY_INNER_FRAME_MASK = 0x1FFFF800;
+
+std::vector<everest::lib::io::can::can_recv_filter> infy_kernel_recv_filters() {
+    return {everest::lib::io::can::can_recv_filter::reject_match(INFY_INNER_FRAME_ID, INFY_INNER_FRAME_MASK)};
+}
 } // namespace
 
 CanBus::CanBus() : rx_thread_online{true}, can_bus(nullptr) {
@@ -35,9 +44,8 @@ CanBus::~CanBus() {
 }
 
 bool CanBus::open_device(const std::string& dev) {
-    can_bus = std::make_unique<can::socket_can>(dev);
+    can_bus = std::make_unique<can::socket_can>(dev, infy_kernel_recv_filters());
     can_bus->set_rx_handler([&](auto const& pl, auto&) {
-        // Use get_can_id_with_flags() to preserve EFF flag for extended frames
         uint32_t can_id = pl.get_can_id_with_flags();
         this->rx_handler(can_id, pl.payload);
     });
@@ -63,32 +71,36 @@ bool CanBus::open_device(const std::string& dev) {
 
     ev_handler.register_event_handler(
         &poll_status_timer, [&](event::fd_event_handler::event_list const& events) { poll_status_handler(); });
+
+    pace_tx_timer.set_single_shot(true);
+    pace_tx_timer.disarm();
+    ev_handler.register_event_handler(&pace_tx_timer,
+                                      [&](event::fd_event_handler::event_list const& events) { pace_tx_handler(); });
+
     rx_thread_handle = std::thread(&CanBus::rx_thread, this);
     return true;
 }
 
 bool CanBus::close_device() {
     if (!can_bus) {
-        return true; // Already closed
+        return true;
     }
 
     EVLOG_info << "Closing CAN device";
 
-    // Stop the RX thread first
     rx_thread_online = false;
     if (rx_thread_handle.joinable()) {
         rx_thread_handle.join();
     }
 
-    // Unregister event handlers (this stops timers and cleans up any pending events)
     ev_handler.unregister_event_handler(&recovery_timer);
     ev_handler.unregister_event_handler(&poll_status_timer);
+    ev_handler.unregister_event_handler(&pace_tx_timer);
     ev_handler.unregister_event_handler(can_bus.get());
 
-    // Close CAN socket
-    can_bus.reset();
+    clear_paced_tx_queue();
 
-    // Reset error state
+    can_bus.reset();
     on_error.store(false);
 
     EVLOG_info << "CAN device closed successfully";
@@ -100,25 +112,67 @@ void CanBus::rx_thread() {
     ev_handler.run(rx_thread_online);
 }
 
-static std::string bytes_to_hex(const std::vector<uint8_t>& bytes) {
-    std::stringstream ss;
-    ss << std::hex << std::setfill('0');
-    for (size_t i = 0; i < bytes.size(); ++i) {
-        ss << std::setw(2) << static_cast<unsigned>(bytes[i]);
+void CanBus::enqueue_paced_tx(uint32_t can_id, std::vector<uint8_t> payload) {
+    m_pace_tx_queue.push_back(paced_tx_frame{can_id, std::move(payload)});
+}
+
+void CanBus::clear_paced_tx_queue() {
+    m_pace_tx_queue.clear();
+    disarm_pace_tx_timer();
+}
+
+void CanBus::start_paced_tx_cycle() {
+    disarm_pace_tx_timer();
+
+    if (m_pace_tx_queue.empty()) {
+        return;
     }
-    return ss.str();
+
+    auto frame = std::move(m_pace_tx_queue.front());
+    m_pace_tx_queue.pop_front();
+    _tx(frame.can_id, frame.payload);
+
+    if (!m_pace_tx_queue.empty()) {
+        arm_pace_tx_one_shot();
+    }
+}
+
+void CanBus::pace_tx_handler() {
+    pace_tx_timer.read();
+
+    if (m_pace_tx_queue.empty()) {
+        disarm_pace_tx_timer();
+        return;
+    }
+
+    auto frame = std::move(m_pace_tx_queue.front());
+    m_pace_tx_queue.pop_front();
+    _tx(frame.can_id, frame.payload);
+
+    if (!m_pace_tx_queue.empty()) {
+        arm_pace_tx_one_shot();
+    } else {
+        disarm_pace_tx_timer();
+    }
+}
+
+bool CanBus::arm_pace_tx_one_shot() {
+    return pace_tx_timer.set_timeout(CAN_PACE_TX_INTERVAL);
+}
+
+void CanBus::disarm_pace_tx_timer() {
+    pace_tx_timer.disarm();
 }
 
 bool CanBus::_tx(uint32_t can_id, const std::vector<uint8_t>& payload) {
-    // Validate payload size for CAN protocol compliance
     if (payload.size() > 8) {
         EVLOG_error << "CAN payload too large (" << payload.size() << " bytes), max 8 bytes allowed";
         return false;
     }
 
-    // InfyPower protocol uses 29-bit extended CAN IDs, so we need to set the extended frame flag
     everest::lib::io::can::can_dataset data;
-    data.set_can_id_with_flags(can_id | CAN_EFF_FLAG);
+    // Use plain 29-bit id only; EFF must not be OR'd into the arbitration field.
+    data.set_can_id_with_flags(can_id & CAN_EFF_MASK, true, false, false);
     data.payload = payload;
 
     if (on_error.load()) {

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/CanBus.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/CanBus.hpp
@@ -4,12 +4,13 @@
 #ifndef CAN_BUS_HPP
 #define CAN_BUS_HPP
 
-#include "CanPackets.hpp"
 #include <atomic>
 #include <condition_variable>
+#include <deque>
 #include <linux/can.h>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 #include <everest/io/can/socket_can.hpp>
 #include <everest/io/event/fd_event_handler.hpp>
@@ -29,12 +30,37 @@ protected:
     virtual void poll_status_handler() = 0;
     bool _tx(uint32_t can_id, const std::vector<uint8_t>& payload);
 
+    /**
+     * @brief Queue a frame for paced transmission on the CAN event thread.
+     * @details Call \ref start_paced_tx_cycle after enqueueing a poll batch.
+     */
+    void enqueue_paced_tx(uint32_t can_id, std::vector<uint8_t> payload);
+
+    /** @brief Discard pending paced frames and disarm the pace timer. */
+    void clear_paced_tx_queue();
+
+    /**
+     * @brief Send the first queued frame immediately and schedule the rest at the pace interval.
+     */
+    void start_paced_tx_cycle();
+
 private:
+    struct paced_tx_frame {
+        uint32_t can_id{0};
+        std::vector<uint8_t> payload;
+    };
+
+    void pace_tx_handler();
+    bool arm_pace_tx_one_shot();
+    void disarm_pace_tx_timer();
+
     std::unique_ptr<can::socket_can> can_bus;
     std::atomic_bool on_error{false};
     event::fd_event_handler ev_handler;
     event::timer_fd recovery_timer;
     event::timer_fd poll_status_timer;
+    event::timer_fd pace_tx_timer;
+    std::deque<paced_tx_frame> m_pace_tx_queue;
     std::atomic_bool rx_thread_online;
     std::thread rx_thread_handle;
     void rx_thread();

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/CanPackets.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/CanPackets.cpp
@@ -39,18 +39,18 @@ uint32_t encode_can_id(uint8_t source_address, uint8_t destination_address, uint
 }
 
 uint8_t destination_address_from_can_id(uint32_t id) {
-    return (id >> CAN_ID_DESTINATION_ADDRESS_SHIFT) & 0xFF;
+    return ((id & CAN_EFF_MASK) >> CAN_ID_DESTINATION_ADDRESS_SHIFT) & 0xFF;
 }
 uint8_t source_address_from_can_id(uint32_t id) {
-    return id & 0xFF;
+    return id & CAN_EFF_MASK & 0xFF;
 }
 
 uint8_t command_number_from_can_id(uint32_t id) {
-    return (id >> CAN_ID_COMMAND_NUMBER_SHIFT) & InfyProtocol::COMMAND_MASK;
+    return ((id & CAN_EFF_MASK) >> CAN_ID_COMMAND_NUMBER_SHIFT) & InfyProtocol::COMMAND_MASK;
 }
 
 uint8_t error_code_from_can_id(uint32_t id) {
-    return (id >> CAN_ID_ERROR_CODE_SHIFT) & InfyProtocol::ERROR_CODE_MASK;
+    return ((id & CAN_EFF_MASK) >> CAN_ID_ERROR_CODE_SHIFT) & InfyProtocol::ERROR_CODE_MASK;
 }
 
 // packet definitions

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.cpp
@@ -177,24 +177,34 @@ void InfyCanDevice::poll_status_handler() {
         signalVoltageCurrent(telemetries);
     }
 
-    // --- Telemetry Polling ---
-    // Poll ALL configured modules (not just active ones) to allow offline modules to recover.
-    // This enables automatic recovery when temporarily offline modules come back online.
-    if (operating_mode == OperatingMode::GROUP_DISCOVERY) {
-        send_command<can_packet_acdc::ReadModuleCount>(group_address, true);
-    }
-    for (const auto& addr : active_module_addresses) {
-        send_command<can_packet_acdc::ReadModuleVI>(addr);
-        send_command<can_packet_acdc::PowerModuleStatus>(addr);
-        send_command<can_packet_acdc::ReadModuleVIAfterDiode>(addr);
+    // --- Telemetry Polling (paced on CAN event thread) ---
+    static const std::vector<uint8_t> empty_read_payload(8, 0);
 
-        // Read serial number if we don't have it yet (only poll once to avoid spam)
+    clear_paced_tx_queue();
+
+    if (operating_mode == OperatingMode::GROUP_DISCOVERY) {
+        enqueue_poll_command(group_address, can_packet_acdc::ReadModuleCount::CMD_ID, empty_read_payload, true);
+    }
+
+    std::vector<uint8_t> poll_addresses;
+    {
+        std::lock_guard<std::mutex> lock(active_modules_mutex);
+        poll_addresses = active_module_addresses;
+    }
+
+    for (const auto& addr : poll_addresses) {
+        enqueue_poll_command(addr, can_packet_acdc::ReadModuleVI::CMD_ID, empty_read_payload);
+        enqueue_poll_command(addr, can_packet_acdc::PowerModuleStatus::CMD_ID, empty_read_payload);
+        enqueue_poll_command(addr, can_packet_acdc::ReadModuleVIAfterDiode::CMD_ID, empty_read_payload);
+
         auto it = telemetries.find(addr);
         if (it == telemetries.end() || it->second.serial_number.empty()) {
-            send_command<can_packet_acdc::ReadModuleCapabilities>(addr);
-            send_command<can_packet_acdc::ReadModuleBarcode>(addr);
+            enqueue_poll_command(addr, can_packet_acdc::ReadModuleCapabilities::CMD_ID, empty_read_payload);
+            enqueue_poll_command(addr, can_packet_acdc::ReadModuleBarcode::CMD_ID, empty_read_payload);
         }
     }
+
+    start_paced_tx_cycle();
 }
 
 bool InfyCanDevice::switch_on_off(bool on) {
@@ -243,12 +253,19 @@ bool InfyCanDevice::send_command_impl(uint8_t destination_address, uint8_t comma
     uint32_t can_id = can_packet_acdc::encode_can_id(
         controller_address, destination_address, command_number,
         group ? InfyProtocol::DEVICE_GROUP_MODULE : InfyProtocol::DEVICE_SINGLE_MODULE, 0x00);
-    can_id |= InfyProtocol::CAN_EXTENDED_FLAG; // Extended frame format
     auto result = _tx(can_id, payload);
     if (not result) {
         EVLOG_warning << "Infy: CAN transmission failed for can_id: 0x" << std::hex << std::uppercase << can_id;
     }
     return result;
+}
+
+void InfyCanDevice::enqueue_poll_command(uint8_t destination_address, uint8_t command_number,
+                                         const std::vector<uint8_t>& payload, bool group) {
+    uint32_t can_id = can_packet_acdc::encode_can_id(
+        controller_address, destination_address, command_number,
+        group ? InfyProtocol::DEVICE_GROUP_MODULE : InfyProtocol::DEVICE_SINGLE_MODULE, 0x00);
+    enqueue_paced_tx(can_id, payload);
 }
 
 void InfyCanDevice::handle_module_count_packet(const std::vector<uint8_t>& payload) {

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.hpp
@@ -5,6 +5,7 @@
 #define INFY_CAN_DEVICE_HPP
 
 #include "CanBus.hpp"
+#include "CanPackets.hpp"
 #include <chrono>
 #include <linux/can.h>
 #include <map>
@@ -111,6 +112,9 @@ private:
     // Private implementation for template methods
     bool send_command_impl(uint8_t destination_address, uint8_t command_number, const std::vector<uint8_t>& payload,
                            bool group = false);
+
+    void enqueue_poll_command(uint8_t destination_address, uint8_t command_number, const std::vector<uint8_t>& payload,
+                              bool group = false);
 };
 
 #endif // INFY_CAN_DEVICE_HPP

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/wireshark/infypower_can.lua
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/wireshark/infypower_can.lua
@@ -1,0 +1,532 @@
+-- InfyPower V1.13 CAN protocol dissector (Lua)
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Install:
+--   mkdir -p ~/.local/lib/wireshark/plugins
+--   cp infypower_can.lua ~/.local/lib/wireshark/plugins/
+-- Reload: Analyze -> Reload Lua Plugins
+--
+-- Display filters:
+--   infypower.src == 240          (controller 0xF0)
+--   infypower.dest == 0           (module 0)
+--   infypower.command == 0x03
+--   infypower.src == 0 && infypower.dest == 240   (module -> controller)
+--   infypower.internal            (cmd 0x17 -> internal controller, default 0xF8)
+--   infypower.command == 0x17 && infypower.dest == 248
+--   infypower.pair contains "req" or "resp" (add custom column in Wireshark)
+--
+-- Optional row color: View -> Coloring Rules -> Import -> infypower_colorfilters
+--
+-- Request/response pairing uses FIFO order per (module, command). Reload once
+-- after opening a capture so request frames also show response links.
+
+local infypower_proto = Proto("infypower", "InfyPower V1.13 CAN")
+
+infypower_proto.prefs.controller_addr = Pref.uint(
+    "Controller address (decimal)", 240, "Default EVerest controller: 0xF0")
+infypower_proto.prefs.internal_controller_addr = Pref.uint(
+    "Internal controller address (decimal)", 248,
+    "Destination for internal cmd 0x17 traffic (default 0xF8)")
+infypower_proto.prefs.highlight_internal = Pref.bool(
+    "Highlight internal cmd 0x17 frames", true,
+    "Label and colorize cmd 0x17 frames to internal controller")
+
+-- Header fields (derived from 29-bit CAN ID, not from payload bytes)
+local f_err = ProtoField.uint8("infypower.error_code", "Error Code", base.HEX)
+local f_dev = ProtoField.uint8("infypower.device_number", "Device Number", base.HEX)
+local f_cmd = ProtoField.uint8("infypower.command", "Command", base.HEX)
+local f_dst = ProtoField.uint8("infypower.dest", "Destination Address", base.HEX)
+local f_src = ProtoField.uint8("infypower.src", "Source Address", base.HEX)
+
+-- Payload fields
+local f_voltage = ProtoField.float("infypower.voltage_v", "Voltage (V)")
+local f_current = ProtoField.float("infypower.current_a", "Current (A)")
+local f_v_ext = ProtoField.float("infypower.v_ext_v", "External Voltage (V)")
+local f_i_avail = ProtoField.float("infypower.i_avail_a", "Available Current (A)")
+local f_max_v = ProtoField.uint16("infypower.max_voltage_v", "Max Voltage (V)", base.DEC)
+local f_min_v = ProtoField.uint16("infypower.min_voltage_v", "Min Voltage (V)", base.DEC)
+local f_max_i = ProtoField.float("infypower.max_current_a", "Max Current (A)")
+local f_rated_pwr = ProtoField.uint32("infypower.rated_power_w", "Rated Power (W)", base.DEC)
+local f_module_count = ProtoField.uint8("infypower.module_count", "Module Count", base.DEC)
+local f_group_no = ProtoField.uint8("infypower.group_no", "Group Number", base.DEC)
+local f_ambient_temp = ProtoField.int8("infypower.ambient_temp_c", "Ambient Temp (C)", base.DEC)
+local f_voltage_mv = ProtoField.uint32("infypower.voltage_mv", "Voltage (mV)", base.DEC)
+local f_current_ma = ProtoField.uint32("infypower.current_ma", "Current (mA)", base.DEC)
+local f_on = ProtoField.bool("infypower.on", "Output On")
+local f_raw = ProtoField.bytes("infypower.raw", "Raw Payload")
+-- Wireshark draws request/response arrows in the packet list when these are set
+local f_response_in = ProtoField.framenum(
+    "infypower.response_in", "Response in", base.NONE, frametype.RESPONSE)
+local f_request_in = ProtoField.framenum(
+    "infypower.request_in", "Request in", base.NONE, frametype.REQUEST)
+local f_pair = ProtoField.string("infypower.pair", "Pairing")
+local f_internal = ProtoField.bool(
+    "infypower.internal", "Internal communication (cmd 0x17 to internal controller)")
+
+infypower_proto.fields = {
+    f_err, f_dev, f_cmd, f_dst, f_src,
+    f_voltage, f_current, f_v_ext, f_i_avail,
+    f_max_v, f_min_v, f_max_i, f_rated_pwr,
+    f_module_count, f_group_no, f_ambient_temp,
+    f_voltage_mv, f_current_ma, f_on, f_raw,
+    f_response_in, f_request_in, f_pair, f_internal,
+}
+
+local can_id_field = Field.new("can.id")
+
+-- Forward declarations (Listener callback must see these as locals, not globals)
+local parse_can_id
+local is_infypower_frame
+local get_can_id
+
+local CMD_NAMES = {
+    [0x02] = "ReadModuleCount",
+    [0x03] = "ReadModuleVI",
+    [0x04] = "PowerModuleStatus",
+    [0x0A] = "ReadModuleCapabilities",
+    [0x0B] = "ReadModuleBarcode",
+    [0x0C] = "ReadModuleVIAfterDiode",
+    [0x17] = "InternalComm",
+    [0x1A] = "SetModuleOnOff",
+    [0x1C] = "SetModuleVI",
+}
+
+local function field_uint(field)
+    if field == nil then
+        return nil
+    end
+    local v = field.value
+    if type(v) == "userdata" then
+        return tonumber(tostring(v))
+    end
+    return tonumber(v)
+end
+
+get_can_id = function()
+    local id_f = can_id_field()
+    if id_f == nil then
+        return nil
+    end
+    return field_uint(id_f)
+end
+
+parse_can_id = function(can_id)
+    local id = bit.band(can_id, 0x1FFFFFFF)
+    return bit.band(id, 0xFF),
+        bit.band(bit.rshift(id, 8), 0xFF),
+        bit.band(bit.rshift(id, 16), 0x3F),
+        bit.band(bit.rshift(id, 22), 0x0F),
+        bit.band(bit.rshift(id, 26), 0x07)
+end
+
+local function internal_controller_addr()
+    return infypower_proto.prefs.internal_controller_addr
+end
+
+local function is_internal_frame(src, dst, cmd)
+    return cmd == 0x17 and dst == internal_controller_addr()
+end
+
+is_infypower_frame = function(can_id)
+    if can_id == nil or can_id <= 0x7FF then
+        return false
+    end
+    local _, dst, cmd, dev = parse_can_id(can_id)
+    if is_internal_frame(nil, dst, cmd) then
+        return true
+    end
+    return (dev == 0x0A or dev == 0x0B) and CMD_NAMES[cmd] ~= nil
+end
+
+-- Request/response pairing state (filled by tap, read during dissection)
+local pair_peer = {}   -- frame number -> peer frame number
+local pair_role = {}   -- frame number -> "request" | "response"
+local pending = {}     -- pending[queue_key][cmd] = { frame, ... }
+local last_group_req = {} -- last_group_req[cmd] = frame (for group reads, device 0x0B)
+local tap_retap_done = false
+local pairing_retap_in_progress = false -- guard: retap_packets() calls reset()
+
+local function controller_addr()
+    return infypower_proto.prefs.controller_addr
+end
+
+local function pending_key_module(addr)
+    return "mod:" .. addr
+end
+
+local function pending_key_group(addr)
+    return "grp:" .. addr
+end
+
+local function pending_queue(key, cmd)
+    if pending[key] == nil then
+        pending[key] = {}
+    end
+    if pending[key][cmd] == nil then
+        pending[key][cmd] = {}
+    end
+    return pending[key][cmd]
+end
+
+local function link_pair(req_frame, resp_frame)
+    pair_peer[req_frame] = resp_frame
+    pair_peer[resp_frame] = req_frame
+    pair_role[req_frame] = "request"
+    pair_role[resp_frame] = "response"
+end
+
+local function is_request_frame(src, dst)
+    return src == controller_addr() and dst ~= controller_addr()
+end
+
+local function is_response_frame(src, dst)
+    return dst == controller_addr() and src ~= controller_addr()
+end
+
+local function pair_reset()
+    -- Reassign tables (avoid pairs() during Wireshark reset; also clears nested queues)
+    pair_peer = {}
+    pair_role = {}
+    pending = {}
+    last_group_req = {}
+    -- retap_packets() invokes reset(); do not re-arm retap in that case
+    if not pairing_retap_in_progress then
+        tap_retap_done = false
+    end
+end
+
+local function pair_process_frame(pinfo, can_id)
+    local src, dst, cmd, dev = parse_can_id(can_id)
+    if not CMD_NAMES[cmd] or is_internal_frame(src, dst, cmd) then
+        return
+    end
+
+    local fnum = pinfo.number
+
+    if is_request_frame(src, dst) then
+        if dev == 0x0B then
+            last_group_req[cmd] = fnum
+            table.insert(pending_queue(pending_key_group(dst), cmd), fnum)
+        else
+            table.insert(pending_queue(pending_key_module(dst), cmd), fnum)
+        end
+    elseif is_response_frame(src, dst) then
+        local req_frame
+
+        local mod_queue = pending_queue(pending_key_module(src), cmd)
+        if #mod_queue > 0 then
+            req_frame = table.remove(mod_queue, 1)
+        elseif last_group_req[cmd] ~= nil then
+            req_frame = last_group_req[cmd]
+        else
+            -- try any pending group queue entry for this cmd
+            for _, grp_queue in pairs(pending) do
+                if grp_queue[cmd] and #grp_queue[cmd] > 0 then
+                    req_frame = table.remove(grp_queue[cmd], 1)
+                    break
+                end
+            end
+        end
+
+        if req_frame ~= nil then
+            link_pair(req_frame, fnum)
+        end
+    end
+end
+
+local function add_pairing_to_tree(subtree, pinfo)
+    local fnum = pinfo.number
+    local peer = pair_peer[fnum]
+    if peer == nil then
+        return
+    end
+
+    local role = pair_role[fnum]
+    if role == "request" then
+        subtree:add(f_response_in, peer):set_text("Response in frame: " .. peer)
+        subtree:add(f_pair, "req"):set_generated()
+        pinfo.cols.info:append(string.format("  \xE2\x86\x92 #%d", peer))
+    elseif role == "response" then
+        subtree:add(f_request_in, peer):set_text("Request in frame: " .. peer)
+        subtree:add(f_pair, "resp"):set_generated()
+        pinfo.cols.info:append(string.format("  \xE2\x86\x90 #%d", peer))
+    end
+end
+
+local DEVICE_NAMES = {
+    [0x0A] = "SingleModule",
+    [0x0B] = "GroupModule",
+}
+
+local STATUS0_BITS = {
+    [0] = "output_short_current",
+    [4] = "sleeping",
+    [5] = "discharge_abnormal",
+}
+
+local STATUS1_BITS = {
+    [0] = "dc_side_off",
+    [1] = "fault_alarm",
+    [2] = "protection_alarm",
+    [3] = "fan_fault_alarm",
+    [4] = "over_temperature_alarm",
+    [5] = "output_over_voltage_alarm",
+    [6] = "walk_in_enable",
+    [7] = "communication_interrupt_alarm",
+}
+
+local STATUS2_BITS = {
+    [0] = "power_limit_status",
+    [1] = "id_repeat_alarm",
+    [2] = "load_sharing_alarm",
+    [3] = "input_phase_lost_alarm",
+    [4] = "input_unbalanced_alarm",
+    [5] = "input_low_voltage_alarm",
+    [6] = "input_over_voltage_protection",
+    [7] = "pfc_side_off",
+}
+
+local function be16(buf, offset)
+    if buf:len() < offset + 2 then
+        return 0
+    end
+    return buf(offset, 2):uint()
+end
+
+local function be32(buf, offset)
+    if buf:len() < offset + 4 then
+        return 0
+    end
+    return buf(offset, 4):uint()
+end
+
+local function tvb_float_be(buf, offset)
+    if buf:len() < offset + 4 then
+        return nil
+    end
+    return buf(offset, 4):float()
+end
+
+local function format_addr(addr)
+    return string.format("0x%02X", addr)
+end
+
+-- Add a field parsed from CAN ID (not from tvb) so it shows in the tree and filters work
+local function add_header_field(tree, field, value, label_fmt, ...)
+    local ti = tree:add(field, value)
+    ti:set_generated()
+    if label_fmt then
+        ti:set_text(string.format(label_fmt, ...))
+    end
+    return ti
+end
+
+local function add_status_bits(tree, title, byte_val, bit_map)
+    local bits_tree = tree:add(infypower_proto, title .. string.format(" (0x%02X)", byte_val))
+    bits_tree:set_generated()
+    for bitpos, name in pairs(bit_map) do
+        if bit.band(byte_val, bit.lshift(1, bitpos)) ~= 0 then
+            local ti = bits_tree:add(infypower_proto, name .. ": set")
+            ti:set_generated()
+        end
+    end
+end
+
+local function payload_is_read_request(buf)
+    if buf:len() < 8 then
+        return false
+    end
+    for i = 0, 7 do
+        if buf(i, 1):uint() ~= 0 then
+            return false
+        end
+    end
+    return true
+end
+
+local function is_controller_to_module(src, dst)
+    local ctrl = controller_addr()
+    return src == ctrl and dst ~= ctrl
+end
+
+local function dissect_payload(buf, cmd, tree, src, dst)
+    local payload_tree = tree:add(infypower_proto, buf(), "Payload")
+    payload_tree:set_generated()
+
+    if buf:len() == 0 then
+        local ti = payload_tree:add(infypower_proto, "No payload bytes in dissector buffer")
+        ti:set_generated()
+        return
+    end
+
+    payload_tree:add(f_raw, buf())
+
+    if buf:len() < 8 then
+        local ti = payload_tree:add(infypower_proto,
+            string.format("Short payload (%d bytes, expected 8)", buf:len()))
+        ti:set_generated()
+        return
+    end
+
+    if payload_is_read_request(buf) and cmd ~= 0x1A and cmd ~= 0x1C then
+        if is_controller_to_module(src, dst) then
+            local ti = payload_tree:add(infypower_proto, "Read request (8 zero bytes)")
+            ti:set_generated()
+        else
+            local ti = payload_tree:add(infypower_proto, "Response with zero payload")
+            ti:set_generated()
+        end
+        return
+    end
+
+    if cmd == 0x03 then
+        local v = tvb_float_be(buf, 0)
+        local c = tvb_float_be(buf, 4)
+        if v ~= nil then
+            payload_tree:add(f_voltage, v):set_text(string.format("Output Voltage: %.3f V", v))
+        end
+        if c ~= nil then
+            payload_tree:add(f_current, c):set_text(string.format("Output Current: %.3f A", c))
+        end
+    elseif cmd == 0x0C then
+        payload_tree:add(f_v_ext, be16(buf, 0) * 0.1)
+            :set_text(string.format("V_ext: %.1f V", be16(buf, 0) * 0.1))
+        payload_tree:add(f_i_avail, be16(buf, 2) * 0.1)
+            :set_text(string.format("I_avail: %.1f A", be16(buf, 2) * 0.1))
+    elseif cmd == 0x0A then
+        payload_tree:add(f_max_v, be16(buf, 0))
+        payload_tree:add(f_min_v, be16(buf, 2))
+        payload_tree:add(f_max_i, be16(buf, 4) * 0.1)
+            :set_text(string.format("Max Current: %.1f A", be16(buf, 4) * 0.1))
+        payload_tree:add(f_rated_pwr, be16(buf, 6) * 10)
+            :set_text(string.format("Rated Power: %d W", be16(buf, 6) * 10))
+    elseif cmd == 0x02 then
+        payload_tree:add(f_module_count, buf(2, 1))
+            :set_text("Module Count: " .. buf(2, 1):uint())
+    elseif cmd == 0x1A then
+        local on = buf(0, 1):uint() == 0
+        payload_tree:add(f_on, on):set_text(on and "Output: ON" or "Output: OFF")
+    elseif cmd == 0x1C then
+        local mv = be32(buf, 0)
+        local ma = be32(buf, 4)
+        payload_tree:add(f_voltage_mv, mv)
+            :set_text(string.format("Voltage: %d mV (%.3f V)", mv, mv / 1000))
+        payload_tree:add(f_current_ma, ma)
+            :set_text(string.format("Current: %d mA (%.3f A)", ma, ma / 1000))
+    elseif cmd == 0x04 then
+        payload_tree:add(f_group_no, buf(2, 1))
+            :set_text("Group Number: " .. buf(2, 1):uint())
+        local amb = buf(4, 1):int()
+        payload_tree:add(f_ambient_temp, amb)
+            :set_text(string.format("Ambient Temp: %d C", amb))
+        add_status_bits(payload_tree, "Module State 0", buf(7, 1):uint(), STATUS0_BITS)
+        add_status_bits(payload_tree, "Module State 1", buf(6, 1):uint(), STATUS1_BITS)
+        add_status_bits(payload_tree, "Module State 2", buf(5, 1):uint(), STATUS2_BITS)
+    elseif cmd == 0x0B then
+        local ti = payload_tree:add(infypower_proto,
+            string.format("Barcode byte 0 (char): '%c' (0x%02X)", buf(0, 1):uint(), buf(0, 1):uint()))
+        ti:set_generated()
+        ti = payload_tree:add(f_raw, buf(1, 7))
+        ti:set_text("Barcode encoding: " .. buf(1, 7):bytes():tohex())
+    elseif cmd == 0x17 then
+        local ti = payload_tree:add(infypower_proto,
+            string.format("Byte0: 0x%02X  Byte1: 0x%02X  Byte2-3: 0x%04X  Byte4-5: 0x%04X",
+                buf(0, 1):uint(), buf(1, 1):uint(), be16(buf, 2), be16(buf, 4)))
+        ti:set_generated()
+        ti = payload_tree:add(infypower_proto, "Bytes 6-7: " .. buf(6, 2):bytes():tohex())
+        ti:set_generated()
+    else
+        local ti = payload_tree:add(infypower_proto, "Payload not decoded for this command")
+        ti:set_generated()
+    end
+end
+
+local function highlight_internal_row(pinfo)
+    if not infypower_proto.prefs.highlight_internal then
+        return
+    end
+    if Color == nil then
+        return
+    end
+    -- Light amber background in packet list (Wireshark 4.x)
+    pinfo.cols.bg = Color.new(65535, 0xFFEE, 0xAA00)
+    pinfo.cols.fg = Color.new(0, 0, 0)
+end
+
+local function dissect_infypower(buf, pinfo, tree, can_id)
+    local src, dst, cmd, dev, err = parse_can_id(can_id)
+    local internal = is_internal_frame(src, dst, cmd)
+
+    if internal then
+        pinfo.cols.protocol:set("InfyPower-INT")
+        highlight_internal_row(pinfo)
+    else
+        pinfo.cols.protocol:set("InfyPower")
+    end
+    pinfo.cols.src:set(format_addr(src))
+    pinfo.cols.dst:set(format_addr(dst))
+    local subtree = tree:add(infypower_proto, buf(),
+        internal and "InfyPower V1.13 (internal)" or "InfyPower V1.13")
+
+    add_header_field(subtree, f_src, src, "Source Address: 0x%02X (%d)", src, src)
+    add_header_field(subtree, f_dst, dst, "Destination Address: 0x%02X (%d)", dst, dst)
+    add_header_field(subtree, f_cmd, cmd, "Command: 0x%02X (%s)", cmd, CMD_NAMES[cmd] or "unknown")
+    add_header_field(subtree, f_dev, dev, "Device Number: 0x%X (%s)", dev, DEVICE_NAMES[dev] or "unknown")
+    add_header_field(subtree, f_err, err, "Error Code: 0x%X", err)
+    if internal then
+        subtree:add(f_internal, true):set_text("Internal communication: cmd 0x17 -> internal controller")
+    end
+
+    local info_prefix = internal and "[INTERNAL 0x17] " or ""
+    pinfo.cols.info:set(string.format("%s%s %02X->%02X cmd=0x%02X",
+        info_prefix, CMD_NAMES[cmd] or "Infy", src, dst, cmd))
+
+    dissect_payload(buf, cmd, subtree, src, dst)
+    add_pairing_to_tree(subtree, pinfo)
+
+    return buf:len()
+end
+
+function infypower_proto.dissector(buf, pinfo, tree)
+    local can_id = get_can_id()
+    if not is_infypower_frame(can_id) then
+        return 0
+    end
+    return dissect_infypower(buf, pinfo, tree, can_id)
+end
+
+local function infypower_heuristic(buf, pinfo, tree)
+    local can_id = get_can_id()
+    if not is_infypower_frame(can_id) then
+        return false
+    end
+    dissect_infypower(buf, pinfo, tree, can_id)
+    return true
+end
+
+infypower_proto:register_heuristic("can", infypower_heuristic)
+
+-- Pass 1: walk frames in order and build request/response pairs (FIFO per module+cmd)
+local infy_pair_tap = Listener.new(nil, nil)
+
+function infy_pair_tap.packet(pinfo, tvb)
+    local can_id = get_can_id()
+    if is_infypower_frame(can_id) then
+        pair_process_frame(pinfo, can_id)
+    end
+end
+
+function infy_pair_tap.reset()
+    pair_reset()
+end
+
+function infy_pair_tap.draw()
+    -- Pass 2: redissect so request frames also get Response-in links
+    if tap_retap_done or retap_packets == nil then
+        return
+    end
+    tap_retap_done = true
+    pairing_retap_in_progress = true
+    retap_packets()
+    pairing_retap_in_progress = false
+end

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/wireshark/infypower_colorfilters
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/wireshark/infypower_colorfilters
@@ -1,0 +1,13 @@
+# Wireshark coloring rules for InfyPower internal traffic
+# Import: View -> Coloring Rules -> Import... -> select this file
+#
+@InfyPower internal (cmd 0x17)
+infypower.internal
+True
+65535
+65535
+43520
+0
+0
+0
+InfyPower internal cmd 0x17

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/wireshark/sim_module0_responses.sh
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/wireshark/sim_module0_responses.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Simulate InfyPower module 0 responses on vcan0/can0.
+#
+# CAN ID: src (bits 7-0) | dst<<8 | cmd<<16 | dev(0x0A)<<22
+#
+#   Request  (controller 0xF0 -> module 0):  ...00F0  (e.g. 028300F0 for cmd 0x03)
+#   Response (module 0 -> controller 0xF0):  ...F000  (e.g. 0283F000 for cmd 0x03)
+#
+# Usage:
+#   ./sim_module0_responses.sh vcan0 once    # one burst after driver polls
+#   ./sim_module0_responses.sh vcan0 loop    # continuous (default)
+
+set -euo pipefail
+
+IFACE="${1:-vcan0}"
+MODE="${2:-loop}"
+
+if ! ip link show "$IFACE" &>/dev/null; then
+    echo "Interface $IFACE not found."
+    exit 1
+fi
+
+send() {
+    cansend "$IFACE" "$1"
+}
+
+send_responses() {
+    # Module 0 -> controller 0xF0 (note F000 suffix, NOT 00F0)
+    send "0283F000#43FA000040600000"   # 0x03 ReadModuleVI: 500 V, 3.5 A
+    send "0284F000#000000021B004000"   # 0x04 PowerModuleStatus
+    send "028CF000#0FA001F400000000"   # 0x0C VI after diode: 400.0 V, 50.0 A
+    send "028AF000#01F400C803E803E8"   # 0x0A capabilities
+    send "0282F000#0000010000000000"   # 0x02 module count = 1
+    send "028BF000#5600000000000000"   # 0x0B barcode (dummy)
+}
+
+if [[ "$MODE" == "once" ]]; then
+    send_responses
+    echo "Sent module-0 responses on $IFACE (src 0x00 -> dst 0xF0)"
+    exit 0
+fi
+
+echo "Looping module-0 responses on $IFACE every 0.5s (Ctrl+C to stop)"
+while true; do
+    send_responses
+    sleep 0.5
+done

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/wireshark/vcan.sh
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/wireshark/vcan.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Create and bring up a **virtual** CAN interface (loopback / Wireshark testing).
+#
+# For physical USB CAN (can0, can1 @ 125 kbit/s) use:
+#   sudo ../setup_can.sh can0
+#
+# Usage:
+#   sudo ./vcan.sh           # vcan0
+#   sudo ./vcan.sh vcan1
+
+set -uo pipefail
+
+IFACE="${1:-vcan0}"
+
+if [[ "${IFACE}" == can0 || "${IFACE}" == can1 ]]; then
+    echo "Error: ${IFACE} is a physical interface, not virtual CAN." >&2
+    echo "Use: sudo $(dirname "$0")/../setup_can.sh ${IFACE}" >&2
+    exit 1
+fi
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "Run as root (e.g. sudo $0)" >&2
+    exit 1
+fi
+
+modprobe vcan 2>/dev/null || true
+
+if ip link show "${IFACE}" &>/dev/null; then
+    echo "${IFACE} already exists"
+else
+    echo "Creating ${IFACE}"
+    ip link add dev "${IFACE}" type vcan
+fi
+
+ip link set "${IFACE}" up
+ip -details link show "${IFACE}" | grep -E 'state|link/vcan' || true
+echo "Done. Use can_device: ${IFACE} in Everest config for simulation."


### PR DESCRIPTION
  feat(io): kernel CAN receive filters and socket timer improvements
 feat(InfyPower): CAN driver fixes, paced polling, and bringup tooling

## Describe your changes

  feat(io): kernel CAN receive filters and socket timer improvements
    
    Add can_recv_filter with reject_match() and apply rules via CAN_RAW_FILTER
    on open, set_recv_filters(), and reset. For an empty filter list install an
    explicit pass-all can_filter instead of NULL/0, which disables RX on the
    socket. Add timer_fd one-shot mode and disarm() for consumers that need
    non-periodic timerfd scheduling.

 feat(InfyPower): CAN driver fixes, paced polling, and bringup tooling
    
    Filter inner 0757F8xx frames via kernel CAN_RAW_FILTER, fix extended ID
    encoding/decoding, pace telemetry polls at 50 ms using timer_fd one-shot,
    and add parallel ACDC/DCDC bringup configs plus Wireshark dissector assets.
    
    Signed-off-by: Florin Mihut <florinmihut1@gmail.com>


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

