### PR TITLE
Only include signed meter values on transaction start if SampledDataSignReadings is enabled

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/transaction.cpp
@@ -63,9 +63,15 @@ void TransactionBlock::on_transaction_started(const std::int32_t evse_id, const 
     evse_handle.open_transaction(session_id, connector_id, timestamp, meter_start, id_token, group_id_token,
                                  reservation_id, charging_state);
 
+    const auto include_signed =
+        this->context.device_model.get_optional_value<bool>(ControllerComponentVariables::SampledDataSignReadings)
+            .value_or(false);
+
     const auto meter_value = utils::get_meter_value_with_measurands_applied(
-        meter_start, utils::get_measurands_vec(this->context.device_model.get_value<std::string>(
-                         ControllerComponentVariables::SampledDataTxStartedMeasurands)));
+        meter_start,
+        utils::get_measurands_vec(this->context.device_model.get_value<std::string>(
+            ControllerComponentVariables::SampledDataTxStartedMeasurands)),
+        include_signed);
 
     const auto& enhanced_transaction = evse_handle.get_transaction();
     Transaction transaction{enhanced_transaction->transactionId};


### PR DESCRIPTION
## Describe your changes

On transaction start, signed meter values were sent to the CSMS regardless of if SampledDataSignReadings was enabled. This PR adds a check so that the data is only sent if the option is enabled

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

