### PR TITLE
Fix typo in evse_security_consumer_API

### DIFF
--- a/modules/API/EVerestAPI/evse_security_consumer_API/evse_security_consumer_API.hpp
+++ b/modules/API/EVerestAPI/evse_security_consumer_API/evse_security_consumer_API.hpp
@@ -53,7 +53,7 @@ public:
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     // insert your public definitions here
     ev_API::Mqtt::ValidatingMqttProxy mqtt_v{mqtt};
-    ev_API::ApiHelper helper{info, mqtt_v, {{"auth_consumer", 1}}, get_config_service_client()};
+    ev_API::ApiHelper helper{info, mqtt_v, {{"evse_security_consumer", 1}}, get_config_service_client()};
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:


### PR DESCRIPTION
## Describe your changes

This would publish the e2m topics accidentally under auth_consumer

This was introduced in #1864 - I checked the other EVerestAPIs for typos as well and this seems to be the only one

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [X] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

