### PR TITLE
Send start_signed_meter_value to CSMS if it is set

### DIFF
--- a/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/yeti_simulator_disable_meter_transaction_start_strategy.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/yeti_simulator_disable_meter_transaction_start_strategy.py
@@ -1,0 +1,18 @@
+from copy import deepcopy
+from typing import Dict
+
+from everest.testing.core_utils._configuration.everest_configuration_strategies.everest_configuration_strategy import EverestConfigAdjustmentStrategy
+
+
+class YetiSimulatorDisableMeterTransactionStartStrategy(EverestConfigAdjustmentStrategy):
+    def adjust_everest_configuration(self, config: Dict) -> Dict:
+
+        adjusted_config = deepcopy(config)
+
+        for module_id, module_config in adjusted_config.get("active_modules", {}).items():
+            if module_config.get("module") == "YetiSimulator":
+                if "config_module" not in module_config:
+                    module_config["config_module"] = {}
+                module_config["config_module"]["dummy_meter_value_send_on_transaction_start"] = False
+
+        return adjusted_config

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
@@ -293,9 +293,11 @@ public:
     /// \param energy_wh_import stop meter value in Wh
     /// \param id_tag_end
     /// \param signed_meter_value e.g. in OCMF format
+    /// \param start_signed_meter_value e.g. in OCMF format
     void on_transaction_stopped(const std::int32_t connector, const std::string& session_id, const Reason& reason,
                                 ocpp::DateTime timestamp, float energy_wh_import,
-                                std::optional<CiString<20>> id_tag_end, std::optional<std::string> signed_meter_value);
+                                std::optional<CiString<20>> id_tag_end, std::optional<std::string> signed_meter_value,
+                                std::optional<std::string> start_signed_meter_value);
 
     /// \brief This function should be called when EV indicates that it suspends charging on the given \p connector
     /// \param connector

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
@@ -621,9 +621,11 @@ public:
     /// \param energy_wh_import stop meter value in Wh
     /// \param id_tag_end
     /// \param signed_meter_value e.g. in OCMF format
+    /// \param start_signed_meter_value e.g. in OCMF format
     void on_transaction_stopped(const std::int32_t connector, const std::string& session_id, const Reason& reason,
                                 ocpp::DateTime timestamp, float energy_wh_import,
-                                std::optional<CiString<20>> id_tag_end, std::optional<std::string> signed_meter_value);
+                                std::optional<CiString<20>> id_tag_end, std::optional<std::string> signed_meter_value,
+                                std::optional<std::string> start_signed_meter_value);
 
     /// \brief This function should be called when EV indicates that it suspends charging on the given \p connector
     /// \param connector

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
@@ -172,12 +172,13 @@ public:
     /// \param reason
     /// \param id_token
     /// \param signed_meter_value
+    /// \param start_signed_meter_value
     /// \param charging_state
-    virtual void on_transaction_finished(const std::int32_t evse_id, const DateTime& timestamp,
-                                         const MeterValue& meter_stop, const ReasonEnum reason,
-                                         const TriggerReasonEnum trigger_reason, const std::optional<IdToken>& id_token,
-                                         const std::optional<std::string>& signed_meter_value,
-                                         const ChargingStateEnum charging_state) = 0;
+    virtual void on_transaction_finished(
+        const std::int32_t evse_id, const DateTime& timestamp, const MeterValue& meter_stop, const ReasonEnum reason,
+        const TriggerReasonEnum trigger_reason, const std::optional<IdToken>& id_token,
+        const std::optional<std::string>& signed_meter_value, const ChargingStateEnum charging_state,
+        const std::optional<SignedMeterValue>& start_signed_meter_value = std::nullopt) = 0;
 
     /// \brief Event handler that should be called when a session has finished
     /// \param evse_id
@@ -607,11 +608,11 @@ public:
                                 const std::optional<std::int32_t>& remote_start_id,
                                 const ChargingStateEnum charging_state) override;
 
