### PR TITLE
test: add an OCPP test that checks if the signed meter values are actually sent

### DIFF
--- a/tests/ocpp_tests/test_sets/ocpp16/eichrecht.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/eichrecht.py
@@ -9,9 +9,9 @@ from everest.testing.ocpp_utils.charge_point_utils import (
 )
 from everest.testing.ocpp_utils.central_system import ChargePoint16
 from everest.testing.ocpp_utils.fixtures import test_utility, charge_point_v16
-from everest_test_utils import get_everest_config_path_str
+from everest_test_utils import get_everest_config_path_str, OcppTestConfiguration
 
-from ocpp.v16 import call_result
+from ocpp.v16 import call, call_result
 
 
 @pytest.mark.asyncio
@@ -61,7 +61,7 @@ async def test_meter_public_key(
     assert any(
         entry['key'] == "MeterPublicKey2" and entry['value'] == "TESTPUBLICKEY2"
         for entry in response.configuration_key)
-    
+
     await charge_point_v16.get_configuration_req(key=["MeterPublicKey"])
 
     assert await wait_for_and_validate(
@@ -79,7 +79,7 @@ async def test_meter_public_key(
         "GetConfiguration",
         {"unknownKey": ["MeterPublicKeyMeterPublicKey1"]}
     )
-    
+
     await charge_point_v16.get_configuration_req(key=["MeterPublicKey1X"])
 
     assert await wait_for_and_validate(
@@ -125,3 +125,100 @@ async def test_meter_public_key(
         "ChangeConfiguration",
         {"status": "Rejected"}
     )
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-two-connectors.yaml")
+)
+async def test_meter_signed_meter_values(
+    charge_point_v16: ChargePoint16, test_utility: TestUtility, test_controller: TestController, test_config: OcppTestConfiguration,
+):
+    test_controller.plug_in(1)
+
+    assert test_config.authorization_info is not None
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
+    # expect authorize.req
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "Authorize",
+        {}
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StartTransaction",
+        {},
+    )
+
+    # expect StatusNotification with status charging
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {}
+    )
+
+    # Because the StartTransaction message can not contain a signed meter value, it is sent in a separate MeterValues message
+    meter_values_msg: call.MeterValues = call.MeterValues(
+        **await wait_for_and_validate(  # pyright: ignore[reportCallIssue]
+            test_utility,
+            charge_point_v16,
+            "MeterValues",
+            {},
+        )
+    )
+
+    assert meter_values_msg is not None
+    start_sv = None
+    for mv in meter_values_msg.meter_value:
+        for sv in mv['sampled_value']:
+            if sv['context'] == 'Transaction.Begin':
+                assert start_sv is None, "MeterValues message contains multiple transaction start signed meter values"
+                start_sv = sv
+    assert start_sv is not None, "MeterValues message does not contain a transaction start signed meter value"
+    assert start_sv['value'] == "test start value"
+    assert start_sv['format'] == 'SignedData'
+
+    assert any(
+        sv.get('context') == 'Transaction.Begin'
+        and sv.get('format') == 'SignedData'
+        and sv.get('value') == 'test start value'
+        for mv in meter_values_msg.meter_value
+        for sv in mv['sampled_value']
+    ), "Initial signed meter value not found in MeterValues"
+
+    test_controller.plug_out()
+
+    # expect StopTransaction.req
+    stop_transaction_msg: call.StopTransaction = call.StopTransaction(
+        **await wait_for_and_validate(  # pyright: ignore[reportCallIssue]
+            test_utility,
+            charge_point_v16,
+            "StopTransaction",
+            {},
+        )
+    )
+
+    # verify start and stop signed meter values (order independent)
+    assert stop_transaction_msg is not None
+    assert stop_transaction_msg.transaction_data is not None
+    start_sv = None
+    stop_sv = None
+    for mv in stop_transaction_msg.transaction_data:
+        for sv in mv['sampled_value']:
+            if sv['context'] == 'Transaction.Begin':
+                assert start_sv is None, "transaction_data contains multiple start signed meter values"
+                start_sv = sv
+            elif sv['context'] == 'Transaction.End':
+                assert stop_sv is None, "transaction_data contains multiple stop signed meter values"
+                stop_sv = sv
+
+    assert start_sv is not None, "Start signed meter value not found"
+    assert start_sv['value'] == "test start value"
+    assert start_sv['format'] == 'SignedData'
+
+    assert stop_sv is not None, "Stop signed meter value not found"
+    assert stop_sv['value'] == "test stop value"
+    assert stop_sv['format'] == 'SignedData'

