### PR TITLE
fix(chargebridge): restore host CAN RX forwarding and avoid false reconnect churn

### DIFF
--- a/applications/pionix_chargebridge/include/charge_bridge/can_bridge.hpp
+++ b/applications/pionix_chargebridge/include/charge_bridge/can_bridge.hpp
@@ -4,7 +4,7 @@
 
 #include <chrono>
 #include <everest/io/can/can_payload.hpp>
-#include <everest/io/can/socket_can.hpp>
+#include <everest/io/can/socket_can_handler.hpp>
 #include <everest/io/event/fd_event_register_interface.hpp>
 #include <everest/io/event/timer_fd.hpp>
 #include <everest/io/udp/udp_client.hpp>
@@ -31,14 +31,16 @@ public:
     bool unregister_events(everest::lib::io::event::fd_event_handler& handler) override;
 
 private:
-    void handle_error_timer();
     void handle_heartbeat_timer();
+    void drain_can_from_vcan();
     void send_can_to_udp(cb_can_message const& pl);
-    std::unique_ptr<everest::lib::io::can::socket_can> m_can;
+    everest::lib::io::can::socket_can_handler m_can;
+    int m_registered_can_fd{-1};
     everest::lib::io::udp::udp_client m_udp;
     std::string m_can_device;
     std::string m_identifier;
     everest::lib::io::event::timer_fd m_heartbeat_timer;
+    everest::lib::io::event::timer_fd m_can_poll_timer;
     std::chrono::steady_clock::time_point m_last_msg_to_cb;
 };
 

