### PR TITLE
fix(db): harden sqlite reads against null/busy

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v2/database_handler.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/database_handler.cpp
@@ -902,11 +902,15 @@ DatabaseHandler::get_charging_profiles_matching_criteria(const std::optional<std
             stmt->bind_int("@evse_id", evse_id.value());
         }
 
-        while (stmt->step() == SQLITE_ROW) {
+        int status = SQLITE_ERROR;
+        while ((status = stmt->step()) == SQLITE_ROW) {
             results.emplace_back(json::parse(stmt->column_text(1)), // profile
                                  stmt->column_int(0),               // EVSE ID
                                  CiString<20>(stmt->column_text(2)) // source
             );
+        }
+        if (status != SQLITE_DONE) {
+            throw QueryExecutionException(this->database->get_error_message());
         }
         return results;
     }
@@ -948,11 +952,15 @@ DatabaseHandler::get_charging_profiles_matching_criteria(const std::optional<std
         stmt->bind_int("@evse_id", evse_id.value());
     }
 
-    while (stmt->step() == SQLITE_ROW) {
+    int status = SQLITE_ERROR;
+    while ((status = stmt->step()) == SQLITE_ROW) {
         results.emplace_back(json::parse(stmt->column_text(1)), // profile
                              stmt->column_int(0),               // EVSE ID
                              CiString<20>(stmt->column_text(2)) // source
         );
+    }
+    if (status != SQLITE_DONE) {
+        throw QueryExecutionException(this->database->get_error_message());
     }
 
     return results;
@@ -967,9 +975,13 @@ std::vector<v2::ChargingProfile> DatabaseHandler::get_charging_profiles_for_evse
 
     stmt->bind_int("@evse_id", evse_id);
 
-    while (stmt->step() == SQLITE_ROW) {
+    int status = SQLITE_ERROR;
+    while ((status = stmt->step()) == SQLITE_ROW) {
         auto profile = json::parse(stmt->column_text(0));
         profiles.push_back(profile);
+    }
+    if (status != SQLITE_DONE) {
+        throw QueryExecutionException(this->database->get_error_message());
     }
 
     return profiles;
@@ -982,9 +994,13 @@ std::vector<v2::ChargingProfile> DatabaseHandler::get_all_charging_profiles() {
 
     auto stmt = this->database->new_statement(sql);
 
-    while (stmt->step() == SQLITE_ROW) {
+    int status = SQLITE_ERROR;
+    while ((status = stmt->step()) == SQLITE_ROW) {
         auto profile = json::parse(stmt->column_text(0));
         profiles.push_back(profile);
+    }
+    if (status != SQLITE_DONE) {
+        throw QueryExecutionException(this->database->get_error_message());
     }
 
     return profiles;
@@ -997,7 +1013,8 @@ std::map<std::int32_t, std::vector<v2::ChargingProfile>> DatabaseHandler::get_al
 
     auto stmt = this->database->new_statement(sql);
 
-    while (stmt->step() == SQLITE_ROW) {
+    int status = SQLITE_ERROR;
+    while ((status = stmt->step()) == SQLITE_ROW) {
         auto evse_id = stmt->column_int(0);
         auto profile = json::parse(stmt->column_text(1));
 
@@ -1005,6 +1022,9 @@ std::map<std::int32_t, std::vector<v2::ChargingProfile>> DatabaseHandler::get_al
         profiles.emplace_back(profile);
 
         map[evse_id] = profiles;
+    }
+    if (status != SQLITE_DONE) {
+        throw QueryExecutionException(this->database->get_error_message());
     }
 
     return map;
@@ -1137,8 +1157,12 @@ DatabaseHandler::get_der_controls_matching_criteria(const std::optional<bool>& i
         stmt->bind_text("@control_id", control_id.value(), SQLiteString::Transient);
     }
 
-    while (stmt->step() == SQLITE_ROW) {
+    int status = SQLITE_ERROR;
+    while ((status = stmt->step()) == SQLITE_ROW) {
         results.emplace_back(stmt->column_text(0));
+    }
+    if (status != SQLITE_DONE) {
+        throw QueryExecutionException(this->database->get_error_message());
     }
     return results;
 }

--- a/lib/everest/ocpp/lib/ocpp/v2/database_handler.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/database_handler.cpp
@@ -902,7 +902,7 @@ DatabaseHandler::get_charging_profiles_matching_criteria(const std::optional<std
             stmt->bind_int("@evse_id", evse_id.value());
         }
 
-        while (stmt->step() != SQLITE_DONE) {
+        while (stmt->step() == SQLITE_ROW) {
             results.emplace_back(json::parse(stmt->column_text(1)), // profile
                                  stmt->column_int(0),               // EVSE ID
                                  CiString<20>(stmt->column_text(2)) // source
@@ -948,7 +948,7 @@ DatabaseHandler::get_charging_profiles_matching_criteria(const std::optional<std
         stmt->bind_int("@evse_id", evse_id.value());
     }
 
-    while (stmt->step() != SQLITE_DONE) {
+    while (stmt->step() == SQLITE_ROW) {
         results.emplace_back(json::parse(stmt->column_text(1)), // profile
                              stmt->column_int(0),               // EVSE ID
                              CiString<20>(stmt->column_text(2)) // source
@@ -967,7 +967,7 @@ std::vector<v2::ChargingProfile> DatabaseHandler::get_charging_profiles_for_evse
 
     stmt->bind_int("@evse_id", evse_id);
 
-    while (stmt->step() != SQLITE_DONE) {
+    while (stmt->step() == SQLITE_ROW) {
         auto profile = json::parse(stmt->column_text(0));
         profiles.push_back(profile);
     }
@@ -982,7 +982,7 @@ std::vector<v2::ChargingProfile> DatabaseHandler::get_all_charging_profiles() {
 
     auto stmt = this->database->new_statement(sql);
 
-    while (stmt->step() != SQLITE_DONE) {
+    while (stmt->step() == SQLITE_ROW) {
         auto profile = json::parse(stmt->column_text(0));
         profiles.push_back(profile);
     }
@@ -997,7 +997,7 @@ std::map<std::int32_t, std::vector<v2::ChargingProfile>> DatabaseHandler::get_al
 
     auto stmt = this->database->new_statement(sql);
 
-    while (stmt->step() != SQLITE_DONE) {
+    while (stmt->step() == SQLITE_ROW) {
         auto evse_id = stmt->column_int(0);
         auto profile = json::parse(stmt->column_text(1));
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_database_handler.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_database_handler.cpp
@@ -1293,3 +1293,81 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_OnlyEVSEIDSet_Re
     EXPECT_THAT(
         sut, testing::Contains(testing::FieldsAre(profile1, DEFAULT_EVSE_ID, ChargingLimitSourceEnumStringType::CSO)));
 }
+
+// Happy-path regression guard for the read-loop refactor: with the status-capturing loop and
+// the post-loop SQLITE_DONE check in place, a normal multi-row read must still return every
+// inserted profile across multiple EVSEs (no off-by-one at the loop boundary, no spurious
+// throw on the DONE path).
+TEST_F(DatabaseHandlerTest, GetAllChargingProfiles_ReturnsAllProfilesAcrossMultipleEvses) {
+    ChargingProfile p1;
+    p1.id = 10;
+    p1.stackLevel = 1;
+    p1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    ChargingProfile p2;
+    p2.id = 11;
+    p2.stackLevel = 2;
+    p2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    p2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    ChargingProfile p3;
+    p3.id = 12;
+    p3.stackLevel = 3;
+    p3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    this->database_handler.insert_or_update_charging_profile(1, p1);
+    this->database_handler.insert_or_update_charging_profile(2, p2);
+    this->database_handler.insert_or_update_charging_profile(3, p3);
+
+    auto profiles = this->database_handler.get_all_charging_profiles();
+    EXPECT_EQ(profiles.size(), 3);
+    EXPECT_THAT(profiles, testing::Contains(p1));
+    EXPECT_THAT(profiles, testing::Contains(p2));
+    EXPECT_THAT(profiles, testing::Contains(p3));
+
+    auto by_evse = this->database_handler.get_all_charging_profiles_group_by_evse();
+    EXPECT_EQ(by_evse.size(), 3);
+    EXPECT_EQ(by_evse[1].size(), 1);
+    EXPECT_EQ(by_evse[2].size(), 1);
+    EXPECT_EQ(by_evse[3].size(), 1);
+}
+
+// Verify that reading charging profiles surfaces a typed exception (rather than silently
+// returning a truncated or empty result) when the database is locked by a concurrent writer
+// on the shared-cache in-memory database.
+//
+// Mechanism: a second Connection to the same "file::memory:?cache=shared" URI holds a
+// BEGIN EXCLUSIVE transaction. In SQLite shared-cache mode the conflict is reported as
+// SQLITE_LOCKED, which sqlite3_busy_timeout does not retry, so the read fails promptly rather
+// than blocking. With the lock held up front the conflict is detected while preparing the
+// statement (new_statement throws QueryExecutionException); the post-loop status guard added
+// alongside this change covers the symmetric case where the conflict appears mid-iteration.
+TEST_F(DatabaseHandlerTest, GetAllChargingProfiles_ThrowsOnLockedDatabase) {
+    ChargingProfile p1;
+    p1.id = 20;
+    p1.stackLevel = 1;
+    p1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    ChargingProfile p2;
+    p2.id = 21;
+    p2.stackLevel = 2;
+    p2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    p2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    this->database_handler.insert_or_update_charging_profile(1, p1);
+    this->database_handler.insert_or_update_charging_profile(2, p2);
+
+    // Take an exclusive write lock via a second connection on the same shared-cache DB.
+    everest::db::sqlite::Connection blocking_conn("file::memory:?cache=shared");
+    ASSERT_TRUE(blocking_conn.open_connection());
+    ASSERT_TRUE(blocking_conn.execute_statement("BEGIN EXCLUSIVE"));
+
+    EXPECT_THROW(this->database_handler.get_all_charging_profiles(), everest::db::Exception);
+
+    // Release the lock so subsequent tests are not affected.
+    blocking_conn.execute_statement("ROLLBACK");
+    blocking_conn.close_connection();
+}

--- a/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
+++ b/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
@@ -76,10 +76,9 @@ bool Connection::open_connection() {
         EVLOG_error << "Error opening database at " << this->database_file_path << ": " << sqlite3_errmsg(db);
         return false;
     }
-    // Retry briefly on SQLITE_BUSY instead of failing immediately. Without this any concurrent
-    // writer (e.g. background workers that update charging profiles) racing with a reader on the
-    // same connection surfaces as SQLITE_BUSY, and callers that loop while(step()!=DONE) on a
-    // non-row state would touch invalid column data.
+    // Retry briefly on SQLITE_BUSY instead of failing immediately, so a reader that races with a
+    // concurrent writer on the same database waits for the lock to clear rather than surfacing a
+    // transient SQLITE_BUSY to the caller.
     constexpr int busy_timeout_ms = 5000;
     sqlite3_busy_timeout(this->db, busy_timeout_ms);
     EVLOG_debug << "Established connection to database: " << this->database_file_path;

--- a/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
+++ b/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
@@ -76,6 +76,12 @@ bool Connection::open_connection() {
         EVLOG_error << "Error opening database at " << this->database_file_path << ": " << sqlite3_errmsg(db);
         return false;
     }
+    // Retry briefly on SQLITE_BUSY instead of failing immediately. Without this any concurrent
+    // writer (e.g. background workers that update charging profiles) racing with a reader on the
+    // same connection surfaces as SQLITE_BUSY, and callers that loop while(step()!=DONE) on a
+    // non-row state would touch invalid column data.
+    constexpr int busy_timeout_ms = 5000;
+    sqlite3_busy_timeout(this->db, busy_timeout_ms);
     EVLOG_debug << "Established connection to database: " << this->database_file_path;
     return true;
 }

--- a/lib/everest/sqlite/lib/everest/database/sqlite/statement.cpp
+++ b/lib/everest/sqlite/lib/everest/database/sqlite/statement.cpp
@@ -141,7 +141,17 @@ SqliteVariant Statement::column_variant(const std::string& name) {
 }
 
 std::string Statement::column_text(const int idx) {
-    return reinterpret_cast<const char*>(sqlite3_column_text(this->stmt, idx));
+    const auto* p = sqlite3_column_text(this->stmt, idx);
+    if (p == nullptr) {
+        // sqlite3_column_text returns NULL for a NULL column value, or when the statement
+        // is not positioned on a row (e.g. step() returned SQLITE_BUSY/ERROR/MISUSE and a
+        // caller misuses the result). Constructing std::string from nullptr is undefined
+        // and aborts the process; surface as a typed exception instead so callers can log
+        // and recover.
+        throw QueryExecutionException("column_text(" + std::to_string(idx) +
+                                      ") returned NULL; use column_text_nullable for nullable columns");
+    }
+    return reinterpret_cast<const char*>(p);
 }
 
 std::optional<std::string> Statement::column_text_nullable(const int idx) {


### PR DESCRIPTION
## Describe your changes

Hardens the shared SQLite layer and the OCPP v2 profile reads against
concurrent access and malformed result handling. These are
general-purpose correctness fixes (they affect every consumer of
`lib/everest/sqlite`), surfaced while building concurrent charging-profile
workers but valuable on their own.

Three changes:

- **`sqlite::Connection`** sets `sqlite3_busy_timeout` (5s) on open, so a
  reader racing a concurrent writer on the same database retries briefly
  instead of getting a raw `SQLITE_BUSY` surfaced to the caller.

- **`sqlite::Statement::column_text`** throws `QueryExecutionException` when
  the column pointer is `NULL` instead of constructing `std::string(nullptr)`,
  which is undefined behavior and aborts the process. NULL arises both for a
  genuine NULL column value and when the statement isn't positioned on a row
  (e.g. `step()` returned `SQLITE_BUSY`/`ERROR`/`MISUSE`). Callers that expect
  nullable columns should continue to use `column_text_nullable`.

- **`v2::DatabaseHandler`** profile-reading loops use
  `while (step() == SQLITE_ROW)` instead of `while (step() != SQLITE_DONE)`,
  so a non-row state ends the loop (and surfaces as a typed exception via the
  change above) rather than being treated as "more rows" and dereferencing an
  invalid column.

This is the base of a 3-part stack splitting a larger change; it is
self-contained and reviewable in isolation.


## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

