### PR TITLE
fix(config): add evse mapping to ISO15118 SIL test configs

### DIFF
--- a/config/config-sil-ocpp-pnc.yaml
+++ b/config/config-sil-ocpp-pnc.yaml
@@ -1,6 +1,9 @@
 active_modules:
   iso15118_charger:
     module: EvseV2G
+    mapping:
+      module:
+        evse: 1
     config_module:
       device: auto
       tls_security: allow

--- a/config/config-sil-ocpp201-pnc.yaml
+++ b/config/config-sil-ocpp201-pnc.yaml
@@ -1,6 +1,9 @@
 active_modules:
   iso15118_charger:
     module: EvseV2G
+    mapping:
+      module:
+        evse: 1
     config_module:
       device: auto
       tls_security: allow

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-iso no-tls.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-iso no-tls.yaml
@@ -1,6 +1,9 @@
 active_modules:
   iso15118_charger:
     module: EvseV2G
+    mapping:
+      module:
+        evse: 1
     config_module:
       device: auto
       tls_security: allow

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-iso.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-iso.yaml
@@ -1,6 +1,9 @@
 active_modules:
   iso15118_charger:
     module: EvseV2G
+    mapping:
+      module:
+        evse: 1
     config_module:
       device: auto
       tls_security: allow


### PR DESCRIPTION
ISO15118 modules require an evse mapping when used together with OCPP when the extensions_15118 interface is connected. Without it, ChargingNeeds are not sent and the following warning is logged: 'ISO15118 Extension interface mapping not set! Not sending ChargingNeeds!'

Added mapping block to:
- everest-config-sil-iso.yaml
- everest-config-sil-iso no-tls.yaml
- config-sil-ocpp201-pnc.yaml
- config-sil-ocpp-pnc.yaml

Fixes #2255 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

