### PR TITLE
feat(yeti-simulator): add sending of fake SignedMeterValues

### DIFF
--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -27,6 +27,8 @@ namespace module {
 struct Conf {
     int connector_id;
     bool reset_powermeter_on_session_start;
+    std::string dummy_meter_value_blob_start;
+    std::string dummy_meter_value_blob_stop;
 };
 
 class YetiSimulator : public Everest::ModuleBase {

--- a/modules/Simulation/YetiSimulator/manifest.yaml
+++ b/modules/Simulation/YetiSimulator/manifest.yaml
@@ -7,6 +7,14 @@ config:
     description: Reset absolute powermeter readings to zero when CP changes from state A to B
     type: boolean
     default: true
+  dummy_meter_value_blob_start:
+    description: Dummy meter value blob sent on transaction start to be used for testing
+    type: string
+    default: "test start value"
+  dummy_meter_value_blob_stop:
+    description: Dummy meter value blob sent on transaction stop to be used for testing
+    type: string
+    default: "test stop value"
 provides:
   powermeter:
     interface: powermeter

--- a/modules/Simulation/YetiSimulator/powermeter/powermeterImpl.cpp
+++ b/modules/Simulation/YetiSimulator/powermeter/powermeterImpl.cpp
@@ -2,6 +2,8 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 
 #include "powermeterImpl.hpp"
+#include "generated/types/powermeter.hpp"
+#include "generated/types/units_signed.hpp"
 #include <string>
 
 namespace module::powermeter {
@@ -13,14 +15,31 @@ void powermeterImpl::ready() {
     this->publish_public_key_ocmf("TESTPUBLICKEY" + std::to_string(this->mod->config.connector_id));
 }
 
-types::powermeter::TransactionStartResponse
-powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& _) {
-    return {types::powermeter::TransactionRequestStatus::OK};
+types::units_signed::SignedMeterValue format_signed_meter_value(const std::string& blob) {
+    types::units_signed::SignedMeterValue value;
+    value.signed_meter_data = blob;
+    value.signing_method = "dummy";
+    value.encoding_method = "plain";
+
+    return value;
 }
 
-types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& transaction_id) {
-    return {types::powermeter::TransactionRequestStatus::NOT_SUPPORTED, std::nullopt, std::nullopt,
-            "YetiDriver does not support stop transaction request."};
+types::powermeter::TransactionStartResponse
+powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& _) {
+    types::powermeter::TransactionStartResponse response;
+    response.status = types::powermeter::TransactionRequestStatus::OK;
+    // Depends on #2214
+    // response.signed_meter_value = format_signed_meter_value(this->mod->config.dummy_meter_value_blob_start);
+    return response;
+}
+
+types::powermeter::TransactionStopResponse powermeterImpl::handle_stop_transaction(std::string& _) {
+    types::powermeter::TransactionStopResponse response;
+    response.status = types::powermeter::TransactionRequestStatus::OK;
+    response.start_signed_meter_value = format_signed_meter_value(this->mod->config.dummy_meter_value_blob_start);
+    response.signed_meter_value = format_signed_meter_value(this->mod->config.dummy_meter_value_blob_stop);
+
+    return response;
 }
 
 } // namespace module::powermeter


### PR DESCRIPTION
## Describe your changes

Makes the simulated powermeter, which is part of the YetiSimulator driver send out static, configurable meter value blobs. This will allow testing how they are handled throughout EVerest

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #2259 
- <kbd>&nbsp;4&nbsp;</kbd> #2239 
- <kbd>&nbsp;3&nbsp;</kbd> #2252 
- <kbd>&nbsp;2&nbsp;</kbd> #2214 
- <kbd>&nbsp;1&nbsp;</kbd> #2236 👈 
<!-- GitButler Footer Boundary Bottom -->

