### PR TITLE
Fix armv7-linux-musleabihf cross build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,7 +15,7 @@ build:ci --disk_cache=~/.cache/bazel-disk-cache
 build:armv7-linux-gnueabihf --repo_env=BAZEL_CONLYOPTS="-std=gnu17"
 build:aarch64-linux-gnu --repo_env=BAZEL_CONLYOPTS=""
 build:aarch64-linux-musl --repo_env=BAZEL_CONLYOPTS=""
-build:armv7-linux-musleabihf --repo_env=BAZEL_CONLYOPTS=""
+build:armv7-linux-musleabihf --repo_env=BAZEL_CONLYOPTS="-std=gnu17"
 
 # With our setup Bazel links every binary statically to `libframework.a` If you
 # want to link dynamically to `libframework.so` use `--dynamic_mode=fully`.


### PR DESCRIPTION
## Describe your changes

Fixes cross compiling from x8_64-linux-gnu to armv7-linux-musleabihf on the latest version of openSUSE Tumbleweed

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

