### PR TITLE
refactor(ConnectivityManager): Introduce ConnectivityManagerConfiguration replacing DeviceModelAbstract

### DIFF
--- a/lib/everest/ocpp/config/common/component_config/standardized/OCPP16LegacyCtrlr.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/OCPP16LegacyCtrlr.json
@@ -199,6 +199,23 @@
             "minimum": 0,
             "default": 60
         },
+        "SwitchSecurityProfileConnectionTimeout": {
+            "variable_name": "SwitchSecurityProfileConnectionTimeout",
+            "characteristics": {
+                "supportsMonitoring": true,
+                "dataType": "integer",
+                "unit": "s"
+            },
+            "attributes": [
+                {
+                    "type": "Actual",
+                    "mutability": "ReadWrite"
+                }
+            ],
+            "description": "Timeout in seconds for a security profile switch to establish a connection before reverting to the previous profile",
+            "type": "integer",
+            "minimum": 1
+        },
         "StopTransactionIfUnlockNotSupported": {
             "variable_name": "StopTransactionIfUnlockNotSupported",
             "characteristics": {

--- a/lib/everest/ocpp/config/v16/config-full.json
+++ b/lib/everest/ocpp/config/v16/config-full.json
@@ -55,6 +55,7 @@
         "ConnectorEvseIds": "DE*PNX*100001,DE*PNX*100002",
         "AllowChargingProfileWithoutStartSchedule": false,
         "WaitForStopTransactionsOnResetTimeout": 60,
+        "SwitchSecurityProfileConnectionTimeout": 30,
         "QueueAllMessages": true,
         "MessageTypesDiscardForQueueing": "Heartbeat",
         "MessageQueueSizeThreshold": 5000,

--- a/lib/everest/ocpp/config/v16/profile_schemas/Internal.json
+++ b/lib/everest/ocpp/config/v16/profile_schemas/Internal.json
@@ -327,6 +327,12 @@
             "minimum": 0,
             "default": 60
         },
+        "SwitchSecurityProfileConnectionTimeout": {
+            "$comment": "Timeout in seconds for a security profile switch to establish a connection before reverting to the previous profile. When unset, the built-in default is used.",
+            "type": "integer",
+            "readOnly": false,
+            "minimum": 1
+        },
         "QueueAllMessages": {
             "$comment": "If set to true, also non-transactional messages are queued in memory in case they cannot be sent immediately.",
             "type": "boolean",

--- a/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/connectivity_manager.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include <ocpp/common/connectivity_manager_configuration.hpp>
 #include <ocpp/common/websocket/websocket.hpp>
 #include <ocpp/v2/messages/SetNetworkProfile.hpp>
-#include <ocpp/v2/ocpp_types.hpp>
 
 #include <everest/util/async/monitor.hpp>
 
@@ -16,9 +16,6 @@
 #include <optional>
 
 namespace ocpp {
-namespace v2 {
-class DeviceModelAbstract;
-} // namespace v2
 
 /// \brief The result of a configuration of a network profile.
 struct ConfigNetworkResult {
@@ -56,6 +53,15 @@ public:
     /// \brief Set the websocket connection options without triggering a reconnect
     ///
     virtual void set_websocket_connection_options_without_reconnect() = 0;
+
+    /// \brief Apply the websocket ping interval to a connection immediately.
+    /// \param ping_interval_s The ping interval in seconds (0 disables pinging)
+    /// \param pong_timeout_s The pong timeout in seconds
+    ///
+    /// Unlike set_websocket_connection_options_without_reconnect(), this takes effect on the current connection
+    /// instead of only on the next reconnect. Only has an effect while the websocket is connected; while
+    /// disconnected the interval is applied from the configuration on the next reconnect.
+    virtual void set_websocket_ping_interval(std::int32_t ping_interval_s, std::int32_t pong_timeout_s) = 0;
 
     /// \brief Set the \p callback that is called when the websocket is connected.
     ///
@@ -150,8 +156,8 @@ public:
 
 class ConnectivityManager : public ConnectivityManagerInterface {
 private:
-    /// \brief Reference to the device model
-    ocpp::v2::DeviceModelAbstract& device_model;
+    /// \brief Configuration interface used to persist and retrieve network configuration
+    ocpp::ConnectivityManagerConfiguration& configuration;
     /// \brief Pointer to the evse security class
     std::shared_ptr<EvseSecurity> evse_security;
     /// \brief Pointer to the logger
@@ -193,8 +199,8 @@ private:
     mutable everest::lib::util::monitor<NetworkProfileCacheState, std::recursive_mutex> m_state;
 
 public:
-    ConnectivityManager(ocpp::v2::DeviceModelAbstract& device_model, std::shared_ptr<EvseSecurity> evse_security,
-                        const fs::path& share_path = {});
+    ConnectivityManager(ocpp::ConnectivityManagerConfiguration& configuration,
+                        std::shared_ptr<EvseSecurity> evse_security, const fs::path& share_path = {});
 
     void reload_network_profiles() override;
     bool set_network_profile(int32_t slot, const ocpp::v2::NetworkConnectionProfile& profile,
@@ -205,6 +211,7 @@ public:
     void set_websocket_authorization_key(const std::string& authorization_key) override;
     void set_websocket_connection_options(const WebsocketConnectionOptions& connection_options) override;
     void set_websocket_connection_options_without_reconnect() override;
+    void set_websocket_ping_interval(std::int32_t ping_interval_s, std::int32_t pong_timeout_s) override;
     void set_websocket_connected_callback(WebsocketConnectionCallback callback) override;
     void set_websocket_disconnected_callback(WebsocketConnectionCallback callback) override;
     void set_websocket_connection_failed_callback(WebsocketConnectionFailedCallback callback) override;
@@ -239,19 +246,11 @@ private:
     ///
     void try_connect_websocket();
 
-    /// \brief Get the current websocket connection options
-    /// \return the current websocket connection options
+    /// \brief Get the current websocket connection options for the given slot.
+    /// Delegates to configuration and appends the local everest version string.
+    /// \return the current websocket connection options, or nullopt on failure.
     ///
     std::optional<WebsocketConnectionOptions> get_ws_connection_options(const std::int32_t configuration_slot);
-
-    /// \brief Resolve the Identity to use for the given slot. Per-slot Identity overrides
-    ///        SecurityCtrlr.Identity (B09.FR.16-18) when present and non-empty.
-    std::string resolve_identity(std::int32_t configuration_slot) const;
-
-    /// \brief Resolve the BasicAuthPassword to use for the given slot. Per-slot BasicAuthPassword
-    ///        overrides the global SecurityCtrlr.BasicAuthPassword (B09.FR.26-28) when present
-    ///        and non-empty.
-    std::optional<std::string> resolve_basic_auth_password(std::int32_t configuration_slot) const;
 
     /// \brief Read the everest version string from the deployed version_information.txt,
     ///        next to the binary. Returns nullopt if the file is missing or contains no usable line.

--- a/lib/everest/ocpp/include/ocpp/common/connectivity_manager_configuration.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/connectivity_manager_configuration.hpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <ocpp/common/websocket/websocket_base.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace ocpp {
+
+/// \brief Configuration interface used by ConnectivityManager to persist and retrieve all network-configuration
+///        data it needs, independently of the OCPP version in use.
+class ConnectivityManagerConfiguration {
+public:
+    virtual ~ConnectivityManagerConfiguration() = default;
+
+    /// \brief Get the comma-separated network-slot priority string (e.g. "1,2,0").
+    /// \return The priority string, or an empty string when none is configured.
+    virtual std::string get_network_configuration_priority() = 0;
+
+    /// \brief Persist an updated priority string.
+    virtual void set_network_configuration_priority(const std::string& priority, const std::string& source) = 0;
+
+    /// \brief Read the NetworkConnectionProfile stored for \p slot.
+    /// \return The profile, or std::nullopt if the slot is absent or malformed.
+    virtual std::optional<ocpp::v2::NetworkConnectionProfile> read_network_connection_profile(std::int32_t slot) = 0;
+
+    /// \brief Persist a NetworkConnectionProfile for \p slot.
+    /// \return true on success.
+    virtual bool write_network_connection_profile(std::int32_t slot, const ocpp::v2::NetworkConnectionProfile& profile,
+                                                  const std::string& source) = 0;
+
+    /// \brief Erase all persisted data for \p slot.
+    virtual void clear_network_connection_profile(std::int32_t slot) = 0;
+
+    /// \brief Return true if security-profile 0 connections are permitted.
+    virtual bool get_allow_security_level_zero_connections() = 0;
+
+    /// \brief Return the currently active security profile level.
+    virtual std::int32_t get_security_profile() = 0;
+
+    /// \brief Return the timeout (in seconds) to wait for a network-configuration callback result,
+    ///        or std::nullopt to use the built-in default (60 s).
+    virtual std::optional<std::int32_t> get_network_config_timeout() = 0;
+
+    /// \brief Build and return the WebsocketConnectionOptions for the given \p slot.
+    ///
+    /// The implementation is responsible for reading the network connection profile for \p slot,
+    /// resolving the identity and basic-auth password (applying any per-slot overrides), parsing
+    /// and validating the CSMS URI, and populating all connection parameters (ciphers, ping/pong
+    /// intervals, TLS flags, retry settings, etc.).
+    ///
+    /// \return The populated options, or std::nullopt if the slot has no valid profile or the CSMS
+    ///         URL is malformed.
+    virtual std::optional<WebsocketConnectionOptions> get_websocket_connection_options(std::int32_t slot) = 0;
+
+    /// \brief Persist the security profile of the currently active connection.
+    virtual void set_active_security_profile(std::int32_t security_profile, const std::string& source) = 0;
+
+    /// \brief Persist the currently active network-profile slot.
+    virtual void set_active_network_profile_slot(std::int32_t slot, const std::string& source) = 0;
+
+    /// \brief Persist the negotiated OCPP protocol version for a specific slot.
+    virtual void set_per_slot_ocpp_version(std::int32_t slot, const std::string& version,
+                                           const std::string& source) = 0;
+
+    /// \brief Persist the security profile on the SecurityCtrlr component after a successful connect.
+    virtual void set_security_ctrl_security_profile(std::int32_t security_profile, const std::string& source) = 0;
+
+    /// \brief Persist the identity on the SecurityCtrlr component after a successful connect.
+    virtual void set_security_ctrl_identity(const std::string& identity, const std::string& source) = 0;
+};
+
+} // namespace ocpp

--- a/lib/everest/ocpp/include/ocpp/common/constants.hpp
+++ b/lib/everest/ocpp/include/ocpp/common/constants.hpp
@@ -28,6 +28,8 @@ constexpr std::int32_t EVSEID_NOT_SET = -1;
 
 constexpr std::chrono::seconds DEFAULT_WAIT_FOR_FUTURE_TIMEOUT = std::chrono::seconds(60);
 
+constexpr std::int32_t DEFAULT_WEBSOCKET_PONG_TIMEOUT_S = 5;
+
 const std::string VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL = "internal";
 const std::string VARIABLE_ATTRIBUTE_VALUE_SOURCE_CSMS = "csms";
 

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
@@ -4,6 +4,7 @@
 #define OCPP_V16_CHARGE_POINT_HPP
 
 #include <ocpp/common/cistring.hpp>
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/common/evse_security.hpp>
 #include <ocpp/common/evse_security_impl.hpp>
 #include <ocpp/common/support_older_cpp_versions.hpp>
@@ -74,6 +75,15 @@ public:
         ChargePointConfigurationInterface& cfg, const fs::path& share_path, const fs::path& database_path,
         const fs::path& sql_init_path, const fs::path& message_log_path,
         const std::shared_ptr<EvseSecurity> evse_security,
+        const std::optional<SecurityConfiguration> security_configuration = std::nullopt,
+        const std::function<void(const std::string& message, MessageDirection direction)>& message_callback = nullptr);
+
+    /// \brief Constructor that allows providing a \p connectivity_manager .
+    explicit ChargePoint(
+        ChargePointConfigurationInterface& cfg, const fs::path& share_path, const fs::path& database_path,
+        const fs::path& sql_init_path, const fs::path& message_log_path,
+        const std::shared_ptr<EvseSecurity> evse_security,
+        std::shared_ptr<ocpp::ConnectivityManagerInterface> connectivity_manager,
         const std::optional<SecurityConfiguration> security_configuration = std::nullopt,
         const std::function<void(const std::string& message, MessageDirection direction)>& message_callback = nullptr);
 
@@ -155,6 +165,21 @@ public:
 
     /// \brief Disconnects the the websocket connection to the CSMS if it is connected
     void disconnect_websocket();
+
+    /// \brief Notifies the charge point that the websocket is connected. This allows an external owner of an injected
+    /// ConnectivityManager to drive the charge point's websocket lifecycle (mirroring ocpp::v2::ChargePointInterface).
+    void on_websocket_connected(const int configuration_slot,
+                                const ocpp::v2::NetworkConnectionProfile& network_connection_profile,
+                                const ocpp::OcppProtocolVersion ocpp_version);
+
+    /// \brief Notifies the charge point that the websocket is disconnected. This allows an external owner of an
+    /// injected ConnectivityManager to drive the charge point's websocket lifecycle
+    void on_websocket_disconnected(const int configuration_slot,
+                                   const ocpp::v2::NetworkConnectionProfile& network_connection_profile);
+
+    /// \brief Notifies the charge point that the websocket connection failed. This allows an external owner of an
+    /// injected ConnectivityManager to drive the charge point's websocket lifecycle
+    void on_websocket_connection_failed(ocpp::ConnectionFailedReason reason);
 
     /// \brief Calls the set_connection_timeout_callback that can be registered. This function is used to notify an
     /// Authorization mechanism about a changed ConnectionTimeout configuration key.

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration.hpp
@@ -10,7 +10,7 @@
 
 #include <ocpp/common/support_older_cpp_versions.hpp>
 #include <ocpp/v16/charge_point_configuration_base.hpp>
-#include <ocpp/v16/charge_point_configuration_interface.hpp>
+#include <ocpp/v16/charge_point_configuration_connectivity.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 #include <ocpp/v16/types.hpp>
 #include <ocpp/v16/utils.hpp>
@@ -19,7 +19,7 @@ namespace ocpp {
 namespace v16 {
 
 /// \brief contains the configuration of the charge point
-class ChargePointConfiguration : private ChargePointConfigurationBase, public ChargePointConfigurationInterface {
+class ChargePointConfiguration : private ChargePointConfigurationBase, public ChargePointConfigurationConnectivity {
 private:
     json config;
     json custom_schema;
@@ -115,6 +115,9 @@ public:
     std::optional<std::int32_t> getSupplyVoltage() override;
     std::optional<KeyValue> getSupplyVoltageKeyValue() override;
     void setSupplyVoltage(std::int32_t supply_voltage) override;
+    std::optional<std::int32_t> getSwitchSecurityProfileConnectionTimeout() override;
+    std::optional<KeyValue> getSwitchSecurityProfileConnectionTimeoutKeyValue() override;
+    void setSwitchSecurityProfileConnectionTimeout(std::int32_t switch_security_profile_connection_timeout) override;
     std::string getSupportedCiphers12() override;
     KeyValue getSupportedCiphers12KeyValue() override;
     std::string getSupportedCiphers13() override;

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_connectivity.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_connectivity.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <ocpp/v16/charge_point_configuration_interface.hpp>
+
+namespace ocpp::v16 {
+
+/// \brief Implements the ConnectivityManagerConfiguration part of ChargePointConfigurationInterface for OCPP 1.6.
+///
+/// The behaviour is identical regardless of how the configuration is stored (JSON config file or device model):
+/// it depends only on the OCPP 1.6 getters/setters declared on ChargePointConfigurationInterface, which are
+/// resolved via virtual dispatch to the concrete implementation. This class remains abstract; it does not
+/// implement those getters/setters.
+class ChargePointConfigurationConnectivity : public ChargePointConfigurationInterface {
+public:
+    std::string get_network_configuration_priority() override;
+    void set_network_configuration_priority(const std::string& priority, const std::string& source) override;
+    std::optional<ocpp::v2::NetworkConnectionProfile> read_network_connection_profile(int32_t slot) override;
+    bool write_network_connection_profile(int32_t slot, const ocpp::v2::NetworkConnectionProfile& profile,
+                                          const std::string& source) override;
+    void clear_network_connection_profile(int32_t slot) override;
+    bool get_allow_security_level_zero_connections() override;
+    int32_t get_security_profile() override;
+    std::optional<int32_t> get_network_config_timeout() override;
+    std::optional<WebsocketConnectionOptions> get_websocket_connection_options(int32_t slot) override;
+    void set_active_security_profile(int32_t security_profile, const std::string& source) override;
+    void set_active_network_profile_slot(int32_t slot, const std::string& source) override;
+    void set_per_slot_ocpp_version(int32_t slot, const std::string& version, const std::string& source) override;
+    void set_security_ctrl_security_profile(int32_t security_profile, const std::string& source) override;
+    void set_security_ctrl_identity(const std::string& identity, const std::string& source) override;
+};
+
+} // namespace ocpp::v16

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_devicemodel.hpp
@@ -5,7 +5,7 @@
 #define OCPP_V16_CHARGE_POINT_CONFIGURATION_DEVICEMODEL_HPP
 
 #include <ocpp/v16/charge_point_configuration_base.hpp>
-#include <ocpp/v16/charge_point_configuration_interface.hpp>
+#include <ocpp/v16/charge_point_configuration_connectivity.hpp>
 #include <ocpp/v16/known_keys.hpp>
 #include <ocpp/v16/types.hpp>
 #include <ocpp/v2/ocpp16_custom_config_mappings.hpp>
@@ -24,7 +24,7 @@ class OrderedUniqueStringList;
 
 /// \brief contains the configuration of the charge point
 class ChargePointConfigurationDeviceModel : private ChargePointConfigurationBase,
-                                            public ChargePointConfigurationInterface {
+                                            public ChargePointConfigurationConnectivity {
 public:
     using SetResult = v2::SetVariableStatusEnum;
 
@@ -48,6 +48,7 @@ protected:
     SetResult setInternalSeccLeafSubjectOrganization(const std::string& value);
     SetResult setInternalStopTransactionIfUnlockNotSupported(const std::string& value);
     SetResult setInternalSupplyVoltage(const std::string& value);
+    SetResult setInternalSwitchSecurityProfileConnectionTimeout(const std::string& value);
     SetResult setInternalVerifyCsmsAllowWildcards(const std::string& value);
     SetResult setInternalWaitForStopTransactionsOnResetTimeout(const std::string& value);
 
@@ -192,6 +193,7 @@ public:
     std::optional<std::int32_t> getCompositeScheduleDefaultLimitWatts() override;
     std::optional<std::int32_t> getCompositeScheduleDefaultNumberPhases() override;
     std::optional<std::int32_t> getSupplyVoltage() override;
+    std::optional<std::int32_t> getSwitchSecurityProfileConnectionTimeout() override;
     std::optional<std::vector<KeyValue>> getAllMeterPublicKeyKeyValues() override;
 
     std::set<MessageType> getSupportedMessageTypesSending() override;
@@ -247,6 +249,7 @@ public:
     std::optional<KeyValue> getSeccLeafSubjectCountryKeyValue() override;
     std::optional<KeyValue> getSeccLeafSubjectOrganizationKeyValue() override;
     std::optional<KeyValue> getSupplyVoltageKeyValue() override;
+    std::optional<KeyValue> getSwitchSecurityProfileConnectionTimeoutKeyValue() override;
 
     void setAllowChargingProfileWithoutStartSchedule(bool allow) override;
     void setCentralSystemURI(const std::string& ocpp_uri) override;
@@ -265,6 +268,7 @@ public:
     void setSeccLeafSubjectOrganization(const std::string& secc_leaf_subject_organization) override;
     void setStopTransactionIfUnlockNotSupported(bool stop_transaction_if_unlock_not_supported) override;
     void setSupplyVoltage(std::int32_t supply_voltage) override;
+    void setSwitchSecurityProfileConnectionTimeout(std::int32_t switch_security_profile_connection_timeout) override;
     void setVerifyCsmsAllowWildcards(bool verify_csms_allow_wildcards) override;
     void setWaitForStopTransactionsOnResetTimeout(std::int32_t wait_for_stop_transactions_on_reset_timeout) override;
 

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_configuration_interface.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <ocpp/common/cistring.hpp>
+#include <ocpp/common/connectivity_manager_configuration.hpp>
 #include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/types.hpp>
 
@@ -18,7 +19,7 @@ namespace ocpp::v16 {
 struct KeyValue;
 
 /// \brief contains the configuration of the charge point
-class ChargePointConfigurationInterface {
+class ChargePointConfigurationInterface : public ocpp::ConnectivityManagerConfiguration {
 public:
     virtual ~ChargePointConfigurationInterface() = default;
     // UserConfig and Internal
@@ -104,6 +105,7 @@ public:
     virtual std::optional<std::int32_t> getCompositeScheduleDefaultLimitWatts() = 0;
     virtual std::optional<std::int32_t> getCompositeScheduleDefaultNumberPhases() = 0;
     virtual std::optional<std::int32_t> getSupplyVoltage() = 0;
+    virtual std::optional<std::int32_t> getSwitchSecurityProfileConnectionTimeout() = 0;
     virtual std::optional<std::vector<KeyValue>> getAllMeterPublicKeyKeyValues() = 0;
 
     virtual std::set<MessageType> getSupportedMessageTypesSending() = 0;
@@ -159,6 +161,7 @@ public:
     virtual std::optional<KeyValue> getSeccLeafSubjectCountryKeyValue() = 0;
     virtual std::optional<KeyValue> getSeccLeafSubjectOrganizationKeyValue() = 0;
     virtual std::optional<KeyValue> getSupplyVoltageKeyValue() = 0;
+    virtual std::optional<KeyValue> getSwitchSecurityProfileConnectionTimeoutKeyValue() = 0;
 
     virtual void setAllowChargingProfileWithoutStartSchedule(bool allow) = 0;
     virtual void setCentralSystemURI(const std::string& ocpp_uri) = 0;
@@ -177,6 +180,7 @@ public:
     virtual void setSeccLeafSubjectOrganization(const std::string& secc_leaf_subject_organization) = 0;
     virtual void setStopTransactionIfUnlockNotSupported(bool stop_transaction_if_unlock_not_supported) = 0;
     virtual void setSupplyVoltage(std::int32_t supply_voltage) = 0;
+    virtual void setSwitchSecurityProfileConnectionTimeout(std::int32_t switch_security_profile_connection_timeout) = 0;
     virtual void setVerifyCsmsAllowWildcards(bool verify_csms_allow_wildcards) = 0;
     virtual void setWaitForStopTransactionsOnResetTimeout(std::int32_t wait_for_stop_transactions_on_reset_timeout) = 0;
 

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
@@ -18,12 +18,14 @@
 
 #include <ocpp/common/aligned_timer.hpp>
 #include <ocpp/common/charging_station_base.hpp>
+#include <ocpp/common/connectivity_manager.hpp>
 #include <ocpp/common/message_dispatcher.hpp>
 #include <ocpp/common/message_queue.hpp>
 #include <ocpp/common/schemas.hpp>
 #include <ocpp/common/types.hpp>
 #include <ocpp/common/websocket/websocket.hpp>
 #include <ocpp/v16/charge_point_configuration_interface.hpp>
+#include <ocpp/v16/charge_point_state_machine.hpp>
 #include <ocpp/v16/connector.hpp>
 #include <ocpp/v16/database_handler.hpp>
 #include <ocpp/v16/message_dispatcher.hpp>
@@ -92,7 +94,6 @@ private:
     BootReasonEnum bootreason{BootReasonEnum::PowerUp};
     bool initialized{false};
     bool InvalidCSMSCertificate_logged{false};
-    bool wants_to_be_connected{false};
     ChargePointConnectionState connection_state{ChargePointConnectionState::Disconnected};
     std::atomic<RegistrationStatus> registration_status{RegistrationStatus::Pending};
     DiagnosticsStatus diagnostics_status{DiagnosticsStatus::Idle};
@@ -106,9 +107,11 @@ private:
     bool firmware_update_is_pending = false;
     bool disable_connectors_during_install = true;
 
-    std::unique_ptr<Websocket> websocket;
+    std::shared_ptr<ocpp::ConnectivityManagerInterface> connectivity_manager;
     std::unique_ptr<ocpp::MessageDispatcherInterface<MessageType>> message_dispatcher;
-    Everest::SteadyTimer websocket_timer;
+    Everest::SteadyTimer security_profile_revert_timer;
+    /// \brief Serializes the revert decision (timer thread) against \ref connected_callback
+    std::mutex security_profile_switch_mutex;
     std::unique_ptr<MessageQueue<v16::MessageType>> message_queue;
     std::map<std::int32_t, std::shared_ptr<Connector>> connectors;
     std::unique_ptr<SmartChargingHandler> smart_charging_handler;
@@ -190,7 +193,6 @@ private:
                                     CiString<20> idTag, std::optional<CiString<20>> parent_id)>
         reserve_now_callback;
     std::function<bool(std::int32_t reservation_id)> cancel_reservation_callback;
-    std::function<void()> switch_security_profile_callback;
     std::function<GetLogResponse(GetLogRequest msg)> upload_logs_callback;
     std::function<void(std::int32_t connection_timeout)> set_connection_timeout_callback;
 
@@ -217,11 +219,16 @@ private:
     std::function<DataTransferResponse(const TariffMessage& message)> tariff_message_callback;
     std::function<void(const TariffMessage& message)> default_price_callback;
 
+    /// \brief Fallback timeout after which a security profile switch that did not result in a successful
+    /// connection is reverted to the previous (fallback) security profile. Used only when the
+    /// SwitchSecurityProfileConnectionTimeout configuration key is not configured; otherwise the configured
+    /// value takes precedence.
+    static constexpr std::chrono::seconds SECURITY_PROFILE_SWITCH_TIMEOUT{20};
+
     /// \brief This function is called after a successful connection to the Websocket
     void connected_callback();
-    void init_websocket();
+    void init_connectivity_manager();
     void init_state_machine(const std::map<int, ChargePointStatus>& connector_status_map);
-    WebsocketConnectionOptions get_ws_connection_options();
     std::unique_ptr<ocpp::MessageQueue<v16::MessageType>> create_message_queue();
     void message_callback(const std::string& message);
     void handle_message(const EnhancedMessage<v16::MessageType>& message);
@@ -351,7 +358,7 @@ private:
     void securityEventNotification(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
                                    const bool triggered_internally, const std::optional<bool>& critical = std::nullopt,
                                    const std::optional<DateTime>& timestamp = std::nullopt);
-    void switchSecurityProfile(std::int32_t new_security_profile, std::int32_t max_connection_attempts);
+    void switchSecurityProfile(std::int32_t new_security_profile, std::int32_t fallback_security_profile);
     // Local Authorization List profile
     void handleSendLocalListRequest(Call<SendLocalListRequest> call);
     void handleGetLocalListVersionRequest(Call<GetLocalListVersionRequest> call);
@@ -407,6 +414,15 @@ private:
     set_configuration_key_internal(CiString<50> key, CiString<500> value, std::optional<MessageId> uniqueId);
 
 public:
+    /// \brief Websocket lifecycle handlers invoked by the \ref ConnectivityManager callbacks (or, for an injected
+    /// manager, by the external owner).
+    void on_websocket_connected(const int configuration_slot,
+                                const ocpp::v2::NetworkConnectionProfile& network_connection_profile,
+                                const ocpp::OcppProtocolVersion ocpp_version);
+    void on_websocket_disconnected(const int configuration_slot,
+                                   const ocpp::v2::NetworkConnectionProfile& network_connection_profile);
+    void on_websocket_connection_failed(ocpp::ConnectionFailedReason reason);
+
     /// \brief The main entrypoint for libOCPP for OCPP 1.6
     /// \param cfg a reference to the configuration provider
     /// \param database_path this points to the location of the sqlite database that libocpp uses to keep track of
@@ -425,6 +441,16 @@ public:
         ChargePointConfigurationInterface& cfg, const fs::path& share_path, const fs::path& database_path,
         const fs::path& sql_init_path, const fs::path& message_log_path,
         const std::shared_ptr<EvseSecurity>& evse_security,
+        const std::optional<SecurityConfiguration>& security_configuration,
+        const std::function<void(const std::string& message, MessageDirection direction)>& message_callback);
+
+    /// \brief Injection constructor that allows providing a \p connectivity_manager . If \p connectivity_manager is
+    /// nullptr, an internal \ref ocpp::ConnectivityManager is constructed and wired up.
+    explicit ChargePointImpl(
+        ChargePointConfigurationInterface& cfg, const fs::path& share_path, const fs::path& database_path,
+        const fs::path& sql_init_path, const fs::path& message_log_path,
+        const std::shared_ptr<EvseSecurity>& evse_security,
+        std::shared_ptr<ocpp::ConnectivityManagerInterface> connectivity_manager,
         const std::optional<SecurityConfiguration>& security_configuration,
         const std::function<void(const std::string& message, MessageDirection direction)>& message_callback);
 

--- a/lib/everest/ocpp/include/ocpp/v16/known_keys.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/known_keys.hpp
@@ -172,6 +172,7 @@ namespace ocpp::v16::keys {
     mapping(ReserveConnectorZeroSupported, ReserveConnectorZeroSupported) \
     mapping(AllowChargingProfileWithoutStartSchedule, AllowChargingProfileWithoutStartSchedule) \
     mapping(WaitForStopTransactionsOnResetTimeout, WaitForStopTransactionsOnResetTimeout) \
+    mapping(SwitchSecurityProfileConnectionTimeout, SwitchSecurityProfileConnectionTimeout) \
     mapping(StopTransactionIfUnlockNotSupported, StopTransactionIfUnlockNotSupported) \
     mapping(MeterPublicKeys, MeterPublicKeys) \
     mapping(DisableSecurityEventNotifications, DisableSecurityEventNotifications) \
@@ -288,6 +289,7 @@ namespace ocpp::v16::keys {
     key(Internal, SupportedChargingProfilePurposeTypes) \
     key(Internal, SupportedCiphers12) \
     key(Internal, SupportedCiphers13) \
+    key(Internal, SwitchSecurityProfileConnectionTimeout) \
     key(Internal, TLSKeylogFile) \
     key(Internal, UseSslDefaultVerifyPaths) \
     key(Internal, UseTPM) \

--- a/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
@@ -336,6 +336,7 @@ extern const RequiredComponentVariable UnlockConnectorOnEVSideDisconnect;
 extern const ComponentVariable ReserveConnectorZeroSupported;
 extern const ComponentVariable AllowChargingProfileWithoutStartSchedule;
 extern const ComponentVariable WaitForStopTransactionsOnResetTimeout;
+extern const ComponentVariable SwitchSecurityProfileConnectionTimeout;
 extern const ComponentVariable StopTransactionIfUnlockNotSupported;
 extern const ComponentVariable MeterPublicKeys;
 extern const ComponentVariable DisableSecurityEventNotifications;

--- a/lib/everest/ocpp/include/ocpp/v2/device_model.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model.hpp
@@ -90,6 +90,14 @@ private:
     ///
     void check_required_variables();
 
+    /// \brief Resolve the identity for \p slot.
+    /// Per-slot Identity overrides SecurityCtrlr.Identity (B09.FR.16-18).
+    std::string resolve_identity(std::int32_t slot);
+
+    /// \brief Resolve the basic-auth password for \p slot.
+    /// Per-slot BasicAuthPassword overrides the global BasicAuthPassword (B09.FR.26-28).
+    std::optional<std::string> resolve_basic_auth_password(std::int32_t slot);
+
 public:
     /// \brief Constructor for the device model
     /// \param device_model_storage_interface pointer to a device model interface class
@@ -149,6 +157,23 @@ public:
     }
 
     void check_integrity(const std::map<std::int32_t, std::int32_t>& evse_connector_structure) override;
+
+    // ConnectivityManagerConfiguration interface
+    std::string get_network_configuration_priority() override;
+    void set_network_configuration_priority(const std::string& priority, const std::string& source) override;
+    std::optional<ocpp::v2::NetworkConnectionProfile> read_network_connection_profile(std::int32_t slot) override;
+    bool write_network_connection_profile(std::int32_t slot, const ocpp::v2::NetworkConnectionProfile& profile,
+                                          const std::string& source) override;
+    void clear_network_connection_profile(std::int32_t slot) override;
+    bool get_allow_security_level_zero_connections() override;
+    std::int32_t get_security_profile() override;
+    std::optional<std::int32_t> get_network_config_timeout() override;
+    std::optional<WebsocketConnectionOptions> get_websocket_connection_options(std::int32_t slot) override;
+    void set_active_security_profile(std::int32_t security_profile, const std::string& source) override;
+    void set_active_network_profile_slot(std::int32_t slot, const std::string& source) override;
+    void set_per_slot_ocpp_version(std::int32_t slot, const std::string& version, const std::string& source) override;
+    void set_security_ctrl_security_profile(std::int32_t security_profile, const std::string& source) override;
+    void set_security_ctrl_identity(const std::string& identity, const std::string& source) override;
 };
 
 } // namespace v2

--- a/lib/everest/ocpp/include/ocpp/v2/device_model_abstract.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/device_model_abstract.hpp
@@ -3,13 +3,16 @@
 
 #pragma once
 
+#include <ocpp/common/connectivity_manager_configuration.hpp>
 #include <ocpp/v2/device_model_base.hpp>
 #include <ocpp/v2/device_model_interface.hpp>
 
 namespace ocpp {
 namespace v2 {
 
-class DeviceModelAbstract : public DeviceModelBase, public DeviceModelInterface {};
+class DeviceModelAbstract : public DeviceModelBase,
+                            public DeviceModelInterface,
+                            public ocpp::ConnectivityManagerConfiguration {};
 
 } // namespace v2
 } // namespace ocpp

--- a/lib/everest/ocpp/lib/CMakeLists.txt
+++ b/lib/everest/ocpp/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ if(LIBOCPP_ENABLE_V16)
             ocpp/v16/smart_charging.cpp
             ocpp/v16/known_keys.cpp
             ocpp/v16/charge_point_configuration_base.cpp
+            ocpp/v16/charge_point_configuration_connectivity.cpp
             ocpp/v16/charge_point_configuration_devicemodel.cpp
             ocpp/v16/charge_point_configuration.cpp
             ocpp/v16/charge_point_state_machine.cpp

--- a/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/connectivity_manager.cpp
@@ -6,9 +6,6 @@
 #include <fstream>
 
 #include <everest/logging.hpp>
-#include <ocpp/v2/ctrlr_component_variables.hpp>
-#include <ocpp/v2/device_model.hpp>
-#include <ocpp/v2/utils.hpp>
 
 namespace {
 const auto WEBSOCKET_INIT_DELAY = std::chrono::seconds(2);
@@ -21,20 +18,13 @@ constexpr std::int32_t default_network_config_timeout_seconds = 60;
 namespace ocpp {
 
 using NetworkConnectionProfile = ocpp::v2::NetworkConnectionProfile;
-using AttributeEnum = ocpp::v2::AttributeEnum;
-using DeviceModel = ocpp::v2::DeviceModel;
-using DeviceModelAbstract = ocpp::v2::DeviceModelAbstract;
 using OCPPInterfaceEnum = ocpp::v2::OCPPInterfaceEnum;
 using SetNetworkProfileRequest = ocpp::v2::SetNetworkProfileRequest;
-namespace ControllerComponentVariables = ocpp::v2::ControllerComponentVariables;
-namespace ControllerComponents = ocpp::v2::ControllerComponents;
-namespace NetworkConfigurationComponentVariables = ocpp::v2::NetworkConfigurationComponentVariables;
-namespace utils = ocpp::v2::utils;
 
-ConnectivityManager::ConnectivityManager(ocpp::v2::DeviceModelAbstract& device_model,
+ConnectivityManager::ConnectivityManager(ocpp::ConnectivityManagerConfiguration& configuration,
                                          std::shared_ptr<EvseSecurity> evse_security, const fs::path& share_path) :
-    device_model{device_model},
-    evse_security{evse_security},
+    configuration{configuration},
+    evse_security{std::move(evse_security)},
     share_path{share_path},
     websocket{nullptr},
     message_callback([](const std::string& message) {
@@ -77,6 +67,12 @@ void ConnectivityManager::set_websocket_connection_options_without_reconnect() {
     }
 }
 
+void ConnectivityManager::set_websocket_ping_interval(std::int32_t ping_interval_s, std::int32_t pong_timeout_s) {
+    if (this->websocket != nullptr && this->websocket->is_connected()) {
+        this->websocket->set_websocket_ping_interval(ping_interval_s, pong_timeout_s);
+    }
+}
+
 void ConnectivityManager::set_websocket_connected_callback(WebsocketConnectionCallback callback) {
     this->websocket_connected_callback = callback;
 }
@@ -99,9 +95,7 @@ ConnectivityManager::get_network_connection_profile(const std::int32_t configura
     auto state = this->m_state.handle();
     for (const auto& network_profile : state->cached_profiles) {
         if (network_profile.configurationSlot == configuration_slot) {
-            if (!this->device_model
-                     .get_optional_value<bool>(ControllerComponentVariables::AllowSecurityLevelZeroConnections)
-                     .value_or(false) &&
+            if (!this->configuration.get_allow_security_level_zero_connections() &&
                 network_profile.connectionData.securityProfile ==
                     security::OCPP_1_6_ONLY_UNSECURED_TRANSPORT_WITHOUT_BASIC_AUTHENTICATION) {
                 EVLOG_error << "security_profile 0 not officially allowed in OCPP 2.0.1, skipping profile";
@@ -211,12 +205,9 @@ void ConnectivityManager::confirm_successful_connection() {
 
     const auto network_connection_profile = this->get_network_connection_profile(config_slot.value());
 
-    if (const auto& security_profile_cv = ControllerComponentVariables::SecurityProfile;
-        security_profile_cv.variable.has_value() and network_connection_profile.has_value()) {
-        this->device_model.set_read_only_value(security_profile_cv.component, security_profile_cv.variable.value(),
-                                               AttributeEnum::Actual,
-                                               std::to_string(network_connection_profile.value().securityProfile),
-                                               VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
+    if (network_connection_profile.has_value()) {
+        this->configuration.set_active_security_profile(network_connection_profile.value().securityProfile,
+                                                        VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
     }
 
     this->remove_network_connection_profiles_below_actual_security_profile();
@@ -224,11 +215,6 @@ void ConnectivityManager::confirm_successful_connection() {
 }
 
 void ConnectivityManager::try_connect_websocket() {
-    if (this->device_model.get_value<std::string>(ControllerComponentVariables::SecurityCtrlrIdentity).find(':') !=
-        std::string::npos) {
-        EVLOG_AND_THROW(std::runtime_error("ChargePointId must not contain \':\'"));
-    }
-
     // Check the cache runtime since security profile might change async
     this->check_cache_for_invalid_security_profiles();
 
@@ -305,12 +291,8 @@ void ConnectivityManager::try_connect_websocket() {
     EVLOG_info << "Open websocket with NetworkConfigurationPriority: " << priority_to_set.value() + 1
                << " which is configurationSlot " << configuration_slot_to_set;
 
-    if (const auto& active_network_profile_cv = ControllerComponentVariables::ActiveNetworkProfile;
-        active_network_profile_cv.variable.has_value()) {
-        this->device_model.set_read_only_value(
-            active_network_profile_cv.component, active_network_profile_cv.variable.value(), AttributeEnum::Actual,
-            std::to_string(configuration_slot_to_set), VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
-    }
+    this->configuration.set_active_network_profile_slot(configuration_slot_to_set,
+                                                        VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
 
     if (this->websocket == nullptr) {
         this->websocket = std::make_unique<Websocket>(connection_options.value(), this->evse_security, this->logging);
@@ -344,8 +326,7 @@ ConnectivityManager::handle_configure_network_connection_profile_callback(int sl
     std::future<ConfigNetworkResult> config_status =
         this->configure_network_connection_profile_callback.value()(slot, profile);
     const std::int32_t config_timeout =
-        this->device_model.get_optional_value<int>(ControllerComponentVariables::NetworkConfigTimeout)
-            .value_or(default_network_config_timeout_seconds);
+        this->configuration.get_network_config_timeout().value_or(default_network_config_timeout_seconds);
 
     if (config_status.wait_for(std::chrono::seconds(config_timeout)) == std::future_status::ready) {
         return config_status.get();
@@ -405,31 +386,6 @@ void ConnectivityManager::on_charging_station_certificate_changed() {
     }
 }
 
-std::string ConnectivityManager::resolve_identity(const std::int32_t configuration_slot) const {
-    std::string identity_to_use =
-        this->device_model.get_value<std::string>(ControllerComponentVariables::SecurityCtrlrIdentity);
-    const auto slot_identity_cv = NetworkConfigurationComponentVariables::get_component_variable(
-        configuration_slot, NetworkConfigurationComponentVariables::Identity);
-    if (const auto slot_identity = this->device_model.get_optional_value<std::string>(slot_identity_cv);
-        slot_identity.has_value() && !slot_identity->empty()) {
-        identity_to_use = *slot_identity;
-        EVLOG_debug << "Using per-slot Identity for slot " << configuration_slot;
-    }
-    return identity_to_use;
-}
-
-std::optional<std::string>
-ConnectivityManager::resolve_basic_auth_password(const std::int32_t configuration_slot) const {
-    const auto slot_pwd_cv = NetworkConfigurationComponentVariables::get_component_variable(
-        configuration_slot, NetworkConfigurationComponentVariables::BasicAuthPassword);
-    if (const auto slot_pwd = this->device_model.get_optional_value<std::string>(slot_pwd_cv);
-        slot_pwd.has_value() && !slot_pwd->empty()) {
-        EVLOG_debug << "Using per-slot BasicAuthPassword for slot " << configuration_slot;
-        return slot_pwd.value();
-    }
-    return this->device_model.get_optional_value<std::string>(ControllerComponentVariables::BasicAuthPassword);
-}
-
 std::optional<std::string> ConnectivityManager::read_everest_version() const {
     const fs::path version_file_path = this->share_path.parent_path().parent_path() / "version_information.txt";
     if (!fs::exists(version_file_path)) {
@@ -448,60 +404,13 @@ std::optional<std::string> ConnectivityManager::read_everest_version() const {
 
 std::optional<WebsocketConnectionOptions>
 ConnectivityManager::get_ws_connection_options(const std::int32_t configuration_slot) {
-    const auto network_connection_profile_opt = this->get_network_connection_profile(configuration_slot);
-    if (!network_connection_profile_opt.has_value()) {
-        EVLOG_critical << "Could not retrieve NetworkProfile of configurationSlot: " << configuration_slot;
-        throw std::runtime_error("Could not retrieve NetworkProfile");
-    }
-    const auto& network_connection_profile = network_connection_profile_opt.value();
-
-    try {
-        const auto identity_to_use = this->resolve_identity(configuration_slot);
-        auto uri = Uri::parse_and_validate(network_connection_profile.ocppCsmsUrl.get(), identity_to_use,
-                                           network_connection_profile.securityProfile);
-        const auto ocpp_versions = utils::get_ocpp_protocol_versions(
-            this->device_model.get_value<std::string>(ControllerComponentVariables::SupportedOcppVersions));
-        const auto basic_auth_password = this->resolve_basic_auth_password(configuration_slot);
-
-        WebsocketConnectionOptions connection_options{
-            ocpp_versions, uri, network_connection_profile.securityProfile, basic_auth_password,
-            // Always use a minimum of 1 second otherwise each message would timeout immediately
-            std::chrono::seconds(std::max(network_connection_profile.messageTimeout, 1)),
-            this->device_model.get_value<int>(ControllerComponentVariables::RetryBackOffRandomRange),
-            this->device_model.get_value<int>(ControllerComponentVariables::RetryBackOffRepeatTimes),
-            this->device_model.get_value<int>(ControllerComponentVariables::RetryBackOffWaitMinimum),
-            this->device_model.get_value<int>(ControllerComponentVariables::NetworkProfileConnectionAttempts),
-            this->device_model.get_value<std::string>(ControllerComponentVariables::SupportedCiphers12),
-            this->device_model.get_value<std::string>(ControllerComponentVariables::SupportedCiphers13),
-            this->device_model.get_value<int>(ControllerComponentVariables::WebSocketPingInterval),
-            this->device_model.get_optional_value<std::string>(ControllerComponentVariables::WebsocketPingPayload)
-                .value_or("payload"),
-            this->device_model.get_optional_value<int>(ControllerComponentVariables::WebsocketPongTimeout).value_or(5),
-            this->device_model.get_optional_value<bool>(ControllerComponentVariables::UseSslDefaultVerifyPaths)
-                .value_or(true),
-            this->device_model.get_optional_value<bool>(ControllerComponentVariables::AdditionalRootCertificateCheck)
-                .value_or(false),
-            std::nullopt, // hostName
-            this->device_model.get_optional_value<bool>(ControllerComponentVariables::VerifyCsmsCommonName)
-                .value_or(true),
-            this->device_model.get_optional_value<bool>(ControllerComponentVariables::UseTPM).value_or(false),
-            this->device_model.get_optional_value<bool>(ControllerComponentVariables::VerifyCsmsAllowWildcards)
-                .value_or(false),
-            this->device_model.get_optional_value<std::string>(ControllerComponentVariables::IFace),
-            this->device_model.get_optional_value<bool>(ControllerComponentVariables::EnableTLSKeylog).value_or(false),
-            this->device_model.get_optional_value<std::string>(ControllerComponentVariables::TLSKeylogFile)};
-
+    auto opts = this->configuration.get_websocket_connection_options(configuration_slot);
+    if (opts.has_value()) {
         if (auto version = this->read_everest_version(); version.has_value()) {
-            connection_options.everest_version = std::move(*version);
+            opts->everest_version = std::move(*version);
         }
-
-        return connection_options;
-
-    } catch (const std::invalid_argument& e) {
-        EVLOG_error << "Could not configure the connection options: " << e.what();
     }
-
-    return std::nullopt;
+    return opts;
 }
 
 void ConnectivityManager::on_websocket_connected(OcppProtocolVersion protocol) {
@@ -529,24 +438,16 @@ void ConnectivityManager::on_websocket_connected(OcppProtocolVersion protocol) {
             break;
         }
         if (!version_str.empty()) {
-            const auto nc_cv = NetworkConfigurationComponentVariables::get_component_variable(
-                actual_configuration_slot.value(), NetworkConfigurationComponentVariables::OcppVersion);
-            if (nc_cv.variable.has_value()) {
-                this->device_model.set_value(nc_cv.component, nc_cv.variable.value(), AttributeEnum::Actual,
-                                             version_str, VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
-            }
+            this->configuration.set_per_slot_ocpp_version(actual_configuration_slot.value(), version_str,
+                                                          VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
         }
     }
     if (network_connection_profile.has_value()) {
-        this->device_model.set_value(ControllerComponents::SecurityCtrlr,
-                                     NetworkConfigurationComponentVariables::SecurityProfile, AttributeEnum::Actual,
-                                     std::to_string(network_connection_profile->securityProfile),
-                                     VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
+        this->configuration.set_security_ctrl_security_profile(network_connection_profile->securityProfile,
+                                                               VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
         if (network_connection_profile->identity.has_value()) {
-            this->device_model.set_value(ControllerComponents::SecurityCtrlr,
-                                         NetworkConfigurationComponentVariables::Identity, AttributeEnum::Actual,
-                                         network_connection_profile->identity.value(),
-                                         VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
+            this->configuration.set_security_ctrl_identity(network_connection_profile->identity.value(),
+                                                           VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
         }
     }
 
@@ -609,31 +510,22 @@ void ConnectivityManager::on_websocket_stopped_connecting(ocpp::WebsocketCloseRe
 
 void ConnectivityManager::append_slot_to_network_configuration_priority_if_absent(const int32_t slot,
                                                                                   const std::string& source) {
-    if (!ControllerComponentVariables::NetworkConfigurationPriority.variable.has_value()) {
-        return;
-    }
-
-    const auto priority_str =
-        this->device_model.get_optional_value<std::string>(ControllerComponentVariables::NetworkConfigurationPriority);
+    const auto priority_str = this->configuration.get_network_configuration_priority();
     const auto slot_str = std::to_string(slot);
     bool slot_found = false;
-    if (priority_str.has_value()) {
-        for (const auto& s : ocpp::split_string(priority_str.value(), ',')) {
-            if (s == slot_str) {
-                slot_found = true;
-                break;
-            }
+    for (const auto& s : ocpp::split_string(priority_str, ',')) {
+        if (s == slot_str) {
+            slot_found = true;
+            break;
         }
     }
     if (!slot_found) {
-        std::string new_priority = priority_str.value_or("");
+        std::string new_priority = priority_str;
         if (!new_priority.empty()) {
             new_priority += ',';
         }
         new_priority += slot_str;
-        this->device_model.set_value(ControllerComponentVariables::NetworkConfigurationPriority.component,
-                                     ControllerComponentVariables::NetworkConfigurationPriority.variable.value(),
-                                     AttributeEnum::Actual, new_priority, source);
+        this->configuration.set_network_configuration_priority(new_priority, source);
     }
 }
 
@@ -643,9 +535,7 @@ void ConnectivityManager::cache_network_connection_profiles() {
     state->slots.clear();
 
     // Build profiles and priority-ordered slot list from NetworkConfiguration DM components
-    for (const std::string& str : ocpp::split_string(
-             this->device_model.get_value<std::string>(ControllerComponentVariables::NetworkConfigurationPriority),
-             ',')) {
+    for (const std::string& str : ocpp::split_string(this->configuration.get_network_configuration_priority(), ',')) {
         int slot = 0;
         try {
             slot = std::stoi(str);
@@ -654,8 +544,7 @@ void ConnectivityManager::cache_network_connection_profiles() {
             continue;
         }
         state->slots.push_back(slot);
-        if (const auto profile =
-                NetworkConfigurationComponentVariables::read_profile_from_device_model(this->device_model, slot)) {
+        if (const auto profile = this->configuration.read_network_connection_profile(slot)) {
             SetNetworkProfileRequest req;
             req.configurationSlot = slot;
             req.connectionData = *profile;
@@ -677,8 +566,7 @@ void ConnectivityManager::warn_if_all_security_level_zero_locked(const NetworkPr
     if (state.cached_profiles.empty()) {
         return;
     }
-    if (this->device_model.get_optional_value<bool>(ControllerComponentVariables::AllowSecurityLevelZeroConnections)
-            .value_or(false)) {
+    if (this->configuration.get_allow_security_level_zero_connections()) {
         return;
     }
     if (std::none_of(state.cached_profiles.begin(), state.cached_profiles.end(),
@@ -703,8 +591,7 @@ bool ConnectivityManager::set_network_profile(const int32_t slot, const NetworkC
     // B09.FR.18: each slot's per-slot Identity / BasicAuthPassword is independent. Do not inherit
     // from the currently-active slot — when the incoming profile omits a per-slot value, reads on
     // the new slot fall back to SecurityCtrlr globals per B09.FR.16.
-    if (!NetworkConfigurationComponentVariables::write_profile_to_device_model(this->device_model, slot, profile,
-                                                                               source)) {
+    if (!this->configuration.write_network_connection_profile(slot, profile, source)) {
         return false;
     }
 
@@ -719,7 +606,7 @@ bool ConnectivityManager::set_network_profile(const int32_t slot, const NetworkC
 }
 
 void ConnectivityManager::check_cache_for_invalid_security_profiles() {
-    const auto security_level = this->device_model.get_value<int>(ControllerComponentVariables::SecurityProfile);
+    const auto security_level = this->configuration.get_security_profile();
 
     // Single critical section over read-modify-write of state->slots and state->pending_configuration_slot.
     // Splitting the lock between the prune step and the pending-slot reassignment can let another writer
@@ -786,7 +673,7 @@ void ConnectivityManager::check_cache_for_invalid_security_profiles() {
 }
 
 void ConnectivityManager::remove_network_connection_profiles_below_actual_security_profile() {
-    const auto security_level = this->device_model.get_value<int>(ControllerComponentVariables::SecurityProfile);
+    const auto security_level = this->configuration.get_security_profile();
 
     std::vector<int32_t> pruned_slots;
     {
@@ -825,15 +712,10 @@ void ConnectivityManager::remove_network_connection_profiles_below_actual_securi
     // Clear per-slot DM variables to prevent re-injection via SetVariables; done outside the state
     // lock because DeviceModel has its own synchronization.
     for (const int32_t slot : pruned_slots) {
-        NetworkConfigurationComponentVariables::clear_slot_in_device_model(this->device_model, slot);
+        this->configuration.clear_network_connection_profile(slot);
     }
 
     // Rebuild and persist NetworkConfigurationPriority from remaining slots
-    if (!ControllerComponentVariables::NetworkConfigurationPriority.variable.has_value()) {
-        EVLOG_warning << "NetworkConfigurationPriority variable is not set, cannot update network priority";
-        return;
-    }
-
     std::string new_priority;
     {
         auto state = this->m_state.handle();
@@ -845,9 +727,7 @@ void ConnectivityManager::remove_network_connection_profiles_below_actual_securi
         }
     }
 
-    this->device_model.set_value(ControllerComponentVariables::NetworkConfigurationPriority.component,
-                                 ControllerComponentVariables::NetworkConfigurationPriority.variable.value(),
-                                 AttributeEnum::Actual, new_priority, VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
+    this->configuration.set_network_configuration_priority(new_priority, VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
 }
 
 } // namespace ocpp

--- a/lib/everest/ocpp/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/everest/ocpp/lib/ocpp/common/websocket/websocket_base.cpp
@@ -183,7 +183,7 @@ void WebsocketBase::set_websocket_ping_interval(std::int32_t ping_interval_s, st
                     pong_elapsed_s += PING_TIMER_INTERVAL;
 
                     // We have waited more than we should for the pong response
-                    if (pong_elapsed_s > this->connection_options.pong_timeout_s) {
+                    if (pong_elapsed_s >= this->connection_options.pong_timeout_s) {
                         on_pong_timeout("Pong not received from server!");
 
                         // Always clear ping value on a fail
@@ -200,7 +200,7 @@ void WebsocketBase::set_websocket_ping_interval(std::int32_t ping_interval_s, st
                 } else { // We need to see if we have to send the ping
                     ping_elapsed_s += PING_TIMER_INTERVAL;
 
-                    if (ping_elapsed_s > this->connection_options.ping_interval_s) {
+                    if (ping_elapsed_s >= this->connection_options.ping_interval_s) {
                         // Set the ping flag before sending it out
                         ping_cleared.store(false);
                         this->ping();

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
@@ -19,6 +19,17 @@ ChargePoint::ChargePoint(
                                           evse_security, security_configuration, message_callback);
 }
 
+ChargePoint::ChargePoint(
+    ChargePointConfigurationInterface& cfg, const fs::path& share_path, const fs::path& database_path,
+    const fs::path& sql_init_path, const fs::path& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+    std::shared_ptr<ocpp::ConnectivityManagerInterface> connectivity_manager,
+    const std::optional<SecurityConfiguration> security_configuration,
+    const std::function<void(const std::string& message, MessageDirection direction)>& message_callback) {
+    this->charge_point = std::make_unique<ChargePointImpl>(cfg, share_path, database_path, sql_init_path,
+                                                           message_log_path, evse_security, connectivity_manager,
+                                                           security_configuration, message_callback);
+}
+
 ChargePoint::~ChargePoint() = default;
 
 void ChargePoint::update_chargepoint_information(const std::string& vendor, const std::string& model,
@@ -63,6 +74,21 @@ void ChargePoint::connect_websocket() {
 
 void ChargePoint::disconnect_websocket() {
     this->charge_point->disconnect_websocket();
+}
+
+void ChargePoint::on_websocket_connected(const int configuration_slot,
+                                         const ocpp::v2::NetworkConnectionProfile& network_connection_profile,
+                                         const ocpp::OcppProtocolVersion ocpp_version) {
+    this->charge_point->on_websocket_connected(configuration_slot, network_connection_profile, ocpp_version);
+}
+
+void ChargePoint::on_websocket_disconnected(const int configuration_slot,
+                                            const ocpp::v2::NetworkConnectionProfile& network_connection_profile) {
+    this->charge_point->on_websocket_disconnected(configuration_slot, network_connection_profile);
+}
+
+void ChargePoint::on_websocket_connection_failed(ocpp::ConnectionFailedReason reason) {
+    this->charge_point->on_websocket_connection_failed(reason);
 }
 
 void ChargePoint::call_set_connection_timeout() {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -11,6 +11,7 @@
 
 #include <ocpp/common/schemas.hpp>
 #include <ocpp/common/utils.hpp>
+#include <ocpp/common/websocket/websocket_uri.hpp>
 #include <ocpp/v16/charge_point_configuration.hpp>
 #include <ocpp/v16/types.hpp>
 #include <ocpp/v16/utils.hpp>
@@ -453,6 +454,34 @@ void ChargePointConfiguration::setSupplyVoltage(std::int32_t supply_voltage) {
     if (this->getSupplyVoltage().has_value()) {
         this->config["Internal"]["SupplyVoltage"] = supply_voltage;
         this->setInUserConfig("Internal", "SupplyVoltage", supply_voltage);
+    }
+}
+
+std::optional<std::int32_t> ChargePointConfiguration::getSwitchSecurityProfileConnectionTimeout() {
+    if (this->config["Internal"].contains("SwitchSecurityProfileConnectionTimeout")) {
+        return this->config["Internal"]["SwitchSecurityProfileConnectionTimeout"];
+    }
+    return std::nullopt;
+}
+
+std::optional<KeyValue> ChargePointConfiguration::getSwitchSecurityProfileConnectionTimeoutKeyValue() {
+    const auto opt_value = this->getSwitchSecurityProfileConnectionTimeout();
+    if (opt_value.has_value()) {
+        KeyValue kv;
+        kv.key = "SwitchSecurityProfileConnectionTimeout";
+        kv.readonly = false;
+        kv.value = std::to_string(opt_value.value());
+        return kv;
+    }
+    return std::nullopt;
+}
+
+void ChargePointConfiguration::setSwitchSecurityProfileConnectionTimeout(
+    std::int32_t switch_security_profile_connection_timeout) {
+    if (this->getSwitchSecurityProfileConnectionTimeout().has_value()) {
+        this->config["Internal"]["SwitchSecurityProfileConnectionTimeout"] = switch_security_profile_connection_timeout;
+        this->setInUserConfig("Internal", "SwitchSecurityProfileConnectionTimeout",
+                              switch_security_profile_connection_timeout);
     }
 }
 
@@ -3213,6 +3242,9 @@ std::optional<KeyValue> ChargePointConfiguration::get(const CiString<50>& key) {
     if (key == "SupplyVoltage") {
         return this->getSupplyVoltageKeyValue();
     }
+    if (key == "SwitchSecurityProfileConnectionTimeout") {
+        return this->getSwitchSecurityProfileConnectionTimeoutKeyValue();
+    }
     if (key == "WebsocketPingPayload") {
         return this->getWebsocketPingPayloadKeyValue();
     }
@@ -3989,6 +4021,22 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
                 return ConfigurationStatus::Rejected;
             }
             this->setSupplyVoltage(_value);
+        } catch (const std::invalid_argument& e) {
+            return ConfigurationStatus::Rejected;
+        } catch (const std::out_of_range& e) {
+            return ConfigurationStatus::Rejected;
+        }
+    } else if (key == "SwitchSecurityProfileConnectionTimeout") {
+        if (not this->getSwitchSecurityProfileConnectionTimeout().has_value()) {
+            return ConfigurationStatus::NotSupported;
+        }
+        try {
+            const auto [valid, _value] = is_positive_integer(value.get());
+            // The schema declares minimum 1
+            if (not valid or _value < 1) {
+                return ConfigurationStatus::Rejected;
+            }
+            this->setSwitchSecurityProfileConnectionTimeout(_value);
         } catch (const std::invalid_argument& e) {
             return ConfigurationStatus::Rejected;
         } catch (const std::out_of_range& e) {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_connectivity.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_connectivity.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <everest/logging.hpp>
+#include <ocpp/common/websocket/websocket_uri.hpp>
+#include <ocpp/v16/charge_point_configuration_connectivity.hpp>
+#include <ocpp/v2/device_model_interface.hpp>
+#include <ocpp/v2/ocpp_enums.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+#include <chrono>
+#include <exception>
+
+namespace ocpp::v16 {
+
+std::string ChargePointConfigurationConnectivity::get_network_configuration_priority() {
+    return "1";
+}
+
+void ChargePointConfigurationConnectivity::set_network_configuration_priority(const std::string& priority,
+                                                                              const std::string& /*source*/) {
+    EVLOG_warning << "OCPP 1.6 does not support multiple network connection profiles, ignoring priority " << priority;
+}
+
+std::optional<ocpp::v2::NetworkConnectionProfile>
+ChargePointConfigurationConnectivity::read_network_connection_profile(int32_t slot) {
+    if (slot != 1) {
+        return std::nullopt;
+    }
+    ocpp::v2::NetworkConnectionProfile profile;
+    profile.ocppCsmsUrl = getCentralSystemURI();
+    profile.securityProfile = getSecurityProfile();
+    profile.ocppInterface = ocpp::v2::OCPPInterfaceEnum::Any; // not used for OCPP1.6
+    profile.ocppTransport = ocpp::v2::OCPPTransportEnum::JSON;
+    profile.messageTimeout = 10;
+    profile.identity = getChargePointId();
+    profile.basicAuthPassword = getAuthorizationKey();
+    return profile;
+}
+
+bool ChargePointConfigurationConnectivity::write_network_connection_profile(
+    int32_t slot, const ocpp::v2::NetworkConnectionProfile& /* profile */, const std::string& /*source*/) {
+    EVLOG_warning << "OCPP 1.6 does not support multiple network connection profiles, ignoring write to slot " << slot;
+    return true;
+}
+
+void ChargePointConfigurationConnectivity::clear_network_connection_profile(int32_t /*slot*/) {
+    EVLOG_warning << "OCPP 1.6 does not support multiple network connection profiles, ignoring clear request";
+}
+
+bool ChargePointConfigurationConnectivity::get_allow_security_level_zero_connections() {
+    return true; // v1.6 explicitly allows security profile 0
+}
+
+int32_t ChargePointConfigurationConnectivity::get_security_profile() {
+    return getSecurityProfile();
+}
+
+std::optional<int32_t> ChargePointConfigurationConnectivity::get_network_config_timeout() {
+    return std::nullopt; // ConnectivityManager will apply its built-in 60 s default
+}
+
+std::optional<WebsocketConnectionOptions>
+ChargePointConfigurationConnectivity::get_websocket_connection_options(int32_t /*slot*/) {
+    try {
+        const auto charge_point_id = getChargePointId();
+        if (charge_point_id.find(':') != std::string::npos) {
+            // Returning std::nullopt lets the caller fall back to another profile instead.
+            EVLOG_error << "ChargePointId must not contain ':'";
+            return std::nullopt;
+        }
+        const auto security_profile = getSecurityProfile();
+        auto uri = Uri::parse_and_validate(getCentralSystemURI(), charge_point_id, security_profile);
+
+        WebsocketConnectionOptions opts{{OcppProtocolVersion::v16},
+                                        uri,
+                                        security_profile,
+                                        getAuthorizationKey(),
+                                        std::chrono::seconds(10),
+                                        getRetryBackoffRandomRange(),
+                                        getRetryBackoffRepeatTimes(),
+                                        getRetryBackoffWaitMinimum(),
+                                        -1, // unlimited connection attempts
+                                        getSupportedCiphers12(),
+                                        getSupportedCiphers13(),
+                                        getWebsocketPingInterval().value_or(0),
+                                        getWebsocketPingPayload(),
+                                        getWebsocketPongTimeout(),
+                                        getUseSslDefaultVerifyPaths(),
+                                        getAdditionalRootCertificateCheck().value_or(false),
+                                        getHostName(),
+                                        getVerifyCsmsCommonName(),
+                                        getUseTPM(),
+                                        getVerifyCsmsAllowWildcards(),
+                                        getIFace(),
+                                        getEnableTLSKeylog(),
+                                        getTLSKeylogFile()};
+        return opts;
+    } catch (const ocpp::v2::DeviceModelError& e) {
+        EVLOG_error << "Could not configure v1.6 connection options, device model error: " << e.what();
+        return std::nullopt;
+    } catch (const std::invalid_argument& e) {
+        EVLOG_error << "Could not configure v1.6 connection options: " << e.what();
+        return std::nullopt;
+    }
+}
+
+void ChargePointConfigurationConnectivity::set_active_security_profile(int32_t security_profile,
+                                                                       const std::string& /*source*/) {
+    setSecurityProfile(security_profile);
+}
+
+void ChargePointConfigurationConnectivity::set_active_network_profile_slot(int32_t slot,
+                                                                           const std::string& /*source*/) {
+    EVLOG_warning << "OCPP 1.6 does not support multiple network connection profiles, ignoring set active slot "
+                  << slot;
+}
+
+void ChargePointConfigurationConnectivity::set_per_slot_ocpp_version(int32_t /*slot*/, const std::string& /*version*/,
+                                                                     const std::string& /*source*/) {
+    EVLOG_warning
+        << "OCPP 1.6 does not support multiple network connection profiles, ignoring set OCPP version for slot";
+}
+
+void ChargePointConfigurationConnectivity::set_security_ctrl_security_profile(int32_t security_profile,
+                                                                              const std::string& /*source*/) {
+    setSecurityProfile(security_profile);
+}
+
+void ChargePointConfigurationConnectivity::set_security_ctrl_identity(const std::string& /*identity*/,
+                                                                      const std::string& /*source*/) {
+    EVLOG_warning << "OCPP 1.6 does not support setting identity, ignoring";
+}
+
+} // namespace ocpp::v16

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration_devicemodel.cpp
@@ -4,6 +4,7 @@
 #include <everest/logging.hpp>
 #include <ocpp/common/cistring.hpp>
 #include <ocpp/common/utils.hpp>
+#include <ocpp/common/websocket/websocket_uri.hpp>
 #include <ocpp/v16/charge_point_configuration_devicemodel.hpp>
 #include <ocpp/v16/known_keys.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
@@ -685,6 +686,17 @@ ChargePointConfigurationDeviceModel::setInternalStopTransactionIfUnlockNotSuppor
 ChargePointConfigurationDeviceModel::SetResult
 ChargePointConfigurationDeviceModel::setInternalSupplyVoltage(const std::string& value) {
     return set_value_check(isPositiveInteger, *storage, keys::valid_keys::SupplyVoltage, value);
+}
+
+ChargePointConfigurationDeviceModel::SetResult
+ChargePointConfigurationDeviceModel::setInternalSwitchSecurityProfileConnectionTimeout(const std::string& value) {
+    if (not getSwitchSecurityProfileConnectionTimeout().has_value()) {
+        return SetResult::UnknownVariable;
+    }
+    if (not isPositiveInteger(value) or std::stoi(value) < 1) {
+        return SetResult::Rejected;
+    }
+    return set_value_check(*storage, keys::valid_keys::SwitchSecurityProfileConnectionTimeout, value);
 }
 
 ChargePointConfigurationDeviceModel::SetResult
@@ -1801,6 +1813,10 @@ std::optional<int32_t> ChargePointConfigurationDeviceModel::getSupplyVoltage() {
     return get_optional<std::int32_t>(*storage, keys::valid_keys::SupplyVoltage);
 }
 
+std::optional<std::int32_t> ChargePointConfigurationDeviceModel::getSwitchSecurityProfileConnectionTimeout() {
+    return get_optional<std::int32_t>(*storage, keys::valid_keys::SwitchSecurityProfileConnectionTimeout);
+}
+
 std::optional<KeyValue> ChargePointConfigurationDeviceModel::getPublicKeyKeyValue(const std::uint32_t connector_id) {
     std::optional<KeyValue> result;
     const auto max = getNumberOfConnectors();
@@ -2081,6 +2097,10 @@ std::optional<KeyValue> ChargePointConfigurationDeviceModel::getSupplyVoltageKey
     return get_key_value_optional(*storage, keys::valid_keys::SupplyVoltage);
 }
 
+std::optional<KeyValue> ChargePointConfigurationDeviceModel::getSwitchSecurityProfileConnectionTimeoutKeyValue() {
+    return get_key_value_optional(*storage, keys::valid_keys::SwitchSecurityProfileConnectionTimeout);
+}
+
 void ChargePointConfigurationDeviceModel::setAllowChargingProfileWithoutStartSchedule(bool allow) {
     setInternalAllowChargingProfileWithoutStartSchedule(to_string(allow));
 }
@@ -2165,6 +2185,11 @@ void ChargePointConfigurationDeviceModel::setStopTransactionIfUnlockNotSupported
 
 void ChargePointConfigurationDeviceModel::setSupplyVoltage(std::int32_t supply_voltage) {
     setInternalSupplyVoltage(std::to_string(supply_voltage));
+}
+
+void ChargePointConfigurationDeviceModel::setSwitchSecurityProfileConnectionTimeout(
+    std::int32_t switch_security_profile_connection_timeout) {
+    setInternalSwitchSecurityProfileConnectionTimeout(std::to_string(switch_security_profile_connection_timeout));
 }
 
 void ChargePointConfigurationDeviceModel::setVerifyCsmsAllowWildcards(bool verify_csms_allow_wildcards) {
@@ -3306,6 +3331,9 @@ std::optional<ConfigurationStatus> ChargePointConfigurationDeviceModel::set(cons
             break;
         case keys::valid_keys::SupplyVoltage:
             result = convert(setInternalSupplyVoltage(value_str));
+            break;
+        case keys::valid_keys::SwitchSecurityProfileConnectionTimeout:
+            result = convert(setInternalSwitchSecurityProfileConnectionTimeout(value_str));
             break;
         case keys::valid_keys::VerifyCsmsAllowWildcards:
             result = convert(setInternalVerifyCsmsAllowWildcards(value_str));

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -31,7 +31,6 @@ const auto CLIENT_CERTIFICATE_TIMER_INTERVAL = std::chrono::hours(12);
 const auto V2G_CERTIFICATE_TIMER_INTERVAL = std::chrono::hours(12);
 const auto OCSP_REQUEST_TIMER_INTERVAL = std::chrono::hours(12);
 const auto INITIAL_CERTIFICATE_REQUESTS_DELAY = std::chrono::seconds(60);
-const auto WEBSOCKET_INIT_DELAY = std::chrono::seconds(2);
 const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 1000;
 const auto DEFAULT_BOOT_NOTIFICATION_INTERVAL_S = 60; // fallback interval if BootNotification returns interval of 0.
 const auto DEFAULT_PRICE_NUMBER_OF_DECIMALS = 3;
@@ -42,11 +41,21 @@ ChargePointImpl::ChargePointImpl(
     const fs::path& sql_init_path, const fs::path& message_log_path, const std::shared_ptr<EvseSecurity>& evse_security,
     const std::optional<SecurityConfiguration>& security_configuration,
     const std::function<void(const std::string& message, MessageDirection direction)>& message_callback) :
+    ChargePointImpl(cfg, share_path, database_path, sql_init_path, message_log_path, evse_security, nullptr,
+                    security_configuration, message_callback) {
+}
+
+ChargePointImpl::ChargePointImpl(
+    ChargePointConfigurationInterface& cfg, const fs::path& share_path, const fs::path& database_path,
+    const fs::path& sql_init_path, const fs::path& message_log_path, const std::shared_ptr<EvseSecurity>& evse_security,
+    std::shared_ptr<ocpp::ConnectivityManagerInterface> connectivity_manager,
+    const std::optional<SecurityConfiguration>& security_configuration,
+    const std::function<void(const std::string& message, MessageDirection direction)>& message_callback) :
     ocpp::ChargingStationBase(evse_security, security_configuration),
     configuration(cfg),
     message_log_path(message_log_path.string()), // .string() for compatibility with boost::filesystem
     share_path(share_path),
-    switch_security_profile_callback(nullptr) {
+    connectivity_manager(connectivity_manager) {
     this->heartbeat_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() { this->heartbeat(); });
     this->heartbeat_interval = this->configuration.getHeartbeatInterval();
     auto database_connection = std::make_unique<everest::db::sqlite::Connection>(
@@ -236,6 +245,13 @@ ChargePointImpl::ChargePointImpl(
             set_time_offset_timer(time_offset_transition_date_time.value());
         }
     }
+
+    if (this->connectivity_manager == nullptr) {
+        this->connectivity_manager =
+            std::make_shared<ocpp::ConnectivityManager>(this->configuration, this->evse_security, this->share_path);
+        this->init_connectivity_manager();
+    }
+    this->connectivity_manager->set_logging(this->logging);
 }
 
 std::unique_ptr<ocpp::MessageQueue<v16::MessageType>> ChargePointImpl::create_message_queue() {
@@ -279,7 +295,7 @@ std::unique_ptr<ocpp::MessageQueue<v16::MessageType>> ChargePointImpl::create_me
     }
 
     return std::make_unique<ocpp::MessageQueue<v16::MessageType>>(
-        [this](json message) -> bool { return this->websocket->send(message.dump()); },
+        [this](json message) -> bool { return this->connectivity_manager->send_to_websocket(message.dump()); },
         MessageQueueConfig<v16::MessageType>{
             this->configuration.getTransactionMessageAttempts(),
             this->configuration.getTransactionMessageRetryInterval(),
@@ -288,84 +304,81 @@ std::unique_ptr<ocpp::MessageQueue<v16::MessageType>> ChargePointImpl::create_me
         this->external_notify, this->database_handler, start_transaction_message_retry_callback);
 }
 
-void ChargePointImpl::init_websocket() {
+void ChargePointImpl::on_websocket_connected(const int /*configuration_slot*/,
+                                             const ocpp::v2::NetworkConnectionProfile& /*network_connection_profile*/,
+                                             const ocpp::OcppProtocolVersion /*ocpp_version*/) {
+    if (this->connection_state_changed_callback != nullptr) {
+        this->connection_state_changed_callback(true);
+    }
+    this->publish_default_price(false);
+    this->message_queue->resume(this->message_queue_resume_delay);
+    this->connected_callback();
 
-    auto connection_options = this->get_ws_connection_options();
+    // There has been a successful connection so a subsequent
+    // InvalidCSMSCertificate should be logged
+    InvalidCSMSCertificate_logged = false;
 
-    this->websocket = std::make_unique<Websocket>(connection_options, this->evse_security, this->logging);
-    this->websocket->register_connected_callback([this](OcppProtocolVersion /*protocol*/) {
-        if (this->connection_state_changed_callback != nullptr) {
-            this->connection_state_changed_callback(true);
-        }
-        this->publish_default_price(false);
-        this->message_queue->resume(this->message_queue_resume_delay);
-        this->connected_callback();
+    // signal_set_charging_profiles_callback since composite schedule could have changed if
+    // IgnoredProfilePurposesOffline are configured when becoming online
+    if (this->signal_set_charging_profiles_callback != nullptr and
+        not this->configuration.getIgnoredProfilePurposesOffline().empty()) {
+        this->signal_set_charging_profiles_callback();
+    }
+}
 
-        // There has been a successful connection so a subsequent
-        // InvalidCSMSCertificate should be logged
-        InvalidCSMSCertificate_logged = false;
+void ChargePointImpl::on_websocket_disconnected(
+    const int /*configuration_slot*/, const ocpp::v2::NetworkConnectionProfile& /*network_connection_profile*/) {
+    if (this->connection_state_changed_callback != nullptr) {
+        this->connection_state_changed_callback(false);
+    }
+    this->publish_default_price(true);
+    this->message_queue->pause();
+    if (this->ocsp_request_timer != nullptr) {
+        this->ocsp_request_timer->stop();
+    }
+    if (this->client_certificate_timer != nullptr) {
+        this->client_certificate_timer->stop();
+    }
+    if (this->v2g_certificate_timer != nullptr) {
+        this->v2g_certificate_timer->stop();
+    }
+    // signal_set_charging_profiles_callback since composite schedule could have changed if
+    // IgnoredProfilePurposesOffline are configured when becoming offline
+    if (this->signal_set_charging_profiles_callback != nullptr and
+        not this->configuration.getIgnoredProfilePurposesOffline().empty()) {
+        this->signal_set_charging_profiles_callback();
+    }
+}
 
-        // signal_set_charging_profiles_callback since composite schedule could have changed if
-        // IgnoredProfilePurposesOffline are configured when becoming online
-        if (this->signal_set_charging_profiles_callback != nullptr and
-            not this->configuration.getIgnoredProfilePurposesOffline().empty()) {
-            this->signal_set_charging_profiles_callback();
+void ChargePointImpl::on_websocket_connection_failed(ocpp::ConnectionFailedReason reason) {
+    if (reason == ocpp::ConnectionFailedReason::FailedToAuthenticateAtCsms) {
+        this->securityEventNotification(CiString<50>(ocpp::security_events::FAILEDTOAUTHENTICATEATCSMS), std::nullopt,
+                                        true);
+    }
+    if (reason == ocpp::ConnectionFailedReason::InvalidCSMSCertificate) {
+        if (InvalidCSMSCertificate_logged) {
+            EVLOG_warning << "Connection failed: InvalidCSMSCertificate";
+        } else {
+            // This event is forced to accommodate TC_078_CS despite this event being not critical
+            this->securityEventNotification(CiString<50>(ocpp::security_events::INVALIDCENTRALSYSTEMCERTIFICATE),
+                                            std::nullopt, true, true);
+            InvalidCSMSCertificate_logged = true;
         }
-        // Reupdate ws connection options once connected so that after upgrading security profile we use the real config
-        // values. Prior we would continue using only 1 connection attempt
-        auto connection_options = this->get_ws_connection_options();
-        this->websocket->set_connection_options(connection_options);
-    });
-    this->websocket->register_disconnected_callback([this]() {
-        if (this->connection_state_changed_callback != nullptr) {
-            this->connection_state_changed_callback(false);
-        }
-        this->publish_default_price(true);
-        this->message_queue->pause();
-        if (this->ocsp_request_timer != nullptr) {
-            this->ocsp_request_timer->stop();
-        }
-        if (this->client_certificate_timer != nullptr) {
-            this->client_certificate_timer->stop();
-        }
-        if (this->v2g_certificate_timer != nullptr) {
-            this->v2g_certificate_timer->stop();
-        }
-        // signal_set_charging_profiles_callback since composite schedule could have changed if
-        // IgnoredProfilePurposesOffline are configured when becoming offline
-        if (this->signal_set_charging_profiles_callback != nullptr and
-            not this->configuration.getIgnoredProfilePurposesOffline().empty()) {
-            this->signal_set_charging_profiles_callback();
-        }
-    });
-    this->websocket->register_stopped_connecting_callback([this](const WebsocketCloseReason /*reason*/) {
-        if (this->switch_security_profile_callback != nullptr) {
-            this->switch_security_profile_callback();
-            return;
-        }
-        if (this->wants_to_be_connected) {
-            EVLOG_warning << "Websocket stopped connecting but wants to be connected. Attempting to reconnect.";
-            this->websocket->start_connecting();
-        }
-    });
-    this->websocket->register_connection_failed_callback([this](const ocpp::ConnectionFailedReason reason) {
-        if (reason == ocpp::ConnectionFailedReason::FailedToAuthenticateAtCsms) {
-            this->securityEventNotification(CiString<50>(ocpp::security_events::FAILEDTOAUTHENTICATEATCSMS),
-                                            std::nullopt, true);
-        }
-        if (reason == ocpp::ConnectionFailedReason::InvalidCSMSCertificate) {
-            if (InvalidCSMSCertificate_logged) {
-                EVLOG_warning << "Connection failed: InvalidCSMSCertificate";
-            } else {
-                // This event is forced to accommodate TC_078_CS despite this event being not critical
-                this->securityEventNotification(CiString<50>(ocpp::security_events::INVALIDCENTRALSYSTEMCERTIFICATE),
-                                                std::nullopt, true, true);
-                InvalidCSMSCertificate_logged = true;
-            }
-        }
-    });
+    }
+}
 
-    this->websocket->register_message_callback([this](const std::string& message) { this->message_callback(message); });
+void ChargePointImpl::init_connectivity_manager() {
+    this->connectivity_manager->set_websocket_connected_callback(
+        [this](int configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile,
+               ocpp::OcppProtocolVersion version) {
+            this->on_websocket_connected(configuration_slot, network_connection_profile, version);
+        });
+    this->connectivity_manager->set_websocket_disconnected_callback(
+        [this](int configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile, auto) {
+            this->on_websocket_disconnected(configuration_slot, network_connection_profile);
+        });
+    this->connectivity_manager->set_websocket_connection_failed_callback(
+        [this](ocpp::ConnectionFailedReason reason) { this->on_websocket_connection_failed(reason); });
 }
 
 void ChargePointImpl::init_state_machine(const std::map<int, ChargePointStatus>& connector_status_map) {
@@ -401,62 +414,15 @@ void ChargePointImpl::init_state_machine(const std::map<int, ChargePointStatus>&
     }
 }
 
-WebsocketConnectionOptions ChargePointImpl::get_ws_connection_options() {
-    auto security_profile = this->configuration.getSecurityProfile();
-    auto uri = Uri::parse_and_validate(this->configuration.getCentralSystemURI(),
-                                       this->configuration.getChargePointId(), security_profile);
-
-    WebsocketConnectionOptions connection_options{{OcppProtocolVersion::v16},
-                                                  uri,
-                                                  security_profile,
-                                                  this->configuration.getAuthorizationKey(),
-                                                  std::chrono::seconds(10),
-                                                  this->configuration.getRetryBackoffRandomRange(),
-                                                  this->configuration.getRetryBackoffRepeatTimes(),
-                                                  this->configuration.getRetryBackoffWaitMinimum(),
-                                                  -1,
-                                                  this->configuration.getSupportedCiphers12(),
-                                                  this->configuration.getSupportedCiphers13(),
-                                                  this->configuration.getWebsocketPingInterval().value_or(0),
-                                                  this->configuration.getWebsocketPingPayload(),
-                                                  this->configuration.getWebsocketPongTimeout(),
-                                                  this->configuration.getUseSslDefaultVerifyPaths(),
-                                                  this->configuration.getAdditionalRootCertificateCheck(),
-                                                  this->configuration.getHostName(),
-                                                  this->configuration.getVerifyCsmsCommonName(),
-                                                  this->configuration.getUseTPM(),
-                                                  this->configuration.getVerifyCsmsAllowWildcards(),
-                                                  this->configuration.getIFace(),
-                                                  this->configuration.getEnableTLSKeylog(),
-                                                  this->configuration.getTLSKeylogFile()};
-
-    // Read version file and add to connection_options
-    fs::path version_file_path = this->share_path.parent_path().parent_path() / "version_information.txt";
-    if (fs::exists(version_file_path)) {
-        std::ifstream ifs(version_file_path);
-        std::string version;
-        std::getline(ifs, version);                               // only get one line to avoid issues
-        std::string trimmed_version = ocpp::trim_string(version); // remove leading/trailing whitespace
-        trimmed_version.erase(std::remove(trimmed_version.begin(), trimmed_version.end(), '\n'),
-                              trimmed_version.end()); // remove unnecessary newline characters
-        if (!trimmed_version.empty()) {
-            connection_options.everest_version = trimmed_version;
-        }
-    }
-    return connection_options;
-}
-
 void ChargePointImpl::connect_websocket() {
-    if (!this->websocket->is_connected()) {
-        this->wants_to_be_connected = true;
-        this->websocket->start_connecting();
+    if (!this->connectivity_manager->is_websocket_connected()) {
+        this->connectivity_manager->connect();
     }
 }
 
 void ChargePointImpl::disconnect_websocket() {
-    if (this->websocket->is_connected()) {
-        this->wants_to_be_connected = false;
-        this->websocket->disconnect(WebsocketCloseReason::Normal);
+    if (this->connectivity_manager->is_websocket_connected()) {
+        this->connectivity_manager->disconnect();
     }
 }
 
@@ -1178,12 +1144,12 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     if (!this->initialized) {
         init(connector_status_map, resuming_session_ids);
     }
-    this->wants_to_be_connected = true;
     this->bootreason = bootreason;
     // Publish the initial default price before connecting (offline state at startup).
     this->publish_default_price(true);
-    this->init_websocket();
-    this->websocket->start_connecting();
+    this->connectivity_manager->set_message_callback(
+        [this](const std::string& message) { this->message_callback(message); });
+    this->connectivity_manager->connect();
     this->boot_notification();
     this->call_set_connection_timeout();
 
@@ -1286,7 +1252,6 @@ void ChargePointImpl::stop_all_transactions(Reason reason) {
 bool ChargePointImpl::stop() {
     if (!this->stopped) {
         EVLOG_info << "Stopping OCPP Chargepoint";
-        this->wants_to_be_connected = false;
         if (this->boot_notification_timer != nullptr) {
             this->boot_notification_timer->stop();
         }
@@ -1315,12 +1280,12 @@ bool ChargePointImpl::stop() {
             }
         }
 
-        this->websocket_timer.stop();
+        this->security_profile_revert_timer.stop();
 
         this->stop_all_transactions();
 
         this->database_handler->close_connection();
-        this->websocket->disconnect(WebsocketCloseReason::Normal);
+        this->connectivity_manager->disconnect();
         this->message_queue->stop();
 
         this->stopped = true;
@@ -1335,7 +1300,10 @@ bool ChargePointImpl::stop() {
 }
 
 void ChargePointImpl::connected_callback() {
-    this->switch_security_profile_callback = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(this->security_profile_switch_mutex);
+        this->security_profile_revert_timer.stop();
+    }
     switch (this->connection_state) {
     case ChargePointConnectionState::Disconnected: {
         this->connection_state = ChargePointConnectionState::Connected;
@@ -1900,7 +1868,6 @@ ChargePointImpl::set_configuration_key_internal(CiString<50> key, CiString<500> 
                     update_clock_aligned_meter_values_interval();
                 } else if (key == "AuthorizationKey") {
                     EVLOG_info << "AuthorizationKey was changed by central system";
-                    websocket->set_authorization_key(configuration.getAuthorizationKey().value());
                     if (configuration.getSecurityProfile() == 0) {
                         EVLOG_info << "AuthorizationKey was changed while on security profile 0.";
                     } else if (configuration.getSecurityProfile() == 1 || configuration.getSecurityProfile() == 2) {
@@ -1913,7 +1880,8 @@ ChargePointImpl::set_configuration_key_internal(CiString<50> key, CiString<500> 
                             message_dispatcher->dispatch_call_result(call_result);
                         }
                         response.reset(); // response has been sent
-                        websocket->reconnect(1000);
+                        this->connectivity_manager->set_websocket_authorization_key(
+                            this->configuration.getAuthorizationKey().value());
                     } else {
                         EVLOG_info << "AuthorizationKey was changed while on security profile 3. Nothing to do.";
                     }
@@ -1952,12 +1920,8 @@ ChargePointImpl::set_configuration_key_internal(CiString<50> key, CiString<500> 
                                 message_dispatcher->dispatch_call_result(call_result);
                             }
                             response.reset(); // response has been sent
-                            const std::int32_t security_profile = std::stoi(value);
-                            switch_security_profile_callback = [this, security_profile]() {
-                                switchSecurityProfile(security_profile, 1);
-                            };
-                            // disconnected_callback will trigger security_profile_callback when it is set
-                            websocket->disconnect(WebsocketCloseReason::Normal);
+                            const std::int32_t old_security_profile = current_security_profile;
+                            this->switchSecurityProfile(security_profile, old_security_profile);
                         }
                     } catch (const std::invalid_argument& e) {
                         result = ConfigurationStatus::Rejected;
@@ -1970,13 +1934,11 @@ ChargePointImpl::set_configuration_key_internal(CiString<50> key, CiString<500> 
                     message_queue->update_transaction_message_retry_interval(
                         configuration.getTransactionMessageRetryInterval());
                 } else if (key == "WebSocketPingInterval") {
-                    auto websocket_ping_interval_option = configuration.getWebsocketPingInterval();
-
+                    const auto websocket_ping_interval_option = configuration.getWebsocketPingInterval();
                     if (websocket_ping_interval_option.has_value()) {
-                        auto websocket_ping_interval = websocket_ping_interval_option.value();
-                        auto websocket_pong_timeout = configuration.getWebsocketPongTimeout();
-
-                        websocket->set_websocket_ping_interval(websocket_ping_interval, websocket_pong_timeout);
+                        // Apply the new ping interval to the live connection directly
+                        this->connectivity_manager->set_websocket_ping_interval(
+                            websocket_ping_interval_option.value(), configuration.getWebsocketPongTimeout());
                     }
                 } else if (key == "ISO15118CertificateManagementEnabled") {
                     if (ocpp::conversions::string_to_bool(value)) {
@@ -2061,27 +2023,35 @@ void ChargePointImpl::handleChangeConfigurationRequest(ocpp::Call<ChangeConfigur
     }
 }
 
-void ChargePointImpl::switchSecurityProfile(std::int32_t new_security_profile, std::int32_t max_connection_attempts) {
+void ChargePointImpl::switchSecurityProfile(std::int32_t new_security_profile, std::int32_t fallback_security_profile) {
     EVLOG_info << "Switching security profile from " << this->configuration.getSecurityProfile() << " to "
                << new_security_profile;
-    const auto old_security_profile = this->configuration.getSecurityProfile();
     this->configuration.setSecurityProfile(new_security_profile);
+    this->connectivity_manager->reload_network_profiles();
+    this->connectivity_manager->connect();
 
-    this->switch_security_profile_callback = [this, old_security_profile]() {
-        EVLOG_warning << "Switching security profile back to fallback because new profile couldnt connect";
-        this->switchSecurityProfile(old_security_profile, -1);
-    };
+    // Use the configured SwitchSecurityProfileConnectionTimeout (seconds) when present, falling back to the
+    // SECURITY_PROFILE_SWITCH_TIMEOUT default otherwise.
+    const std::chrono::seconds revert_timeout{this->configuration.getSwitchSecurityProfileConnectionTimeout().value_or(
+        SECURITY_PROFILE_SWITCH_TIMEOUT.count())};
 
-    // we need to reinitialize because it could be plain or tls websocket
-    this->websocket_timer.timeout(
-        [this, max_connection_attempts, new_security_profile]() {
-            auto connection_options = this->get_ws_connection_options();
-            connection_options.security_profile = new_security_profile;
-            connection_options.max_connection_attempts = max_connection_attempts;
-            this->websocket->set_connection_options(connection_options);
-            this->websocket->start_connecting();
+    // Arm a revert timer: if the new security profile does not result in a successful connection within the timeout,
+    // revert to the fallback security profile. A successful connection cancels this timer via connected_callback().
+    this->security_profile_revert_timer.timeout(
+        [this, fallback_security_profile]() {
+            std::lock_guard<std::mutex> lock(this->security_profile_switch_mutex);
+            if (this->connectivity_manager->is_websocket_connected()) {
+                EVLOG_info << "Security profile switch connected within the revert timeout window; not reverting.";
+                return;
+            }
+            EVLOG_warning << "Security profile switch did not connect within timeout; reverting.";
+            this->connectivity_manager
+                ->disconnect(); // ensures that connectivity_manager does not initiate a reconnect on its own
+            this->configuration.setSecurityProfile(fallback_security_profile);
+            this->connectivity_manager->reload_network_profiles();
+            this->connectivity_manager->connect();
         },
-        WEBSOCKET_INIT_DELAY);
+        revert_timeout);
 }
 
 void ChargePointImpl::handleClearCacheRequest(ocpp::Call<ClearCacheRequest> call) {
@@ -2562,7 +2532,7 @@ void ChargePointImpl::handleGetCompositeScheduleRequest(ocpp::Call<GetCompositeS
 
     const auto connector_id = call.msg.connectorId;
     const auto allowed_charging_rate_units = this->configuration.getChargingScheduleAllowedChargingRateUnitVector();
-    const auto is_offline = this->websocket == nullptr or not this->websocket->is_connected();
+    const auto is_offline = not this->connectivity_manager->is_websocket_connected();
 
     if (connector_id > this->configuration.getNumberOfConnectors() or connector_id < 0) {
         response.status = GetCompositeScheduleStatus::Rejected;
@@ -2932,7 +2902,7 @@ void ChargePointImpl::handleCertificateSignedRequest(ocpp::Call<CertificateSigne
 
     // reconnect with new certificate if valid and security profile is 3
     if (response.status == CertificateSignedStatusEnumType::Accepted && this->configuration.getSecurityProfile() == 3) {
-        this->websocket->reconnect(1000);
+        this->connectivity_manager->on_charging_station_certificate_changed();
     }
 }
 
@@ -3533,15 +3503,13 @@ EnhancedIdTagInfo ChargePointImpl::authorize_id_token(CiString<20> id_token, con
     // - LocalPreAuthorize is true and CP is online
     // OR
     // - LocalAuthorizeOffline is true and CP is offline
-    if ((this->configuration.getLocalPreAuthorize() &&
-         (this->websocket != nullptr && this->websocket->is_connected())) ||
-        (this->configuration.getLocalAuthorizeOffline() &&
-         (this->websocket == nullptr || !this->websocket->is_connected()))) {
+    if ((this->configuration.getLocalPreAuthorize() && this->connectivity_manager->is_websocket_connected()) ||
+        (this->configuration.getLocalAuthorizeOffline() && !this->connectivity_manager->is_websocket_connected())) {
 
         const auto update_tariff_message_if_eligible = [this](EnhancedIdTagInfo& enhanced_id_tag_info) {
             if (enhanced_id_tag_info.id_tag_info.status == AuthorizationStatus::Accepted &&
                 this->configuration.getCustomDisplayCostAndPriceEnabled()) {
-                enhanced_id_tag_info.tariff_message = this->websocket->is_connected()
+                enhanced_id_tag_info.tariff_message = this->connectivity_manager->is_websocket_connected()
                                                           ? this->configuration.getDefaultTariffMessage(false)
                                                           : this->configuration.getDefaultTariffMessage(true);
             }
@@ -3658,7 +3626,7 @@ ChargePointImpl::get_all_composite_charging_schedules(const std::int32_t duratio
 
     std::map<std::int32_t, ChargingSchedule> charging_schedules;
     std::set<ChargingProfilePurposeType> purposes_to_ignore;
-    const auto is_offline = this->websocket == nullptr or not this->websocket->is_connected();
+    const auto is_offline = not this->connectivity_manager->is_websocket_connected();
 
     if (not is_offline) {
         const auto purposes_to_ignore_vec = this->configuration.getIgnoredProfilePurposesOffline();
@@ -3687,7 +3655,7 @@ ChargePointImpl::get_all_enhanced_composite_charging_schedules(const std::int32_
     std::map<std::int32_t, EnhancedChargingSchedule> charging_schedules;
     std::set<ChargingProfilePurposeType> purposes_to_ignore;
 
-    if (this->websocket == nullptr or not this->websocket->is_connected()) {
+    if (not this->connectivity_manager->is_websocket_connected()) {
         const auto purposes_to_ignore_vec = this->configuration.getIgnoredProfilePurposesOffline();
         purposes_to_ignore.insert(purposes_to_ignore_vec.begin(), purposes_to_ignore_vec.end());
     }
@@ -3745,7 +3713,7 @@ ocpp::v2::AuthorizeResponse ChargePointImpl::data_transfer_pnc_authorize(
     bool try_local_auth_list_or_cache = false;
     bool forward_to_csms = false;
 
-    if (this->websocket->is_connected() and iso15118_certificate_hash_data.has_value()) {
+    if (this->connectivity_manager->is_websocket_connected() and iso15118_certificate_hash_data.has_value()) {
         authorize_req.iso15118CertificateHashData = iso15118_certificate_hash_data;
         forward_to_csms = true;
     } else if (certificate.has_value()) {
@@ -3760,7 +3728,7 @@ ocpp::v2::AuthorizeResponse ChargePointImpl::data_transfer_pnc_authorize(
 
         // C07.FR.01: When CS is online, it shall send an AuthorizeRequest
         // C07.FR.02: The AuthorizeRequest shall at least contain the OCSP data
-        if (this->websocket->is_connected()) {
+        if (this->connectivity_manager->is_websocket_connected()) {
             if (local_verify_result == CertificateValidationResult::IssuerNotFound) {
                 // C07.FR.06: Pass contract validation to CSMS when no contract root is found
                 if (central_contract_validation_allowed) {
@@ -4272,7 +4240,7 @@ std::optional<DataTransferResponse> ChargePointImpl::data_transfer(const CiStrin
     const ocpp::Call<DataTransferRequest> call(req);
     auto data_transfer_future = this->message_dispatcher->dispatch_call_async(call);
 
-    if (this->websocket == nullptr or !this->websocket->is_connected()) {
+    if (not this->connectivity_manager->is_websocket_connected()) {
         EVLOG_warning << "Attempting to send DataTransfer.req but charging station is offline";
         return std::nullopt;
     }

--- a/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -1310,6 +1310,12 @@ const ComponentVariable WaitForStopTransactionsOnResetTimeout = {
         "WaitForStopTransactionsOnResetTimeout",
     }),
 };
+const ComponentVariable SwitchSecurityProfileConnectionTimeout = {
+    ControllerComponents::OCPP16LegacyCtrlr,
+    std::optional<Variable>({
+        "SwitchSecurityProfileConnectionTimeout",
+    }),
+};
 const ComponentVariable StopTransactionIfUnlockNotSupported = {
     ControllerComponents::OCPP16LegacyCtrlr,
     std::optional<Variable>({

--- a/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/device_model.cpp
@@ -2,7 +2,9 @@
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
 #include <everest/database/exceptions.hpp>
+#include <ocpp/common/constants.hpp>
 #include <ocpp/common/utils.hpp>
+#include <ocpp/common/websocket/websocket_uri.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/device_model_storage_sqlite.hpp>
@@ -1044,6 +1046,156 @@ std::int32_t DeviceModel::clear_custom_monitors() {
     }
 
     return 0;
+}
+
+// ConnectivityManagerConfiguration implementations
+
+std::string DeviceModel::get_network_configuration_priority() {
+    return get_optional_value<std::string>(ControllerComponentVariables::NetworkConfigurationPriority).value_or("");
+}
+
+void DeviceModel::set_network_configuration_priority(const std::string& priority, const std::string& source) {
+    if (!ControllerComponentVariables::NetworkConfigurationPriority.variable.has_value()) {
+        EVLOG_warning << "NetworkConfigurationPriority variable is not defined in the device model, cannot set value";
+        return;
+    }
+    set_value(ControllerComponentVariables::NetworkConfigurationPriority.component,
+              ControllerComponentVariables::NetworkConfigurationPriority.variable.value(), AttributeEnum::Actual,
+              priority, source);
+}
+
+std::optional<ocpp::v2::NetworkConnectionProfile> DeviceModel::read_network_connection_profile(int32_t slot) {
+    return NetworkConfigurationComponentVariables::read_profile_from_device_model(*this, slot);
+}
+
+bool DeviceModel::write_network_connection_profile(int32_t slot, const ocpp::v2::NetworkConnectionProfile& profile,
+                                                   const std::string& source) {
+    return NetworkConfigurationComponentVariables::write_profile_to_device_model(*this, slot, profile, source);
+}
+
+void DeviceModel::clear_network_connection_profile(int32_t slot) {
+    NetworkConfigurationComponentVariables::clear_slot_in_device_model(*this, slot);
+}
+
+bool DeviceModel::get_allow_security_level_zero_connections() {
+    return get_optional_value<bool>(ControllerComponentVariables::AllowSecurityLevelZeroConnections).value_or(false);
+}
+
+int32_t DeviceModel::get_security_profile() {
+    return get_value<int>(ControllerComponentVariables::SecurityProfile);
+}
+
+std::optional<int32_t> DeviceModel::get_network_config_timeout() {
+    return get_optional_value<int>(ControllerComponentVariables::NetworkConfigTimeout);
+}
+
+std::string DeviceModel::resolve_identity(int32_t slot) {
+    std::string identity = get_value<std::string>(ControllerComponentVariables::SecurityCtrlrIdentity);
+    const auto slot_identity_cv = NetworkConfigurationComponentVariables::get_component_variable(
+        slot, NetworkConfigurationComponentVariables::Identity);
+    if (const auto slot_identity = get_optional_value<std::string>(slot_identity_cv);
+        slot_identity.has_value() && !slot_identity->empty()) {
+        identity = *slot_identity;
+        EVLOG_debug << "Using per-slot Identity for slot " << slot;
+    }
+    return identity;
+}
+
+std::optional<std::string> DeviceModel::resolve_basic_auth_password(int32_t slot) {
+    const auto slot_pwd_cv = NetworkConfigurationComponentVariables::get_component_variable(
+        slot, NetworkConfigurationComponentVariables::BasicAuthPassword);
+    if (const auto slot_pwd = get_optional_value<std::string>(slot_pwd_cv);
+        slot_pwd.has_value() && !slot_pwd->empty()) {
+        EVLOG_debug << "Using per-slot BasicAuthPassword for slot " << slot;
+        return *slot_pwd;
+    }
+    return get_optional_value<std::string>(ControllerComponentVariables::BasicAuthPassword);
+}
+
+std::optional<WebsocketConnectionOptions> DeviceModel::get_websocket_connection_options(int32_t slot) {
+    const auto charge_point_id = get_value<std::string>(ControllerComponentVariables::SecurityCtrlrIdentity);
+    if (charge_point_id.find(':') != std::string::npos) {
+        EVLOG_AND_THROW(std::runtime_error("ChargePointId must not contain ':'"));
+    }
+
+    const auto profile_opt = read_network_connection_profile(slot);
+    if (!profile_opt.has_value()) {
+        EVLOG_critical << "Could not retrieve NetworkProfile of configurationSlot: " << slot;
+        return std::nullopt;
+    }
+    const auto& profile = *profile_opt;
+
+    const std::string identity = resolve_identity(slot);
+    const std::optional<std::string> basic_auth_password = resolve_basic_auth_password(slot);
+
+    try {
+        auto uri = Uri::parse_and_validate(profile.ocppCsmsUrl.get(), identity, profile.securityProfile);
+        const auto ocpp_versions = utils::get_ocpp_protocol_versions(
+            get_value<std::string>(ControllerComponentVariables::SupportedOcppVersions));
+
+        WebsocketConnectionOptions opts{
+            ocpp_versions,
+            uri,
+            profile.securityProfile,
+            basic_auth_password,
+            std::chrono::seconds(std::max(profile.messageTimeout, 1)),
+            get_value<int>(ControllerComponentVariables::RetryBackOffRandomRange),
+            get_value<int>(ControllerComponentVariables::RetryBackOffRepeatTimes),
+            get_value<int>(ControllerComponentVariables::RetryBackOffWaitMinimum),
+            get_value<int>(ControllerComponentVariables::NetworkProfileConnectionAttempts),
+            get_value<std::string>(ControllerComponentVariables::SupportedCiphers12),
+            get_value<std::string>(ControllerComponentVariables::SupportedCiphers13),
+            get_value<int>(ControllerComponentVariables::WebSocketPingInterval),
+            get_optional_value<std::string>(ControllerComponentVariables::WebsocketPingPayload).value_or("payload"),
+            get_optional_value<int>(ControllerComponentVariables::WebsocketPongTimeout)
+                .value_or(DEFAULT_WEBSOCKET_PONG_TIMEOUT_S),
+            get_optional_value<bool>(ControllerComponentVariables::UseSslDefaultVerifyPaths).value_or(true),
+            get_optional_value<bool>(ControllerComponentVariables::AdditionalRootCertificateCheck).value_or(false),
+            std::nullopt, // hostName
+            get_optional_value<bool>(ControllerComponentVariables::VerifyCsmsCommonName).value_or(true),
+            get_optional_value<bool>(ControllerComponentVariables::UseTPM).value_or(false),
+            get_optional_value<bool>(ControllerComponentVariables::VerifyCsmsAllowWildcards).value_or(false),
+            get_optional_value<std::string>(ControllerComponentVariables::IFace),
+            get_optional_value<bool>(ControllerComponentVariables::EnableTLSKeylog).value_or(false),
+            get_optional_value<std::string>(ControllerComponentVariables::TLSKeylogFile)};
+        return opts;
+    } catch (const std::invalid_argument& e) {
+        EVLOG_error << "Could not configure the connection options for slot " << slot << ": " << e.what();
+        return std::nullopt;
+    }
+}
+
+void DeviceModel::set_active_security_profile(int32_t security_profile, const std::string& source) {
+    const auto& cv = ControllerComponentVariables::SecurityProfile;
+    if (cv.variable.has_value()) {
+        set_read_only_value(cv.component, cv.variable.value(), AttributeEnum::Actual, std::to_string(security_profile),
+                            source);
+    }
+}
+
+void DeviceModel::set_active_network_profile_slot(int32_t slot, const std::string& source) {
+    const auto& cv = ControllerComponentVariables::ActiveNetworkProfile;
+    if (cv.variable.has_value()) {
+        set_read_only_value(cv.component, cv.variable.value(), AttributeEnum::Actual, std::to_string(slot), source);
+    }
+}
+
+void DeviceModel::set_per_slot_ocpp_version(int32_t slot, const std::string& version, const std::string& source) {
+    const auto nc_cv = NetworkConfigurationComponentVariables::get_component_variable(
+        slot, NetworkConfigurationComponentVariables::OcppVersion);
+    if (nc_cv.variable.has_value()) {
+        set_value(nc_cv.component, nc_cv.variable.value(), AttributeEnum::Actual, version, source);
+    }
+}
+
+void DeviceModel::set_security_ctrl_security_profile(int32_t security_profile, const std::string& source) {
+    set_read_only_value(ControllerComponents::SecurityCtrlr, NetworkConfigurationComponentVariables::SecurityProfile,
+                        AttributeEnum::Actual, std::to_string(security_profile), source);
+}
+
+void DeviceModel::set_security_ctrl_identity(const std::string& identity, const std::string& source) {
+    set_read_only_value(ControllerComponents::SecurityCtrlr, NetworkConfigurationComponentVariables::Identity,
+                        AttributeEnum::Actual, identity, source);
 }
 
 } // namespace v2

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/provisioning.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/provisioning.cpp
@@ -607,6 +607,14 @@ void Provisioning::handle_variable_changed(const SetVariableData& set_variable_d
         this->context.connectivity_manager.set_websocket_connection_options_without_reconnect();
     }
 
+    if (component_variable == ControllerComponentVariables::WebSocketPingInterval) {
+        // Apply the new ping interval to the live connection directly
+        this->context.connectivity_manager.set_websocket_ping_interval(
+            this->context.device_model.get_value<int>(ControllerComponentVariables::WebSocketPingInterval),
+            this->context.device_model.get_optional_value<int>(ControllerComponentVariables::WebsocketPongTimeout)
+                .value_or(DEFAULT_WEBSOCKET_PONG_TIMEOUT_S));
+    }
+
     if (component_variable == ControllerComponentVariables::MessageAttemptInterval) {
         if (component_variable.variable.has_value()) {
             this->message_queue.update_transaction_message_retry_interval(
@@ -976,11 +984,12 @@ namespace {
 bool component_variable_change_requires_websocket_option_update_without_reconnect(
     const ComponentVariable& component_variable) {
 
+    // WebSocketPingInterval is handled separately: it is applied directly to the live connection via
+    // set_websocket_ping_interval() rather than only being stored for the next reconnect.
     return component_variable == ControllerComponentVariables::RetryBackOffRandomRange or
            component_variable == ControllerComponentVariables::RetryBackOffRepeatTimes or
            component_variable == ControllerComponentVariables::RetryBackOffWaitMinimum or
-           component_variable == ControllerComponentVariables::NetworkProfileConnectionAttempts or
-           component_variable == ControllerComponentVariables::WebSocketPingInterval;
+           component_variable == ControllerComponentVariables::NetworkProfileConnectionAttempts;
 }
 } // namespace
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/common/mocks/connectivity_manager_mock.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/common/mocks/connectivity_manager_mock.hpp
@@ -7,7 +7,7 @@
 
 #include <ocpp/common/connectivity_manager.hpp>
 
-namespace ocpp::v2 {
+namespace ocpp {
 class ConnectivityManagerMock : public ocpp::ConnectivityManagerInterface {
 public:
     MOCK_METHOD(void, set_message_callback, (const std::function<void(const std::string& message)>& callback));
@@ -15,12 +15,13 @@ public:
     MOCK_METHOD(void, set_websocket_authorization_key, (const std::string& authorization_key));
     MOCK_METHOD(void, set_websocket_connection_options, (const WebsocketConnectionOptions& connection_options));
     MOCK_METHOD(void, set_websocket_connection_options_without_reconnect, ());
+    MOCK_METHOD(void, set_websocket_ping_interval, (std::int32_t ping_interval_s, std::int32_t pong_timeout_s));
     MOCK_METHOD(void, set_websocket_connected_callback, (WebsocketConnectionCallback callback));
     MOCK_METHOD(void, set_websocket_disconnected_callback, (WebsocketConnectionCallback callback));
     MOCK_METHOD(void, set_websocket_connection_failed_callback, (WebsocketConnectionFailedCallback callback));
     MOCK_METHOD(void, set_configure_network_connection_profile_callback,
                 (ConfigureNetworkConnectionProfileCallback callback));
-    MOCK_METHOD(std::optional<NetworkConnectionProfile>, get_network_connection_profile,
+    MOCK_METHOD(std::optional<ocpp::v2::NetworkConnectionProfile>, get_network_connection_profile,
                 (const std::int32_t configuration_slot), (const));
     MOCK_METHOD(std::optional<std::int32_t>, get_priority_from_configuration_slot, (const int configuration_slot),
                 (const));
@@ -30,11 +31,11 @@ public:
     MOCK_METHOD(void, connect, (std::optional<std::int32_t> network_profile_slot));
     MOCK_METHOD(void, disconnect, ());
     MOCK_METHOD(bool, send_to_websocket, (const std::string& message));
-    MOCK_METHOD(void, on_network_disconnected, (OCPPInterfaceEnum ocpp_interface));
+    MOCK_METHOD(void, on_network_disconnected, (ocpp::v2::OCPPInterfaceEnum ocpp_interface));
     MOCK_METHOD(void, on_charging_station_certificate_changed, ());
     MOCK_METHOD(void, confirm_successful_connection, ());
     MOCK_METHOD(void, reload_network_profiles, ());
     MOCK_METHOD(bool, set_network_profile,
-                (int32_t slot, const NetworkConnectionProfile& profile, const std::string& source));
+                (int32_t slot, const ocpp::v2::NetworkConnectionProfile& profile, const std::string& source));
 };
-} // namespace ocpp::v2
+} // namespace ocpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_include_directories(libocpp_unit_tests PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../common/mocks
 )
 
 target_sources(libocpp_unit_tests PRIVATE
@@ -26,6 +27,7 @@ target_sources(libocpp_unit_tests PRIVATE
         test_message_queue.cpp
         test_charge_point_state_machine.cpp
         test_composite_schedule.cpp
+        test_charge_point_connectivity.cpp
         test_config_validation.cpp
         utils_tests.cpp
         test_configuration.cpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/test_charge_point_connectivity.cpp
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+/// \file test_charge_point_connectivity.cpp
+/// \brief Behavioural unit tests for the v16 ChargePointImpl <-> ConnectivityManager wiring.
+///
+/// These tests construct a ChargePointImpl through its constructor, passing a mocked
+/// ConnectivityManager, and assert observable interactions only:
+///   * that an injected manager is NOT auto-wired for the websocket lifecycle at construction (only set_logging),
+///     and that the message callback is registered later in start(),
+///   * that the drive surface (start/stop/outgoing message/offline query) hits the manager, and
+///   * the security-profile switch + revert behaviour orchestrated via the manager and the
+///     internal websocket revert timer.
+
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <ocpp/common/connectivity_manager.hpp>
+#include <ocpp/v16/charge_point_configuration.hpp>
+#include <ocpp/v16/charge_point_impl.hpp>
+#include <ocpp/v16/charge_point_state_machine.hpp>
+
+#include "connectivity_manager_mock.hpp"
+#include "evse_security_mock.hpp"
+
+namespace fs = std::filesystem;
+
+using ::testing::_;
+using ::testing::AtLeast;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+using ::testing::Return;
+
+namespace ocpp {
+namespace v16 {
+
+class ChargePointConnectivityTestBase : public ::testing::Test {
+protected:
+    void SetUp() override {
+        this->evse_security = std::make_shared<NiceMock<EvseSecurityMock>>();
+        this->connectivity_manager = std::make_shared<NiceMock<ConnectivityManagerMock>>();
+
+        std::ifstream ifs(CONFIG_FILE_LOCATION_V16);
+        const std::string config_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+        this->configuration =
+            std::make_unique<ChargePointConfiguration>(config_file, CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+        // Each test gets its own temporary directory so the on-disk sqlite db and message logs do not collide.
+        this->tmp_dir = fs::temp_directory_path() /
+                        ("ocpp_v16_connectivity_test_" + std::to_string(reinterpret_cast<std::uintptr_t>(this)));
+        fs::create_directories(this->tmp_dir);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(this->tmp_dir, ec);
+    }
+
+    /// \brief Construct a ChargePointImpl wired to the mocked ConnectivityManager. EXPECT_CALLs that need to
+    /// observe construction-time interactions must be set before calling this.
+    std::unique_ptr<ChargePointImpl> make_charge_point() {
+        return std::make_unique<ChargePointImpl>(
+            *this->configuration, /*share_path=*/fs::path(CONFIG_DIR_V16), /*database_path=*/this->tmp_dir,
+            /*sql_init_path=*/fs::path(MIGRATION_FILES_LOCATION_V16), /*message_log_path=*/this->tmp_dir,
+            this->evse_security, this->connectivity_manager, /*security_configuration=*/std::nullopt,
+            /*message_callback=*/nullptr);
+    }
+
+    /// \brief Construct a ChargePointImpl with a nullptr connectivity_manager, exercising the internal-manager build
+    /// path: ChargePointImpl constructs a real ocpp::ConnectivityManager from the configuration, evse_security and
+    /// share path, and wires it up itself.
+    std::unique_ptr<ChargePointImpl> make_charge_point_internal_cm() {
+        return std::make_unique<ChargePointImpl>(
+            *this->configuration, /*share_path=*/fs::path(CONFIG_DIR_V16), /*database_path=*/this->tmp_dir,
+            /*sql_init_path=*/fs::path(MIGRATION_FILES_LOCATION_V16), /*message_log_path=*/this->tmp_dir,
+            this->evse_security, /*connectivity_manager=*/nullptr, /*security_configuration=*/std::nullopt,
+            /*message_callback=*/nullptr);
+    }
+
+    std::shared_ptr<NiceMock<EvseSecurityMock>> evse_security;
+    std::shared_ptr<NiceMock<ConnectivityManagerMock>> connectivity_manager;
+    std::unique_ptr<ChargePointConfiguration> configuration;
+    fs::path tmp_dir;
+};
+
+using ChargePointConnectivityTest = ChargePointConnectivityTestBase;
+
+// An INJECTED ConnectivityManager is treated like the OCPP 2.x path: the charge point does NOT auto-wire the
+// websocket lifecycle callbacks onto it at construction. Construction only sets the logging hook; the message
+// callback is registered later, in start(). The external owner drives the lifecycle handlers directly.
+TEST_F(ChargePointConnectivityTest, InjectedManagerNotAutoWiredForLifecycle) {
+    // At construction the injected manager receives only set_logging -- no lifecycle or message callbacks.
+    EXPECT_CALL(*this->connectivity_manager, set_logging(_)).Times(1);
+    EXPECT_CALL(*this->connectivity_manager, set_websocket_connected_callback(_)).Times(0);
+    EXPECT_CALL(*this->connectivity_manager, set_websocket_disconnected_callback(_)).Times(0);
+    EXPECT_CALL(*this->connectivity_manager, set_websocket_connection_failed_callback(_)).Times(0);
+    EXPECT_CALL(*this->connectivity_manager, set_message_callback(_)).Times(0);
+
+    auto charge_point = make_charge_point();
+
+    // Separate construction-time expectations from start-time expectations.
+    testing::Mock::VerifyAndClearExpectations(this->connectivity_manager.get());
+
+    // The message callback is registered in start(), not at construction.
+    EXPECT_CALL(*this->connectivity_manager, set_message_callback(_)).Times(1);
+    ON_CALL(*this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(false));
+
+    charge_point->start({}, BootReasonEnum::PowerUp, {});
+    charge_point->stop();
+}
+
+// Starting the charge point must drive connect() on the manager; stopping must drive disconnect().
+TEST_F(ChargePointConnectivityTest, StartConnectsStopDisconnects) {
+    ON_CALL(*this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(false));
+    EXPECT_CALL(*this->connectivity_manager, connect(_)).Times(AtLeast(1));
+    EXPECT_CALL(*this->connectivity_manager, disconnect()).Times(AtLeast(1));
+
+    auto charge_point = make_charge_point();
+    charge_point->start({}, BootReasonEnum::PowerUp, {});
+    charge_point->stop();
+}
+
+// Once the charge point observes a successful connection (connected callback -> message queue resume), queued
+// outgoing OCPP messages such as the BootNotification.req are handed to the websocket via send_to_websocket().
+TEST_F(ChargePointConnectivityTest, OutgoingMessageGoesToSendToWebsocket) {
+    ON_CALL(*this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(true));
+
+    std::mutex mtx;
+    std::condition_variable cv;
+    bool sent = false;
+
+    // The message-queue worker flushes on its own thread; notify a condvar from send_to_websocket so the test
+    // can deterministically wait for the transmission instead of racing a fixed sleep.
+    EXPECT_CALL(*this->connectivity_manager, send_to_websocket(_))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Invoke([&](const std::string&) {
+            std::lock_guard<std::mutex> lock(mtx);
+            sent = true;
+            cv.notify_all();
+            return true;
+        }));
+
+    auto charge_point = make_charge_point();
+    charge_point->start({}, BootReasonEnum::PowerUp, {});
+
+    // Simulate the websocket coming up: this resumes the message queue, flushing the queued BootNotification.req.
+    charge_point->on_websocket_connected(0, ocpp::v2::NetworkConnectionProfile{}, ocpp::OcppProtocolVersion::v16);
+
+    // Wait (bounded) for the worker thread to hand the queued message to send_to_websocket.
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        const bool transmitted = cv.wait_for(lock, std::chrono::seconds(5), [&]() { return sent; });
+        EXPECT_TRUE(transmitted) << "Queued outgoing message was not handed to send_to_websocket within the timeout";
+    }
+
+    charge_point->stop();
+}
+
+// An outgoing DataTransfer.req queries is_websocket_connected() on the ConnectivityManager to decide its
+// offline-sensitive path.
+TEST_F(ChargePointConnectivityTest, OutgoingMessageObservesWebsocketConnected) {
+    EXPECT_CALL(*this->connectivity_manager, is_websocket_connected()).Times(AtLeast(1)).WillRepeatedly(Return(false));
+
+    auto charge_point = make_charge_point();
+    charge_point->start({}, BootReasonEnum::PowerUp, {});
+
+    charge_point->data_transfer("VendorId", CiString<50>("MessageId"), "data");
+
+    charge_point->stop();
+}
+
+class ChargePointSecuritySwitchTest : public ChargePointConnectivityTestBase {
+protected:
+    static constexpr auto REVERT_TIMEOUT = std::chrono::seconds(1);
+
+    void SetUp() override {
+        ChargePointConnectivityTestBase::SetUp();
+
+        std::ifstream ifs(CONFIG_FILE_LOCATION_V16);
+        const std::string config_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+        auto cfg = nlohmann::json::parse(config_file);
+        cfg["Internal"]["SwitchSecurityProfileConnectionTimeout"] = REVERT_TIMEOUT.count();
+        this->configuration =
+            std::make_unique<ChargePointConfiguration>(cfg.dump(), CONFIG_DIR_V16, USER_CONFIG_FILE_LOCATION_V16);
+
+        // Security profile 1 only requires an authorization key (no certificates), making it the cheapest
+        // accepted switch from the default profile 0.
+        this->configuration->setAuthorizationKey("DEADBEEFDEADBEEFDEADBEEFDEADBEEF");
+    }
+};
+
+// A CSMS-driven, accepted SecurityProfile switch sets the new profile, reloads the network profiles and connects.
+// When the new profile yields a successful connection (connected callback), the revert timer is cancelled: the new
+// profile is kept and no second reload/connect (which would carry the old profile) ever fires.
+TEST_F(ChargePointSecuritySwitchTest, AcceptedSwitchKeptOnSuccessfulConnect) {
+    auto charge_point = make_charge_point();
+
+    ASSERT_NE(this->configuration->getSecurityProfile(), 1);
+
+    // The accepted switch must reload profiles and connect exactly once. If the revert erroneously fired, it would
+    // produce a second reload_network_profiles()/connect() and exceed these cardinalities.
+    EXPECT_CALL(*this->connectivity_manager, reload_network_profiles()).Times(1);
+    EXPECT_CALL(*this->connectivity_manager, connect(_)).Times(1);
+
+    const auto status = charge_point->set_configuration_key("SecurityProfile", "1");
+    EXPECT_EQ(status, ConfigurationStatus::Accepted);
+    EXPECT_EQ(this->configuration->getSecurityProfile(), 1);
+
+    // A successful connection cancels the armed revert.
+    charge_point->on_websocket_connected(0, ocpp::v2::NetworkConnectionProfile{}, ocpp::OcppProtocolVersion::v16);
+
+    // Wait past the revert timeout to prove the revert does not fire
+    std::this_thread::sleep_for(REVERT_TIMEOUT + std::chrono::seconds(1));
+    EXPECT_EQ(this->configuration->getSecurityProfile(), 1);
+}
+
+// A CSMS-driven, accepted SecurityProfile switch that never sees a successful connection (no connected callback)
+// must, after the configured revert timeout, revert to the previous profile and reload/connect again.
+TEST_F(ChargePointSecuritySwitchTest, AcceptedSwitchRevertedOnTimeout) {
+    auto charge_point = make_charge_point();
+
+    const std::int32_t old_profile = this->configuration->getSecurityProfile();
+    ASSERT_NE(old_profile, 1);
+
+    std::mutex mtx;
+    std::condition_variable cv;
+    int connect_count = 0;
+    int reload_count = 0;
+
+    // Count the switch's reload+connect and the revert's reload+connect; signal when the revert (2nd) has happened.
+    ON_CALL(*this->connectivity_manager, connect(_)).WillByDefault(Invoke([&](std::optional<std::int32_t>) {
+        std::lock_guard<std::mutex> lock(mtx);
+        ++connect_count;
+        cv.notify_all();
+    }));
+    ON_CALL(*this->connectivity_manager, reload_network_profiles()).WillByDefault(Invoke([&]() {
+        std::lock_guard<std::mutex> lock(mtx);
+        ++reload_count;
+        cv.notify_all();
+    }));
+
+    const auto status = charge_point->set_configuration_key("SecurityProfile", "1");
+    EXPECT_EQ(status, ConfigurationStatus::Accepted);
+    EXPECT_EQ(this->configuration->getSecurityProfile(), 1);
+
+    // No connected callback is delivered: wait for the revert timer to fire (return as soon as the 2nd connect lands).
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        const bool reverted =
+            cv.wait_for(lock, REVERT_TIMEOUT + std::chrono::seconds(2), [&]() { return connect_count >= 2; });
+        EXPECT_TRUE(reverted) << "Revert timer did not fire within the timeout window";
+    }
+
+    // The revert restored the previous profile and issued a second reload/connect.
+    EXPECT_EQ(this->configuration->getSecurityProfile(), old_profile);
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        EXPECT_EQ(connect_count, 2);
+        EXPECT_EQ(reload_count, 2);
+    }
+
+    // No further revert is armed: give a brief grace window and confirm nothing else fires.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        EXPECT_EQ(connect_count, 2);
+        EXPECT_EQ(reload_count, 2);
+    }
+}
+
+} // namespace v16
+} // namespace ocpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/memory_storage.cpp
@@ -144,6 +144,10 @@ const std::map<std::string, std::string> full_vars_california_pricing = {
     {"Language", "en"},
 };
 
+const std::map<std::string, std::string> full_vars_internal = {
+    {"SwitchSecurityProfileConnectionTimeout", "30"},
+};
+
 using MemoryStorage = ocpp::v16::stubs::MemoryStorage;
 MemoryStorage::Storage vars_internal;
 MemoryStorage::Storage vars_core;
@@ -277,6 +281,7 @@ MemoryStorage::MemoryStorage() {
 
 void MemoryStorage::apply_full_config() {
     vars_california_pricing.insert(full_vars_california_pricing.begin(), full_vars_california_pricing.end());
+    vars_internal.insert(full_vars_internal.begin(), full_vars_internal.end());
 }
 
 std::optional<MemoryStorage::Storage::iterator> MemoryStorage::locate_v16(const std::string& name) const {

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_config.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_config.cpp
@@ -176,6 +176,25 @@ TEST(V2Mapping, V2ToV16) {
     EXPECT_EQ(cv->second.instance, "ChargingProfiles");
 }
 
+TEST(V2Mapping, SwitchSecurityProfileConnectionTimeout) {
+    using namespace ocpp::v16::keys;
+    using namespace ocpp::v2;
+
+    auto res = convert_v2(valid_keys::SwitchSecurityProfileConnectionTimeout);
+    ASSERT_TRUE(res);
+    auto component = std::get<Component>(res.value());
+    auto variable = std::get<Variable>(res.value());
+    EXPECT_EQ(component.name, "OCPP16LegacyCtrlr");
+    EXPECT_EQ(variable.name, "SwitchSecurityProfileConnectionTimeout");
+
+    Component comp;
+    comp.name = "OCPP16LegacyCtrlr";
+    Variable var;
+    var.name = "SwitchSecurityProfileConnectionTimeout";
+    auto rev = convert_v2(comp, var, ocpp::v2::AttributeEnum::Actual);
+    EXPECT_EQ(rev, "SwitchSecurityProfileConnectionTimeout");
+}
+
 // Tests for get_all_key_value() with maxLimit keys.
 // These keys map to VariableCharacteristics.maxLimit rather than VariableAttribute,
 // so they are populated via a separate code path in get_all_key_value().

--- a/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/v2config/test_internal.cpp
@@ -816,6 +816,43 @@ TEST_P(Configuration, SupplyVoltage) {
     EXPECT_FALSE(kv.value().readonly);
 }
 
+TEST_P(Configuration, SwitchSecurityProfileConnectionTimeoutAbsent) {
+    ASSERT_NE(get(), nullptr);
+
+    EXPECT_FALSE(get()->getSwitchSecurityProfileConnectionTimeout().has_value());
+    EXPECT_FALSE(get()->getSwitchSecurityProfileConnectionTimeoutKeyValue().has_value());
+    EXPECT_EQ(get()->set("SwitchSecurityProfileConnectionTimeout", "15"), ocpp::v16::ConfigurationStatus::NotSupported);
+}
+
+TEST_P(ConfigurationFull, SwitchSecurityProfileConnectionTimeout) {
+    ASSERT_NE(get(), nullptr);
+    // initial values are from the JSON unit test config files
+
+    EXPECT_TRUE(get()->getSwitchSecurityProfileConnectionTimeout().has_value());
+    EXPECT_EQ(get()->getSwitchSecurityProfileConnectionTimeout(), 30);
+    auto kv = get()->getSwitchSecurityProfileConnectionTimeoutKeyValue();
+    ASSERT_TRUE(kv.has_value());
+    EXPECT_EQ(kv.value().key, "SwitchSecurityProfileConnectionTimeout");
+    EXPECT_EQ(kv.value().value, "30");
+    EXPECT_FALSE(kv.value().readonly);
+
+    get()->setSwitchSecurityProfileConnectionTimeout(45);
+    EXPECT_TRUE(get()->getSwitchSecurityProfileConnectionTimeout().has_value());
+    EXPECT_EQ(get()->getSwitchSecurityProfileConnectionTimeout(), 45);
+    kv = get()->getSwitchSecurityProfileConnectionTimeoutKeyValue();
+    ASSERT_TRUE(kv.has_value());
+    EXPECT_EQ(kv.value().key, "SwitchSecurityProfileConnectionTimeout");
+    EXPECT_EQ(kv.value().value, "45");
+    EXPECT_FALSE(kv.value().readonly);
+
+    EXPECT_EQ(get()->set("SwitchSecurityProfileConnectionTimeout", "-1"), ocpp::v16::ConfigurationStatus::Rejected);
+    EXPECT_EQ(get()->getSwitchSecurityProfileConnectionTimeout(), 45);
+
+    // The schema declares minimum 1; a 0 s window would revert immediately, so 0 must be rejected at runtime too.
+    EXPECT_EQ(get()->set("SwitchSecurityProfileConnectionTimeout", "0"), ocpp::v16::ConfigurationStatus::Rejected);
+    EXPECT_EQ(get()->getSwitchSecurityProfileConnectionTimeout(), 45);
+}
+
 TEST_P(Configuration, AllMeterPublicKeys) {
     ASSERT_NE(get(), nullptr);
     EXPECT_EQ(get()->getAllMeterPublicKeyKeyValues(), std::nullopt);

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_include_directories(libocpp_unit_tests PUBLIC 
         mocks
+        ${CMAKE_CURRENT_SOURCE_DIR}/../common/mocks
         ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_sources(libocpp_unit_tests PRIVATE

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_include_directories(libocpp_unit_tests PUBLIC
         ../mocks
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../common/mocks
         ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_sources(libocpp_unit_tests PRIVATE
@@ -41,6 +42,7 @@ target_include_directories(libocpp_test_security PUBLIC
         ${LIBOCPP_3RDPARTY_PATH}
         ${CMAKE_CURRENT_SOURCE_DIR}/../stubs/timer
         ${CMAKE_CURRENT_SOURCE_DIR}/../mocks
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../common/mocks
         ${LIBOCPP_TESTS_V2_ROOT_DIR}
 )
 
@@ -65,6 +67,7 @@ target_include_directories(libocpp_test_authorization PUBLIC
         ${LIBOCPP_INCLUDE_PATH}
         ${LIBOCPP_3RDPARTY_PATH}
         ${CMAKE_CURRENT_SOURCE_DIR}/../mocks
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../common/mocks
         ${LIBOCPP_TESTS_V2_ROOT_DIR}
 )
 
@@ -87,6 +90,7 @@ target_include_directories(libocpp_test_availability PUBLIC
         ${LIBOCPP_INCLUDE_PATH}
         ${LIBOCPP_3RDPARTY_PATH}
         ${CMAKE_CURRENT_SOURCE_DIR}/../mocks
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../common/mocks
         ${LIBOCPP_TESTS_V2_ROOT_DIR}
 )
 
@@ -113,5 +117,6 @@ target_include_directories(libocpp_test_tariff_and_cost PUBLIC
         ${LIBOCPP_INCLUDE_PATH}
         ${LIBOCPP_3RDPARTY_PATH}
         ${CMAKE_CURRENT_SOURCE_DIR}/../mocks
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../common/mocks
         ${LIBOCPP_TESTS_V2_ROOT_DIR}
 )

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
@@ -38,7 +38,7 @@ protected: // Members
     DeviceModelTestHelper device_model_test_helper;
     MockMessageDispatcher mock_dispatcher;
     DeviceModel* device_model;
-    ::testing::NiceMock<ConnectivityManagerMock> connectivity_manager;
+    ::testing::NiceMock<ocpp::ConnectivityManagerMock> connectivity_manager;
     ::testing::NiceMock<ocpp::v2::DatabaseHandlerMock> database_handler_mock;
     ocpp::EvseSecurityMock evse_security;
     EvseManagerFake evse_manager;

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_availability.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_availability.cpp
@@ -37,7 +37,7 @@ protected: // Members
     DeviceModelTestHelper device_model_test_helper;
     MockMessageDispatcher mock_dispatcher;
     DeviceModel* device_model;
-    ::testing::NiceMock<ConnectivityManagerMock> connectivity_manager;
+    ::testing::NiceMock<ocpp::ConnectivityManagerMock> connectivity_manager;
     ::testing::NiceMock<ocpp::v2::DatabaseHandlerMock> database_handler_mock;
     ocpp::EvseSecurityMock evse_security;
     EvseManagerFake evse_manager;

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_data_transfer.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_data_transfer.cpp
@@ -36,7 +36,7 @@ public:
 protected: // Members
     MockMessageDispatcher mock_dispatcher;
     DeviceModel* device_model;
-    ::testing::NiceMock<ConnectivityManagerMock> connectivity_manager;
+    ::testing::NiceMock<ocpp::ConnectivityManagerMock> connectivity_manager;
     ::testing::NiceMock<DatabaseHandlerMock> database_handler_mock;
     ocpp::EvseSecurityMock evse_security;
     EvseManagerFake evse_manager;

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_reservation.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_reservation.cpp
@@ -168,7 +168,7 @@ protected: // Functions
     }
 
 protected: // Members
-    ConnectivityManagerMock connectivity_manager;
+    ocpp::ConnectivityManagerMock connectivity_manager;
     ocpp::v2::DatabaseHandlerMock database_handler;
     ocpp::EvseSecurityMock evse_security;
     ComponentStateManagerMock component_state_manager;

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_tariff_and_cost.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_tariff_and_cost.cpp
@@ -42,7 +42,7 @@ protected:
     DeviceModelTestHelper device_model_test_helper;
     MockMessageDispatcher mock_dispatcher;
     DeviceModel* device_model;
-    NiceMock<ConnectivityManagerMock> connectivity_manager;
+    NiceMock<ocpp::ConnectivityManagerMock> connectivity_manager;
     NiceMock<DatabaseHandlerMock> database_handler_mock;
     ocpp::EvseSecurityMock evse_security;
     EvseManagerFake evse_manager;

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_include_directories(libocpp_unit_tests PUBLIC
     ../ mocks
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../common/mocks
     ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_sources(libocpp_unit_tests PRIVATE

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_der_control.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_der_control.cpp
@@ -44,7 +44,7 @@ protected:
     DeviceModelTestHelper device_model_test_helper;
     MockMessageDispatcher mock_dispatcher;
     DeviceModel* device_model;
-    ::testing::NiceMock<ConnectivityManagerMock> connectivity_manager;
+    ::testing::NiceMock<ocpp::ConnectivityManagerMock> connectivity_manager;
     ::testing::NiceMock<DatabaseHandlerMock> database_handler_mock;
     ocpp::EvseSecurityMock evse_security;
     EvseManagerFake evse_manager;

--- a/lib/everest/ocpp/tests/libocpp-unittests.cmake
+++ b/lib/everest/ocpp/tests/libocpp-unittests.cmake
@@ -76,8 +76,10 @@ set(LIBOCPP_TEST_INCLUDE_COMMON_SOURCES ${LIBOCPP_LIB_PATH}/ocpp/common/types.cp
 set(LIBOCPP_TEST_INCLUDE_V2_SOURCES ${LIBOCPP_LIB_PATH}/ocpp/v16/ocpp_enums.cpp   # This is currently still needed but might be removed in the future.
                                       ${LIBOCPP_LIB_PATH}/ocpp/v16/known_keys.cpp
                                       ${LIBOCPP_LIB_PATH}/ocpp/v16/charge_point_configuration_base.cpp
+                                      ${LIBOCPP_LIB_PATH}/ocpp/v16/charge_point_configuration_connectivity.cpp
                                       ${LIBOCPP_LIB_PATH}/ocpp/v16/utils.cpp
                                       ${LIBOCPP_LIB_PATH}/ocpp/v16/messages/StopTransaction.cpp
+                                      ${LIBOCPP_LIB_PATH}/ocpp/common/websocket/websocket_uri.cpp
                                       ${LIBOCPP_LIB_PATH}/ocpp/v2/ctrlr_component_variables.cpp
                                       ${LIBOCPP_LIB_PATH}/ocpp/v2/types.cpp
                                       ${LIBOCPP_LIB_PATH}/ocpp/v2/ocpp_types.cpp

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -6497,6 +6497,7 @@ async def test_chargepoint_update_security_profile(
         [
             ("Internal", "RetryBackoffRandomRange", 1),
             ("Internal", "RetryBackoffWaitMinimum", 2),
+            ("Internal", "SwitchSecurityProfileConnectionTimeout", 5)
         ]
     )
 )


### PR DESCRIPTION

## Describe your changes

Decouple from DeviceModelAbstract via ConnectivityManagerConfiguration interface:

- Introduce the pure-virtual ConnectivityManagerConfiguration as the sole dependency of ConnectivityManager, replacing the direct reference to DeviceModelAbstract.
- DeviceModelAbstract and ChargePointConfigurationInterface both inherit from it, enabling a single ConnectivityManager to serve OCPP 1.6 and 2.x.
- Move get_websocket_connection_options and the identity/password resolution helpers into each implementation
- fix set_security_ctrl_* to use set_read_only_value for ReadOnly DM variables.

This PR prepares the usage of the ConnectivityManager also for OCPP1.6.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