--- a/applications/pionix_chargebridge/src/can_bridge.cpp
+++ b/applications/pionix_chargebridge/src/can_bridge.cpp
@@ -18,7 +18,7 @@ using namespace std::chrono_literals;
 
 namespace {
 
-void msg_cb_to_host(cb_can_message const& src, everest::lib::io::can::socket_can::ClientPayloadT& tar) {
+void msg_cb_to_host(cb_can_message const& src, everest::lib::io::can::can_dataset& tar) {
     tar.set_can_id_with_flags(src.can_id, src.can_flags & CanFlags_EFF, src.can_flags & CanFlags_RTR,
                               src.can_flags & CanFlags_ERR);
     tar.len8_dlc = 0;
@@ -26,7 +26,7 @@ void msg_cb_to_host(cb_can_message const& src, everest::lib::io::can::socket_can
     std::memcpy(tar.payload.data(), src.data, src.dlc);
 }
 
-void msg_host_to_cb(everest::lib::io::can::socket_can::ClientPayloadT const& src, cb_can_message& tar) {
+void msg_host_to_cb(everest::lib::io::can::can_dataset const& src, cb_can_message& tar) {
     tar = cb_can_message_set_zero;
     tar.can_id = src.get_can_id();
     tar.can_flags = 0;
@@ -54,45 +54,36 @@ can_bridge::can_bridge(can_bridge_config const& config) :
     m_can_device(config.can_device),
     m_last_msg_to_cb(std::chrono::steady_clock::time_point()) {
 
+    m_identifier = config.cb + "/" + config.item;
+
     auto& manager = everest::lib::io::netlink::vcan_netlink_manager::Instance();
     auto success = manager.create(config.can_device) && manager.bring_up(config.can_device);
-    if (success) {
-        m_can = std::make_unique<everest::lib::io::can::socket_can>(config.can_device);
-    } else {
+    if (not success) {
         manager.destroy(config.can_device);
         success = manager.create(config.can_device) && manager.bring_up(config.can_device);
-        if (success) {
-            m_can = std::make_unique<everest::lib::io::can::socket_can>(config.can_device);
-        } else {
+        if (not success) {
             manager.destroy(config.can_device);
             throw std::runtime_error("Failed to setup virtual CAN device: " + config.can_device);
         }
     }
 
-    m_can->set_rx_handler([this](auto const& data, auto&) {
-        everest::lib::io::udp::udp_client::ClientPayloadT pl;
-        cb_can_message msg;
-        msg_host_to_cb(data, msg);
-        send_can_to_udp(msg);
-    });
+    if (not m_can.open(config.can_device)) {
+        manager.destroy(config.can_device);
+        throw std::runtime_error("Failed to open CAN socket on: " + config.can_device);
+    }
 
     m_udp.set_rx_handler([this](auto const& data, auto&) {
-        everest::lib::io::can::socket_can::ClientPayloadT pl;
+        everest::lib::io::can::can_dataset pl;
         cb_can_message msg;
         std::memcpy(&msg, data.buffer.data(), sizeof(cb_can_message));
 
         msg_cb_to_host(msg, pl);
         if (is_data_msg(msg)) {
-            m_can->tx(pl);
-        }
-    });
-
-    m_identifier = config.cb + "/" + config.item;
-    m_can->set_error_handler([this](auto id, auto const& msg) {
-        utilities::print_error(m_identifier, "CAN/HW", id) << msg << std::endl;
-        if (id not_eq 0) {
-            // This is a smart pointer!! Using .reset() would delete the obj!
-            m_can->reset();
+            if (not m_can.tx(pl)) {
+                auto const err = m_can.get_error();
+                utilities::print_error(m_identifier, "CAN/HW", err ? err : EIO)
+                    << "Failed to write frame to " << m_can_device << std::endl;
+            }
         }
     });
 
@@ -104,32 +95,67 @@ can_bridge::can_bridge(can_bridge_config const& config) :
     });
 
     m_heartbeat_timer.set_timeout(10s);
+    m_can_poll_timer.set_timeout(50ms);
 }
 
 can_bridge::~can_bridge() {
     auto& manager = everest::lib::io::netlink::vcan_netlink_manager::Instance();
-    if (m_can) {
-        m_can.reset();
-        manager.destroy(m_can_device);
+    m_can.close();
+    manager.destroy(m_can_device);
+}
+
+void can_bridge::drain_can_from_vcan() {
+    if (not m_can.is_open()) {
+        return;
+    }
+
+    everest::lib::io::can::can_dataset frame;
+    while (m_can.rx(frame)) {
+        cb_can_message msg;
+        msg_host_to_cb(frame, msg);
+        if (is_data_msg(msg)) {
+            send_can_to_udp(msg);
+        }
     }
 }
 
 bool can_bridge::register_events(everest::lib::io::event::fd_event_handler& handler) {
-    auto result = handler.register_event_handler(m_can.get());
-    result = handler.register_event_handler(&m_udp) && result;
-    result = handler.register_event_handler(&m_heartbeat_timer, [this](auto&) { handle_heartbeat_timer(); }) && result;
+    using everest::lib::io::event::poll_events;
+
+    bool can_registered = false;
+    if (m_can.is_open()) {
+        m_registered_can_fd = m_can.get_fd();
+        can_registered = handler.register_event_handler(
+            m_registered_can_fd, [this](auto const&) { drain_can_from_vcan(); }, poll_events::read);
+    }
+
+    auto udp_registered = handler.register_event_handler(&m_udp);
+    auto timer_registered =
+        handler.register_event_handler(&m_heartbeat_timer, [this](auto&) { handle_heartbeat_timer(); });
+    auto poll_registered =
+        handler.register_event_handler(&m_can_poll_timer, [this](auto&) { drain_can_from_vcan(); });
+
+    auto result = can_registered && udp_registered && timer_registered && poll_registered;
 
     if (result) {
-        handler.add_action([this]() { handle_heartbeat_timer(); });
+        handler.add_action([this]() {
+            drain_can_from_vcan();
+            handle_heartbeat_timer();
+        });
     }
 
     return result;
 }
 
 bool can_bridge::unregister_events(everest::lib::io::event::fd_event_handler& handler) {
-    auto result = handler.unregister_event_handler(m_can.get());
+    auto result = true;
+    if (m_registered_can_fd >= 0) {
+        result = handler.unregister_event_handler(m_registered_can_fd) && result;
+        m_registered_can_fd = -1;
+    }
     result = handler.unregister_event_handler(&m_udp) && result;
     result = handler.unregister_event_handler(&m_heartbeat_timer) && result;
+    result = handler.unregister_event_handler(&m_can_poll_timer) && result;
     return result;
 }
 
@@ -142,15 +168,15 @@ void can_bridge::send_can_to_udp(cb_can_message const& msg) {
 }
 
 void can_bridge::handle_heartbeat_timer() {
+    drain_can_from_vcan();
+
     if (m_udp.on_error()) {
-        // If the connection is not available, retry soon and invalidate last hearbeat
         m_heartbeat_timer.set_timeout(250ms);
         m_last_msg_to_cb = std::chrono::steady_clock::time_point();
         return;
-    } else {
-        // otherwise go back to regular interval
-        m_heartbeat_timer.set_timeout(10s);
     }
+    m_heartbeat_timer.set_timeout(10s);
+
     auto delta = std::chrono::steady_clock::now() - m_last_msg_to_cb;
     if (delta > 10s) {
         cb_can_message msg = cb_can_message_set_zero;

--- a/applications/pionix_chargebridge/src/charge_bridge.cpp
+++ b/applications/pionix_chargebridge/src/charge_bridge.cpp
@@ -151,7 +151,7 @@ void charge_bridge::manage(everest::lib::io::event::fd_event_handler& handler, s
     m_event_handler = &handler;
     m_force_firmware_update = force_update;
 
-    auto action = [this](bool is_connected, bool discovery_pending, int& error_count) {
+    auto action = [this](bool discovery_pending, int& error_count, bool heartbeat_disconnected) {
         if (discovery_pending) {
             if (m_discovery_active) {
                 return;
@@ -160,7 +160,7 @@ void charge_bridge::manage(everest::lib::io::event::fd_event_handler& handler, s
             m_event_handler->add_action([this]() { register_events(*m_event_handler); });
             return;
         }
-        if (m_was_connected and not is_connected) {
+        if (m_was_connected and heartbeat_disconnected) {
             if (error_count > 1) {
                 m_event_handler->add_action([this]() { unregister_events(*m_event_handler); });
                 m_was_connected = false;
@@ -195,9 +195,11 @@ void charge_bridge::manage(everest::lib::io::event::fd_event_handler& handler, s
             return false;
         };
         while (run.load()) {
-            action(handle->is_connected, handle->discovery_pending, error_count);
+            auto const is_connected = handle->is_connected;
+            auto const heartbeat_disconnected = last_is_connected and not is_connected;
+            action(handle->discovery_pending, error_count, heartbeat_disconnected);
             handle.wait_for(condition, 10s);
-            last_is_connected = handle->is_connected;
+            last_is_connected = is_connected;
             last_discovery_pending = handle->discovery_pending;
         }
     });

--- a/lib/everest/framework/src/controller/CMakeLists.txt
+++ b/lib/everest/framework/src/controller/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(controller
 
         everest::log
         everest::yaml
+        ryml::ryml
 
         ${STD_FILESYSTEM_COMPAT_LIB}
 )

--- a/lib/everest/io/include/everest/io/can/can_recv_filter.hpp
+++ b/lib/everest/io/include/everest/io/can/can_recv_filter.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 
 namespace everest::lib::io::can {
 

--- a/lib/everest/io/include/everest/io/can/can_recv_filter.hpp
+++ b/lib/everest/io/include/everest/io/can/can_recv_filter.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+/** \file */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace everest::lib::io::can {
+
+/**
+ * @brief Userspace description of a SocketCAN \c CAN_RAW_FILTER rule.
+ *
+ * Rules are applied on the raw socket via \c setsockopt(SOL_CAN_RAW, CAN_RAW_FILTER).
+ * A frame is delivered when it matches at least one rule (OR). Use \p invert on a rule
+ * to drop matching frames instead (\c CAN_INV_FILTER).
+ *
+ * \p can_id and \p can_mask are the 29-bit (EFF) or 11-bit identifier bits without
+ * \c CAN_EFF_FLAG / \c CAN_RTR_FLAG / \c CAN_ERR_FLAG. When \p extended is true,
+ * \c CAN_EFF_FLAG is added to both fields when installing the kernel filter.
+ */
+struct can_recv_filter {
+    uint32_t can_id{0};
+    uint32_t can_mask{0};
+    bool extended{true};
+    bool invert{false};
+
+    /**
+     * @brief Drop frames whose identifier matches \p id under \p mask.
+     * @param[in] id Plain CAN identifier bits (no SocketCAN flags).
+     * @param[in] mask Bits to compare; set bits are significant.
+     * @param[in] extended If true, match extended (29-bit) frames only.
+     */
+    static can_recv_filter reject_match(uint32_t id, uint32_t mask, bool extended = true);
+};
+
+} // namespace everest::lib::io::can

--- a/lib/everest/io/include/everest/io/can/socket_can_handler.hpp
+++ b/lib/everest/io/include/everest/io/can/socket_can_handler.hpp
@@ -6,8 +6,10 @@
 #pragma once
 
 #include <everest/io/can/can_payload.hpp>
+#include <everest/io/can/can_recv_filter.hpp>
 #include <everest/io/event/unique_fd.hpp>
 #include <string>
+#include <vector>
 
 namespace everest::lib::io {
 
@@ -74,12 +76,30 @@ public:
 
     /**
      * @brief Open the socket_can device.
-     * @details Sets the socket non blocking and reduces send buffer. <br>
+     * @details Sets the socket non blocking and reduces send buffer. Kernel receive
+     * filters from the last \ref set_recv_filters call or \p recv_filters are installed
+     * after bind. <br>
      * Implementation for \p ClientPolicy
      * @param[in] can_dev The device to bind the socket to.
+     * @param[in] recv_filters Optional filters applied on open (replaces stored filters).
      * @return True on success, false otherwise.
      */
-    bool open(std::string const& can_dev);
+    bool open(std::string const& can_dev, std::vector<can_recv_filter> const& recv_filters = {});
+
+    /**
+     * @brief Set kernel receive filters for this handler.
+     * @details Stored filters are applied on the next \ref open and on \ref reset via
+     * \ref fd_event_client. If the socket is already open, filters are applied immediately.
+     * An empty list clears filtering (receive all frames).
+     * @param[in] recv_filters Filter rules (OR semantics unless \p invert is set on a rule).
+     * @return True on success, false otherwise.
+     */
+    bool set_recv_filters(std::vector<can_recv_filter> const& recv_filters);
+
+    /**
+     * @brief Get the currently configured receive filters.
+     */
+    std::vector<can_recv_filter> const& get_recv_filters() const;
 
     /**
      * @brief Check if the objects owns a device
@@ -116,9 +136,11 @@ public:
 
 private:
     int open_device();
+    bool apply_recv_filters();
 
     event::unique_fd m_owned_can_fd;
     std::string m_can_dev;
+    std::vector<can_recv_filter> m_recv_filters;
 };
 } // namespace can
 } // namespace everest::lib::io

--- a/lib/everest/io/src/CMakeLists.txt
+++ b/lib/everest/io/src/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(everest_io
         event/event_fd.cpp
         event/timer_fd.cpp
         can/socket_can_handler.cpp
+        can/can_recv_filter.cpp
         can/can_payload.cpp
         socket/socket.cpp
         utilities/generic_error_state.cpp

--- a/lib/everest/io/src/can/can_recv_filter.cpp
+++ b/lib/everest/io/src/can/can_recv_filter.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/io/can/can_recv_filter.hpp>
+
+namespace everest::lib::io::can {
+
+can_recv_filter can_recv_filter::reject_match(uint32_t id, uint32_t mask, bool extended) {
+    return can_recv_filter{id, mask, extended, true};
+}
+
+} // namespace everest::lib::io::can

--- a/lib/everest/io/src/can/socket_can_handler.cpp
+++ b/lib/everest/io/src/can/socket_can_handler.cpp
@@ -142,7 +142,8 @@ bool socket_can_handler::apply_recv_filters() {
     }
 
     if (m_recv_filters.empty()) {
-        return ::setsockopt(m_owned_can_fd, SOL_CAN_RAW, CAN_RAW_FILTER, nullptr, 0) == 0;
+        struct can_filter accept_all {};
+        return ::setsockopt(m_owned_can_fd, SOL_CAN_RAW, CAN_RAW_FILTER, &accept_all, sizeof(accept_all)) == 0;
     }
 
     std::vector<can_filter> linux_filters;

--- a/lib/everest/io/src/can/socket_can_handler.cpp
+++ b/lib/everest/io/src/can/socket_can_handler.cpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 #include <algorithm>
+#include <everest/io/can/can_recv_filter.hpp>
 #include <everest/io/can/socket_can_handler.hpp>
 #include <everest/io/event/fd_event_handler.hpp>
 #include <everest/io/event/unique_fd.hpp>
@@ -20,6 +21,29 @@
 #include <net/if.h>
 
 namespace everest::lib::io::can {
+
+namespace {
+
+canid_t to_linux_can_id(can_recv_filter const& filter) {
+    auto id = filter.can_id & CAN_EFF_MASK;
+    if (filter.extended) {
+        id |= CAN_EFF_FLAG;
+    }
+    if (filter.invert) {
+        id |= CAN_INV_FILTER;
+    }
+    return id;
+}
+
+canid_t to_linux_can_mask(can_recv_filter const& filter) {
+    auto mask = filter.can_mask & CAN_EFF_MASK;
+    if (filter.extended) {
+        mask |= CAN_EFF_FLAG;
+    }
+    return mask;
+}
+
+} // namespace
 
 bool socket_can_handler::data_valid(can_payload const& payload) {
     return payload.size() <= CAN_MAX_DLEN;
@@ -86,7 +110,7 @@ bool socket_can_handler::rx(can_dataset& data) {
     return status == 0;
 }
 
-bool socket_can_handler::open(std::string const& can_device) {
+bool socket_can_handler::open(std::string const& can_device, std::vector<can_recv_filter> const& recv_filters) {
     // IFNAMSIZ is the size of the buffer to write the name to.
     // This situation is special concerning null termination,
     // The name can occupy the fill buffer. If it does not, nulltermination is necessary
@@ -95,8 +119,40 @@ bool socket_can_handler::open(std::string const& can_device) {
     if (can_device.size() >= IFNAMSIZ) {
         return false;
     }
+    m_recv_filters = recv_filters;
     m_can_dev = can_device;
     return open_device() == 0;
+}
+
+bool socket_can_handler::set_recv_filters(std::vector<can_recv_filter> const& recv_filters) {
+    m_recv_filters = recv_filters;
+    if (!is_open()) {
+        return true;
+    }
+    return apply_recv_filters();
+}
+
+std::vector<can_recv_filter> const& socket_can_handler::get_recv_filters() const {
+    return m_recv_filters;
+}
+
+bool socket_can_handler::apply_recv_filters() {
+    if (!is_open()) {
+        return false;
+    }
+
+    if (m_recv_filters.empty()) {
+        return ::setsockopt(m_owned_can_fd, SOL_CAN_RAW, CAN_RAW_FILTER, nullptr, 0) == 0;
+    }
+
+    std::vector<can_filter> linux_filters;
+    linux_filters.reserve(m_recv_filters.size());
+    for (auto const& filter : m_recv_filters) {
+        linux_filters.push_back({to_linux_can_id(filter), to_linux_can_mask(filter)});
+    }
+
+    return ::setsockopt(m_owned_can_fd, SOL_CAN_RAW, CAN_RAW_FILTER, linux_filters.data(),
+                        linux_filters.size() * sizeof(can_filter)) == 0;
 }
 
 int socket_can_handler::open_device() {
@@ -129,6 +185,12 @@ int socket_can_handler::open_device() {
     socket::set_non_blocking(can_fd);
     socket::set_socket_send_buffer_to_min(can_fd);
     m_owned_can_fd = std::move(can_fd);
+
+    if (!apply_recv_filters()) {
+        m_owned_can_fd.close();
+        return errno != 0 ? errno : EINVAL;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION

Host-injected frames on cb_can were not reaching ChargeBridge because empty CAN_RAW filter configuration used NULL/0, which puts the raw socket in send-only mode and suppresses RX delivery for that socket. Replace the empty-filter behavior with an explicit pass-all filter to keep default receive semantics.

Also move can_bridge host->UDP forwarding to direct socket_can_handler reads registered on the main event loop (plus a lightweight drain timer fallback), which avoids missed RX callbacks seen through the nested fd_event_client path. In parallel, tighten heartbeat disconnect handling to only unregister on real edge transitions instead of every 10s wait wakeup, preventing unnecessary event teardown while still connected. Include ryml::ryml in controller linking to keep this branch buildable.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