-    void on_transaction_finished(const std::int32_t evse_id, const DateTime& timestamp, const MeterValue& meter_stop,
-                                 const ReasonEnum reason, const TriggerReasonEnum trigger_reason,
-                                 const std::optional<IdToken>& id_token,
-                                 const std::optional<std::string>& signed_meter_value,
-                                 const ChargingStateEnum charging_state) override;
+    void on_transaction_finished(
+        const std::int32_t evse_id, const DateTime& timestamp, const MeterValue& meter_stop, const ReasonEnum reason,
+        const TriggerReasonEnum trigger_reason, const std::optional<IdToken>& id_token,
+        const std::optional<std::string>& signed_meter_value, const ChargingStateEnum charging_state,
+        const std::optional<SignedMeterValue>& start_signed_meter_value = std::nullopt) override;
 
     void on_session_finished(const std::int32_t evse_id, const std::int32_t connector_id) override;
 

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/transaction.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/transaction.hpp
@@ -55,11 +55,11 @@ public:
     /// \param id_token
     /// \param signed_meter_value
     /// \param charging_state
-    virtual void on_transaction_finished(const std::int32_t evse_id, const DateTime& timestamp,
-                                         const MeterValue& meter_stop, const ReasonEnum reason,
-                                         const TriggerReasonEnum trigger_reason, const std::optional<IdToken>& id_token,
-                                         const std::optional<std::string>& signed_meter_value,
-                                         const ChargingStateEnum charging_state) = 0;
+    virtual void on_transaction_finished(
+        const std::int32_t evse_id, const DateTime& timestamp, const MeterValue& meter_stop, const ReasonEnum reason,
+        const TriggerReasonEnum trigger_reason, const std::optional<IdToken>& id_token,
+        const std::optional<std::string>& signed_meter_value, const ChargingStateEnum charging_state,
+        const std::optional<SignedMeterValue>& start_signed_meter_value = std::nullopt) = 0;
 
     /* OCPP message requests */
 
@@ -100,7 +100,8 @@ public:
                                  const ReasonEnum reason, const TriggerReasonEnum trigger_reason,
                                  const std::optional<IdToken>& id_token,
                                  const std::optional<std::string>& signed_meter_value,
