### PR TITLE
refactor(ocpp): clear profiles returns deleted ids

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v2/database_handler.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/database_handler.hpp
@@ -179,9 +179,11 @@ public:
     /// \brief Deletes all profiles from table CHARGING_PROFILES
     virtual bool clear_charging_profiles() = 0;
 
-    /// \brief Deletes all profiles from table CHARGING_PROFILES matching \p profile_id or \p criteria
-    virtual bool clear_charging_profiles_matching_criteria(const std::optional<std::int32_t> profile_id,
-                                                           const std::optional<ClearChargingProfile>& criteria) = 0;
+    /// \brief Deletes all profiles from table CHARGING_PROFILES matching \p profile_id or \p criteria.
+    /// \return the ids of the rows actually deleted (empty when nothing matched).
+    virtual std::vector<std::int32_t>
+    clear_charging_profiles_matching_criteria(const std::optional<std::int32_t> profile_id,
+                                              const std::optional<ClearChargingProfile>& criteria) = 0;
 
     /// \brief Get all profiles from table CHARGING_PROFILES matching \p profile_id or \p criteria
     virtual std::vector<ReportedChargingProfile>
@@ -353,8 +355,9 @@ public:
     bool delete_charging_profile(const int profile_id) override;
     void delete_charging_profile_by_transaction_id(const std::string& transaction_id) override;
     bool clear_charging_profiles() override;
-    bool clear_charging_profiles_matching_criteria(const std::optional<std::int32_t> profile_id,
-                                                   const std::optional<ClearChargingProfile>& criteria) override;
+    std::vector<std::int32_t>
+    clear_charging_profiles_matching_criteria(const std::optional<std::int32_t> profile_id,
+                                              const std::optional<ClearChargingProfile>& criteria) override;
     std::vector<ReportedChargingProfile>
     get_charging_profiles_matching_criteria(const std::optional<std::int32_t> evse_id,
                                             const ChargingProfileCriterion& criteria) override;