--- a/tests/ocpp_tests/test_sets/ocpp201/eichrecht201.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/eichrecht201.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+import pytest
+
+from everest.testing.core_utils._configuration.libocpp_configuration_helper import (
+    GenericOCPP2XConfigAdjustment,
+    OCPP2XConfigVariableIdentifier,
+)
+from everest.testing.core_utils.controller.test_controller_interface import TestController
+from everest.testing.ocpp_utils.charge_point_utils import wait_for_and_validate, TestUtility
+from everest.testing.ocpp_utils.charge_point_v201 import ChargePoint201
+from everest.testing.ocpp_utils.fixtures import charge_point_v201
+
+from everest_test_utils import get_everest_config_path_str
+from ocpp.v201 import call as call201
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+@pytest.mark.everest_core_config(get_everest_config_path_str("everest-config-ocpp201.yaml"))
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP2XConfigAdjustment(
+        [
+            (
+                OCPP2XConfigVariableIdentifier(
+                    "SampledDataCtrlr", "SampledDataSignReadings", "Actual"
+                ),
+                "true",
+            ),
+        ]
+    )
+)
+async def test_meter_signed_meter_values(
+    charge_point_v201: ChargePoint201,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    def validate_event(event, context, expected_meter_value):
+        found = None
+        for meter_value in event.meter_value or []:
+            for sampled_value in meter_value['sampled_value']:
+                if sampled_value.get('context') != context or sampled_value.get('signed_meter_value') is None:
+                    continue
+                assert found is None, (
+                    f"multiple signed sampled values found for context {context}"
+                )
+                found = sampled_value
+        assert found is not None, f"no signed sampled value found for context {context}"
+        assert found['signed_meter_value']['signed_meter_data'] == expected_meter_value, (
+            f"expected meter value {expected_meter_value}, got {found['signed_meter_value']['signed_meter_data']}"
+        )
+
+    test_controller.plug_in(1)
+    test_controller.swipe("DEADBEEF")
+
+    started_event: call201.TransactionEvent = call201.TransactionEvent(
+        **await wait_for_and_validate(  # pyright: ignore[reportCallIssue]
+            test_utility,
+            charge_point_v201,
+            "TransactionEvent",
+            {"eventType": "Started"},
+        )
+    )
+
+    validate_event(started_event, "Transaction.Begin", "test start value")
+
+    test_controller.plug_out()
+
+    ended_event: call201.TransactionEvent = call201.TransactionEvent(
+        **await wait_for_and_validate(  # pyright: ignore[reportCallIssue]
+            test_utility,
+            charge_point_v201,
+            "TransactionEvent",
+            {"eventType": "Ended"},
+        )
+    )
+
+    validate_event(ended_event, "Transaction.End", "test stop value")


### PR DESCRIPTION
## Describe your changes

Adds a test that checks if the signed meter values from the simulated powermeter are correctly sent to the CSMS

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #2259 
- <kbd>&nbsp;4&nbsp;</kbd> #2239 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #2252 
- <kbd>&nbsp;2&nbsp;</kbd> #2214 
- <kbd>&nbsp;1&nbsp;</kbd> #2236 
<!-- GitButler Footer Boundary Bottom -->