-                                 const ChargingStateEnum charging_state) override;
+                                 const ChargingStateEnum charging_state,
+                                 const std::optional<SignedMeterValue>& start_signed_meter_value) override;
     void transaction_event_req(const TransactionEventEnum& event_type, const DateTime& timestamp,
                                const Transaction& transaction, const TriggerReasonEnum& trigger_reason,
                                const std::int32_t seq_no, const std::optional<std::int32_t>& cable_max_current,

--- a/lib/everest/ocpp/include/ocpp/v2/utils.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/utils.hpp
@@ -50,6 +50,13 @@ std::vector<MeterValue> get_meter_values_with_measurands_applied(
 ///
 MeterValue set_meter_value_reading_context(const MeterValue& meter_value, const ReadingContextEnum reading_context);
 
+/// \brief Searches \p meter_values for the first SampledValue with the given \p reading_context that is suitable to
+/// carry a signed meter value (already has a signedMeterValue set or measures Energy_Active_Import_Register).
+/// \param meter_values the meter values to search
+/// \param reading_context the ReadingContext the SampledValue is matched against
+/// \return pointer to the matching SampledValue inside the passed meter_values. nullptr if no match was found
+SampledValue* find_sampled_value_by_context(std::vector<MeterValue>& meter_values, ReadingContextEnum reading_context);
+
 /// \brief Returns the given \p str hashed using SHA256
 /// \param str
 /// \return

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
@@ -138,9 +138,10 @@ void ChargePoint::on_transaction_started(const std::int32_t& connector, const st
 void ChargePoint::on_transaction_stopped(const std::int32_t connector, const std::string& session_id,
                                          const Reason& reason, ocpp::DateTime timestamp, float energy_wh_import,
                                          std::optional<CiString<20>> id_tag_end,
-                                         std::optional<std::string> signed_meter_value) {
+                                         std::optional<std::string> signed_meter_value,
+                                         std::optional<std::string> start_signed_meter_value) {
     this->charge_point->on_transaction_stopped(connector, session_id, reason, timestamp, energy_wh_import, id_tag_end,
-                                               signed_meter_value);
+                                               signed_meter_value, start_signed_meter_value);
 }
 
 void ChargePoint::on_suspend_charging_ev(std::int32_t connector, const std::optional<CiString<50>> info) {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -4466,7 +4466,8 @@ void ChargePointImpl::on_transaction_started(const std::int32_t& connector, cons
 void ChargePointImpl::on_transaction_stopped(const std::int32_t connector, const std::string& session_id,
                                              const Reason& reason, ocpp::DateTime timestamp, float energy_wh_import,
                                              std::optional<CiString<20>> id_tag_end,
-                                             std::optional<std::string> signed_meter_value) {
+                                             std::optional<std::string> signed_meter_value,
+                                             std::optional<std::string> start_signed_meter_value) {
     auto transaction = this->transaction_handler->get_transaction(connector);
     if (transaction == nullptr) {
         EVLOG_error << "Trying to stop a transaction that is unknown on connector: " << connector
@@ -4475,6 +4476,27 @@ void ChargePointImpl::on_transaction_stopped(const std::int32_t connector, const
     }
     if (connector <= 0 or connector > this->connectors.size()) {
         EVLOG_error << "Attempting to stop transaction for invalid connector id: " << connector;
+    }
+
+    if (start_signed_meter_value.has_value()) {
+        // Some meters only provide the start signed value at stop time.
+        // Add a new Transaction.Begin entry only if one does not yet exist
+        auto has_start_entry = false;
+        const auto existing_meter_values = transaction->get_meter_values();
+        for (const auto& mv : existing_meter_values) {
+            for (const auto& sv : mv.sampledValue) {
+                if (sv.format == ValueFormat::SignedData && sv.context == ReadingContext::Transaction_Begin) {
+                    has_start_entry = true;
+                    break;
+                }
+            }
+        }
+        if (!has_start_entry) {
+            const auto start_meter_value =
+                get_signed_meter_value(start_signed_meter_value.value(), ReadingContext::Transaction_Begin,
+                                       transaction->get_start_energy_wh()->timestamp);
+            transaction->add_meter_value(start_meter_value);
+        }
     }
 
     if (signed_meter_value) {

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -219,9 +219,10 @@ void ChargePoint::on_transaction_finished(const std::int32_t evse_id, const Date
                                           const TriggerReasonEnum trigger_reason,
                                           const std::optional<IdToken>& id_token,
                                           const std::optional<std::string>& signed_meter_value,
-                                          const ChargingStateEnum charging_state) {
+                                          const ChargingStateEnum charging_state,
+                                          const std::optional<SignedMeterValue>& start_signed_meter_value) {
     this->transaction->on_transaction_finished(evse_id, timestamp, meter_stop, reason, trigger_reason, id_token,
-                                               signed_meter_value, charging_state);
+                                               signed_meter_value, charging_state, start_signed_meter_value);
 }
 
 void ChargePoint::on_session_finished(const std::int32_t evse_id, const std::int32_t connector_id) {

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
+#include "ocpp/v2/ocpp_enums.hpp"
+#include "ocpp/v2/ocpp_types.hpp"
 #include <ocpp/v2/functional_blocks/transaction.hpp>
 
 #include <ocpp/common/connectivity_manager.hpp>
@@ -17,6 +19,8 @@
 
 #include <ocpp/v2/messages/GetTransactionStatus.hpp>
 #include <ocpp/v2/messages/TransactionEvent.hpp>
+#include <optional>
+#include <unistd.h>
 
 namespace ocpp::v2 {
 TransactionBlock::TransactionBlock(
@@ -98,7 +102,8 @@ void TransactionBlock::on_transaction_finished(const std::int32_t evse_id, const
                                                const TriggerReasonEnum trigger_reason,
                                                const std::optional<IdToken>& id_token,
                                                const std::optional<std::string>& /*signed_meter_value*/,
-                                               const ChargingStateEnum charging_state) {
+                                               const ChargingStateEnum charging_state,
+                                               const std::optional<SignedMeterValue>& start_signed_meter_value) {
     auto& evse_handle = this->context.evse_manager.get_evse(evse_id);
     auto& enhanced_transaction = evse_handle.get_transaction();
     if (enhanced_transaction == nullptr) {
@@ -129,6 +134,36 @@ void TransactionBlock::on_transaction_finished(const std::int32_t evse_id, const
         }
     } catch (const everest::db::Exception& e) {
         EVLOG_warning << "Could not get metervalues of transaction: " << e.what();
+    }
+
+    // If the meter only returns a start_signed_meter_value once the transaction stops we inject it here
+    // Otherwise the one recorded on transaction start will be kept
+    if (start_signed_meter_value.has_value() &&
+        this->context.device_model.get_optional_value<bool>(ControllerComponentVariables::SampledDataSignReadings)
+            .value_or(false)) {
+
+        if (!meter_values.has_value()) {
+            meter_values.emplace(std::vector<MeterValue>{});
+        }
+
+        SampledValue* begin_sampled_value =
+            utils::find_sampled_value_by_context(meter_values.value(), ReadingContextEnum::Transaction_Begin);
+
+        if (begin_sampled_value == nullptr) {
+            // No suitable SampledValue was found. Construct one to store the start signed meter value in
+            meter_values->emplace_back();
+            MeterValue& mv = meter_values->back();
+            mv.timestamp = timestamp;
+            mv.sampledValue.emplace_back();
+            begin_sampled_value = &mv.sampledValue.back();
+            begin_sampled_value->context = ReadingContextEnum::Transaction_Begin;
+            begin_sampled_value->measurand = MeasurandEnum::Energy_Active_Import_Register;
+        }
+
+        // Attach our start_signed_meter_value to the (found or created) sampled value if none had been recorded before
+        if (!begin_sampled_value->signedMeterValue.has_value()) {
+            begin_sampled_value->signedMeterValue = start_signed_meter_value;
+        }
     }
 
     // E07.FR.02 The field idToken is provided when the authorization of the transaction has been ended

--- a/lib/everest/ocpp/lib/ocpp/v2/utils.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/utils.cpp
@@ -111,6 +111,19 @@ MeterValue set_meter_value_reading_context(const MeterValue& meter_value, const 
     return return_value;
 }
 
+SampledValue* find_sampled_value_by_context(std::vector<MeterValue>& meter_values, ReadingContextEnum reading_context) {
+    for (auto& meter_value : meter_values) {
+        for (auto& sampled_value : meter_value.sampledValue) {
+            if (sampled_value.context == reading_context &&
+                (sampled_value.signedMeterValue.has_value() ||
+                 sampled_value.measurand == MeasurandEnum::Energy_Active_Import_Register)) {
+                return &sampled_value;
+            }
+        }
+    }
+    return nullptr;
+}
+
 std::string sha256(const std::string& str) {
     std::array<unsigned char, SHA256_DIGEST_LENGTH> hash;
     EVP_Digest(str.c_str(), str.size(), hash.data(), nullptr, EVP_sha256(), nullptr);

--- a/lib/everest/ocpp/src/charge_point.cpp
+++ b/lib/everest/ocpp/src/charge_point.cpp
@@ -20,6 +20,7 @@
 #include <everest/logging.hpp>
 
 #include <ocpp/v16/charge_point.hpp>
+#include <ocpp/v16/charge_point_configuration.hpp>
 #include <ocpp/v16/database_handler.hpp>
 
 #include <ocpp/common/cistring.hpp>
@@ -135,8 +136,9 @@ int main(int argc, char* argv[]) {
     secConfig.secc_leaf_cert_directory = fs::path("/tmp/client/cso/");
     secConfig.secc_leaf_key_directory = fs::path("/tmp/client/cso/");
 
-    charge_point = new ocpp::v16::ChargePoint(json_config.dump(), share_path, user_config_path, database_path,
-                                              sql_init_path, fs::path("/tmp"), nullptr, secConfig);
+    ocpp::v16::ChargePointConfiguration chargePointConfiguration(json_config.dump(), share_path, user_config_path);
+    charge_point = new ocpp::v16::ChargePoint(chargePointConfiguration, share_path, database_path, sql_init_path,
+                                              fs::path("/tmp"), nullptr, secConfig);
 
     /************************************** START REGISTERING CALLBACKS **************************************/
 
@@ -291,7 +293,7 @@ int main(int argc, char* argv[]) {
             } else if (command == "stop_transaction") {
                 if (transaction_running) {
                     charge_point->on_transaction_stopped(1, uuid, ocpp::v16::Reason::Local, ocpp::DateTime(), 2500,
-                                                         std::nullopt, std::nullopt);
+                                                         std::nullopt, std::nullopt, std::nullopt);
                     charge_point->on_session_stopped(1, uuid);
                     transaction_running = false;
                 } else {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_network_config_sync.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_network_config_sync.cpp
@@ -1072,7 +1072,8 @@ public:
                 (override));
     MOCK_METHOD(void, on_transaction_finished,
                 (std::int32_t, const DateTime&, const MeterValue&, ReasonEnum, TriggerReasonEnum,
-                 const std::optional<IdToken>&, const std::optional<std::string>&, ChargingStateEnum),
+                 const std::optional<IdToken>&, const std::optional<std::string>&, ChargingStateEnum,
+                 const std::optional<SignedMeterValue>&),
                 (override));
     MOCK_METHOD(void, transaction_event_req,
                 (const TransactionEventEnum&, const DateTime&, const Transaction&, const TriggerReasonEnum&,

--- a/modules/EVSE/OCPP/OCPP.cpp
+++ b/modules/EVSE/OCPP/OCPP.cpp
@@ -262,8 +262,13 @@ void OCPP::process_session_event(int32_t evse_id, const types::evse_manager::Ses
             // custom data transfer
             signed_meter_data.emplace(signed_meter_value.value().signed_meter_data);
         }
+        std::optional<std::string> start_signed_meter_data;
+        if (transaction_finished.start_signed_meter_value.has_value()) {
+            start_signed_meter_data.emplace(transaction_finished.start_signed_meter_value.value().signed_meter_data);
+        }
         this->charge_point->on_transaction_stopped(ocpp_connector_id, session_event.uuid, reason, timestamp,
-                                                   energy_Wh_import, id_tag_opt, signed_meter_data);
+                                                   energy_Wh_import, id_tag_opt, signed_meter_data,
+                                                   start_signed_meter_data);
         // always triggered by libocpp
     } else if (session_event.event == types::evse_manager::SessionEventEnum::SessionStarted) {
         EVLOG_info << "Connector#" << ocpp_connector_id << ": "

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -1461,10 +1461,16 @@ void OCPP201::process_tx_event_effect(const int32_t evse_id, const TxEventEffect
         transaction_data->meter_value = conversions::to_ocpp_meter_value(get_meter_value(session_event),
                                                                          ocpp::v2::ReadingContextEnum::Transaction_End,
                                                                          get_signed_meter_value(session_event));
+        std::optional<ocpp::v2::SignedMeterValue> start_signed_meter_value;
+        if (session_event.transaction_finished.has_value() &&
+            session_event.transaction_finished.value().start_signed_meter_value.has_value()) {
+            start_signed_meter_value = conversions::to_ocpp_signed_meter_value(
+                session_event.transaction_finished.value().start_signed_meter_value.value());
+        }
         this->charge_point->on_transaction_finished(evse_id, transaction_data->timestamp, transaction_data->meter_value,
                                                     transaction_data->stop_reason, transaction_data->trigger_reason,
                                                     transaction_data->id_token, std::nullopt,
-                                                    transaction_data->charging_state);
+                                                    transaction_data->charging_state, start_signed_meter_value);
         this->transaction_handler->reset_transaction_data(evse_id);
     }
 }

--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -27,6 +27,7 @@ namespace module {
 struct Conf {
     int connector_id;
     bool reset_powermeter_on_session_start;
+    bool dummy_meter_value_send_on_transaction_start;
     std::string dummy_meter_value_blob_start;
     std::string dummy_meter_value_blob_stop;
 };

--- a/modules/Simulation/YetiSimulator/manifest.yaml
+++ b/modules/Simulation/YetiSimulator/manifest.yaml
@@ -7,6 +7,10 @@ config:
     description: Reset absolute powermeter readings to zero when CP changes from state A to B
     type: boolean
     default: true
+  dummy_meter_value_send_on_transaction_start:
+    description: Send dummy meter start value blob on transaction start
+    type: boolean
+    default: true
   dummy_meter_value_blob_start:
     description: Dummy meter value blob sent on transaction start to be used for testing
     type: string

--- a/modules/Simulation/YetiSimulator/powermeter/powermeterImpl.cpp
+++ b/modules/Simulation/YetiSimulator/powermeter/powermeterImpl.cpp
@@ -28,7 +28,9 @@ types::powermeter::TransactionStartResponse
 powermeterImpl::handle_start_transaction(types::powermeter::TransactionReq& _) {
     types::powermeter::TransactionStartResponse response;
     response.status = types::powermeter::TransactionRequestStatus::OK;
-    response.signed_meter_value = format_signed_meter_value(this->mod->config.dummy_meter_value_blob_start);
+    if (this->mod->config.dummy_meter_value_send_on_transaction_start) {
+        response.signed_meter_value = format_signed_meter_value(this->mod->config.dummy_meter_value_blob_start);
+    }
     return response;
 }
 

--- a/tests/ocpp_tests/test_sets/ocpp16/eichrecht.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/eichrecht.py
@@ -13,6 +13,14 @@ from everest_test_utils import get_everest_config_path_str, OcppTestConfiguratio
 
 from ocpp.v16 import call, call_result
 
+from copy import deepcopy
+from typing import Dict
+
+from everest.testing.core_utils._configuration.everest_configuration_strategies.everest_configuration_strategy import \
+    EverestConfigAdjustmentStrategy
+from everest.testing.core_utils._configuration.everest_configuration_strategies.yeti_simulator_disable_meter_transaction_start_strategy import \
+    YetiSimulatorDisableMeterTransactionStartStrategy
+
 
 @pytest.mark.asyncio
 @pytest.mark.everest_core_config(
@@ -126,6 +134,7 @@ async def test_meter_public_key(
         {"status": "Rejected"}
     )
 
+
 @pytest.mark.asyncio
 @pytest.mark.everest_core_config(
     get_everest_config_path_str("everest-config-two-connectors.yaml")
@@ -188,6 +197,85 @@ async def test_meter_signed_meter_values(
         for mv in meter_values_msg.meter_value
         for sv in mv['sampled_value']
     ), "Initial signed meter value not found in MeterValues"
+
+    test_controller.plug_out()
+
+    # expect StopTransaction.req
+    stop_transaction_msg: call.StopTransaction = call.StopTransaction(
+        **await wait_for_and_validate(  # pyright: ignore[reportCallIssue]
+            test_utility,
+            charge_point_v16,
+            "StopTransaction",
+            {},
+        )
+    )
+
+    # verify start and stop signed meter values (order independent)
+    assert stop_transaction_msg is not None
+    assert stop_transaction_msg.transaction_data is not None
+    start_sv = None
+    stop_sv = None
+    for mv in stop_transaction_msg.transaction_data:
+        for sv in mv['sampled_value']:
+            if sv['context'] == 'Transaction.Begin':
+                assert start_sv is None, "transaction_data contains multiple start signed meter values"
+                start_sv = sv
+            elif sv['context'] == 'Transaction.End':
+                assert stop_sv is None, "transaction_data contains multiple stop signed meter values"
+                stop_sv = sv
+
+    assert start_sv is not None, "Start signed meter value not found"
+    assert start_sv['value'] == "test start value"
+    assert start_sv['format'] == 'SignedData'
+
+    assert stop_sv is not None, "Stop signed meter value not found"
+    assert stop_sv['value'] == "test stop value"
+    assert stop_sv['format'] == 'SignedData'
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-two-connectors.yaml")
+)
+@pytest.mark.everest_config_adaptions(YetiSimulatorDisableMeterTransactionStartStrategy())
+async def test_meter_signed_meter_values_no_start(
+    charge_point_v16: ChargePoint16, test_utility: TestUtility, test_controller: TestController, test_config: OcppTestConfiguration,
+):
+    test_controller.plug_in(1)
+
+    assert test_config.authorization_info is not None
+    test_controller.swipe(test_config.authorization_info.valid_id_tag_1)
+    # expect authorize.req
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "Authorize",
+        {}
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StartTransaction",
+        {},
+    )
+
+    # expect StatusNotification with status charging
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        {}
+    )
+
+    # Assert that no MeterValues message is sent when the meter transaction starts
+    assert not await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "MeterValues",
+        {},
+        timeout=5,
+    ), "No MeterValues message should be sent at transaction start when dummy_meter_value_send_on_transaction_start is disabled"
 
     test_controller.plug_out()
 

--- a/tests/ocpp_tests/test_sets/ocpp201/eichrecht201.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/eichrecht201.py
@@ -11,9 +11,27 @@ from everest.testing.core_utils.controller.test_controller_interface import Test
 from everest.testing.ocpp_utils.charge_point_utils import wait_for_and_validate, TestUtility
 from everest.testing.ocpp_utils.charge_point_v201 import ChargePoint201
 from everest.testing.ocpp_utils.fixtures import charge_point_v201
+from everest.testing.core_utils._configuration.everest_configuration_strategies.yeti_simulator_disable_meter_transaction_start_strategy import \
+    YetiSimulatorDisableMeterTransactionStartStrategy
 
 from everest_test_utils import get_everest_config_path_str
 from ocpp.v201 import call as call201
+
+
+def validate_event(event, context, expected_meter_value):
+    found = None
+    for meter_value in event.meter_value or []:
+        for sampled_value in meter_value['sampled_value']:
+            if sampled_value.get('context') != context or sampled_value.get('signed_meter_value') is None:
+                continue
+            assert found is None, (
+                f"multiple signed sampled values found for context {context}"
+            )
+            found = sampled_value
+    assert found is not None, f"no signed sampled value found for context {context}"
+    assert found['signed_meter_value']['signed_meter_data'] == expected_meter_value, (
+        f"expected meter value {expected_meter_value}, got {found['signed_meter_value']['signed_meter_data']}"
+    )
 
 
 @pytest.mark.asyncio
@@ -36,21 +54,6 @@ async def test_meter_signed_meter_values(
     test_utility: TestUtility,
     test_controller: TestController,
 ):
-    def validate_event(event, context, expected_meter_value):
-        found = None
-        for meter_value in event.meter_value or []:
-            for sampled_value in meter_value['sampled_value']:
-                if sampled_value.get('context') != context or sampled_value.get('signed_meter_value') is None:
-                    continue
-                assert found is None, (
-                    f"multiple signed sampled values found for context {context}"
-                )
-                found = sampled_value
-        assert found is not None, f"no signed sampled value found for context {context}"
-        assert found['signed_meter_value']['signed_meter_data'] == expected_meter_value, (
-            f"expected meter value {expected_meter_value}, got {found['signed_meter_value']['signed_meter_data']}"
-        )
-
     test_controller.plug_in(1)
     test_controller.swipe("DEADBEEF")
 
@@ -76,4 +79,58 @@ async def test_meter_signed_meter_values(
         )
     )
 
+    validate_event(ended_event, "Transaction.End", "test stop value")
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+@pytest.mark.everest_core_config(get_everest_config_path_str("everest-config-ocpp201.yaml"))
+@pytest.mark.ocpp_config_adaptions(
+    GenericOCPP2XConfigAdjustment(
+        [
+            (
+                OCPP2XConfigVariableIdentifier(
+                    "SampledDataCtrlr", "SampledDataSignReadings", "Actual"
+                ),
+                "true",
+            ),
+        ]
+    )
+)
+@pytest.mark.everest_config_adaptions(YetiSimulatorDisableMeterTransactionStartStrategy())
+async def test_meter_signed_meter_values_no_start(
+    charge_point_v201: ChargePoint201,
+    test_utility: TestUtility,
+    test_controller: TestController,
+):
+    test_controller.plug_in(1)
+    test_controller.swipe("DEADBEEF")
+
+    started_event: call201.TransactionEvent = call201.TransactionEvent(
+        **await wait_for_and_validate(  # pyright: ignore[reportCallIssue]
+            test_utility,
+            charge_point_v201,
+            "TransactionEvent",
+            {"eventType": "Started"},
+        )
+    )
+
+    # The transaction start event should not contain signed meter values
+    for meter_value in started_event.meter_value or []:
+        for sampled_value in meter_value['sampled_value']:
+            assert sampled_value.get('context') != "Transaction.Begin" or sampled_value.get('signed_meter_value') is None, \
+                "Unexpected signed meter value in Transaction.Begin while the powermeter is configured to not send signed meter values on transaction start"
+
+    test_controller.plug_out()
+
+    ended_event: call201.TransactionEvent = call201.TransactionEvent(
+        **await wait_for_and_validate(  # pyright: ignore[reportCallIssue]
+            test_utility,
+            charge_point_v201,
+            "TransactionEvent",
+            {"eventType": "Ended"},
+        )
+    )
+
+    validate_event(ended_event, "Transaction.Begin", "test start value")
     validate_event(ended_event, "Transaction.End", "test stop value")


### PR DESCRIPTION
## Describe your changes

The start_signed_meter_value that a powermeter can return in its TransactionStopResponse was not sent to the CSMS at all.
This PR implements sending that value if it is set and adds a test for both OCPP 1.6 and 2.0.1 to ensure that this actually works

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #2259 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #2239 
- <kbd>&nbsp;3&nbsp;</kbd> #2252 
- <kbd>&nbsp;2&nbsp;</kbd> #2214 
- <kbd>&nbsp;1&nbsp;</kbd> #2236 
<!-- GitButler Footer Boundary Bottom -->