--- a/lib/everest/ocpp/lib/ocpp/v2/database_handler.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/database_handler.cpp
@@ -834,8 +834,12 @@ DatabaseHandler::clear_charging_profiles_matching_criteria(const std::optional<s
     if (!criteria.has_value()) {
         std::vector<std::int32_t> ids;
         auto select_all = this->database->new_statement("SELECT ID FROM CHARGING_PROFILES");
-        while (select_all->step() == SQLITE_ROW) {
+        int status;
+        while ((status = select_all->step()) == SQLITE_ROW) {
             ids.push_back(select_all->column_int(0));
+        }
+        if (status != SQLITE_DONE) {
+            throw QueryExecutionException(this->database->get_error_message());
         }
         if (!this->clear_charging_profiles()) {
             return {};
@@ -880,8 +884,12 @@ DatabaseHandler::clear_charging_profiles_matching_criteria(const std::optional<s
         std::vector<std::int32_t> ids;
         auto select_stmt = this->database->new_statement("SELECT ID FROM CHARGING_PROFILES" + where);
         bind_criteria(*select_stmt);
-        while (select_stmt->step() == SQLITE_ROW) {
+        int status;
+        while ((status = select_stmt->step()) == SQLITE_ROW) {
             ids.push_back(select_stmt->column_int(0));
+        }
+        if (status != SQLITE_DONE) {
+            throw QueryExecutionException(this->database->get_error_message());
         }
 
         auto delete_stmt = this->database->new_statement("DELETE FROM CHARGING_PROFILES" + where);

--- a/lib/everest/ocpp/lib/ocpp/v2/database_handler.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/database_handler.cpp
@@ -816,62 +816,85 @@ bool DatabaseHandler::clear_charging_profiles() {
     return this->database->clear_table("CHARGING_PROFILES");
 }
 
-bool DatabaseHandler::clear_charging_profiles_matching_criteria(const std::optional<std::int32_t> profile_id,
-                                                                const std::optional<ClearChargingProfile>& criteria) {
-    // K10.FR.03, K10.FR.09
+std::vector<std::int32_t>
+DatabaseHandler::clear_charging_profiles_matching_criteria(const std::optional<std::int32_t> profile_id,
+                                                           const std::optional<ClearChargingProfile>& criteria) {
+    // K10.FR.03, K10.FR.09: explicit id.
     if (profile_id.has_value()) {
-        return this->delete_charging_profile(profile_id.value());
+        if (this->delete_charging_profile(profile_id.value())) {
+            return {profile_id.value()};
+        }
+        return {};
     }
 
-    // criteria has no value, so clear all
+    auto transaction = this->database->begin_transaction();
+
+    // No criteria means clear all. Snapshot the ids first so the caller can drop their deadline
+    // tracking for exactly the rows that were removed.
     if (!criteria.has_value()) {
-        return this->clear_charging_profiles();
+        std::vector<std::int32_t> ids;
+        auto select_all = this->database->new_statement("SELECT ID FROM CHARGING_PROFILES");
+        while (select_all->step() == SQLITE_ROW) {
+            ids.push_back(select_all->column_int(0));
+        }
+        if (!this->clear_charging_profiles()) {
+            return {};
+        }
+        transaction->commit();
+        return ids;
     }
 
     if (criteria->chargingProfilePurpose.has_value() || criteria->evseId.has_value() ||
         criteria->stackLevel.has_value()) {
-        std::string delete_query = "DELETE FROM CHARGING_PROFILES";
-        // Start with K10.FR.04, prevent deleting external constraints
+        // Shared criteria WHERE: the K10.FR.04 guard (never delete ChargingStationExternalConstraints)
+        // plus the optional purpose/stack/evse filters. The SAME clause and binds drive both the id
+        // SELECT and the DELETE, so the returned ids are exactly the deleted rows; callers never
+        // mirror this filter.
         std::vector<std::string> filters = {"CHARGING_PROFILE_PURPOSE != 'ChargingStationExternalConstraints'"};
-
         if (criteria->chargingProfilePurpose.has_value()) {
             filters.emplace_back("CHARGING_PROFILE_PURPOSE = @charging_profile_purpose");
         }
-
         if (criteria->stackLevel.has_value()) {
             filters.emplace_back("STACK_LEVEL = @stack_level");
         }
-
         if (criteria->evseId.has_value()) {
             filters.emplace_back("EVSE_ID = @evse_id");
         }
+        const std::string where = " WHERE " + boost::algorithm::join(filters, " AND ");
 
-        delete_query += " WHERE " + boost::algorithm::join(filters, " AND ");
+        const auto bind_criteria = [&criteria](everest::db::sqlite::StatementInterface& stmt) {
+            if (criteria->chargingProfilePurpose.has_value()) {
+                stmt.bind_text(
+                    "@charging_profile_purpose",
+                    conversions::charging_profile_purpose_enum_to_string(criteria->chargingProfilePurpose.value()),
+                    SQLiteString::Transient);
+            }
+            if (criteria->stackLevel.has_value()) {
+                stmt.bind_int("@stack_level", criteria->stackLevel.value());
+            }
+            if (criteria->evseId.has_value()) {
+                stmt.bind_int("@evse_id", criteria->evseId.value());
+            }
+        };
 
-        auto stmt = this->database->new_statement(delete_query);
-        if (criteria->chargingProfilePurpose.has_value()) {
-            stmt->bind_text(
-                "@charging_profile_purpose",
-                conversions::charging_profile_purpose_enum_to_string(criteria->chargingProfilePurpose.value()),
-                SQLiteString::Transient);
+        std::vector<std::int32_t> ids;
+        auto select_stmt = this->database->new_statement("SELECT ID FROM CHARGING_PROFILES" + where);
+        bind_criteria(*select_stmt);
+        while (select_stmt->step() == SQLITE_ROW) {
+            ids.push_back(select_stmt->column_int(0));
         }
 
-        if (criteria->stackLevel.has_value()) {
-            stmt->bind_int("@stack_level", criteria->stackLevel.value());
-        }
-
-        if (criteria->evseId.has_value()) {
-            stmt->bind_int("@evse_id", criteria->evseId.value());
-        }
-
-        if (stmt->step() != SQLITE_DONE) {
+        auto delete_stmt = this->database->new_statement("DELETE FROM CHARGING_PROFILES" + where);
+        bind_criteria(*delete_stmt);
+        if (delete_stmt->step() != SQLITE_DONE) {
             throw QueryExecutionException(this->database->get_error_message());
         }
 
-        return stmt->changes() > 0;
+        transaction->commit();
+        return ids;
     }
 
-    return false;
+    return {};
 }
 
 std::vector<ReportedChargingProfile>

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -1162,8 +1162,9 @@ ClearChargingProfileResponse SmartCharging::clear_profiles(const ClearChargingPr
     ClearChargingProfileResponse response;
     response.status = ClearChargingProfileStatusEnum::Unknown;
 
-    if (this->context.database_handler.clear_charging_profiles_matching_criteria(request.chargingProfileId,
-                                                                                 request.chargingProfileCriteria)) {
+    const auto cleared_ids = this->context.database_handler.clear_charging_profiles_matching_criteria(
+        request.chargingProfileId, request.chargingProfileCriteria);
+    if (!cleared_ids.empty()) {
         response.status = ClearChargingProfileStatusEnum::Accepted;
     }
 

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -1162,10 +1162,14 @@ ClearChargingProfileResponse SmartCharging::clear_profiles(const ClearChargingPr
     ClearChargingProfileResponse response;
     response.status = ClearChargingProfileStatusEnum::Unknown;
 
-    const auto cleared_ids = this->context.database_handler.clear_charging_profiles_matching_criteria(
-        request.chargingProfileId, request.chargingProfileCriteria);
-    if (!cleared_ids.empty()) {
-        response.status = ClearChargingProfileStatusEnum::Accepted;
+    try {
+        const auto cleared_ids = this->context.database_handler.clear_charging_profiles_matching_criteria(
+            request.chargingProfileId, request.chargingProfileCriteria);
+        if (!cleared_ids.empty()) {
+            response.status = ClearChargingProfileStatusEnum::Accepted;
+        }
+    } catch (const everest::db::QueryExecutionException& e) {
+        EVLOG_error << "Could not clear ChargingProfiles from the database: " << e.what();
     }
 
     return response;

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/mocks/database_handler_mock.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/mocks/database_handler_mock.hpp
@@ -60,7 +60,7 @@ public:
     MOCK_METHOD(bool, delete_charging_profile, (const int profile_id));
     MOCK_METHOD(void, delete_charging_profile_by_transaction_id, (const std::string& transaction_id));
     MOCK_METHOD(bool, clear_charging_profiles, ());
-    MOCK_METHOD(bool, clear_charging_profiles_matching_criteria,
+    MOCK_METHOD(std::vector<std::int32_t>, clear_charging_profiles_matching_criteria,
                 (const std::optional<std::int32_t> profile_id, const std::optional<ClearChargingProfile>& criteria),
                 (override));
     MOCK_METHOD(std::vector<ReportedChargingProfile>, get_charging_profiles_matching_criteria,

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_database_handler.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_database_handler.cpp
@@ -558,7 +558,7 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_WhenGivenProfi
     EXPECT_EQ(profiles.size(), 1);
 
     auto sut = this->database_handler.clear_charging_profiles_matching_criteria(profile_id, clear_criteria);
-    EXPECT_TRUE(sut);
+    EXPECT_EQ(sut, (std::vector<std::int32_t>{profile_id}));
 
     profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 0);
@@ -579,7 +579,7 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_WhenNotGivenPr
     EXPECT_EQ(profiles.size(), 1);
 
     auto sut = this->database_handler.clear_charging_profiles_matching_criteria({}, clear_criteria);
-    EXPECT_FALSE(sut);
+    EXPECT_TRUE(sut.empty());
 
     profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 1);
@@ -605,7 +605,7 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_WhenNotGivenCr
     EXPECT_EQ(profiles.size(), 2);
 
     auto sut = this->database_handler.clear_charging_profiles_matching_criteria({}, {});
-    EXPECT_TRUE(sut);
+    EXPECT_THAT(sut, testing::UnorderedElementsAre(p1.id, p2.id));
 
     profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 0);
@@ -631,7 +631,7 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_WhenAllCriteri
     EXPECT_EQ(profiles.size(), 1);
 
     auto sut = this->database_handler.clear_charging_profiles_matching_criteria({}, clear_criteria);
-    EXPECT_TRUE(sut);
+    EXPECT_EQ(sut, (std::vector<std::int32_t>{p1.id}));
 
     profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 0);
@@ -658,7 +658,7 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_UnknownPurpose
     EXPECT_THAT(profiles, testing::Contains(p1));
 
     auto sut = this->database_handler.clear_charging_profiles_matching_criteria({}, clear_criteria);
-    EXPECT_FALSE(sut);
+    EXPECT_TRUE(sut.empty());
 
     profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 1);
@@ -686,7 +686,7 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_UnknownStackLe
     EXPECT_THAT(profiles, testing::Contains(p1));
 
     auto sut = this->database_handler.clear_charging_profiles_matching_criteria({}, clear_criteria);
-    EXPECT_FALSE(sut);
+    EXPECT_TRUE(sut.empty());
 
     profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 1);
@@ -715,7 +715,7 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_UnknownEvseId_
     EXPECT_THAT(profiles, testing::Contains(p1));
 
     auto sut = this->database_handler.clear_charging_profiles_matching_criteria({}, clear_criteria);
-    EXPECT_FALSE(sut);
+    EXPECT_TRUE(sut.empty());
 
     profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 1);
@@ -742,7 +742,7 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_DoesNotDeleteE
     EXPECT_EQ(profiles.size(), 1);
 
     auto sut = this->database_handler.clear_charging_profiles_matching_criteria({}, clear_criteria);
-    EXPECT_FALSE(sut);
+    EXPECT_TRUE(sut.empty());
 
     profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 1);


### PR DESCRIPTION
## Describe your changes

Changes `DatabaseHandler::clear_charging_profiles_matching_criteria` to
return the ids of the rows it actually deleted instead of a `bool`. The
matching `SELECT` and the `DELETE` now run inside a single transaction and
share the exact same `WHERE` clause and bound parameters, so the returned
ids are guaranteed to be precisely the rows that were removed.

Motivation: callers that keep per-profile state (e.g. background tracking
of charging profiles) need to know *which* ids were cleared so they can
drop that state without re-deriving the delete filter on their side — a
mirrored filter could drift from the DB query and leak or over-drop state.
The previous `bool` only signalled "something / nothing was deleted."

Included in this change:

- `clear_charging_profiles_matching_criteria` returns
  `std::vector<std::int32_t>` (empty when nothing matched), with the
  SELECT+DELETE wrapped in one transaction.
- `DatabaseHandlerInterface` / `DatabaseHandler` signatures updated, and the
  GMock `database_handler_mock` updated to match.
- `DatabaseHandlerTest` clear-criteria assertions updated to check the
  returned ids.
- The one call site (`SmartCharging::clear_profiles`) updated to treat a
  non-empty result as "accepted".

The SQLite read-robustness change this previously stacked on has merged to
`main` (#2277), so this PR now applies directly on top of `main` and
contains only the refactor commit. The dynamic charging profiles consumer
that uses the returned ids stacks on top of this PR (#2279). Reviewable in
isolation.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
