### PR TITLE
feat(ocpp v21): K28 dynamic charging profiles

### DIFF
--- a/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
+++ b/lib/everest/ocpp/doc/v2/ocpp_2x_status.md
@@ -2032,18 +2032,21 @@ This document contains the status of which OCPP 2.0.1 and OCPP2.1 numbered funct
 
 | ID        | Status | Remark |
 | --------- | ------ | ------ |
-| K28.FR.01 |        |        |
-| K28.FR.02 |        |        |
-| K28.FR.03 |        |        |
-| K28.FR.04 |        |        |
-| K28.FR.05 |        |        |
-| K28.FR.06 |        |        |
-| K28.FR.07 |        |        |
-| K28.FR.08 |        |        |
-| K28.FR.09 |        |        |
-| K28.FR.10 |        |        |
-| K28.FR.11 |        |        |
-| K28.FR.12 |        |        |
+| K28.FR.01 | ✅     |        |
+| K28.FR.02 | ✅     |        |
+| K28.FR.03 | ✅     |        |
+| K28.FR.04 | ✅     | covered by K01.FR.122 |
+| K28.FR.05 | ✅     |        |
+| K28.FR.06 | ✅     |        |
+| K28.FR.07 | 🌐     |        |
+| K28.FR.08 | ✅     |        |
+| K28.FR.09 | ✅     | push and pull apply |
+| K28.FR.10 | ✅     | adaptive pull-dispatch timer |
+| K28.FR.11 | ✅     |        |
+| K28.FR.12 | 🌐     |        |
+| K28.FR.13 | ✅     | expiry filter + timer |
+| K28.FR.14 | ✅     | refreshes dynUpdateTime |
+| K28.FR.15 | ✅     | duration semantics |
 
 ## SmartCharging - Dynamic charging profiles by external system (New in OCPP 2.1)
 

--- a/lib/everest/ocpp/include/ocpp/v2/dynamic_schedule_manager.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/dynamic_schedule_manager.hpp
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <future>
+#include <map>
+#include <memory>
+#include <optional>
+#include <thread>
+#include <vector>
+
+#include <date/date.h>
+#include <everest/timer.hpp>
+#include <everest/util/async/monitor.hpp>
+
+#include <ocpp/common/cistring.hpp>
+#include <ocpp/v2/message_handler.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+#include <ocpp/v2/types.hpp>
+
+namespace ocpp::v2 {
+
+struct FunctionalBlockContext;
+
+/// \brief A Dynamic profile's two K28 deadlines: when to pull the next schedule update and when the
+/// current schedule expires.
+struct ProfileDeadlines {
+    /// \brief K28.FR.10 pull deadline: absolute UTC time the next PullDynamicScheduleUpdateRequest
+    /// should be dispatched. Set from \c dynUpdateTime + \c dynUpdateInterval, or "now" on bootstrap
+    /// (missing \c dynUpdateTime); \c std::nullopt when the profile is not pull-tracked.
+    std::optional<date::utc_clock::time_point> pull;
+
+    /// \brief K28.FR.13 expiry deadline: \c dynUpdateTime + \c chargingSchedule[0].duration.
+    /// \c std::nullopt when the profile has no schedule duration or no \c dynUpdateTime.
+    std::optional<date::utc_clock::time_point> expire;
+};
+
+/// \brief Owns adaptive-pull and expiry deadline tracking for K28 Dynamic charging profiles plus
+/// the in-flight pull-response futures, multiplexed onto a single reaper thread. Composed inside
+/// \ref SmartCharging.
+///
+/// Public methods are safe to call from the smart-charging message-handler threads; the internal
+/// timer fires on its own io_context thread and all state is guarded by monitors.
+class DynamicScheduleManager {
+public:
+    /// \param context                         Functional-block context (device model, database,
+    ///                                        message dispatcher) shared with \ref SmartCharging.
+    /// \param set_charging_profiles_callback  Fired whenever the set of valid Dynamic profiles
+    ///                                        changes (K28.FR.06 push apply, K28.FR.13 expiry).
+    DynamicScheduleManager(const FunctionalBlockContext& context, std::function<void()> set_charging_profiles_callback);
+
+    /// Signals teardown so the reaper thread, possibly waiting on an in-flight CSMS response,
+    /// wakes within one poll slice instead of stalling for the full per-pull wait bound, then
+    /// joins the reaper (it captures \c this, so it must not outlive this object).
+    ~DynamicScheduleManager();
+
+    DynamicScheduleManager(const DynamicScheduleManager&) = delete;
+    DynamicScheduleManager& operator=(const DynamicScheduleManager&) = delete;
+    DynamicScheduleManager(DynamicScheduleManager&&) = delete;
+    DynamicScheduleManager& operator=(DynamicScheduleManager&&) = delete;
+
+    /// \brief K28.FR.10: rebuild pull- and expiry-deadline tracking by walking all persisted
+    /// profiles. Called once from \ref SmartCharging's constructor; also exposed so tests that
+    /// pre-populate the database can exercise the rebuild path.
+    void rebuild_from_db();
+
+    /// \brief Refresh adaptive-pull and expiry deadlines for \p profile, then rearm the timer.
+    /// K28.FR.14 reactivation is implicit: a refreshed \c dynUpdateTime moves both deadlines forward.
+    void update_tracking(const ChargingProfile& profile);
+
+    /// \brief Erase pull- and expiry-deadline tracking for \p charging_profile_id and rearm the
+    /// timer. Called from ClearChargingProfile and SetChargingProfile replace paths so a removed
+    /// or replaced profile cannot leave a stale deadline behind.
+    void erase_tracking(std::int32_t charging_profile_id);
+
+    /// \brief Handle a K28 UpdateDynamicScheduleRequest from the CSMS.
+    ///
+    /// Resolves the target profile by id and rejects with reasonCode \c "InvalidProfile" if missing
+    /// or non-Dynamic (K28.FR.11). Otherwise applies the update, refreshes pull-deadline tracking
+    /// (K28.FR.10), and fires the smart-charging callback only when fields actually changed. The
+    /// response is dispatched before the callback so the CSMS sees Accepted before downstream
+    /// effects.
+    void handle_update_dynamic_schedule_request(const ocpp::EnhancedMessage<MessageType>& message);
+
+private:
+    /// \brief Adaptive timer plus its shutdown flag, guarded as one unit so the two move and read
+    /// together. \c shutting_down lets a concurrent \ref reschedule_timer bail instead of re-arming
+    /// a timer the destructor is tearing down.
+    struct TimerState {
+        std::unique_ptr<Everest::SteadyTimer> timer;
+        bool shutting_down{false};
+    };
+
+    /// \brief One in-flight PullDynamicScheduleUpdate: the profile id, the response future the
+    /// reaper polls, and the absolute steady-clock deadline past which the wait is abandoned.
+    struct PendingPull {
+        std::int32_t id;
+        std::future<ocpp::EnhancedMessage<MessageType>> future;
+        std::chrono::steady_clock::time_point deadline;
+    };
+
+    /// \brief Outcome of \ref apply_update.
+    enum class ApplyResult {
+        AppliedFieldsCallbackPending,   ///< Persisted; caller fires set_charging_profiles_callback.
+        AppliedNoFieldsCallbackSkipped, ///< Persisted (heartbeat-style ping); no callback to fire.
+        PersistFailed,                  ///< Database write failed; caller should respond Rejected/InternalError.
+    };
+
+    /// \brief Apply a K28.FR.06 \c ChargingScheduleUpdate to the target Dynamic profile.
+    /// \param profile               Profile to mutate (also persisted to the database).
+    /// \param update                Fields to overwrite on the profile's single
+    ///                                \c chargingSchedulePeriod (K28.FR.01 guarantees one period).
+    /// \param evse_id               EVSE id the profile is bound to (used by the persistence layer).
+    /// \param charging_limit_source Source string (CSO / EMS / etc.) preserved on persist.
+    ApplyResult apply_update(ChargingProfile& profile, const ChargingScheduleUpdate& update, std::int32_t evse_id,
+                             const CiString<20>& charging_limit_source);
+
+    /// \brief Adaptive timer fire callback (timer io_context thread): run the pull and expiry passes,
+    /// then rearm. See \ref dispatch_due_pulls and \ref commit_due_expiries.
+    void on_deadline();
+
+    /// \brief Pull pass of \ref on_deadline: snapshot the ids whose pull deadline is due as of
+    /// \p now, then for each re-read the profile, drop tracking for ones that are gone / no longer
+    /// Dynamic / have no positive interval, dispatch a \c PullDynamicScheduleUpdateRequest, and
+    /// advance (or back off) the pull deadline. Runs on the timer's io_context thread.
+    void dispatch_due_pulls(date::utc_clock::time_point now);
+
+    /// \brief Expiry pass of \ref on_deadline: snapshot the ids whose expiry deadline is due as of
+    /// \p now, fire a single composite recompute, and clear the expire field only after the
+    /// callback succeeds (rethrowing on failure so the entries are kept for the next tick). Runs on
+    /// the timer's io_context thread.
+    void commit_due_expiries(date::utc_clock::time_point now);
+
+    /// \brief Result of \ref lookup_dynamic_profile, separating a confirmed-absent profile from a
+    /// database error so a transient failure does not look like a deletion.
+    struct DynamicProfileLookup {
+        /// \brief The match, set only when the id exists and its kind is Dynamic.
+        std::optional<ReportedChargingProfile> profile;
+        /// \brief True when the query threw: \c profile is empty but absence is unknown, so callers
+        /// must keep tracking and retry rather than erase.
+        bool db_error{false};
+    };
+
+    /// \brief Look up a single Dynamic charging profile by id. \c profile is set only when the id
+    /// exists AND its \c chargingProfileKind is \c Dynamic. A failed query sets \c db_error (logged
+    /// as a warning) so callers can distinguish a deleted profile from an unreachable database.
+    DynamicProfileLookup lookup_dynamic_profile(std::int32_t charging_profile_id) const;
+
+    /// \brief Map mutation for \ref update_tracking and \ref rebuild_from_db: write/erase the pull
+    /// and expiry deadlines for \p profile without rearming the timer. \return true if any deadline
+    /// was added, removed, or changed.
+    bool write_deadlines(const ChargingProfile& profile);
+
+    /// \brief Recompute the earliest deadline across all pull and expiry deadlines and (re)arm
+    /// the timer held in \ref timer_state.
+    /// \note Lock order is the \ref timer_state monitor, then the \ref deadlines monitor. Callers
+    /// must release any \ref deadlines handle before calling.
+    void reschedule_timer();
+
+    /// \brief Dispatch a \c PullDynamicScheduleUpdateRequest for \p charging_profile_id.
+    ///
+    /// Single-flight: if a pull for this id is already in flight (present in \ref pending_pulls),
+    /// the dispatch is skipped without emitting a wire request and \c true is returned, so the
+    /// timer advances the deadline normally. Otherwise the response future is stored in
+    /// \ref pending_pulls and consumed by the single \ref reaper_loop thread (not the timer's
+    /// io_context) so a slow CSMS cannot block the timer or deadlock by re-entering
+    /// \ref update_tracking on the timer thread.
+    ///
+    /// \return \c true on successful dispatch (or single-flight skip); \c false when
+    /// \c dispatch_call_async throws synchronously (queue full, websocket down, serialization
+    /// failure). On \c false, the timer-thread caller must skip the deadline overwrite so the next
+    /// tick retries promptly.
+    bool dispatch_pull_request(std::int32_t charging_profile_id);
+
+    /// \brief Single reaper thread: poll every in-flight pull future in slices, applying each
+    /// response as it lands. One thread services all \ref pending_pulls regardless of count; the
+    /// per-pull deadline bounds each wait, and \ref teardown_requested is observed every slice so
+    /// the destructor join cannot hang on a silent CSMS. Validates each response (timeout,
+    /// future-throw, offline, unexpected type) before calling \ref apply_pull_response.
+    void reaper_loop();
+
+    /// \brief Parse the response, re-look-up the profile
+    /// (it may have been cleared/replaced in flight), and apply the schedule update.
+    /// On success the recompute callback is fired first and the pull deadline is
+    /// advanced only afterwards, so a callback failure leaves the deadline unchanged
+    /// and the next tick retries. Logs and returns on any non-actionable state (parse
+    /// fail, not Accepted, profile gone/non-Dynamic, persist fail).
+    void apply_pull_response(std::int32_t charging_profile_id,
+                             const ocpp::EnhancedMessage<MessageType>& enhanced_message);
+
+    const FunctionalBlockContext& context;
+    std::function<void()> set_charging_profiles_callback;
+
+    /// \brief K28.FR.10/.13 deadline tracking. Keyed by chargingProfileId; value carries both the
+    /// pull and expiry deadlines for that profile. Tracking both deadlines under one map entry
+    /// makes a cross-deadline refresh (\ref update_tracking) atomic from the timer thread's view.
+    /// Mutated from \ref on_deadline (timer thread) and from \ref update_tracking /
+    /// \ref erase_tracking (message-handler threads); all access goes through the monitor's scoped
+    /// handle.
+    everest::lib::util::monitor<std::map<std::int32_t, ProfileDeadlines>> deadlines;
+
+    /// \brief Set by the destructor before joining the reaper. The reaper observes this each poll
+    /// slice and on its monitor wait predicate, abandoning and dropping all in-flight futures so
+    /// teardown is not stalled for the full per-pull wait bound on a silent CSMS. Declared before
+    /// \ref pending_pulls and \ref reaper_thread so destruction tears down in the reverse order.
+    std::atomic<bool> teardown_requested{false};
+
+    /// \brief In-flight PullDynamicScheduleUpdate responses, multiplexed onto \ref reaper_thread.
+    /// A vector (not a thread_safe_queue) because the reaper must scan all entries each tick and
+    /// erase arbitrary entries on completion/timeout, and \ref dispatch_pull_request scans it for
+    /// the single-flight check. The monitor's own condition variable wakes the reaper on a fresh
+    /// dispatch or on teardown. Pushed by the timer thread (the sole producer); entries are only
+    /// removed by the reaper, so the single-flight check-then-push is race-free.
+    everest::lib::util::monitor<std::vector<PendingPull>> pending_pulls;
+
+    /// \brief The single thread running \ref reaper_loop. Started in the constructor, joined in the
+    /// destructor body before its implicit std::thread destructor (which would std::terminate on a
+    /// still-joinable thread). Captures \c this, so it must not outlive this object.
+    std::thread reaper_thread;
+
+    /// \brief Mutated from \ref reschedule_timer (message-handler and timer threads) and from the
+    /// destructor.
+    everest::lib::util::monitor<TimerState> timer_state;
+};
+
+} // namespace ocpp::v2

--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
@@ -3,8 +3,14 @@
 
 #pragma once
 
+#include <chrono>
+#include <functional>
+#include <map>
+#include <optional>
 #include <utility>
+#include <vector>
 
+#include <ocpp/v2/dynamic_schedule_manager.hpp>
 #include <ocpp/v2/message_handler.hpp>
 
 #include <ocpp/v2/evse.hpp>
@@ -56,6 +62,8 @@ enum class ProfileValidationResultEnum {
     ChargingProfileUnsupportedPurpose,
     ChargingProfileUnsupportedKind,
     ChargingProfileNotDynamic,
+    ChargingProfileDynamicMustHaveSinglePeriod,
+    ChargingProfileDynamicMustHaveSingleSchedule,
     ChargingScheduleChargingRateUnitUnsupported,
     ChargingScheduleNonFiniteValue,
     ChargingSchedulePriorityExtranousDuration,
@@ -174,10 +182,31 @@ private: // Members
     std::map<ChargingProfilePurposeEnum, DateTime> last_charging_profile_update;
     StopTransactionCallback stop_transaction_callback;
 
+protected: // Members
+    /// \brief K28 dynamic-profile state: pull/expire deadlines, async pull-response handlers, and
+    /// the adaptive timer. Engaged only when the device model advertises SupportsDynamicProfiles, so
+    /// stations without Dynamic support pay no thread/timer cost. Declared last so it destructs first:
+    /// its timer joins the io_context thread before the rest of SmartCharging tears down.
+    std::optional<DynamicScheduleManager> dynamic_schedule_manager;
+
 public:
+    /// \brief Construct the SmartCharging functional block.
+    /// \param functional_block_context        Shared context (device model, database, dispatcher).
+    /// \param set_charging_profiles_callback  Invoked whenever the set of valid charging profiles
+    ///                                         changes and consumers must recompute composite
+    ///                                         schedules. Also fired from the timer thread on
+    ///                                         K28.FR.13 expiry and K28.FR.06 push apply.
+    /// \param stop_transaction_callback       Invoked from the NotifyEVChargingNeeds response path
+    ///                                         when the schedule mandates transaction termination
+    ///                                         (K18.FR.23 / K19.FR.16).
+    /// \note On construction, rebuilds pull- and expiry-deadline tracking from persisted profiles
+    /// (K28.FR.10) and arms the adaptive timer.
     SmartCharging(const FunctionalBlockContext& functional_block_context,
                   std::function<void()> set_charging_profiles_callback,
                   StopTransactionCallback stop_transaction_callback);
+
+    ~SmartCharging() override = default;
+
     void handle_message(const ocpp::EnhancedMessage<MessageType>& message) override;
     EnhancedCompositeScheduleResponse get_composite_schedule(const GetCompositeScheduleRequest& request) override;
     std::optional<EnhancedCompositeSchedule> get_composite_schedule(std::int32_t evse_id, std::chrono::seconds duration,
@@ -277,10 +306,10 @@ protected:
     SetChargingProfileResponse add_profile(ChargingProfile& profile, std::int32_t evse_id,
                                            CiString<20> charging_limit_source = ChargingLimitSourceEnumStringType::CSO);
 
-    ///
-    /// \brief Clears profiles from the system using the given \p request
-    ///
-    ClearChargingProfileResponse clear_profiles(const ClearChargingProfileRequest& request);
+    /// \brief Clears profiles using \p request and reports the ids actually deleted in
+    /// \p cleared_ids (exactly the rows the DB removed; no mirrored filter).
+    ClearChargingProfileResponse clear_profiles(const ClearChargingProfileRequest& request,
+                                                std::vector<std::int32_t>& cleared_ids);
 
     ///
     /// \brief Gets the charging profiles for the given \p request
@@ -293,6 +322,20 @@ protected:
     ///
     std::vector<ChargingProfile>
     get_valid_profiles(std::int32_t evse_id, const std::vector<ChargingProfilePurposeEnum>& purposes_to_ignore = {});
+
+    /// \brief Return valid (non-expired, conforming) profiles for \p evse_id.
+    /// \param evse_id            EVSE the profiles must belong to.
+    /// \param purposes_to_ignore Profile purposes to exclude from the result (e.g. when the caller
+    ///                            is computing a composite limit for a specific purpose subset).
+    /// \return Filtered profile list. Beyond the existing purpose filter and offline-validity check
+    ///         (Q11/Q12), K28.FR.13 Dynamic profiles whose \c chargingSchedule[0].duration has
+    ///         elapsed since \c dynUpdateTime are skipped. The boundary check uses
+    ///         \c now\ >=\ deadline so it agrees with the manager timer's
+    ///         \c deadline\ <=\ now at the exact boundary instant.
+    /// \note Profiles without \c dynUpdateTime defer to bootstrap pull and are NOT expiry-filtered.
+    std::vector<ChargingProfile>
+    get_valid_profiles_for_evse(std::int32_t evse_id,
+                                const std::vector<ChargingProfilePurposeEnum>& purposes_to_ignore = {});
 
 private: // Functions
     /* OCPP message requests */
@@ -320,9 +363,6 @@ private: // Functions
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;
     std::vector<ChargingProfile> get_station_wide_tx_default_profiles() const;
     std::vector<ChargingProfile> get_charging_station_max_profiles() const;
-    std::vector<ChargingProfile>
-    get_valid_profiles_for_evse(std::int32_t evse_id,
-                                const std::vector<ChargingProfilePurposeEnum>& purposes_to_ignore = {});
 
     CurrentPhaseType get_current_phase_type(const std::optional<EvseInterface*> evse_opt) const;
 

--- a/lib/everest/ocpp/include/ocpp/v2/profile.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/profile.hpp
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#include <optional>
+
+#include <date/date.h>
 
 #include <ocpp/common/constants.hpp>
 #include <ocpp/v2/types.hpp>
@@ -63,6 +67,22 @@ std::int32_t elapsed_seconds(const ocpp::DateTime& to, const ocpp::DateTime& fro
 
 /// \brief Rounds down the \param dt to the nearest second
 ocpp::DateTime floor_seconds(const ocpp::DateTime& dt);
+
+/// \brief K28.FR.13 single source of the Dynamic-profile expiry invariant.
+/// \return \c dynUpdateTime + \c chargingSchedule[0].duration, or \c std::nullopt when the profile
+/// is not Dynamic, has no positive schedule duration, or has no \c dynUpdateTime.
+std::optional<date::utc_clock::time_point> dynamic_expiry_deadline(const ChargingProfile& profile);
+
+/// \brief K28.FR.10 single source of the Dynamic-profile adaptive-pull deadline.
+/// \return \c dynUpdateTime + \c dynUpdateInterval, "now" on bootstrap (Dynamic with a positive
+/// interval but no \c dynUpdateTime yet), or \c std::nullopt when the profile is not Dynamic or
+/// has no positive \c dynUpdateInterval.
+std::optional<date::utc_clock::time_point> dynamic_pull_deadline(const ChargingProfile& profile);
+
+/// \brief True when \p profile is a Dynamic profile past its expiry deadline at \p now.
+/// Boundary is inclusive (\c now \>= deadline) so the composite filter and the manager timer
+/// agree at the exact deadline instant.
+bool dynamic_profile_expired(const ChargingProfile& profile, date::utc_clock::time_point now);
 
 /// \brief Map an optional OperationMode to its effective value.
 ///

--- a/lib/everest/ocpp/lib/CMakeLists.txt
+++ b/lib/everest/ocpp/lib/CMakeLists.txt
@@ -97,6 +97,7 @@ if(LIBOCPP_ENABLE_V2)
             ocpp/v2/functional_blocks/authorization.cpp
             ocpp/v2/functional_blocks/availability.cpp
             ocpp/v2/functional_blocks/security.cpp
+            ocpp/v2/dynamic_schedule_manager.cpp
             ocpp/v2/functional_blocks/smart_charging.cpp
             ocpp/v2/functional_blocks/data_transfer.cpp
             ocpp/v2/functional_blocks/firmware_update.cpp

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -771,6 +771,7 @@ void ChargePoint::handle_message(const EnhancedMessage<v2::MessageType>& message
         case MessageType::GetChargingProfiles:
         case MessageType::GetCompositeSchedule:
         case MessageType::NotifyEVChargingNeedsResponse:
+        case MessageType::UpdateDynamicSchedule:
             if (this->smart_charging != nullptr) {
                 this->smart_charging->handle_message(message);
             } else {
@@ -937,7 +938,6 @@ void ChargePoint::handle_message(const EnhancedMessage<v2::MessageType>& message
         case MessageType::ReportDERControl:
         case MessageType::ReportDERControlResponse:
         case MessageType::SetDERControlResponse:
-        case MessageType::UpdateDynamicSchedule:
         case MessageType::UpdateDynamicScheduleResponse:
         case MessageType::UsePriorityCharging:
         case MessageType::UsePriorityChargingResponse:

--- a/lib/everest/ocpp/lib/ocpp/v2/dynamic_schedule_manager.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/dynamic_schedule_manager.cpp
@@ -1,0 +1,600 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/v2/dynamic_schedule_manager.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include <everest/database/exceptions.hpp>
+
+#include <ocpp/common/constants.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/database_handler.hpp>
+#include <ocpp/v2/functional_blocks/functional_block_context.hpp>
+#include <ocpp/v2/message_dispatcher.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+#include <ocpp/v2/profile.hpp>
+
+#include <ocpp/v21/messages/PullDynamicScheduleUpdate.hpp>
+#include <ocpp/v21/messages/UpdateDynamicSchedule.hpp>
+
+namespace ocpp::v2 {
+
+DynamicScheduleManager::DynamicScheduleManager(const FunctionalBlockContext& functional_block_context,
+                                               std::function<void()> set_charging_profiles_callback) :
+    context(functional_block_context),
+    set_charging_profiles_callback(std::move(set_charging_profiles_callback)),
+    timer_state(TimerState{std::make_unique<Everest::SteadyTimer>()}) {
+    this->reaper_thread = std::thread(&DynamicScheduleManager::reaper_loop, this);
+}
+
+DynamicScheduleManager::~DynamicScheduleManager() {
+    // Signal teardown before anything else so the reaper, possibly mid-wait on a silent CSMS,
+    // wakes within one poll slice instead of holding the join for the full per-pull bound.
+    this->teardown_requested.store(true, std::memory_order_relaxed);
+    // Wake the reaper if it is blocked on the monitor's condition variable, then join it (in the
+    // destructor body, before the implicit std::thread destructor would std::terminate on a
+    // still-joinable thread). On observing teardown the reaper drops all in-flight futures.
+    this->pending_pulls.notify_all();
+    if (this->reaper_thread.joinable()) {
+        this->reaper_thread.join();
+    }
+    // Retire the timer so a concurrent reschedule_timer bails instead of re-arming during teardown.
+    std::unique_ptr<Everest::SteadyTimer> retired_timer;
+    {
+        auto state = this->timer_state.handle();
+        state->shutting_down = true;
+        retired_timer = std::move(state->timer);
+    }
+    retired_timer.reset();
+}
+
+void DynamicScheduleManager::rebuild_from_db() {
+    // K28.FR.10: on construction, walk persisted profiles and seed deadline state.
+    std::vector<ChargingProfile> all;
+    try {
+        all = this->context.database_handler.get_all_charging_profiles();
+    } catch (const everest::db::QueryExecutionException& e) {
+        EVLOG_error << "Could not load charging profiles during deadline-state rebuild: " << e.what();
+        return;
+    }
+    for (const auto& profile : all) {
+        this->write_deadlines(profile);
+    }
+    // One arm after seeding every profile instead of O(N) rearms.
+    this->reschedule_timer();
+}
+
+bool DynamicScheduleManager::write_deadlines(const ChargingProfile& profile) {
+    auto handle = this->deadlines.handle();
+
+    // K28.FR.10 pull deadline and K28.FR.13/.14/.15 schedule-duration expiry deadline.
+    // Reactivation (FR.14) is implicit: a refreshed dynUpdateTime flows through both helpers
+    // and re-arms the deadlines.
+    const auto pull = dynamic_pull_deadline(profile);
+    const auto expire = dynamic_expiry_deadline(profile);
+
+    // Atomic cross-deadline write: both fields land in one entry under one handle. When neither
+    // deadline applies the entry is dropped entirely.
+    const auto it = handle->find(profile.id);
+    if (pull.has_value() || expire.has_value()) {
+        if (it == handle->end() || it->second.pull != pull || it->second.expire != expire) {
+            auto& entry = (*handle)[profile.id];
+            entry.pull = pull;
+            entry.expire = expire;
+            return true;
+        }
+        return false;
+    }
+    if (it != handle->end()) {
+        handle->erase(it);
+        return true;
+    }
+    return false;
+}
+
+void DynamicScheduleManager::update_tracking(const ChargingProfile& profile) {
+    // Rearm only when a deadline actually changed. A non-Dynamic profile (the common SetChargingProfile
+    // case) writes nothing and needs no timer churn. Handle released before arming (lock order:
+    // timer_state then deadlines).
+    if (this->write_deadlines(profile)) {
+        this->reschedule_timer();
+    }
+}
+
+void DynamicScheduleManager::erase_tracking(std::int32_t charging_profile_id) {
+    bool changed = false;
+    {
+        auto handle = this->deadlines.handle();
+        changed = handle->erase(charging_profile_id) > 0;
+    }
+    if (changed) {
+        this->reschedule_timer();
+    }
+}
+
+void DynamicScheduleManager::handle_update_dynamic_schedule_request(const ocpp::EnhancedMessage<MessageType>& message) {
+    const Call<v21::UpdateDynamicScheduleRequest> call = message.message;
+
+    v21::UpdateDynamicScheduleResponse response;
+    response.status = ChargingProfileStatusEnum::Rejected;
+
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfileId = std::vector<std::int32_t>{call.msg.chargingProfileId};
+    std::vector<ReportedChargingProfile> matches;
+    try {
+        matches = this->context.database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
+    } catch (const everest::db::QueryExecutionException& e) {
+        const std::string detail = "Could not look up profile " + std::to_string(call.msg.chargingProfileId) +
+                                   " for UpdateDynamicSchedule: " + e.what();
+        EVLOG_error << detail;
+        response.statusInfo = StatusInfo();
+        response.statusInfo->reasonCode = "InternalError";
+        response.statusInfo->additionalInfo = CiString<1024>(detail, StringTooLarge::Truncate);
+        const ocpp::CallResult<v21::UpdateDynamicScheduleResponse> call_result(response, call.uniqueId);
+        this->context.message_dispatcher.dispatch_call_result(call_result);
+        return;
+    }
+
+    bool fire_callback = false;
+
+    // K28.FR.11: reject when the target profile is missing or non-Dynamic. additionalInfo
+    // discriminates the two cases so a CSMS can tell "id unknown" from "id exists, wrong kind".
+    if (matches.empty() || matches.front().profile.chargingProfileKind != ChargingProfileKindEnum::Dynamic) {
+        response.statusInfo = StatusInfo();
+        response.statusInfo->reasonCode = "InvalidProfile";
+        response.statusInfo->additionalInfo = matches.empty() ? "ProfileNotFound" : "ProfileNotDynamic";
+    } else {
+        auto& matched = matches.front();
+        const auto apply_result =
+            this->apply_update(matched.profile, call.msg.scheduleUpdate, matched.evse_id, matched.source);
+        switch (apply_result) {
+        case ApplyResult::AppliedFieldsCallbackPending:
+            fire_callback = true;
+            [[fallthrough]];
+        case ApplyResult::AppliedNoFieldsCallbackSkipped:
+            // K28.FR.10: refresh the pull deadline from the updated dynUpdateTime (an empty
+            // heartbeat-style update still refreshed it).
+            response.status = ChargingProfileStatusEnum::Accepted;
+            this->update_tracking(matched.profile);
+            break;
+        case ApplyResult::PersistFailed:
+            response.statusInfo = StatusInfo();
+            response.statusInfo->reasonCode = "InternalError";
+            response.statusInfo->additionalInfo = "ProfilePersistFailed";
+            break;
+        }
+    }
+
+    const ocpp::CallResult<v21::UpdateDynamicScheduleResponse> call_result(response, call.uniqueId);
+    this->context.message_dispatcher.dispatch_call_result(call_result);
+
+    // Fire the smart-charging callback only when the apply succeeded AND fields were updated;
+    // never fire on persist failure or empty (heartbeat-style) updates.
+    if (fire_callback) {
+        this->set_charging_profiles_callback();
+    }
+}
+
+DynamicScheduleManager::ApplyResult DynamicScheduleManager::apply_update(ChargingProfile& profile,
+                                                                         const ChargingScheduleUpdate& update,
+                                                                         std::int32_t evse_id,
+                                                                         const CiString<20>& charging_limit_source) {
+    static constexpr std::pair<std::optional<float> ChargingScheduleUpdate::*,
+                               std::optional<float> ChargingSchedulePeriod::*>
+        K28_UPDATE_FIELDS[] = {
+            {&ChargingScheduleUpdate::limit, &ChargingSchedulePeriod::limit},
+            {&ChargingScheduleUpdate::limit_L2, &ChargingSchedulePeriod::limit_L2},
+            {&ChargingScheduleUpdate::limit_L3, &ChargingSchedulePeriod::limit_L3},
+            {&ChargingScheduleUpdate::dischargeLimit, &ChargingSchedulePeriod::dischargeLimit},
+            {&ChargingScheduleUpdate::dischargeLimit_L2, &ChargingSchedulePeriod::dischargeLimit_L2},
+            {&ChargingScheduleUpdate::dischargeLimit_L3, &ChargingSchedulePeriod::dischargeLimit_L3},
+            {&ChargingScheduleUpdate::setpoint, &ChargingSchedulePeriod::setpoint},
+            {&ChargingScheduleUpdate::setpoint_L2, &ChargingSchedulePeriod::setpoint_L2},
+            {&ChargingScheduleUpdate::setpoint_L3, &ChargingSchedulePeriod::setpoint_L3},
+            {&ChargingScheduleUpdate::setpointReactive, &ChargingSchedulePeriod::setpointReactive},
+            {&ChargingScheduleUpdate::setpointReactive_L2, &ChargingSchedulePeriod::setpointReactive_L2},
+            {&ChargingScheduleUpdate::setpointReactive_L3, &ChargingSchedulePeriod::setpointReactive_L3},
+        };
+    const bool no_fields_set = std::none_of(std::begin(K28_UPDATE_FIELDS), std::end(K28_UPDATE_FIELDS),
+                                            [&](const auto& f) { return (update.*f.first).has_value(); });
+
+    // Defensive invariant guard, unreachable by valid CSMS traffic: K28.FR.01 is enforced at
+    // SetChargingProfile ingress and only validated profiles ever reach here, so an empty schedule
+    // or period vector means the stored row is corrupt (schema drift / hand-edited DB) - an
+    // InternalError, not user input. Reject before mutating dynUpdateTime so the pull-deadline
+    // state stays consistent with what's persisted.
+    if (!no_fields_set &&
+        (profile.chargingSchedule.empty() || profile.chargingSchedule.at(0).chargingSchedulePeriod.empty())) {
+        EVLOG_error << "Cannot apply ChargingScheduleUpdate to profile " << profile.id << ": malformed schedule shape.";
+        return ApplyResult::PersistFailed;
+    }
+
+    // K28.FR.09: refresh dynUpdateTime even when the update is empty (heartbeat-style ping).
+    profile.dynUpdateTime = ocpp::DateTime();
+
+    if (no_fields_set) {
+        EVLOG_debug << "UpdateDynamicSchedule for profile " << profile.id
+                    << ": empty update (FR.09 heartbeat refresh).";
+    } else {
+        auto& period = profile.chargingSchedule.at(0).chargingSchedulePeriod.at(0);
+        for (const auto& [u, p] : K28_UPDATE_FIELDS) {
+            if ((update.*u).has_value()) {
+                period.*p = (update.*u).value();
+            }
+        }
+    }
+
+    try {
+        this->context.database_handler.insert_or_update_charging_profile(evse_id, profile, charging_limit_source);
+    } catch (const everest::db::QueryExecutionException& e) {
+        EVLOG_error << "Could not persist updated Dynamic ChargingProfile in the database: " << e.what();
+        return ApplyResult::PersistFailed;
+    }
+
+    return no_fields_set ? ApplyResult::AppliedNoFieldsCallbackSkipped : ApplyResult::AppliedFieldsCallbackPending;
+}
+
+void DynamicScheduleManager::reschedule_timer() {
+    auto state = this->timer_state.handle();
+    if (state->shutting_down || !state->timer) {
+        return;
+    }
+
+    std::optional<date::utc_clock::time_point> earliest_deadline;
+    {
+        auto handle = this->deadlines.handle();
+        for (const auto& [id, entry] : *handle) {
+            if (entry.pull.has_value() &&
+                (!earliest_deadline.has_value() || entry.pull.value() < earliest_deadline.value())) {
+                earliest_deadline = entry.pull;
+            }
+            if (entry.expire.has_value() &&
+                (!earliest_deadline.has_value() || entry.expire.value() < earliest_deadline.value())) {
+                earliest_deadline = entry.expire;
+            }
+        }
+    }
+
+    if (earliest_deadline.has_value()) {
+        state->timer->at([this]() { this->on_deadline(); }, earliest_deadline.value());
+    } else {
+        state->timer->stop();
+    }
+}
+
+DynamicScheduleManager::DynamicProfileLookup
+DynamicScheduleManager::lookup_dynamic_profile(std::int32_t charging_profile_id) const {
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfileId = std::vector<std::int32_t>{charging_profile_id};
+    std::vector<ReportedChargingProfile> matches;
+    try {
+        matches = this->context.database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
+    } catch (const everest::db::QueryExecutionException& e) {
+        EVLOG_warning << "Could not look up profile " << charging_profile_id << ": " << e.what();
+        return {std::nullopt, true};
+    }
+    if (matches.empty() || matches.front().profile.chargingProfileKind != ChargingProfileKindEnum::Dynamic) {
+        return {std::nullopt, false};
+    }
+    return {matches.front(), false};
+}
+
+void DynamicScheduleManager::dispatch_due_pulls(date::utc_clock::time_point now) {
+    // Snapshot ids whose pull deadline has passed; release the handle before doing any work.
+    std::vector<std::int32_t> due_pull_ids;
+    {
+        auto handle = this->deadlines.handle();
+        for (const auto& [id, entry] : *handle) {
+            if (entry.pull.has_value() && entry.pull.value() <= now) {
+                due_pull_ids.push_back(id);
+            }
+        }
+    }
+
+    for (const auto id : due_pull_ids) {
+        // Re-read profile to get fresh dynUpdateInterval (may have been mutated since deadline was set).
+        const auto match = this->lookup_dynamic_profile(id);
+        if (match.db_error) {
+            // Database error, not a deletion: the profile may still exist. Keep tracking and back off
+            // 1s (same as the dispatch-failure path below) so the next tick retries.
+            auto handle = this->deadlines.handle();
+            auto it = handle->find(id);
+            if (it != handle->end() && it->second.pull.has_value() && it->second.pull.value() <= now) {
+                it->second.pull = now + std::chrono::seconds(1);
+            }
+            continue;
+        }
+        if (!match.profile.has_value() || !match.profile->profile.dynUpdateInterval.has_value() ||
+            match.profile->profile.dynUpdateInterval.value() <= 0) {
+            // Profile gone / non-Dynamic / no interval: drop tracking. Inlined (not
+            // erase_tracking) to avoid reschedule_timer re-arming mid-tick; on_deadline
+            // reschedules once at the end.
+            {
+                auto handle = this->deadlines.handle();
+                handle->erase(id);
+            }
+            continue;
+        }
+
+        const auto interval = std::chrono::seconds(match.profile->profile.dynUpdateInterval.value());
+        const bool dispatch_succeeded = this->dispatch_pull_request(id);
+        if (!dispatch_succeeded) {
+            // Dispatch failed: 1s backoff so a past-due deadline doesn't busy-loop the timer.
+            auto handle = this->deadlines.handle();
+            auto it = handle->find(id);
+            if (it != handle->end() && it->second.pull.has_value() && it->second.pull.value() <= now) {
+                it->second.pull = now + std::chrono::seconds(1);
+            }
+            continue;
+        }
+        {
+            // Re-check before overwriting: a concurrent update_tracking may have written a
+            // fresh deadline we must not stomp.
+            auto handle = this->deadlines.handle();
+            auto it = handle->find(id);
+            if (it != handle->end() && it->second.pull.has_value() && it->second.pull.value() <= now) {
+                it->second.pull = now + interval;
+            }
+        }
+    }
+}
+
+void DynamicScheduleManager::commit_due_expiries(date::utc_clock::time_point now) {
+    // K28.FR.13 expiry: fire the composite recompute, then clear expire only if the callback
+    // succeeds (on throw, keep entries so the next tick retries). The deferred clear re-checks
+    // the deadline so a concurrent reactivation is not wiped.
+    std::vector<std::int32_t> expired_ids;
+    {
+        auto handle = this->deadlines.handle();
+        for (const auto& [id, entry] : *handle) {
+            if (entry.expire.has_value() && entry.expire.value() <= now) {
+                expired_ids.push_back(id);
+            }
+        }
+    }
+    if (expired_ids.empty()) {
+        return;
+    }
+    try {
+        this->set_charging_profiles_callback();
+    } catch (...) {
+        // Keep the expire entries so the next tick retries the recompute. Rethrow so the
+        // outer catch records the exception type; the entries are intentionally NOT cleared.
+        EVLOG_error << "K28-expiry: composite recompute callback threw for " << expired_ids.size()
+                    << " expired profile(s); entries kept, recompute retried next timer tick";
+        throw;
+    }
+    // Callback succeeded: clear the expire field, but only while it is still the past
+    // deadline (preserve a refreshed future deadline from a concurrent FR.14 reactivation).
+    // Erase the key when both deadlines become nullopt.
+    auto handle = this->deadlines.handle();
+    for (const auto id : expired_ids) {
+        auto it = handle->find(id);
+        if (it != handle->end() && it->second.expire.has_value() && it->second.expire.value() <= now) {
+            it->second.expire.reset();
+            if (!it->second.pull.has_value()) {
+                handle->erase(it);
+            }
+        }
+    }
+}
+
+void DynamicScheduleManager::on_deadline() {
+    // Runs on the timer io_context thread; any uncaught exception would terminate the process.
+    try {
+        const auto now = date::utc_clock::now();
+        this->dispatch_due_pulls(now);
+        // commit_due_expiries rethrows on callback failure (entries already kept inside it); that
+        // propagates here so the outer catch records the type and keeps the timer thread alive.
+        this->commit_due_expiries(now);
+    } catch (const std::exception& e) {
+        EVLOG_error << "on_deadline: unhandled exception swallowed to keep timer thread alive: " << e.what();
+    } catch (...) {
+        EVLOG_error << "on_deadline: unknown exception swallowed to keep timer thread alive";
+    }
+
+    // Always rearm; an exception in reschedule_timer must not kill the timer thread either.
+    try {
+        this->reschedule_timer();
+    } catch (const std::exception& e) {
+        EVLOG_error << "on_deadline: reschedule_timer threw: " << e.what();
+    } catch (...) {
+        EVLOG_error << "on_deadline: reschedule_timer threw unknown exception";
+    }
+}
+
+bool DynamicScheduleManager::dispatch_pull_request(std::int32_t charging_profile_id) {
+    v21::PullDynamicScheduleUpdateRequest req;
+    req.chargingProfileId = charging_profile_id;
+
+    const ocpp::Call<v21::PullDynamicScheduleUpdateRequest> call(req);
+
+    // Single-flight: skip if a pull for this id is already in flight. Only the timer thread
+    // pushes here and the reaper only removes, so check-then-push is race-free. Return true so
+    // the timer advances the deadline, treating the suppressed pull as in flight.
+    {
+        auto handle = this->pending_pulls.handle();
+        if (std::any_of(handle->begin(), handle->end(),
+                        [charging_profile_id](const PendingPull& p) { return p.id == charging_profile_id; })) {
+            EVLOG_debug << "K28: PullDynamicScheduleUpdate for profile " << charging_profile_id
+                        << " already in flight; suppressing duplicate dispatch";
+            return true;
+        }
+    }
+
+    // dispatch_call_async may sync-throw on queue-full / websocket-down / serialization failure.
+    // Catch locally and report failure so the timer-thread caller skips advancing the pull deadline:
+    // we want the next tick to retry promptly rather than wait a full interval.
+    std::future<ocpp::EnhancedMessage<MessageType>> future;
+    try {
+        future = this->context.message_dispatcher.dispatch_call_async(call);
+    } catch (const std::exception& e) {
+        EVLOG_warning << "PullDynamicScheduleUpdate dispatch_call_async threw for profile " << charging_profile_id
+                      << ": " << e.what();
+        return false;
+    }
+
+    // Bound the reaper's per-pull wait (MessageTimeout + 10s slack) so the destructor join
+    // can't hang on a silent CSMS; fall back to the default if the device-model read throws.
+    std::chrono::seconds pull_wait{DEFAULT_WAIT_FOR_FUTURE_TIMEOUT};
+    try {
+        const auto msg_timeout =
+            this->context.device_model.get_value<int>(ControllerComponentVariables::MessageTimeout);
+        pull_wait = std::chrono::seconds(msg_timeout) + std::chrono::seconds(10);
+    } catch (const std::exception& e) {
+        EVLOG_warning << "K28: MessageTimeout read failed, using " << DEFAULT_WAIT_FOR_FUTURE_TIMEOUT.count()
+                      << "s worker bound: " << e.what();
+    }
+
+    // Hand the future to the reaper (not the timer thread) so a slow CSMS can't block the timer.
+    // Notify so the reaper wakes immediately instead of waiting a poll slice.
+    {
+        auto handle = this->pending_pulls.handle();
+        handle->push_back(
+            PendingPull{charging_profile_id, std::move(future), std::chrono::steady_clock::now() + pull_wait});
+    }
+    this->pending_pulls.notify_one();
+    return true;
+}
+
+void DynamicScheduleManager::reaper_loop() {
+    constexpr auto poll_slice = std::chrono::milliseconds(200);
+    while (!this->teardown_requested.load(std::memory_order_relaxed)) {
+        std::vector<PendingPull> ready;
+        {
+            auto handle = this->pending_pulls.handle();
+            // Wait on teardown, else time out after poll_slice and re-scan. A ready future does
+            // NOT notify the monitor, so the timeout is load-bearing: it drives the periodic
+            // re-scan for ready/expired entries. A dispatch's notify only trims wake latency.
+            handle.wait_for([&] { return this->teardown_requested.load(std::memory_order_relaxed); }, poll_slice);
+            if (this->teardown_requested.load(std::memory_order_relaxed)) {
+                // Drop everything: let handle (and the futures it owns) destruct.
+                break;
+            }
+            // Still holding the lock: collect entries that are ready or past their deadline, moving
+            // their futures out, and erase them from the live vector.
+            const auto now = std::chrono::steady_clock::now();
+            auto& pulls = *handle;
+            const auto split = std::remove_if(pulls.begin(), pulls.end(), [&](PendingPull& p) {
+                const bool is_ready =
+                    p.future.valid() && p.future.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+                if (is_ready || now >= p.deadline) {
+                    ready.push_back(std::move(p));
+                    return true;
+                }
+                return false;
+            });
+            pulls.erase(split, pulls.end());
+        }
+
+        // Lock released: validate and apply each collected entry.
+        for (auto& entry : ready) {
+            if (this->teardown_requested.load(std::memory_order_relaxed)) {
+                EVLOG_debug << "K28-reaper: teardown requested, abandoning PullDynamicScheduleUpdate wait for profile "
+                            << entry.id;
+                break;
+            }
+            if (std::chrono::steady_clock::now() >= entry.deadline) {
+                EVLOG_warning << "K28: PullDynamicScheduleUpdate response timed out for profile " << entry.id
+                              << "; pull skipped, retry next dynUpdateInterval";
+                continue;
+            }
+            ocpp::EnhancedMessage<MessageType> enhanced_message;
+            try {
+                enhanced_message = entry.future.get();
+            } catch (const std::exception& e) {
+                // Transient failure (e.g. websocket drop): no deadline feedback, the profile stays
+                // one dynUpdateInterval stale until the next attempt.
+                EVLOG_error << "K28-reaper: PullDynamicScheduleUpdate future threw for profile " << entry.id
+                            << "; pull skipped, next attempt in one dynUpdateInterval: " << e.what();
+                continue;
+            }
+            if (enhanced_message.offline) {
+                // CSMS unreachable on response: no deadline feedback, profile stays stale.
+                EVLOG_error << "K28-reaper: PullDynamicScheduleUpdate response offline for profile " << entry.id
+                            << "; pull skipped, next attempt in one dynUpdateInterval";
+                continue;
+            }
+            if (enhanced_message.messageType != MessageType::PullDynamicScheduleUpdateResponse) {
+                EVLOG_warning << "Unexpected response type for PullDynamicScheduleUpdate: "
+                              << enhanced_message.messageType;
+                continue;
+            }
+            try {
+                this->apply_pull_response(entry.id, enhanced_message);
+            } catch (const std::exception& e) {
+                EVLOG_error << "K28-reaper: pull-response apply for profile " << entry.id
+                            << " threw; result dropped, next attempt in one dynUpdateInterval: " << e.what();
+            } catch (...) {
+                EVLOG_error << "K28-reaper: pull-response apply for profile " << entry.id
+                            << " threw unknown exception; result dropped, next attempt in one dynUpdateInterval";
+            }
+        }
+    }
+}
+
+void DynamicScheduleManager::apply_pull_response(std::int32_t charging_profile_id,
+                                                 const ocpp::EnhancedMessage<MessageType>& enhanced_message) {
+    v21::PullDynamicScheduleUpdateResponse response;
+    try {
+        const ocpp::CallResult<v21::PullDynamicScheduleUpdateResponse> call_result = enhanced_message.message;
+        response = call_result.msg;
+    } catch (const std::exception& e) {
+        EVLOG_warning << "Could not parse PullDynamicScheduleUpdateResponse: " << e.what();
+        return;
+    }
+
+    if (response.status != ChargingProfileStatusEnum::Accepted || !response.scheduleUpdate.has_value()) {
+        EVLOG_debug << "PullDynamicScheduleUpdate not Accepted or scheduleUpdate missing for profile "
+                    << charging_profile_id;
+        return;
+    }
+
+    // Look up the profile fresh; it may have been cleared or replaced while in flight.
+    auto match = this->lookup_dynamic_profile(charging_profile_id);
+    if (!match.profile.has_value()) {
+        if (match.db_error) {
+            EVLOG_warning << "Could not look up profile " << charging_profile_id
+                          << " for pull response (database error); ignoring, retry next dynUpdateInterval.";
+        } else {
+            EVLOG_debug << "Profile " << charging_profile_id
+                        << " missing or no longer Dynamic; ignoring pull response.";
+        }
+        return;
+    }
+
+    auto& matched = match.profile.value();
+    const auto apply_result =
+        this->apply_update(matched.profile, response.scheduleUpdate.value(), matched.evse_id, matched.source);
+    switch (apply_result) {
+    case ApplyResult::AppliedFieldsCallbackPending:
+        // Fire-then-commit: publish the recompute BEFORE advancing pull tracking. If the
+        // callback throws, do NOT advance tracking; the pull deadline is left unchanged
+        // so the next tick retries.
+        try {
+            this->set_charging_profiles_callback();
+        } catch (const std::exception& e) {
+            EVLOG_error << "K28-reaper: composite recompute callback threw for profile " << charging_profile_id
+                        << "; pull tracking NOT advanced, next attempt in one dynUpdateInterval: " << e.what();
+            break;
+        }
+        this->update_tracking(matched.profile);
+        break;
+    case ApplyResult::AppliedNoFieldsCallbackSkipped:
+        this->update_tracking(matched.profile);
+        break;
+    case ApplyResult::PersistFailed:
+        EVLOG_error << "Could not persist Dynamic profile " << charging_profile_id << " from pull response.";
+        break;
+    }
+}
+
+} // namespace ocpp::v2

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -3,7 +3,9 @@
 
 #include <ocpp/v2/functional_blocks/smart_charging.hpp>
 
+#include <algorithm>
 #include <cmath>
+#include <future>
 #include <optional>
 
 #include <ocpp/common/constants.hpp>
@@ -22,6 +24,9 @@
 #include <ocpp/v2/messages/NotifyEVChargingNeeds.hpp>
 #include <ocpp/v2/messages/ReportChargingProfiles.hpp>
 #include <ocpp/v2/messages/SetChargingProfile.hpp>
+
+#include <ocpp/v21/messages/PullDynamicScheduleUpdate.hpp>
+#include <ocpp/v21/messages/UpdateDynamicSchedule.hpp>
 
 const std::int32_t STATION_WIDE_ID = 0;
 
@@ -158,6 +163,10 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingProfileUnsupportedKind";
     case ProfileValidationResultEnum::ChargingProfileNotDynamic:
         return "ChargingProfileNotDynamic";
+    case ProfileValidationResultEnum::ChargingProfileDynamicMustHaveSinglePeriod:
+        return "ChargingProfileDynamicMustHaveSinglePeriod";
+    case ProfileValidationResultEnum::ChargingProfileDynamicMustHaveSingleSchedule:
+        return "ChargingProfileDynamicMustHaveSingleSchedule";
     case ProfileValidationResultEnum::ChargingScheduleChargingRateUnitUnsupported:
         return "ChargingScheduleChargingRateUnitUnsupported";
     case ProfileValidationResultEnum::ChargingScheduleNonFiniteValue:
@@ -244,6 +253,8 @@ std::string profile_validation_result_to_reason_code(ProfileValidationResultEnum
         return "UnsupportedKind";
     case ProfileValidationResultEnum::ChargingProfileNotDynamic:
         return "InvalidProfile";
+    case ProfileValidationResultEnum::ChargingProfileDynamicMustHaveSinglePeriod:
+    case ProfileValidationResultEnum::ChargingProfileDynamicMustHaveSingleSchedule:
     case ProfileValidationResultEnum::ChargingProfileNoChargingSchedulePeriods:
     case ProfileValidationResultEnum::ChargingProfileFirstStartScheduleIsNotZero:
     case ProfileValidationResultEnum::ChargingProfileMissingRequiredStartSchedule:
@@ -340,6 +351,16 @@ SmartCharging::SmartCharging(const FunctionalBlockContext& functional_block_cont
     context(functional_block_context),
     set_charging_profiles_callback(set_charging_profiles_callback),
     stop_transaction_callback(stop_transaction_callback) {
+    // K28: only stand up the Dynamic-profile machinery (reaper thread + adaptive timer) when the
+    // device model advertises support; otherwise leave the optional disengaged to save the resources.
+    const bool supports_dynamic_profiles =
+        this->context.device_model.get_optional_value<bool>(ControllerComponentVariables::SupportsDynamicProfiles)
+            .value_or(false);
+    if (supports_dynamic_profiles) {
+        this->dynamic_schedule_manager.emplace(functional_block_context, this->set_charging_profiles_callback);
+        // K28.FR.10: rebuild adaptive-pull state from persisted Dynamic profiles, then arm the timer.
+        this->dynamic_schedule_manager->rebuild_from_db();
+    }
 }
 
 void SmartCharging::handle_message(const ocpp::EnhancedMessage<MessageType>& message) {
@@ -355,6 +376,13 @@ void SmartCharging::handle_message(const ocpp::EnhancedMessage<MessageType>& mes
         this->handle_get_composite_schedule_req(json_message);
     } else if (message.messageType == MessageType::NotifyEVChargingNeedsResponse) {
         this->handle_notify_ev_charging_needs_response(message);
+    } else if (message.messageType == MessageType::UpdateDynamicSchedule) {
+        if (not this->dynamic_schedule_manager.has_value()) {
+            // Dynamic profiles unsupported, so the manager was never built. The CSMS gates this
+            // message on SupportsDynamicProfiles, so this is defensive: answer NotImplemented.
+            throw MessageTypeNotImplementedException(message.messageType);
+        }
+        this->dynamic_schedule_manager->handle_update_dynamic_schedule_request(message);
     } else {
         throw MessageTypeNotImplementedException(message.messageType);
     }
@@ -540,6 +568,10 @@ SetChargingProfileResponse SmartCharging::conform_validate_and_add_profile(Charg
     }
 
     if (result == ProfileValidationResultEnum::Valid) {
+        // K28.FR.05: Auto-populate dynUpdateTime on accept for Dynamic profiles.
+        if (profile.chargingProfileKind == ChargingProfileKindEnum::Dynamic && !profile.dynUpdateTime.has_value()) {
+            profile.dynUpdateTime = ocpp::DateTime();
+        }
         response = this->add_profile(profile, evse_id, charging_limit_source);
     } else {
         response.statusInfo = StatusInfo();
@@ -901,6 +933,11 @@ ProfileValidationResultEnum SmartCharging::validate_profile_schedules(ChargingPr
         return ProfileValidationResultEnum::ChargingProfileEmptyChargingSchedules;
     }
 
+    // K28.FR.01: Dynamic profile must have exactly one schedule with one period.
+    if (profile.chargingProfileKind == ChargingProfileKindEnum::Dynamic && profile.chargingSchedule.size() != 1) {
+        return ProfileValidationResultEnum::ChargingProfileDynamicMustHaveSingleSchedule;
+    }
+
     auto charging_station_supply_phases =
         this->context.device_model.get_value<std::int32_t>(ControllerComponentVariables::ChargingStationSupplyPhases);
 
@@ -958,6 +995,13 @@ ProfileValidationResultEnum SmartCharging::validate_profile_schedules(ChargingPr
             if ((profile.dynUpdateInterval.has_value() || profile.dynUpdateTime.has_value()) &&
                 profile.chargingProfileKind != ChargingProfileKindEnum::Dynamic) {
                 return ProfileValidationResultEnum::ChargingProfileNotDynamic;
+            }
+
+            // K28.FR.01: Dynamic profile's single schedule must have exactly one period.
+            // (K28.FR.02 is enforced by the K01.FR.31 startPeriod=0 check below.)
+            if (profile.chargingProfileKind == ChargingProfileKindEnum::Dynamic &&
+                schedule.chargingSchedulePeriod.size() != 1) {
+                return ProfileValidationResultEnum::ChargingProfileDynamicMustHaveSinglePeriod;
             }
 
             // K01.FR.123 Local time is not supported
@@ -1153,17 +1197,37 @@ SetChargingProfileResponse SmartCharging::add_profile(ChargingProfile& profile, 
         response.status = ChargingProfileStatusEnum::Rejected;
         response.statusInfo = StatusInfo();
         response.statusInfo->reasonCode = "InternalError";
+        return response;
+    }
+
+    // K28.FR.10: refresh the adaptive-pull deadline for this profile id (handles Dynamic +
+    // non-Dynamic-replacing-Dynamic transitions). Run in its own try-block: the profile is already
+    // in the DB, so we must not lie to the CSMS with Rejected if pull-tracking refresh fails
+    // (e.g. std::bad_alloc on a map insert, std::system_error from timer rearm). Log the local
+    // mismatch and keep the Accepted response.
+    try {
+        if (this->dynamic_schedule_manager.has_value()) {
+            this->dynamic_schedule_manager->update_tracking(profile);
+        }
+    } catch (const std::exception& e) {
+        // The profile is persisted, so the response stays Accepted (responding Rejected would lie
+        // to the CSMS about a stored profile). The tracking refresh that would (re)arm the adaptive
+        // timer was lost; the next profile change re-arms tracking.
+        EVLOG_error << "[K28-tracking] ChargingProfile " << profile.id << " stored but pull-tracking refresh failed ("
+                    << e.what() << "); adaptive pull disabled for profile " << profile.id
+                    << " until next profile change";
     }
 
     return response;
 }
 
-ClearChargingProfileResponse SmartCharging::clear_profiles(const ClearChargingProfileRequest& request) {
+ClearChargingProfileResponse SmartCharging::clear_profiles(const ClearChargingProfileRequest& request,
+                                                           std::vector<std::int32_t>& cleared_ids) {
     ClearChargingProfileResponse response;
     response.status = ClearChargingProfileStatusEnum::Unknown;
 
     try {
-        const auto cleared_ids = this->context.database_handler.clear_charging_profiles_matching_criteria(
+        cleared_ids = this->context.database_handler.clear_charging_profiles_matching_criteria(
             request.chargingProfileId, request.chargingProfileCriteria);
         if (!cleared_ids.empty()) {
             response.status = ClearChargingProfileStatusEnum::Accepted;
@@ -1297,7 +1361,16 @@ void SmartCharging::handle_clear_charging_profile_req(Call<ClearChargingProfileR
         EVLOG_debug << "Rejecting SetChargingProfileRequest:\n reasonCode: " << response.statusInfo->reasonCode.get()
                     << "\nadditionalInfo: " << response.statusInfo->additionalInfo->get();
     } else {
-        response = this->clear_profiles(msg);
+        // K28.FR.10: the DELETE returns exactly the ids it removed, so dropping their deadline
+        // tracking needs no mirrored lookup and cannot drift from the DB delete filter.
+        std::vector<std::int32_t> cleared_ids;
+        response = this->clear_profiles(msg, cleared_ids);
+
+        if (response.status == ClearChargingProfileStatusEnum::Accepted && this->dynamic_schedule_manager.has_value()) {
+            for (const auto id : cleared_ids) {
+                this->dynamic_schedule_manager->erase_tracking(id);
+            }
+        }
     }
 
     if (response.status == ClearChargingProfileStatusEnum::Accepted) {
@@ -1492,7 +1565,7 @@ bool SmartCharging::is_overlapping_validity_period(const ChargingProfile& candid
     overlap_stmt->bind_text(
         "@purpose", conversions::charging_profile_purpose_enum_to_string(candidate_profile.chargingProfilePurpose),
         everest::db::sqlite::SQLiteString::Transient);
-    while (overlap_stmt->step() != SQLITE_DONE) {
+    while (overlap_stmt->step() == SQLITE_ROW) {
         const ChargingProfile existing_profile = json::parse(overlap_stmt->column_text(0));
         if (candidate_profile.validFrom <= existing_profile.validTo &&
             candidate_profile.validTo >= existing_profile.validFrom) {
@@ -1509,7 +1582,7 @@ std::vector<ChargingProfile> SmartCharging::get_evse_specific_tx_default_profile
     auto stmt =
         this->context.database_handler.new_statement("SELECT PROFILE FROM CHARGING_PROFILES WHERE "
                                                      "EVSE_ID != 0 AND CHARGING_PROFILE_PURPOSE = 'TxDefaultProfile'");
-    while (stmt->step() != SQLITE_DONE) {
+    while (stmt->step() == SQLITE_ROW) {
         const ChargingProfile profile = json::parse(stmt->column_text(0));
         evse_specific_tx_default_profiles.push_back(profile);
     }
@@ -1522,7 +1595,7 @@ std::vector<ChargingProfile> SmartCharging::get_station_wide_tx_default_profiles
 
     auto stmt = this->context.database_handler.new_statement(
         "SELECT PROFILE FROM CHARGING_PROFILES WHERE EVSE_ID = 0 AND CHARGING_PROFILE_PURPOSE = 'TxDefaultProfile'");
-    while (stmt->step() != SQLITE_DONE) {
+    while (stmt->step() == SQLITE_ROW) {
         const ChargingProfile profile = json::parse(stmt->column_text(0));
         station_wide_tx_default_profiles.push_back(profile);
     }
@@ -1535,7 +1608,7 @@ std::vector<ChargingProfile> SmartCharging::get_charging_station_max_profiles() 
     auto stmt =
         this->context.database_handler.new_statement("SELECT PROFILE FROM CHARGING_PROFILES WHERE EVSE_ID = 0 AND "
                                                      "CHARGING_PROFILE_PURPOSE = 'ChargingStationMaxProfile'");
-    while (stmt->step() != SQLITE_DONE) {
+    while (stmt->step() == SQLITE_ROW) {
         const ChargingProfile profile = json::parse(stmt->column_text(0));
         charging_station_max_profiles.push_back(profile);
     }
@@ -1549,6 +1622,7 @@ SmartCharging::get_valid_profiles_for_evse(std::int32_t evse_id,
     std::vector<ChargingProfile> valid_profiles;
 
     auto evse_profiles = this->context.database_handler.get_charging_profiles_for_evse(evse_id);
+    const auto now = date::utc_clock::now();
     for (auto profile : evse_profiles) {
         // Q11
         if (const auto [valid, clear] = this->validate_profile_with_offline_time(profile); !valid) {
@@ -1558,6 +1632,13 @@ SmartCharging::get_valid_profiles_for_evse(std::int32_t evse_id,
                             << ", because it is invalid after offline duration";
                 this->context.database_handler.clear_charging_profiles_matching_criteria(profile.id, std::nullopt);
             }
+            continue;
+        }
+
+        // K28.FR.13: drop a Dynamic profile whose schedule duration has elapsed since dynUpdateTime.
+        if (dynamic_profile_expired(profile, now)) {
+            EVLOG_debug << "Skipping expired Dynamic profile " << profile.id
+                        << " from composite calc (duration elapsed)";
             continue;
         }
 

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -1565,12 +1565,16 @@ bool SmartCharging::is_overlapping_validity_period(const ChargingProfile& candid
     overlap_stmt->bind_text(
         "@purpose", conversions::charging_profile_purpose_enum_to_string(candidate_profile.chargingProfilePurpose),
         everest::db::sqlite::SQLiteString::Transient);
-    while (overlap_stmt->step() == SQLITE_ROW) {
+    int status;
+    while ((status = overlap_stmt->step()) == SQLITE_ROW) {
         const ChargingProfile existing_profile = json::parse(overlap_stmt->column_text(0));
         if (candidate_profile.validFrom <= existing_profile.validTo &&
             candidate_profile.validTo >= existing_profile.validFrom) {
             return true;
         }
+    }
+    if (status != SQLITE_DONE) {
+        EVLOG_error << "Error while checking is_overlapping_validity_period, db error: " << status;
     }
 
     return false;
@@ -1582,9 +1586,13 @@ std::vector<ChargingProfile> SmartCharging::get_evse_specific_tx_default_profile
     auto stmt =
         this->context.database_handler.new_statement("SELECT PROFILE FROM CHARGING_PROFILES WHERE "
                                                      "EVSE_ID != 0 AND CHARGING_PROFILE_PURPOSE = 'TxDefaultProfile'");
-    while (stmt->step() == SQLITE_ROW) {
+    int status;
+    while ((status = stmt->step()) == SQLITE_ROW) {
         const ChargingProfile profile = json::parse(stmt->column_text(0));
         evse_specific_tx_default_profiles.push_back(profile);
+    }
+    if (status != SQLITE_DONE) {
+        EVLOG_error << "Error during get_evse_specific_tx_default_profiles, db error: " << status;
     }
 
     return evse_specific_tx_default_profiles;
@@ -1595,9 +1603,13 @@ std::vector<ChargingProfile> SmartCharging::get_station_wide_tx_default_profiles
 
     auto stmt = this->context.database_handler.new_statement(
         "SELECT PROFILE FROM CHARGING_PROFILES WHERE EVSE_ID = 0 AND CHARGING_PROFILE_PURPOSE = 'TxDefaultProfile'");
-    while (stmt->step() == SQLITE_ROW) {
+    int status;
+    while ((status = stmt->step()) == SQLITE_ROW) {
         const ChargingProfile profile = json::parse(stmt->column_text(0));
         station_wide_tx_default_profiles.push_back(profile);
+    }
+    if (status != SQLITE_DONE) {
+        EVLOG_error << "Error during get_station_wide_tx_default_profiles, db error: " << status;
     }
 
     return station_wide_tx_default_profiles;
@@ -1608,9 +1620,13 @@ std::vector<ChargingProfile> SmartCharging::get_charging_station_max_profiles() 
     auto stmt =
         this->context.database_handler.new_statement("SELECT PROFILE FROM CHARGING_PROFILES WHERE EVSE_ID = 0 AND "
                                                      "CHARGING_PROFILE_PURPOSE = 'ChargingStationMaxProfile'");
-    while (stmt->step() == SQLITE_ROW) {
+    int status;
+    while ((status = stmt->step()) == SQLITE_ROW) {
         const ChargingProfile profile = json::parse(stmt->column_text(0));
         charging_station_max_profiles.push_back(profile);
+    }
+    if (status != SQLITE_DONE) {
+        EVLOG_error << "Error during get_charging_station_max_profiles, db error: " << status;
     }
 
     return charging_station_max_profiles;

--- a/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/profile.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
 #include "ocpp/v2/profile.hpp"
 #include "everest/logging.hpp"
@@ -44,6 +44,31 @@ std::int32_t elapsed_seconds(const ocpp::DateTime& to, const ocpp::DateTime& fro
 
 ocpp::DateTime floor_seconds(const ocpp::DateTime& dt) {
     return ocpp::DateTime(std::chrono::floor<seconds>(dt.to_time_point()));
+}
+
+std::optional<date::utc_clock::time_point> dynamic_expiry_deadline(const ChargingProfile& profile) {
+    if (profile.chargingProfileKind != ChargingProfileKindEnum::Dynamic || profile.chargingSchedule.empty() ||
+        !profile.chargingSchedule.front().duration.has_value() ||
+        profile.chargingSchedule.front().duration.value() <= 0 || !profile.dynUpdateTime.has_value()) {
+        return std::nullopt;
+    }
+    return profile.dynUpdateTime.value().to_time_point() + seconds(profile.chargingSchedule.front().duration.value());
+}
+
+std::optional<date::utc_clock::time_point> dynamic_pull_deadline(const ChargingProfile& profile) {
+    if (profile.chargingProfileKind != ChargingProfileKindEnum::Dynamic || !profile.dynUpdateInterval.has_value() ||
+        profile.dynUpdateInterval.value() <= 0) {
+        return std::nullopt;
+    }
+    const auto interval = seconds(profile.dynUpdateInterval.value());
+    // Bootstrap (no dynUpdateTime): pull immediately the first time.
+    return profile.dynUpdateTime.has_value() ? profile.dynUpdateTime.value().to_time_point() + interval
+                                             : date::utc_clock::now();
+}
+
+bool dynamic_profile_expired(const ChargingProfile& profile, date::utc_clock::time_point now) {
+    const auto deadline = dynamic_expiry_deadline(profile);
+    return deadline.has_value() && now >= deadline.value();
 }
 
 OperationModeEnum effective_mode(const std::optional<OperationModeEnum>& mode) {
@@ -240,7 +265,8 @@ std::vector<DateTime> calculate_start(const DateTime& in_now, const DateTime& in
         start_times.push_back(start);
         break;
     case ChargingProfileKindEnum::Dynamic:
-        // FIXME: check if other requirements for dynamic exist
+        // Single period anchored at the schedule start; K28 pull/expiry/reactivation are handled
+        // by DynamicScheduleManager and the expiry filter, not the composite start-time logic.
         start_times.push_back(floor_seconds(start));
         break;
     }

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_smart_charging.cpp
@@ -1476,8 +1476,10 @@ TEST_F(SmartChargingTest, K10_ClearChargingProfile_ClearsId) {
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::Contains(profile));
 
-    auto sut = smart_charging.clear_profiles(create_clear_charging_profile_request(DEFAULT_PROFILE_ID));
+    std::vector<std::int32_t> cleared_ids;
+    auto sut = smart_charging.clear_profiles(create_clear_charging_profile_request(DEFAULT_PROFILE_ID), cleared_ids);
     EXPECT_THAT(sut.status, testing::Eq(ClearChargingProfileStatusEnum::Accepted));
+    EXPECT_THAT(cleared_ids, testing::ElementsAre(DEFAULT_PROFILE_ID));
 
     profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::Not(testing::Contains(profile)));
@@ -1489,10 +1491,14 @@ TEST_F(SmartChargingTest, K10_ClearChargingProfile_ClearsStackLevelPurposeCombin
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::Not(testing::IsEmpty()));
 
-    auto sut = smart_charging.clear_profiles(create_clear_charging_profile_request(
-        std::nullopt, create_clear_charging_profile(std::nullopt, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                                    DEFAULT_STACK_LEVEL)));
+    std::vector<std::int32_t> cleared_ids;
+    auto sut = smart_charging.clear_profiles(
+        create_clear_charging_profile_request(
+            std::nullopt, create_clear_charging_profile(std::nullopt, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                                        DEFAULT_STACK_LEVEL)),
+        cleared_ids);
     EXPECT_THAT(sut.status, testing::Eq(ClearChargingProfileStatusEnum::Accepted));
+    EXPECT_THAT(cleared_ids, testing::ElementsAre(DEFAULT_PROFILE_ID));
 
     profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::IsEmpty());
@@ -1504,10 +1510,14 @@ TEST_F(SmartChargingTest, K10_ClearChargingProfile_UnknownStackLevelPurposeCombi
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::Not(testing::IsEmpty()));
 
-    auto sut = smart_charging.clear_profiles(create_clear_charging_profile_request(
-        std::nullopt, create_clear_charging_profile(std::nullopt, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
-                                                    STATION_WIDE_ID)));
+    std::vector<std::int32_t> cleared_ids;
+    auto sut = smart_charging.clear_profiles(
+        create_clear_charging_profile_request(
+            std::nullopt, create_clear_charging_profile(
+                              std::nullopt, ChargingProfilePurposeEnum::ChargingStationMaxProfile, STATION_WIDE_ID)),
+        cleared_ids);
     EXPECT_THAT(sut.status, testing::Eq(ClearChargingProfileStatusEnum::Unknown));
+    EXPECT_THAT(cleared_ids, testing::IsEmpty());
 
     profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::Not(testing::IsEmpty()));
@@ -1524,8 +1534,10 @@ TEST_F(SmartChargingTest, K10_ClearChargingProfile_UnknownId) {
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::Contains(profile));
 
-    auto sut = smart_charging.clear_profiles(create_clear_charging_profile_request(178));
+    std::vector<std::int32_t> cleared_ids;
+    auto sut = smart_charging.clear_profiles(create_clear_charging_profile_request(178), cleared_ids);
     EXPECT_THAT(sut.status, testing::Eq(ClearChargingProfileStatusEnum::Unknown));
+    EXPECT_THAT(cleared_ids, testing::IsEmpty());
 
     profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::Contains(profile));

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/smart_charging_test_utils.hpp
@@ -8,6 +8,10 @@
 #include "ocpp/v2/ocpp_types.hpp"
 #include "ocpp/v2/profile.hpp"
 #include "ocpp/v2/utils.hpp"
+#include <ocpp/common/call_types.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/database_handler.hpp>
+#include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/messages/ClearChargingProfile.hpp>
 #include <ocpp/v2/messages/GetChargingProfiles.hpp>
 #include <ocpp/v2/messages/GetCompositeSchedule.hpp>
@@ -27,16 +31,22 @@
 #include <gmock/gmock.h>
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 
+#include <atomic>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <chrono>
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <openssl/evp.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
+#include <sqlite3.h>
 #include <sstream>
+#include <string>
+#include <system_error>
+#include <unistd.h>
 #include <vector>
 
 using ::testing::MockFunction;
@@ -132,8 +142,10 @@ public:
     using SmartCharging::add_profile;
     using SmartCharging::calculate_composite_schedule;
     using SmartCharging::clear_profiles;
+    using SmartCharging::dynamic_schedule_manager;
     using SmartCharging::get_reported_profiles;
     using SmartCharging::get_valid_profiles;
+    using SmartCharging::get_valid_profiles_for_evse;
     using SmartCharging::SmartCharging;
     using SmartCharging::validate_evse_exists;
     using SmartCharging::validate_phase_conflict;
@@ -176,6 +188,90 @@ public:
 class CompositeScheduleTestFixtureV21 : public CompositeScheduleTestFixtureV2 {
 public:
     CompositeScheduleTestFixtureV21();
+};
+
+class SmartChargingTestV21 : public DatabaseTestingUtils {
+protected:
+    void SetUp() override {
+        const auto& charging_rate_unit_cv = ControllerComponentVariables::ChargingScheduleChargingRateUnit;
+        device_model->set_value(charging_rate_unit_cv.component, charging_rate_unit_cv.variable.value(),
+                                AttributeEnum::Actual, "A,W", "test", true);
+
+        const auto& ac_phase_switching_cv = ControllerComponentVariables::ACPhaseSwitchingSupported;
+        device_model->set_value(ac_phase_switching_cv.component, ac_phase_switching_cv.variable.value(),
+                                AttributeEnum::Actual, "true", "test", true);
+    }
+
+    void TearDown() override {
+        // Each test gets its own DB file (see create_smart_charging), so there is no shared state
+        // to reset. Unlink it; if a background K28 worker/timer still holds the connection the
+        // inode survives until that fd closes and the next test uses a fresh, distinct path.
+        std::error_code ec;
+        std::filesystem::remove(this->test_db_path, ec);
+    }
+
+    TestSmartCharging create_smart_charging() {
+        // Unique DB file per fixture instance. The shared /tmp/ocpp201/cp.db was raced by the
+        // DynamicScheduleManager timer/async-worker threads, corrupting migrations for the next
+        // test's fixture constructor; a distinct path per test removes the cross-test contention.
+        static std::atomic<unsigned> db_seq{0};
+        this->test_db_path = std::filesystem::temp_directory_path() /
+                             ("ocpp201_test_" + std::to_string(::getpid()) + "_" +
+                              std::to_string(db_seq.fetch_add(1, std::memory_order_relaxed)) + ".db");
+        std::unique_ptr<everest::db::sqlite::Connection> database_connection =
+            std::make_unique<everest::db::sqlite::Connection>(this->test_db_path);
+        database_handler =
+            std::make_shared<DatabaseHandler>(std::move(database_connection), MIGRATION_FILES_LOCATION_V2);
+        database_handler->open_connection();
+        device_model = device_model_test_helper.get_device_model();
+        // SupportsDynamicProfiles is read in the SmartCharging constructor to decide whether to build
+        // the optional DynamicScheduleManager. Set it before constructing so the K28 tests get one.
+        const auto& supports_dynamic = ControllerComponentVariables::SupportsDynamicProfiles;
+        device_model->set_value(supports_dynamic.component, supports_dynamic.variable.value(), AttributeEnum::Actual,
+                                "true", "test", true);
+        this->functional_block_context = std::make_unique<FunctionalBlockContext>(
+            this->mock_dispatcher, *this->device_model, this->connectivity_manager, *this->evse_manager,
+            *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version);
+        return TestSmartCharging(*functional_block_context, set_charging_profiles_callback_mock.AsStdFunction(),
+                                 stop_transaction_callback_mock.AsStdFunction());
+    }
+
+    template <class T> void call_to_json(json& j, const ocpp::Call<T>& call) {
+        j = json::array();
+        j.push_back(ocpp::MessageTypeId::CALL);
+        j.push_back(call.uniqueId.get());
+        j.push_back(call.msg.get_type());
+        j.push_back(json(call.msg));
+    }
+
+    template <class T, MessageType M> ocpp::EnhancedMessage<MessageType> request_to_enhanced_message(const T& req) {
+        auto message_id = ocpp::create_message_id();
+        ocpp::Call<T> call(req);
+        call.uniqueId = message_id;
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.uniqueId = message_id;
+        enhanced_message.messageType = M;
+        enhanced_message.messageTypeId = ocpp::MessageTypeId::CALL;
+        call_to_json(enhanced_message.message, call);
+        return enhanced_message;
+    }
+
+    // Default values used within the tests
+    DeviceModelTestHelper device_model_test_helper;
+    MockMessageDispatcher mock_dispatcher;
+    std::unique_ptr<EvseManagerFake> evse_manager = std::make_unique<EvseManagerFake>(NR_OF_TWO_EVSES);
+    std::shared_ptr<DatabaseHandler> database_handler;
+    DeviceModel* device_model;
+    ::testing::NiceMock<ConnectivityManagerMock> connectivity_manager;
+    ocpp::EvseSecurityMock evse_security;
+    ComponentStateManagerMock component_state_manager;
+    MockFunction<void()> set_charging_profiles_callback_mock;
+    MockFunction<RequestStartStopStatusEnum(const std::int32_t evse_id, const ReasonEnum& stop_reason)>
+        stop_transaction_callback_mock;
+    std::filesystem::path test_db_path;
+    std::unique_ptr<FunctionalBlockContext> functional_block_context;
+    TestSmartCharging smart_charging = create_smart_charging();
+    std::atomic<OcppProtocolVersion> ocpp_version = OcppProtocolVersion::v21;
 };
 
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/CMakeLists.txt
@@ -4,4 +4,5 @@ target_include_directories(libocpp_unit_tests PUBLIC
 
 target_sources(libocpp_unit_tests PRIVATE
     test_smart_charging.cpp
-    test_der_control.cpp)
+    test_der_control.cpp
+    test_smart_charging_dynamic.cpp)

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
@@ -6,9 +6,19 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <filesystem>
+#include <future>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <thread>
+
+#include <unistd.h>
 
 #include <date/tz.h>
 #include <sqlite3.h>
@@ -23,6 +33,8 @@
 #include <ocpp/v2/functional_blocks/functional_block_context.hpp>
 #include <ocpp/v2/ocpp_enums.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
+#include <ocpp/v21/messages/PullDynamicScheduleUpdate.hpp>
+#include <ocpp/v21/messages/UpdateDynamicSchedule.hpp>
 
 #include "component_state_manager_mock.hpp"
 #include "connectivity_manager_mock.hpp"
@@ -42,53 +54,6 @@ using ::testing::Return;
 using ::testing::ReturnRef;
 
 namespace ocpp::v2 {
-class SmartChargingTestV21 : public DatabaseTestingUtils {
-protected:
-    void SetUp() override {
-        const auto& charging_rate_unit_cv = ControllerComponentVariables::ChargingScheduleChargingRateUnit;
-        device_model->set_value(charging_rate_unit_cv.component, charging_rate_unit_cv.variable.value(),
-                                AttributeEnum::Actual, "A,W", "test", true);
-
-        const auto& ac_phase_switching_cv = ControllerComponentVariables::ACPhaseSwitchingSupported;
-        device_model->set_value(ac_phase_switching_cv.component, ac_phase_switching_cv.variable.value(),
-                                AttributeEnum::Actual, "true", "test", true);
-    }
-
-    void TearDown() override {
-        // TODO: use in-memory db so we don't need to reset the db between tests
-        this->database_handler->clear_charging_profiles();
-    }
-
-    TestSmartCharging create_smart_charging() {
-        std::unique_ptr<everest::db::sqlite::Connection> database_connection =
-            std::make_unique<everest::db::sqlite::Connection>(fs::path("/tmp/ocpp201") / "cp.db");
-        database_handler =
-            std::make_shared<DatabaseHandler>(std::move(database_connection), MIGRATION_FILES_LOCATION_V2);
-        database_handler->open_connection();
-        device_model = device_model_test_helper.get_device_model();
-        this->functional_block_context = std::make_unique<FunctionalBlockContext>(
-            this->mock_dispatcher, *this->device_model, this->connectivity_manager, *this->evse_manager,
-            *this->database_handler, this->evse_security, this->component_state_manager, this->ocpp_version);
-        return TestSmartCharging(*functional_block_context, set_charging_profiles_callback_mock.AsStdFunction(),
-                                 stop_transaction_callback_mock.AsStdFunction());
-    }
-
-    // Default values used within the tests
-    DeviceModelTestHelper device_model_test_helper;
-    MockMessageDispatcher mock_dispatcher;
-    std::unique_ptr<EvseManagerFake> evse_manager = std::make_unique<EvseManagerFake>(NR_OF_TWO_EVSES);
-    std::shared_ptr<DatabaseHandler> database_handler;
-    DeviceModel* device_model;
-    ::testing::NiceMock<ConnectivityManagerMock> connectivity_manager;
-    ocpp::EvseSecurityMock evse_security;
-    ComponentStateManagerMock component_state_manager;
-    MockFunction<void()> set_charging_profiles_callback_mock;
-    MockFunction<RequestStartStopStatusEnum(const std::int32_t evse_id, const ReasonEnum& stop_reason)>
-        stop_transaction_callback_mock;
-    std::unique_ptr<FunctionalBlockContext> functional_block_context;
-    TestSmartCharging smart_charging = create_smart_charging();
-    std::atomic<OcppProtocolVersion> ocpp_version = OcppProtocolVersion::v21;
-};
 
 TEST_F(SmartChargingTestV21,
        K01FR44_IfPhaseToUseProvidedForDCChargingStationAndDCInputPhaseControlFalse_ThenProfileIsInvalid) {

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging_dynamic.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging_dynamic.cpp
@@ -1,0 +1,2195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/v2/functional_blocks/smart_charging.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <thread>
+
+#include <unistd.h>
+
+#include <date/tz.h>
+#include <sqlite3.h>
+
+#include <comparators.hpp>
+#include <ocpp/common/call_types.hpp>
+#include <ocpp/common/types.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/database_handler.hpp>
+#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/evse.hpp>
+#include <ocpp/v2/functional_blocks/functional_block_context.hpp>
+#include <ocpp/v2/ocpp_enums.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+#include <ocpp/v21/messages/PullDynamicScheduleUpdate.hpp>
+#include <ocpp/v21/messages/UpdateDynamicSchedule.hpp>
+
+#include "component_state_manager_mock.hpp"
+#include "connectivity_manager_mock.hpp"
+#include "device_model_test_helper.hpp"
+#include "evse_manager_fake.hpp"
+#include "evse_mock.hpp"
+#include "evse_security_mock.hpp"
+#include "lib/ocpp/common/database_testing_utils.hpp"
+#include "message_dispatcher_mock.hpp"
+#include "smart_charging_test_utils.hpp"
+
+using ::testing::_;
+using ::testing::ByMove;
+using ::testing::Invoke;
+using ::testing::MockFunction;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+namespace ocpp::v2 {
+
+// Helper for K28 tests: enable Dynamic profile support on the device model.
+static void enable_dynamic_profiles(DeviceModel* device_model) {
+    const ComponentVariable supports_dynamic_profiles = ControllerComponentVariables::SupportsDynamicProfiles;
+    device_model->set_value(supports_dynamic_profiles.component, supports_dynamic_profiles.variable.value(),
+                            AttributeEnum::Actual, "true", "test", true);
+}
+
+TEST_F(SmartChargingTestV21, K28FR01_DynamicProfile_RejectMultipleSchedules) {
+    enable_dynamic_profiles(device_model);
+    auto periods = create_charging_schedule_periods(0, 1, 1, 0.5f);
+    auto schedule_a = create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00"));
+    auto schedule_b = create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00"));
+    std::vector<ChargingSchedule> schedules{schedule_a, schedule_b};
+
+    auto profile =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile, schedules, {},
+                                ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL,
+                                ocpp::DateTime("2024-01-01T13:00:00"), ocpp::DateTime("2024-02-01T13:00:00"));
+
+    auto response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Rejected));
+    EXPECT_EQ(response.statusInfo.value().reasonCode, "InvalidSchedule");
+    EXPECT_EQ(response.statusInfo.value().additionalInfo, "ChargingProfileDynamicMustHaveSingleSchedule");
+}
+
+TEST_F(SmartChargingTestV21, K28FR01_DynamicProfile_RejectMultiplePeriods) {
+    enable_dynamic_profiles(device_model);
+    auto periods = create_charging_schedule_periods({0, 60});
+    ASSERT_EQ(periods.size(), 2);
+    periods.at(0).limit = 16.0f;
+    periods.at(1).limit = 8.0f;
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2024-02-01T13:00:00"));
+
+    auto response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Rejected));
+    EXPECT_EQ(response.statusInfo.value().reasonCode, "InvalidSchedule");
+    EXPECT_EQ(response.statusInfo.value().additionalInfo, "ChargingProfileDynamicMustHaveSinglePeriod");
+}
+
+TEST_F(SmartChargingTestV21, K28FR02_DynamicProfile_RejectStartPeriodNonZero) {
+    enable_dynamic_profiles(device_model);
+    auto periods = create_charging_schedule_periods(60, 1, 1, 0.5f);
+    ASSERT_EQ(periods.size(), 1);
+    ASSERT_NE(periods.at(0).startPeriod, 0);
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2024-02-01T13:00:00"));
+
+    auto response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Rejected));
+    EXPECT_EQ(response.statusInfo.value().reasonCode, "InvalidSchedule");
+    EXPECT_EQ(response.statusInfo.value().additionalInfo, "ChargingProfileFirstStartScheduleIsNotZero");
+}
+
+TEST_F(SmartChargingTestV21, K28FR03_DynamicProfile_ResponseHasInvalidScheduleReasonCode) {
+    enable_dynamic_profiles(device_model);
+    // Trigger via multi-schedule rejection — verifies reasonCode wiring goes through InvalidSchedule cluster.
+    auto periods = create_charging_schedule_periods(0, 1, 1, 0.5f);
+    auto schedule_a = create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00"));
+    auto schedule_b = create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00"));
+    std::vector<ChargingSchedule> schedules{schedule_a, schedule_b};
+
+    auto profile =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile, schedules, {},
+                                ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL,
+                                ocpp::DateTime("2024-01-01T13:00:00"), ocpp::DateTime("2024-02-01T13:00:00"));
+
+    auto response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Rejected));
+    ASSERT_TRUE(response.statusInfo.has_value());
+    EXPECT_EQ(response.statusInfo.value().reasonCode, "InvalidSchedule");
+}
+
+TEST_F(SmartChargingTestV21, K28FR04_NonDynamicProfile_WithDynUpdateInterval_Rejected) {
+    // Regression: K01.FR.122 covers K28.FR.04 — a non-Dynamic profile carrying dynUpdateInterval is rejected.
+    enable_dynamic_profiles(device_model);
+    auto periods = create_charging_schedule_periods(0, 1, 1, 0.5f);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2024-02-01T13:00:00"));
+    profile.dynUpdateInterval = 60;
+
+    auto response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Rejected));
+    EXPECT_EQ(response.statusInfo.value().reasonCode, "InvalidProfile");
+    EXPECT_EQ(response.statusInfo.value().additionalInfo, "ChargingProfileNotDynamic");
+}
+
+TEST_F(SmartChargingTestV21, K28FR05_DynamicProfile_DynUpdateTimeAutoSetOnAccept) {
+    enable_dynamic_profiles(device_model);
+    auto periods = create_charging_schedule_periods(0, 1, 1, 0.5f);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2024-02-01T13:00:00"));
+    ASSERT_FALSE(profile.dynUpdateTime.has_value());
+
+    const auto before = ocpp::DateTime().to_time_point();
+    auto response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    const auto after = ocpp::DateTime().to_time_point();
+    EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto stored = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored.size(), 1);
+    ASSERT_TRUE(stored.front().dynUpdateTime.has_value());
+    const auto persisted = stored.front().dynUpdateTime.value().to_time_point();
+    EXPECT_GE(persisted, before - std::chrono::seconds(2));
+    EXPECT_LE(persisted, after + std::chrono::seconds(2));
+}
+
+TEST_F(SmartChargingTestV21, K28FR05_DynUpdateTime_PersistsAcrossDbRestart) {
+    enable_dynamic_profiles(device_model);
+    auto periods = create_charging_schedule_periods(0, 1, 1, 0.5f);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2024-02-01T13:00:00"));
+
+    auto response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto stored_first = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_first.size(), 1);
+    ASSERT_TRUE(stored_first.front().dynUpdateTime.has_value());
+    const auto first_dyn_update_time = stored_first.front().dynUpdateTime.value();
+
+    // Force a JSON round-trip through DB persistence: close + reopen the on-disk connection,
+    // then refetch. This exercises the same insert_or_update_charging_profile + load paths
+    // that a libocpp restart would use.
+    database_handler->close_connection();
+    database_handler->open_connection();
+
+    auto stored_second = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_second.size(), 1);
+    ASSERT_TRUE(stored_second.front().dynUpdateTime.has_value());
+    EXPECT_EQ(stored_second.front().dynUpdateTime.value().to_rfc3339(), first_dyn_update_time.to_rfc3339());
+}
+
+namespace {
+
+ChargingProfile make_dynamic_profile(std::int32_t profile_id, float setpoint_value) {
+    auto periods = create_charging_schedule_periods(0, 1, 1, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = setpoint_value;
+    return create_charging_profile(
+        profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2024-02-01T13:00:00"));
+}
+
+} // namespace
+
+TEST_F(SmartChargingTestV21, K28FR06_UpdateDynamicSchedule_AppliesUpdateAndRespondsAccepted) {
+    enable_dynamic_profiles(device_model);
+    auto profile = make_dynamic_profile(DEFAULT_PROFILE_ID, 10000.0f);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    req.scheduleUpdate.setpoint = 5000.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<v21::UpdateDynamicScheduleResponse>();
+        EXPECT_EQ(response.status, ChargingProfileStatusEnum::Accepted);
+    }));
+
+    smart_charging.handle_message(enhanced);
+
+    auto stored = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored.size(), 1);
+    ASSERT_FALSE(stored.front().chargingSchedule.empty());
+    ASSERT_FALSE(stored.front().chargingSchedule.at(0).chargingSchedulePeriod.empty());
+    const auto& period = stored.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0);
+    ASSERT_TRUE(period.setpoint.has_value());
+    EXPECT_FLOAT_EQ(period.setpoint.value(), 5000.0f);
+}
+
+TEST_F(SmartChargingTestV21, K28FR06_UpdateDynamicSchedule_FiresChargingProfilesCallback) {
+    enable_dynamic_profiles(device_model);
+    auto profile = make_dynamic_profile(DEFAULT_PROFILE_ID, 10000.0f);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    req.scheduleUpdate.setpoint = 5000.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+    // The add_profile call already invoked set_charging_profiles_callback once on the Set path.
+    // Apply path fires the callback when at least one field is updated.
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(testing::AtLeast(1));
+
+    smart_charging.handle_message(enhanced);
+}
+
+TEST_F(SmartChargingTestV21, K28FR09_UpdateDynamicSchedule_RefreshesDynUpdateTime) {
+    enable_dynamic_profiles(device_model);
+    auto profile = make_dynamic_profile(DEFAULT_PROFILE_ID, 10000.0f);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto stored_initial = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_initial.size(), 1);
+    ASSERT_TRUE(stored_initial.front().dynUpdateTime.has_value());
+    const auto initial_time = stored_initial.front().dynUpdateTime.value().to_time_point();
+
+    // Force a measurable gap so before/after comparisons are robust.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    req.scheduleUpdate.setpoint = 5000.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+    smart_charging.handle_message(enhanced);
+
+    auto stored_after = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_after.size(), 1);
+    ASSERT_TRUE(stored_after.front().dynUpdateTime.has_value());
+    const auto after_time = stored_after.front().dynUpdateTime.value().to_time_point();
+    EXPECT_GT(after_time, initial_time);
+    const auto now = ocpp::DateTime().to_time_point();
+    EXPECT_LE(after_time, now + std::chrono::seconds(2));
+}
+
+TEST_F(SmartChargingTestV21, K28FR11_UpdateDynamicSchedule_NonDynamicProfile_Rejected) {
+    enable_dynamic_profiles(device_model);
+    auto periods = create_charging_schedule_periods(0, 1, 1, 5.0f);
+    auto absolute_profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2024-02-01T13:00:00"));
+    auto add_response = smart_charging.conform_validate_and_add_profile(absolute_profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    req.scheduleUpdate.limit = 12.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<v21::UpdateDynamicScheduleResponse>();
+        EXPECT_EQ(response.status, ChargingProfileStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().reasonCode, "InvalidProfile");
+        // K28.FR.11: discriminate from "missing profile" via additionalInfo.
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value(), "ProfileNotDynamic");
+    }));
+
+    smart_charging.handle_message(enhanced);
+}
+
+TEST_F(SmartChargingTestV21, K28FR11_UpdateDynamicSchedule_MissingProfile_Rejected) {
+    enable_dynamic_profiles(device_model);
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = 9999;
+    req.scheduleUpdate.limit = 12.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<v21::UpdateDynamicScheduleResponse>();
+        EXPECT_EQ(response.status, ChargingProfileStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().reasonCode, "InvalidProfile");
+        // K28.FR.11: discriminate from "wrong kind" via additionalInfo.
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value(), "ProfileNotFound");
+    }));
+
+    smart_charging.handle_message(enhanced);
+}
+
+TEST_F(SmartChargingTestV21, K28_UpdateDynamicSchedule_AllFieldsUnset_SkipsCallback) {
+    enable_dynamic_profiles(device_model);
+    auto profile = make_dynamic_profile(DEFAULT_PROFILE_ID, 10000.0f);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto stored_initial = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_initial.size(), 1);
+    const float initial_setpoint =
+        stored_initial.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f);
+    const auto initial_dyn_update_time = stored_initial.front().dynUpdateTime.value().to_time_point();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    // No fields set on scheduleUpdate.
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<v21::UpdateDynamicScheduleResponse>();
+        EXPECT_EQ(response.status, ChargingProfileStatusEnum::Accepted);
+    }));
+    // Set path already invoked the callback once during add. The empty-update apply path must not.
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
+
+    smart_charging.handle_message(enhanced);
+
+    auto stored_after = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_after.size(), 1);
+    EXPECT_FLOAT_EQ(stored_after.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f),
+                    initial_setpoint);
+    ASSERT_TRUE(stored_after.front().dynUpdateTime.has_value());
+    EXPECT_GT(stored_after.front().dynUpdateTime.value().to_time_point(), initial_dyn_update_time);
+}
+
+TEST_F(SmartChargingTestV21, K28_UpdateDynamicSchedule_OneFieldSet_FiresCallback) {
+    enable_dynamic_profiles(device_model);
+    auto profile = make_dynamic_profile(DEFAULT_PROFILE_ID, 10000.0f);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    // Set the same value the period already carries — equality with current is deliberately not checked.
+    req.scheduleUpdate.setpoint = 10000.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(testing::AtLeast(1));
+
+    smart_charging.handle_message(enhanced);
+}
+
+TEST_F(SmartChargingTestV21, K28_UpdateDynamicSchedule_PersistFailure_RejectedWithInternalError) {
+    enable_dynamic_profiles(device_model);
+    auto profile = make_dynamic_profile(DEFAULT_PROFILE_ID, 10000.0f);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Block all subsequent INSERTs into CHARGING_PROFILES so the matching-criteria lookup
+    // still finds the existing row but the persist step throws QueryExecutionException.
+    auto trigger_stmt = database_handler->new_statement(
+        "CREATE TRIGGER block_charging_profile_inserts BEFORE INSERT ON CHARGING_PROFILES "
+        "BEGIN SELECT RAISE(ABORT, 'persist disabled for test'); END;");
+    ASSERT_EQ(trigger_stmt->step(), SQLITE_DONE);
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    req.scheduleUpdate.setpoint = 5000.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<v21::UpdateDynamicScheduleResponse>();
+        EXPECT_EQ(response.status, ChargingProfileStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().reasonCode.get(), "InternalError");
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value().get(), "ProfilePersistFailed");
+    }));
+    // No callback on persist failure.
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
+
+    smart_charging.handle_message(enhanced);
+
+    // Drop the trigger so TearDown's clear_charging_profiles can run cleanly.
+    auto drop_stmt = database_handler->new_statement("DROP TRIGGER IF EXISTS block_charging_profile_inserts");
+    ASSERT_EQ(drop_stmt->step(), SQLITE_DONE);
+}
+
+namespace {
+
+// Builds a Dynamic profile that carries an explicit dynUpdateInterval for FR.10 timer tests.
+ChargingProfile make_dynamic_profile_with_interval(std::int32_t profile_id, std::int32_t interval_seconds,
+                                                   std::optional<ocpp::DateTime> dyn_update_time = std::nullopt) {
+    auto periods = create_charging_schedule_periods(0, 1, 1, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 10000.0f;
+    auto profile = create_charging_profile(
+        profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2034-02-01T13:00:00"));
+    profile.dynUpdateInterval = interval_seconds;
+    if (dyn_update_time.has_value()) {
+        profile.dynUpdateTime = dyn_update_time.value();
+    }
+    return profile;
+}
+
+ocpp::EnhancedMessage<MessageType>
+make_pull_response_enhanced(const std::string& message_id, ChargingProfileStatusEnum status,
+                            std::optional<ChargingScheduleUpdate> schedule_update = std::nullopt) {
+    v21::PullDynamicScheduleUpdateResponse response;
+    response.status = status;
+    response.scheduleUpdate = schedule_update;
+    ocpp::CallResult<v21::PullDynamicScheduleUpdateResponse> call_result(response, message_id);
+    ocpp::EnhancedMessage<MessageType> enhanced;
+    enhanced.messageType = MessageType::PullDynamicScheduleUpdateResponse;
+    enhanced.uniqueId = message_id;
+    enhanced.message = json(call_result);
+    return enhanced;
+}
+
+} // namespace
+
+TEST_F(SmartChargingTestV21, K28FR10_PullTimer_FiresAfterInterval) {
+    enable_dynamic_profiles(device_model);
+
+    std::atomic<int> dispatch_count{0};
+    std::promise<json> dispatched_call_promise;
+    auto dispatched_call_future = dispatched_call_promise.get_future();
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count, p = std::make_shared<std::promise<json>>(std::move(dispatched_call_promise))](
+                       const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                if (dispatch_count.fetch_add(1) == 0) {
+                    p->set_value(call);
+                }
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                ocpp::EnhancedMessage<MessageType> enhanced;
+                enhanced.offline = true;
+                resp.set_value(enhanced);
+                return resp.get_future();
+            }));
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // dynUpdateTime + 1s should be in the past or very near; timer should fire shortly.
+    ASSERT_EQ(dispatched_call_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    auto dispatched_call = dispatched_call_future.get();
+    EXPECT_EQ(dispatched_call.at(CALL_ACTION).get<std::string>(), "PullDynamicScheduleUpdate");
+    EXPECT_EQ(dispatched_call.at(CALL_PAYLOAD).at("chargingProfileId").get<std::int32_t>(), DEFAULT_PROFILE_ID);
+}
+
+TEST_F(SmartChargingTestV21, K28FR10_PullTimer_DoesNotFireBeforeInterval) {
+    enable_dynamic_profiles(device_model);
+
+    // gmock auto-verifies Times(0) on test exit; no sleep needed to assert "did not fire".
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _)).Times(0);
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/3600, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+}
+
+TEST_F(SmartChargingTestV21, K28FR10_PullTimer_RebuildsAfterRestart) {
+    enable_dynamic_profiles(device_model);
+
+    auto periods = create_charging_schedule_periods(0, 1, 1, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 10000.0f;
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2034-02-01T13:00:00"));
+    profile.dynUpdateInterval = 1;
+    profile.dynUpdateTime = ocpp::DateTime();
+    profile.validFrom = ocpp::DateTime("2024-01-01T13:00:00");
+    profile.validTo = ocpp::DateTime("2034-02-01T13:00:00");
+
+    // Pre-populate DB directly, then re-trigger the rebuild path on the fixture's smart_charging.
+    // (Reusing the existing instance avoids spawning a second SmartCharging with a stale context
+    // reference — see TearDown which only clears the profile table.)
+    database_handler->insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile,
+                                                        ChargingLimitSourceEnumStringType::CSO);
+
+    std::atomic<int> dispatch_count{0};
+    std::promise<json> dispatched_call_promise;
+    auto dispatched_call_future = dispatched_call_promise.get_future();
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count, p = std::make_shared<std::promise<json>>(std::move(dispatched_call_promise))](
+                       const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                if (dispatch_count.fetch_add(1) == 0) {
+                    p->set_value(call);
+                }
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                ocpp::EnhancedMessage<MessageType> enhanced;
+                enhanced.offline = true;
+                resp.set_value(enhanced);
+                return resp.get_future();
+            }));
+
+    // Re-run the rebuild path with a Dynamic profile already persisted.
+    smart_charging.dynamic_schedule_manager->rebuild_from_db();
+
+    ASSERT_EQ(dispatched_call_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    auto dispatched_call = dispatched_call_future.get();
+    EXPECT_EQ(dispatched_call.at(CALL_PAYLOAD).at("chargingProfileId").get<std::int32_t>(), DEFAULT_PROFILE_ID);
+}
+
+TEST_F(SmartChargingTestV21, K28FR10_PullTimer_BootstrapOnMissingDynUpdateTime) {
+    enable_dynamic_profiles(device_model);
+
+    auto periods = create_charging_schedule_periods(0, 1, 1, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 10000.0f;
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2034-02-01T13:00:00"));
+    profile.dynUpdateInterval = 60;
+    profile.validFrom = ocpp::DateTime("2024-01-01T13:00:00");
+    profile.validTo = ocpp::DateTime("2034-02-01T13:00:00");
+    // No dynUpdateTime → bootstrap-immediate.
+
+    database_handler->insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile,
+                                                        ChargingLimitSourceEnumStringType::CSO);
+
+    std::atomic<int> dispatch_count{0};
+    std::promise<json> dispatched_call_promise;
+    auto dispatched_call_future = dispatched_call_promise.get_future();
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count, p = std::make_shared<std::promise<json>>(std::move(dispatched_call_promise))](
+                       const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                if (dispatch_count.fetch_add(1) == 0) {
+                    p->set_value(call);
+                }
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                ocpp::EnhancedMessage<MessageType> enhanced;
+                enhanced.offline = true;
+                resp.set_value(enhanced);
+                return resp.get_future();
+            }));
+
+    smart_charging.dynamic_schedule_manager->rebuild_from_db();
+
+    ASSERT_EQ(dispatched_call_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+}
+
+TEST_F(SmartChargingTestV21, K28FR10_PullTimer_NonDynamicProfile_NoTimer) {
+    enable_dynamic_profiles(device_model);
+
+    // gmock auto-verifies Times(0) on test exit; no sleep needed to assert "did not fire".
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _)).Times(0);
+
+    auto periods = create_charging_schedule_periods(0, 1, 1, 5.0f);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2034-02-01T13:00:00"));
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+}
+
+TEST_F(SmartChargingTestV21, K28FR10_ClearChargingProfile_StopsPullTimer) {
+    enable_dynamic_profiles(device_model);
+
+    // interval=3600s — pull would only fire an hour out, so any dispatch in this test is a bug.
+    // gmock auto-verifies Times(0) on test exit, no sleep needed.
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _)).Times(0);
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/3600, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Clear the profile via the public handler.
+    ClearChargingProfileRequest clear_req;
+    clear_req.chargingProfileId = DEFAULT_PROFILE_ID;
+    auto enhanced =
+        request_to_enhanced_message<ClearChargingProfileRequest, MessageType::ClearChargingProfile>(clear_req);
+    smart_charging.handle_message(enhanced);
+}
+
+TEST_F(SmartChargingTestV21, K28FR10_ReplaceDynamicWithNonDynamic_ErasesPullTracking) {
+    enable_dynamic_profiles(device_model);
+
+    // interval=3600s — pull would only fire an hour out. gmock Times(0) auto-verifies on exit.
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _)).Times(0);
+
+    auto dyn_profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/3600, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(dyn_profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Replace with non-Dynamic profile at the same id.
+    auto periods = create_charging_schedule_periods(0, 1, 1, 5.0f);
+    auto absolute_profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
+        ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2034-02-01T13:00:00"));
+    auto replace_response = smart_charging.conform_validate_and_add_profile(absolute_profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(replace_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+}
+
+TEST_F(SmartChargingTestV21, K28FR08_PullResponse_AppliesUpdate) {
+    enable_dynamic_profiles(device_model);
+
+    std::promise<std::string> message_id_promise;
+    auto message_id_future = message_id_promise.get_future();
+    std::atomic<int> dispatch_count{0};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count, p = std::make_shared<std::promise<std::string>>(std::move(message_id_promise))](
+                       const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                if (dispatch_count.fetch_add(1) == 0) {
+                    const auto message_id = call.at(MESSAGE_ID).get<std::string>();
+                    p->set_value(message_id);
+
+                    ChargingScheduleUpdate schedule_update;
+                    schedule_update.setpoint = 7777.0f;
+                    auto enhanced =
+                        make_pull_response_enhanced(message_id, ChargingProfileStatusEnum::Accepted, schedule_update);
+                    resp.set_value(enhanced);
+                } else {
+                    ocpp::EnhancedMessage<MessageType> offline;
+                    offline.offline = true;
+                    resp.set_value(offline);
+                }
+                return resp.get_future();
+            }));
+
+    // Signal completion when the pull-response apply path invokes the set-charging-profiles
+    // callback — that runs on the worker thread AFTER the database write, so the test can read
+    // the stored profile without an arbitrary sleep.
+    std::promise<void> apply_done_promise;
+    auto apply_done_future = apply_done_promise.get_future();
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call)
+        .WillOnce(Invoke([&apply_done_promise]() { apply_done_promise.set_value(); }))
+        .WillRepeatedly(Return());
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    ASSERT_EQ(message_id_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    ASSERT_EQ(apply_done_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    auto stored = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored.size(), 1);
+    ASSERT_FALSE(stored.front().chargingSchedule.empty());
+    ASSERT_FALSE(stored.front().chargingSchedule.at(0).chargingSchedulePeriod.empty());
+    const auto& period = stored.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0);
+    ASSERT_TRUE(period.setpoint.has_value());
+    EXPECT_FLOAT_EQ(period.setpoint.value(), 7777.0f);
+}
+
+TEST_F(SmartChargingTestV21, K28FR08_PullResponse_RejectedStatus_NoOp) {
+    enable_dynamic_profiles(device_model);
+
+    std::promise<std::string> message_id_promise;
+    auto message_id_future = message_id_promise.get_future();
+    // The Rejected branch fires no test-observable callback, so use the SECOND dispatch (which
+    // the timer schedules ~1s after the first, since the rejected response does not refresh the
+    // pull deadline) as the signal that the first response was fully processed by the worker.
+    std::promise<void> second_dispatch_promise;
+    auto second_dispatch_future = second_dispatch_promise.get_future();
+    std::atomic<int> dispatch_count{0};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count, mid_p = std::make_shared<std::promise<std::string>>(std::move(message_id_promise)),
+                    snd_p = std::make_shared<std::promise<void>>(std::move(second_dispatch_promise))](
+                       const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                const int n = dispatch_count.fetch_add(1);
+                if (n == 0) {
+                    const auto message_id = call.at(MESSAGE_ID).get<std::string>();
+                    mid_p->set_value(message_id);
+                    auto enhanced =
+                        make_pull_response_enhanced(message_id, ChargingProfileStatusEnum::Rejected, std::nullopt);
+                    resp.set_value(enhanced);
+                } else {
+                    if (n == 1) {
+                        snd_p->set_value();
+                    }
+                    ocpp::EnhancedMessage<MessageType> offline;
+                    offline.offline = true;
+                    resp.set_value(offline);
+                }
+                return resp.get_future();
+            }));
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto stored_initial = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_initial.size(), 1);
+    const float initial_setpoint =
+        stored_initial.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f);
+
+    ASSERT_EQ(message_id_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    ASSERT_EQ(second_dispatch_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    auto stored_after = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_after.size(), 1);
+    EXPECT_FLOAT_EQ(stored_after.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f),
+                    initial_setpoint);
+}
+
+TEST_F(SmartChargingTestV21, K28FR08_PullResponse_ProfileClearedDuringFlight_NoOp) {
+    enable_dynamic_profiles(device_model);
+
+    std::promise<std::pair<std::string, json>> dispatched_promise;
+    auto dispatched_future = dispatched_promise.get_future();
+    std::atomic<int> dispatch_count{0};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count,
+                    p = std::make_shared<std::promise<std::pair<std::string, json>>>(std::move(dispatched_promise))](
+                       const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                ocpp::EnhancedMessage<MessageType> offline;
+                offline.offline = true;
+                if (dispatch_count.fetch_add(1) == 0) {
+                    const auto message_id = call.at(MESSAGE_ID).get<std::string>();
+                    p->set_value({message_id, call});
+                }
+                resp.set_value(offline);
+                return resp.get_future();
+            }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Wait for first dispatch.
+    ASSERT_EQ(dispatched_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    // Clear the profile while a pull is in flight. The dispatcher returned an offline future, so
+    // the worker exits early without touching the DB; the clear executes synchronously on the
+    // test thread so the post-condition (no stored profile) holds immediately.
+    ClearChargingProfileRequest clear_req;
+    clear_req.chargingProfileId = DEFAULT_PROFILE_ID;
+    auto enhanced =
+        request_to_enhanced_message<ClearChargingProfileRequest, MessageType::ClearChargingProfile>(clear_req);
+    smart_charging.handle_message(enhanced);
+
+    auto stored_after = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    EXPECT_EQ(stored_after.size(), 0);
+}
+
+TEST_F(SmartChargingTestV21, K28FR10_PushApply_RefreshesNextPullDeadline) {
+    enable_dynamic_profiles(device_model);
+
+    // Long interval (3600s) — neither the timer nor the push apply may dispatch a pull. gmock
+    // Times(0) auto-verifies on exit, so no sleep is needed to assert "did not fire".
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _)).Times(0);
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/3600, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Push an update — the push apply path must call update_pull_tracking on the matched profile.
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    req.scheduleUpdate.setpoint = 5000.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+    smart_charging.handle_message(enhanced);
+}
+
+TEST_F(SmartChargingTestV21, K28_Shutdown_DestructorReturnsCleanlyWithInFlightPullWorkers) {
+    // Forces destruction with workers in-flight.
+    enable_dynamic_profiles(device_model);
+
+    std::atomic<int> dispatch_count{0};
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke([&dispatch_count](const json&, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+            dispatch_count.fetch_add(1, std::memory_order_relaxed);
+            std::promise<ocpp::EnhancedMessage<MessageType>> p;
+            ocpp::EnhancedMessage<MessageType> offline;
+            offline.offline = true;
+            p.set_value(offline);
+            return p.get_future();
+        }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    auto local_sc = std::make_unique<TestSmartCharging>(*functional_block_context,
+                                                        set_charging_profiles_callback_mock.AsStdFunction(),
+                                                        stop_transaction_callback_mock.AsStdFunction());
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    ASSERT_THAT(local_sc->conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID).status,
+                testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (dispatch_count.load(std::memory_order_relaxed) == 0 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_GE(dispatch_count.load(), 1);
+
+    local_sc.reset();
+}
+
+TEST_F(SmartChargingTestV21, K28_Shutdown_DestructorDoesNotBlockOnStuckPullWorker) {
+    // A worker blocked on a never-ready CSMS response must not stall teardown for the full
+    // worker wait bound (DEFAULT_WAIT_FOR_FUTURE_TIMEOUT = 60s). The destructor signals
+    // teardown and the bounded response wait is interrupted, so it returns promptly.
+    enable_dynamic_profiles(device_model);
+
+    std::mutex promises_mtx;
+    std::vector<std::shared_ptr<std::promise<ocpp::EnhancedMessage<MessageType>>>> stuck_promises;
+    std::atomic<int> dispatch_count{0};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke([&](const json&, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+            auto p = std::make_shared<std::promise<ocpp::EnhancedMessage<MessageType>>>();
+            auto fut = p->get_future();
+            {
+                std::lock_guard<std::mutex> lk(promises_mtx);
+                stuck_promises.push_back(std::move(p)); // never satisfied: the future never becomes ready
+            }
+            dispatch_count.fetch_add(1, std::memory_order_relaxed);
+            return fut;
+        }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    auto local_sc = std::make_unique<TestSmartCharging>(*functional_block_context,
+                                                        set_charging_profiles_callback_mock.AsStdFunction(),
+                                                        stop_transaction_callback_mock.AsStdFunction());
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    ASSERT_THAT(local_sc->conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID).status,
+                testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    const auto spawn_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (dispatch_count.load(std::memory_order_relaxed) == 0 && std::chrono::steady_clock::now() < spawn_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_GE(dispatch_count.load(), 1) << "no pull worker was spawned";
+
+    // Time the destructor on another thread; a stuck worker must not hold it for ~60s.
+    std::packaged_task<void()> teardown([&] { local_sc.reset(); });
+    auto teardown_done = teardown.get_future();
+    std::thread teardown_thread(std::move(teardown));
+
+    const auto status = teardown_done.wait_for(std::chrono::seconds(5));
+    EXPECT_EQ(status, std::future_status::ready)
+        << "destructor blocked on a stuck pull worker (teardown wait not interrupted)";
+
+    // Release the stuck promises so the worker unwinds even if the assertion failed
+    // (broken_promise -> future throws -> worker returns), then join.
+    {
+        std::lock_guard<std::mutex> lk(promises_mtx);
+        stuck_promises.clear();
+    }
+    teardown_thread.join();
+}
+
+namespace {
+
+// Build a Dynamic profile with a chargingSchedule[0].duration set, suitable for K28.FR.13/.14/.15
+// expiry tests. A long interval (3600s) avoids spurious pull dispatches during the test.
+ChargingProfile make_dynamic_profile_with_duration(std::int32_t profile_id, std::int32_t duration_seconds,
+                                                   std::optional<ocpp::DateTime> dyn_update_time = std::nullopt) {
+    auto periods = create_charging_schedule_periods(0, 1, 1, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 10000.0f;
+    auto profile =
+        create_charging_profile(profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::W, periods,
+                                                       ocpp::DateTime("2024-01-17T17:00:00"), duration_seconds),
+                                {}, ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL,
+                                ocpp::DateTime("2024-01-01T13:00:00"), ocpp::DateTime("2034-02-01T13:00:00"));
+    profile.dynUpdateInterval = 3600;
+    if (dyn_update_time.has_value()) {
+        profile.dynUpdateTime = dyn_update_time.value();
+    }
+    return profile;
+}
+
+} // namespace
+
+TEST_F(SmartChargingTestV21, K28FR13_DynamicProfile_ExpiredByDuration_SkippedInComposite) {
+    enable_dynamic_profiles(device_model);
+
+    // duration=10s, dynUpdateTime 30s ago → expired.
+    const auto past = ocpp::DateTime(date::utc_clock::now() - std::chrono::seconds(30));
+    auto profile = make_dynamic_profile_with_duration(DEFAULT_PROFILE_ID, /*duration=*/10, past);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // The Set path overwrites dynUpdateTime to "now" (FR.05). Restore the past timestamp directly
+    // in the DB to simulate a profile that has been sitting expired since then.
+    auto stmt =
+        database_handler->new_statement("UPDATE CHARGING_PROFILES SET PROFILE = json_set(PROFILE, '$.dynUpdateTime', "
+                                        "?) WHERE ID = ?");
+    stmt->bind_text(1, past.to_rfc3339(), everest::db::sqlite::SQLiteString::Transient);
+    stmt->bind_int(2, DEFAULT_PROFILE_ID);
+    ASSERT_EQ(stmt->step(), SQLITE_DONE);
+
+    auto valid = smart_charging.get_valid_profiles_for_evse(DEFAULT_EVSE_ID);
+    EXPECT_TRUE(valid.empty()) << "Expired Dynamic profile must be filtered from composite calc";
+}
+
+namespace {
+
+// True if any period of the composite schedule carries the given setpoint value.
+bool composite_contains_setpoint(const EnhancedCompositeSchedule& schedule, float setpoint) {
+    for (const auto& period : schedule.chargingSchedulePeriod) {
+        if (period.setpoint.has_value() && period.setpoint.value() == setpoint) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+// Expiry filtering must hold through the REAL composite path, not just the get_valid_profiles_for_evse
+// helper. Drive SmartCharging::get_composite_schedule(evse_id, duration, unit) directly: an expired
+// Dynamic profile's setpoint must not appear in the composite, while a fresh (non-expired) Dynamic
+// profile's setpoint does. The positive control proves the composite API is actually exercised here
+// (a non-expired Dynamic setpoint reaches the composite), so the negative assertion is not vacuous.
+TEST_F(SmartChargingTestV21, K28FR13_DynamicProfile_ExpiredByDuration_AbsentFromGetCompositeSchedule) {
+    enable_dynamic_profiles(device_model);
+
+    constexpr float dynamic_setpoint = 10000.0f;
+
+    // A CentralSetpoint TxDefaultProfile only contributes its setpoint to the composite while a
+    // transaction is active on the EVSE (see CompositeScheduleTestFixtureV21.setpoint_tx_profile).
+    evse_manager->open_transaction(DEFAULT_EVSE_ID, "f1522902-1170-416f-8e43-9e3bce28fde7");
+
+    // Positive control: a fresh Dynamic profile (dynUpdateTime = now) within its duration window
+    // contributes its setpoint to the real composite.
+    auto fresh = make_dynamic_profile_with_duration(DEFAULT_PROFILE_ID, /*duration=*/10, ocpp::DateTime());
+    ASSERT_THAT(smart_charging.conform_validate_and_add_profile(fresh, DEFAULT_EVSE_ID).status,
+                testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto fresh_composite =
+        smart_charging.get_composite_schedule(DEFAULT_EVSE_ID, std::chrono::seconds(60), ChargingRateUnitEnum::W);
+    ASSERT_TRUE(fresh_composite.has_value()) << "composite schedule API returned nullopt for a valid EVSE";
+    EXPECT_TRUE(composite_contains_setpoint(fresh_composite.value(), dynamic_setpoint))
+        << "non-expired Dynamic profile setpoint must reach the real composite (positive control)";
+
+    // Now expire it: backdate dynUpdateTime well past the 10s duration window so the profile is
+    // expired. The Set path overwrote dynUpdateTime to "now"; restore a past timestamp directly.
+    const auto past = ocpp::DateTime(date::utc_clock::now() - std::chrono::seconds(30));
+    auto stmt =
+        database_handler->new_statement("UPDATE CHARGING_PROFILES SET PROFILE = json_set(PROFILE, '$.dynUpdateTime', "
+                                        "?) WHERE ID = ?");
+    stmt->bind_text(1, past.to_rfc3339(), everest::db::sqlite::SQLiteString::Transient);
+    stmt->bind_int(2, DEFAULT_PROFILE_ID);
+    ASSERT_EQ(stmt->step(), SQLITE_DONE);
+
+    auto expired_composite =
+        smart_charging.get_composite_schedule(DEFAULT_EVSE_ID, std::chrono::seconds(60), ChargingRateUnitEnum::W);
+    ASSERT_TRUE(expired_composite.has_value()) << "composite schedule API returned nullopt for a valid EVSE";
+    EXPECT_FALSE(composite_contains_setpoint(expired_composite.value(), dynamic_setpoint))
+        << "expired Dynamic profile setpoint must be filtered from the real composite schedule";
+}
+
+TEST_F(SmartChargingTestV21, K28FR13_DynamicProfile_NoDuration_NeverExpires) {
+    enable_dynamic_profiles(device_model);
+
+    // No duration on the schedule → expiry check does not apply, regardless of dynUpdateTime.
+    auto profile = make_dynamic_profile(DEFAULT_PROFILE_ID, 10000.0f);
+    profile.dynUpdateInterval = 3600;
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Backdate dynUpdateTime to 30s ago.
+    const auto past = ocpp::DateTime(date::utc_clock::now() - std::chrono::seconds(30));
+    auto stmt =
+        database_handler->new_statement("UPDATE CHARGING_PROFILES SET PROFILE = json_set(PROFILE, '$.dynUpdateTime', "
+                                        "?) WHERE ID = ?");
+    stmt->bind_text(1, past.to_rfc3339(), everest::db::sqlite::SQLiteString::Transient);
+    stmt->bind_int(2, DEFAULT_PROFILE_ID);
+    ASSERT_EQ(stmt->step(), SQLITE_DONE);
+
+    auto valid = smart_charging.get_valid_profiles_for_evse(DEFAULT_EVSE_ID);
+    EXPECT_EQ(valid.size(), 1) << "Dynamic profile without schedule duration must not be expired";
+}
+
+TEST_F(SmartChargingTestV21, K28FR13_DynamicProfile_NoDynUpdateTime_NotConsideredExpired) {
+    enable_dynamic_profiles(device_model);
+
+    // Pre-populate DB with a Dynamic profile that has duration=10s but NO dynUpdateTime.
+    auto profile = make_dynamic_profile_with_duration(DEFAULT_PROFILE_ID, /*duration=*/10, std::nullopt);
+    profile.dynUpdateInterval = 3600;
+    database_handler->insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile,
+                                                        ChargingLimitSourceEnumStringType::CSO);
+
+    auto valid = smart_charging.get_valid_profiles_for_evse(DEFAULT_EVSE_ID);
+    EXPECT_EQ(valid.size(), 1) << "Profile lacking dynUpdateTime defers to bootstrap pull, not expiry";
+}
+
+TEST_F(SmartChargingTestV21, K28FR13_ExpiryBoundary_TimerFiresComposite) {
+    enable_dynamic_profiles(device_model);
+
+    // Suppress timer-driven pulls (interval=3600 long enough); ignore any unexpected calls.
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke([](const json&, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+            std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+            ocpp::EnhancedMessage<MessageType> offline;
+            offline.offline = true;
+            resp.set_value(offline);
+            return resp.get_future();
+        }));
+
+    // conform_validate_and_add_profile does not itself fire the composite-recompute callback —
+    // that's done by handle_set_charging_profile_req on the message-handler path. So the FIRST
+    // callback observed in this test is the expiry-fire composite recompute.
+    std::promise<void> fired_promise;
+    auto fired_future = fired_promise.get_future();
+    std::atomic<bool> already_fired{false};
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).WillRepeatedly(Invoke([&fired_promise, &already_fired]() {
+        if (!already_fired.exchange(true)) {
+            fired_promise.set_value();
+        }
+    }));
+
+    // duration=1s, dynUpdateTime=now → boundary at now + 1s; the timer must fire the composite
+    // recompute callback within ~2s.
+    auto profile = make_dynamic_profile_with_duration(DEFAULT_PROFILE_ID, /*duration=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    EXPECT_EQ(fired_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+}
+
+TEST_F(SmartChargingTestV21, K28FR14_DynamicProfile_ReactivatedOnUpdateAfterExpiry) {
+    enable_dynamic_profiles(device_model);
+
+    // Install profile with duration=10s, dynUpdateTime in the past → already expired.
+    const auto past = ocpp::DateTime(date::utc_clock::now() - std::chrono::seconds(30));
+    auto profile = make_dynamic_profile_with_duration(DEFAULT_PROFILE_ID, /*duration=*/10, past);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Backdate the auto-set dynUpdateTime to make the profile expired.
+    auto backdate =
+        database_handler->new_statement("UPDATE CHARGING_PROFILES SET PROFILE = json_set(PROFILE, '$.dynUpdateTime', "
+                                        "?) WHERE ID = ?");
+    backdate->bind_text(1, past.to_rfc3339(), everest::db::sqlite::SQLiteString::Transient);
+    backdate->bind_int(2, DEFAULT_PROFILE_ID);
+    ASSERT_EQ(backdate->step(), SQLITE_DONE);
+
+    auto before = smart_charging.get_valid_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_TRUE(before.empty()) << "Profile must be expired before update";
+
+    // Update via UpdateDynamicScheduleRequest — handler refreshes dynUpdateTime to now (FR.09).
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    req.scheduleUpdate.setpoint = 5000.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+    smart_charging.handle_message(enhanced);
+
+    auto after = smart_charging.get_valid_profiles_for_evse(DEFAULT_EVSE_ID);
+    EXPECT_EQ(after.size(), 1) << "Profile must be reactivated after dynUpdateTime is refreshed";
+}
+
+TEST_F(SmartChargingTestV21, K28FR15_Duration_SemanticsMatchSpec) {
+    enable_dynamic_profiles(device_model);
+
+    // dynUpdateTime = now-5s, duration = 10s → boundary 5s in the future; profile is valid.
+    const auto five_seconds_ago = ocpp::DateTime(date::utc_clock::now() - std::chrono::seconds(5));
+    auto profile = make_dynamic_profile_with_duration(DEFAULT_PROFILE_ID, /*duration=*/10, five_seconds_ago);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Set path overwrote dynUpdateTime to "now"; restore the 5-seconds-ago value.
+    auto stmt =
+        database_handler->new_statement("UPDATE CHARGING_PROFILES SET PROFILE = json_set(PROFILE, '$.dynUpdateTime', "
+                                        "?) WHERE ID = ?");
+    stmt->bind_text(1, five_seconds_ago.to_rfc3339(), everest::db::sqlite::SQLiteString::Transient);
+    stmt->bind_int(2, DEFAULT_PROFILE_ID);
+    ASSERT_EQ(stmt->step(), SQLITE_DONE);
+
+    auto valid = smart_charging.get_valid_profiles_for_evse(DEFAULT_EVSE_ID);
+    EXPECT_EQ(valid.size(), 1) << "5s elapsed of a 10s duration is still within the validity window";
+
+    // Rewind further so 30s elapsed of a 10s duration → expired.
+    const auto thirty_seconds_ago = ocpp::DateTime(date::utc_clock::now() - std::chrono::seconds(30));
+    auto stmt2 =
+        database_handler->new_statement("UPDATE CHARGING_PROFILES SET PROFILE = json_set(PROFILE, '$.dynUpdateTime', "
+                                        "?) WHERE ID = ?");
+    stmt2->bind_text(1, thirty_seconds_ago.to_rfc3339(), everest::db::sqlite::SQLiteString::Transient);
+    stmt2->bind_int(2, DEFAULT_PROFILE_ID);
+    ASSERT_EQ(stmt2->step(), SQLITE_DONE);
+
+    auto valid_after = smart_charging.get_valid_profiles_for_evse(DEFAULT_EVSE_ID);
+    EXPECT_TRUE(valid_after.empty()) << "30s elapsed of a 10s duration must be expired";
+}
+
+// Regression: a callback throw on the timer thread must not kill the timer thread. Configure a
+// Dynamic profile with a short duration already in the past so the expiry-fire branch invokes the
+// set_charging_profiles_callback; the first invocation throws and subsequent timer ticks (driven
+// by the still-pending pull deadline) must still dispatch. With fire-then-commit (SLICE C1) the
+// throwing tick KEEPS the expire entry (logs "K28-expiry" and rethrows to on_deadline's
+// top-level catch, which keeps the timer thread alive); the entry is only cleared once the
+// recompute callback later succeeds. This test asserts the timer thread survives the throw.
+TEST_F(SmartChargingTestV21, K28_OnTimerFire_SwallowsExceptionInCallback) {
+    enable_dynamic_profiles(device_model);
+
+    // First callback throws; subsequent ones no-op. The callback is fired on the timer thread when
+    // the expiry pass retires an entry; the throw is logged with the K28-expiry errorId and
+    // rethrown to on_deadline's top-level catch so the timer survives (the expire entry is kept
+    // for a retry on the next tick rather than being cleared committed-but-unpublished).
+    std::atomic<bool> callback_threw{false};
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call)
+        .WillOnce(Invoke([&callback_threw]() {
+            callback_threw.store(true);
+            throw std::runtime_error("simulated callback failure");
+        }))
+        .WillRepeatedly(Return());
+
+    // Count timer-driven dispatches; the second-and-later ones prove the timer thread survived.
+    std::atomic<int> dispatch_count{0};
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke([&dispatch_count](const json&, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+            dispatch_count.fetch_add(1);
+            std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+            ocpp::EnhancedMessage<MessageType> enhanced;
+            enhanced.offline = true;
+            resp.set_value(enhanced);
+            return resp.get_future();
+        }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    // Build a Dynamic profile with both an expiry boundary at now+1s AND a pull interval of 1s.
+    // The first timer fire after ~1s detects the expired entry → fires callback (throws). With
+    // fire-then-commit the expire entry is KEPT (not cleared) and the throw is logged + rethrown
+    // to the top-level catch, which keeps the timer thread alive; the rearmed timer keeps
+    // dispatching pulls and the expiry recompute is retried on a later tick.
+    auto periods = create_charging_schedule_periods(0, 1, 1, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 10000.0f;
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00"), /*duration=*/1),
+        {}, ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2034-02-01T13:00:00"));
+    profile.dynUpdateInterval = 1;
+    profile.dynUpdateTime = ocpp::DateTime();
+
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Wait for the callback throw to fire AND for at least two more dispatches afterwards,
+    // proving the timer thread is still alive. Generous window so a loaded CI box still catches
+    // the retry ticks.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(4);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (callback_threw.load() && dispatch_count.load() >= 2) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    EXPECT_TRUE(callback_threw.load()) << "set_charging_profiles_callback throw branch never ran";
+    EXPECT_GE(dispatch_count.load(), 2) << "Timer thread died after callback threw — fewer dispatches than expected";
+}
+
+// Regression: a sync-throw from dispatch_call_async inside dispatch_pull_request must be caught
+// locally so the timer thread survives AND the pull deadline is NOT advanced. The first
+// dispatch throws; the second (which is the next timer tick within the same interval window)
+// proves both that the timer thread survived AND that the deadline did not roll forward past the
+// expected retry window.
+TEST_F(SmartChargingTestV21, K28_DispatchPull_SwallowsSyncThrow) {
+    enable_dynamic_profiles(device_model);
+
+    std::atomic<int> dispatch_count{0};
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke([&dispatch_count](const json&, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+            const int n = dispatch_count.fetch_add(1);
+            if (n == 0) {
+                throw std::runtime_error("simulated dispatch sync-throw");
+            }
+            std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+            ocpp::EnhancedMessage<MessageType> enhanced;
+            enhanced.offline = true;
+            resp.set_value(enhanced);
+            return resp.get_future();
+        }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    // 1s interval; dynUpdateTime = now → first pull fires almost immediately and throws.
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Wait for the second dispatch attempt — proves (1) the timer thread did not die and
+    // (2) the deadline was not wrongly advanced past now+interval after the throw. Observation
+    // window kept generous so a loaded CI box still catches the retry tick.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(4);
+    while (dispatch_count.load() < 2 && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    EXPECT_GE(dispatch_count.load(), 2)
+        << "Timer either died after dispatch_call_async threw, or the pull deadline was advanced "
+           "past the retry window";
+
+    // Busy-loop guard: with the 1s backoff on dispatch failure the second dispatch must NOT fire
+    // immediately after the first throws. Without the backoff, the pull deadline stays past-due, the
+    // timer re-arms at a past time, and on_deadline spins — dispatch_count would balloon well
+    // beyond the natural ~interval rate over the 4s window. With backoff, the count over a
+    // 1s-interval/4s window stays bounded around 4-5. Use a generous upper bound so CI noise
+    // doesn't flake while still catching a runaway loop.
+    EXPECT_LE(dispatch_count.load(), 10)
+        << "Dispatch fired far more often than the interval permits — failure path is not "
+           "deferring the pull deadline, busy-looping the timer thread";
+}
+
+// Regression: a transient database error during the pull-timer lookup must NOT erase deadline
+// tracking. lookup_dynamic_profile cannot tell "profile absent" from "query threw", so on a DB
+// error dispatch_due_pulls must back off and retry, not drop the profile. Rename CHARGING_PROFILES
+// while the 1s timer is running so the lookup throws, then restore it and assert pulls resume.
+TEST_F(SmartChargingTestV21, K28_DispatchPull_DbErrorPreservesTracking) {
+    enable_dynamic_profiles(device_model);
+
+    std::atomic<int> dispatch_count{0};
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke([&dispatch_count](const json&, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+            dispatch_count.fetch_add(1);
+            std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+            ocpp::EnhancedMessage<MessageType> enhanced;
+            enhanced.offline = true;
+            resp.set_value(enhanced);
+            return resp.get_future();
+        }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    // ALTER TABLE retried on QueryExecutionException: the timer thread runs SELECTs concurrently, so a
+    // rename can race a read and come back busy. Retry briefly until it lands.
+    auto alter_table = [this](const std::string& from, const std::string& to) {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (true) {
+            try {
+                database_handler->new_statement("ALTER TABLE " + from + " RENAME TO " + to)->step();
+                return;
+            } catch (const everest::db::QueryExecutionException&) {
+                if (std::chrono::steady_clock::now() >= deadline) {
+                    throw;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            }
+        }
+    };
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Pulls are firing on the 1s interval; wait for the first to confirm tracking is armed.
+    const auto armed_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (dispatch_count.load() < 1 && std::chrono::steady_clock::now() < armed_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    ASSERT_GE(dispatch_count.load(), 1) << "Pull timer never armed";
+
+    // Rename the table so the next lookup in dispatch_due_pulls throws QueryExecutionException.
+    // RAII net restores it if an assertion below throws while renamed.
+    bool renamed = false;
+    struct Restorer {
+        std::function<void()> restore;
+        bool* renamed;
+        ~Restorer() {
+            if (*renamed) {
+                try {
+                    restore();
+                } catch (...) {
+                }
+            }
+        }
+    };
+    Restorer restorer{[&] { alter_table("CHARGING_PROFILES_BAK", "CHARGING_PROFILES"); }, &renamed};
+
+    alter_table("CHARGING_PROFILES", "CHARGING_PROFILES_BAK");
+    renamed = true;
+
+    // Let several ticks hit the missing table. The buggy path erases the entry on the first one.
+    std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+    const int before_restore = dispatch_count.load();
+
+    alter_table("CHARGING_PROFILES_BAK", "CHARGING_PROFILES");
+    renamed = false;
+
+    // With tracking preserved, pulls resume once the table is back. With the entry erased they never do.
+    const auto resume_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (dispatch_count.load() <= before_restore && std::chrono::steady_clock::now() < resume_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    }
+    EXPECT_GT(dispatch_count.load(), before_restore)
+        << "Pulls did not resume after the database recovered — a transient DB error erased deadline tracking";
+}
+
+// With SupportsDynamicProfiles disabled the manager must not be constructed, so no reaper thread or
+// timer is spun up. Flip the flag off and build a second SmartCharging against the same context.
+TEST_F(SmartChargingTestV21, K28_DynamicProfilesUnsupported_ManagerNotConstructed) {
+    const auto& supports_dynamic = ControllerComponentVariables::SupportsDynamicProfiles;
+    device_model->set_value(supports_dynamic.component, supports_dynamic.variable.value(), AttributeEnum::Actual,
+                            "false", "test", true);
+
+    TestSmartCharging unsupported{*functional_block_context, set_charging_profiles_callback_mock.AsStdFunction(),
+                                  stop_transaction_callback_mock.AsStdFunction()};
+    EXPECT_FALSE(unsupported.dynamic_schedule_manager.has_value());
+}
+
+// Regression: handle_update_dynamic_schedule_request must catch QueryExecutionException from the matching-criteria
+// lookup and respond Rejected/InternalError. Rename CHARGING_PROFILES out from under the lookup
+// so it fails at statement preparation, then restore it for TearDown's clear_charging_profiles.
+TEST_F(SmartChargingTestV21, K28FR11_UpdateDynamicSchedule_DbLookupThrows_RespondsInternalError) {
+    enable_dynamic_profiles(device_model);
+
+    auto profile = make_dynamic_profile(DEFAULT_PROFILE_ID, 10000.0f);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Rename the table so any SELECT against CHARGING_PROFILES throws QueryExecutionException at
+    // statement preparation time. RAII guard always restores it, even if an assertion below throws.
+    struct TableRestorer {
+        std::shared_ptr<DatabaseHandler> db;
+        ~TableRestorer() {
+            try {
+                db->new_statement("ALTER TABLE CHARGING_PROFILES_BAK RENAME TO CHARGING_PROFILES")->step();
+            } catch (...) {
+                // best-effort restore; TearDown will fail loudly if this didn't work.
+            }
+        }
+    };
+    auto rename_stmt = database_handler->new_statement("ALTER TABLE CHARGING_PROFILES RENAME TO CHARGING_PROFILES_BAK");
+    ASSERT_EQ(rename_stmt->step(), SQLITE_DONE);
+    TableRestorer restorer{database_handler};
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    req.scheduleUpdate.setpoint = 5000.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<v21::UpdateDynamicScheduleResponse>();
+        EXPECT_EQ(response.status, ChargingProfileStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().reasonCode.get(), "InternalError");
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        // additionalInfo carries the full diagnostic message (not just the bare exception text).
+        EXPECT_THAT(response.statusInfo.value().additionalInfo.value().get(),
+                    testing::HasSubstr("Could not look up profile"));
+        EXPECT_THAT(response.statusInfo.value().additionalInfo.value().get(),
+                    testing::HasSubstr("for UpdateDynamicSchedule:"));
+    }));
+    // No callback on DB lookup failure.
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
+
+    smart_charging.handle_message(enhanced);
+}
+
+// When the on-disk profile has a malformed schedule (empty chargingSchedulePeriod vector),
+// apply_update rejects without mutating dynUpdateTime. Corrupting the persisted JSON directly is
+// the only way to reach the apply path with a malformed shape: K28.FR.01 blocks empty period
+// vectors at SetChargingProfile ingress.
+TEST_F(SmartChargingTestV21, K28_ApplyUpdate_MalformedShape_RejectsWithoutMutation) {
+    enable_dynamic_profiles(device_model);
+    auto profile = make_dynamic_profile(DEFAULT_PROFILE_ID, 10000.0f);
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto stored_before = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_before.size(), 1);
+    ASSERT_TRUE(stored_before.front().dynUpdateTime.has_value());
+    const auto dyn_update_time_before = stored_before.front().dynUpdateTime.value().to_rfc3339();
+
+    // Corrupt the persisted profile: replace the period vector with an empty array.
+    auto corrupt_stmt = database_handler->new_statement(
+        "UPDATE CHARGING_PROFILES SET PROFILE = json_set(PROFILE, '$.chargingSchedule[0].chargingSchedulePeriod', "
+        "json('[]')) WHERE ID = ?");
+    corrupt_stmt->bind_int(1, DEFAULT_PROFILE_ID);
+    ASSERT_EQ(corrupt_stmt->step(), SQLITE_DONE);
+
+    v21::UpdateDynamicScheduleRequest req;
+    req.chargingProfileId = DEFAULT_PROFILE_ID;
+    req.scheduleUpdate.setpoint = 5000.0f;
+    auto enhanced =
+        request_to_enhanced_message<v21::UpdateDynamicScheduleRequest, MessageType::UpdateDynamicSchedule>(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<v21::UpdateDynamicScheduleResponse>();
+        EXPECT_EQ(response.status, ChargingProfileStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().reasonCode.get(), "InternalError");
+    }));
+    // Must not fire the composite-recompute callback on malformed-shape rejection.
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
+
+    smart_charging.handle_message(enhanced);
+
+    // dynUpdateTime must be unchanged: the shape check runs ahead of the dynUpdateTime mutation.
+    auto stored_after = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_after.size(), 1);
+    ASSERT_TRUE(stored_after.front().dynUpdateTime.has_value());
+    EXPECT_EQ(stored_after.front().dynUpdateTime.value().to_rfc3339(), dyn_update_time_before);
+}
+
+// A profile that has vanished from the DB between two timer fires must not leave a stale expiry
+// deadline: when on_deadline takes the profile-gone branch it erases the profile's whole deadline
+// entry (pull and expire), so a subsequent expiry pass on the same tick cannot fire a stale
+// composite recompute. Setup: dynUpdateInterval=1s, duration=20s, dynUpdateTime in the past so the pull
+// deadline is overdue; duration window still in the future so the expire entry survives the first
+// scan. Delete the row directly so the DB lookup in the pull branch returns empty -> profile-gone.
+TEST_F(SmartChargingTestV21, K28_OnTimerFire_ProfileGone_ErasesExpireTracking) {
+    enable_dynamic_profiles(device_model);
+
+    // Count dispatch_call_async invocations so we can observe timer ticks event-style instead of
+    // sleeping for a fixed wall-clock budget. Each tick on a tracked profile drives at most one
+    // dispatch attempt before the profile-gone branch erases the entry.
+    std::atomic<int> dispatch_count{0};
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke([&dispatch_count](const json&, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+            dispatch_count.fetch_add(1);
+            std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+            ocpp::EnhancedMessage<MessageType> offline;
+            offline.offline = true;
+            resp.set_value(offline);
+            return resp.get_future();
+        }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    // Insert directly with duration set + small interval + past dynUpdateTime. Use a 1s interval
+    // so pull deadline = past_time + 1s = still in the past; expire deadline = past_time + 20s =
+    // ~10s in the future. Critical: profile must reach the timer's pull pass; if we went through
+    // add_profile, the Set path would reset dynUpdateTime to now and the pull deadline becomes 1s
+    // out.
+    const auto past = ocpp::DateTime(date::utc_clock::now() - std::chrono::seconds(10));
+    auto profile = make_dynamic_profile_with_duration(DEFAULT_PROFILE_ID, /*duration=*/20, past);
+    profile.dynUpdateInterval = 1;
+    database_handler->insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile,
+                                                        ChargingLimitSourceEnumStringType::CSO);
+
+    // Count expiry-pass callback invocations. The timer's profile-gone branch must erase the
+    // expire entry before the expiry pass runs, so this stays at 0 for the full observation
+    // window. The DB row will be cleaned up by TearDown's clear_charging_profiles; no separate
+    // restoration needed.
+    std::atomic<int> callback_count{0};
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).WillRepeatedly(Invoke([&callback_count]() {
+        callback_count.fetch_add(1);
+    }));
+
+    // Seed pull + expire tracking from the persisted row, then drop the row from under the timer.
+    smart_charging.dynamic_schedule_manager->rebuild_from_db();
+    auto delete_stmt = database_handler->new_statement("DELETE FROM CHARGING_PROFILES WHERE ID = ?");
+    delete_stmt->bind_int(1, DEFAULT_PROFILE_ID);
+    ASSERT_EQ(delete_stmt->step(), SQLITE_DONE);
+
+    // Snapshot dispatch_count after the delete -- the count must stay flat afterwards because the
+    // profile-gone branch is taken before dispatch_call_async is reached.
+    const int dispatches_at_delete = dispatch_count.load();
+
+    // Observation window: timer interval is 1s, so 2.5s spans at least two ticks and gives the
+    // profile-gone branch ample wall-clock budget on a loaded CI box. We exit early if the negative
+    // event we care about (callback_count incrementing) is ever observed, so a failing test fails
+    // quickly. A passing test pays the full window; that is fine because the assertion is "nothing
+    // fires" -- absence-of-event has no positive trigger we can poll on.
+    const auto observation_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(2500);
+    while (std::chrono::steady_clock::now() < observation_deadline) {
+        if (callback_count.load() > 0) {
+            break; // Negative case: fail fast on the assertion below.
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    EXPECT_EQ(callback_count.load(), 0)
+        << "Expiry callback fired despite profile-gone branch -- deadline entry not erased.";
+    // Sanity: dispatch_call_async must NOT have been called after the delete, because the lookup
+    // yields an empty match and the profile-gone branch erases tracking before dispatch.
+    EXPECT_EQ(dispatch_count.load(), dispatches_at_delete)
+        << "dispatch_call_async was invoked after delete -- profile-gone branch did not erase pull tracking.";
+}
+
+// Two Dynamic profiles tagged with different chargingLimitSource metadata (CSO, EMS). Clearing
+// by stackLevel must remove the matched profile and erase its pull tracking, while the unmatched
+// profile remains in the DB, keeps its tracking firing, and retains its original source metadata.
+TEST_F(SmartChargingTestV21, K28FR10_ClearChargingProfile_StackLevelFilter_ErasesOnlyMatchedPullTracking) {
+    enable_dynamic_profiles(device_model);
+
+    constexpr std::int32_t profile_id_cso = DEFAULT_PROFILE_ID;
+    constexpr std::int32_t profile_id_ems = DEFAULT_PROFILE_ID + 1;
+    constexpr int stack_level_cso = DEFAULT_STACK_LEVEL;
+    constexpr int stack_level_ems = DEFAULT_STACK_LEVEL + 1;
+
+    std::atomic<int> dispatch_count_cso{0};
+    std::atomic<int> dispatch_count_ems{0};
+    std::promise<void> first_ems_dispatch_promise;
+    auto first_ems_dispatch_future = first_ems_dispatch_promise.get_future();
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count_cso, &dispatch_count_ems,
+                    ems_p = std::make_shared<std::promise<void>>(std::move(first_ems_dispatch_promise))](
+                       const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                const auto profile_id = call.at(CALL_PAYLOAD).at("chargingProfileId").get<std::int32_t>();
+                if (profile_id == profile_id_cso) {
+                    dispatch_count_cso.fetch_add(1);
+                } else if (profile_id == profile_id_ems) {
+                    if (dispatch_count_ems.fetch_add(1) == 0) {
+                        ems_p->set_value();
+                    }
+                }
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                ocpp::EnhancedMessage<MessageType> offline;
+                offline.offline = true;
+                resp.set_value(offline);
+                return resp.get_future();
+            }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    auto profile_cso = make_dynamic_profile_with_interval(profile_id_cso, /*interval=*/1, ocpp::DateTime());
+    profile_cso.stackLevel = stack_level_cso;
+    auto profile_ems = make_dynamic_profile_with_interval(profile_id_ems, /*interval=*/1, ocpp::DateTime());
+    profile_ems.stackLevel = stack_level_ems;
+
+    ASSERT_THAT(
+        smart_charging
+            .conform_validate_and_add_profile(profile_cso, DEFAULT_EVSE_ID, ChargingLimitSourceEnumStringType::CSO)
+            .status,
+        testing::Eq(ChargingProfileStatusEnum::Accepted));
+    ASSERT_THAT(
+        smart_charging
+            .conform_validate_and_add_profile(profile_ems, DEFAULT_EVSE_ID, ChargingLimitSourceEnumStringType::EMS)
+            .status,
+        testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    ClearChargingProfileRequest clear_req;
+    ClearChargingProfile criteria;
+    criteria.stackLevel = stack_level_cso;
+    clear_req.chargingProfileCriteria = criteria;
+    auto enhanced =
+        request_to_enhanced_message<ClearChargingProfileRequest, MessageType::ClearChargingProfile>(clear_req);
+    smart_charging.handle_message(enhanced);
+
+    // CSO row deleted; EMS row preserved with its original limit source.
+    auto stored = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored.size(), 1u);
+    EXPECT_EQ(stored.front().id, profile_id_ems);
+
+    ChargingProfileCriterion ems_lookup;
+    ems_lookup.chargingProfileId = std::vector<std::int32_t>{profile_id_ems};
+    auto ems_rows = database_handler->get_charging_profiles_matching_criteria(std::nullopt, ems_lookup);
+    ASSERT_EQ(ems_rows.size(), 1u);
+    EXPECT_EQ(ems_rows.front().source, ChargingLimitSourceEnumStringType::EMS);
+
+    // Observable behavior of tracking: the EMS timer keeps firing after the clear, while the CSO
+    // entry stays at whatever count it reached before erase_tracking dropped it.
+    ASSERT_EQ(first_ems_dispatch_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    const int cso_dispatches_after_clear = dispatch_count_cso.load();
+
+    // Give the timer at least one more tick at the 1s cadence to confirm no spurious CSO dispatch
+    // and that EMS continues to be polled.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    EXPECT_EQ(dispatch_count_cso.load(), cso_dispatches_after_clear)
+        << "CSO profile pull tracking was not erased -- timer still firing for a deleted profile.";
+    EXPECT_GE(dispatch_count_ems.load(), 1) << "EMS profile pull tracking lost -- timer no longer firing for it.";
+}
+
+// The response worker's catch branch for fut.get() must swallow without applying state. Use a
+// promise that resolves to an exception; the worker drops the future result and exits. The
+// stored profile's setpoint stays at the initial value and the second timer-driven dispatch
+// (~1s after the first, since the throw branch does not refresh the pull deadline) signals that
+// the worker fully consumed the failed future.
+TEST_F(SmartChargingTestV21, K28FR08_PullResponse_FutureThrows_NoOp) {
+    enable_dynamic_profiles(device_model);
+
+    std::promise<void> first_dispatched_promise;
+    auto first_dispatched_future = first_dispatched_promise.get_future();
+    std::promise<void> second_dispatched_promise;
+    auto second_dispatched_future = second_dispatched_promise.get_future();
+    std::atomic<int> dispatch_count{0};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke(
+            [&dispatch_count, first_p = std::make_shared<std::promise<void>>(std::move(first_dispatched_promise)),
+             second_p = std::make_shared<std::promise<void>>(std::move(second_dispatched_promise))](
+                const json& /*call*/, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                const int n = dispatch_count.fetch_add(1);
+                if (n == 0) {
+                    resp.set_exception(std::make_exception_ptr(std::runtime_error("simulated future exception")));
+                    first_p->set_value();
+                } else {
+                    if (n == 1) {
+                        second_p->set_value();
+                    }
+                    ocpp::EnhancedMessage<MessageType> offline;
+                    offline.offline = true;
+                    resp.set_value(offline);
+                }
+                return resp.get_future();
+            }));
+
+    // The throw branch must not invoke the composite-recompute callback.
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto stored_initial = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_initial.size(), 1u);
+    ASSERT_FALSE(stored_initial.front().chargingSchedule.empty());
+    ASSERT_FALSE(stored_initial.front().chargingSchedule.at(0).chargingSchedulePeriod.empty());
+    const float initial_setpoint =
+        stored_initial.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f);
+
+    ASSERT_EQ(first_dispatched_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    ASSERT_EQ(second_dispatched_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    auto stored_after = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_after.size(), 1u);
+    EXPECT_FLOAT_EQ(stored_after.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f),
+                    initial_setpoint);
+}
+
+// A response whose messageType is anything other than PullDynamicScheduleUpdateResponse takes the
+// "unexpected response type" branch. Use Heartbeat as a stand-in for a wrong but well-formed
+// envelope. The setpoint stays at the initial value and the second dispatch signals the worker
+// finished processing the first response.
+TEST_F(SmartChargingTestV21, K28FR08_PullResponse_UnexpectedMessageType_NoOp) {
+    enable_dynamic_profiles(device_model);
+
+    std::promise<void> first_dispatched_promise;
+    auto first_dispatched_future = first_dispatched_promise.get_future();
+    std::promise<void> second_dispatched_promise;
+    auto second_dispatched_future = second_dispatched_promise.get_future();
+    std::atomic<int> dispatch_count{0};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke(
+            [&dispatch_count, first_p = std::make_shared<std::promise<void>>(std::move(first_dispatched_promise)),
+             second_p = std::make_shared<std::promise<void>>(std::move(second_dispatched_promise))](
+                const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                const int n = dispatch_count.fetch_add(1);
+                if (n == 0) {
+                    const auto message_id = call.at(MESSAGE_ID).get<std::string>();
+                    ocpp::EnhancedMessage<MessageType> wrong_type;
+                    wrong_type.messageType = MessageType::Heartbeat;
+                    wrong_type.uniqueId = message_id;
+                    wrong_type.message = json::array({ocpp::MessageTypeId::CALLRESULT, message_id, json::object()});
+                    resp.set_value(wrong_type);
+                    first_p->set_value();
+                } else {
+                    if (n == 1) {
+                        second_p->set_value();
+                    }
+                    ocpp::EnhancedMessage<MessageType> offline;
+                    offline.offline = true;
+                    resp.set_value(offline);
+                }
+                return resp.get_future();
+            }));
+
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto stored_initial = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_initial.size(), 1u);
+    const float initial_setpoint =
+        stored_initial.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f);
+
+    ASSERT_EQ(first_dispatched_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    ASSERT_EQ(second_dispatched_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    auto stored_after = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_after.size(), 1u);
+    EXPECT_FLOAT_EQ(stored_after.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f),
+                    initial_setpoint);
+}
+
+// A response with the correct messageType but a malformed JSON payload must take the parse-catch
+// branch. The envelope here is shaped as a CALLRESULT carrying an empty object, which fails the
+// PullDynamicScheduleUpdateResponse from_json conversion (status is a required field).
+TEST_F(SmartChargingTestV21, K28FR08_PullResponse_MalformedPayload_NoOp) {
+    enable_dynamic_profiles(device_model);
+
+    std::promise<void> first_dispatched_promise;
+    auto first_dispatched_future = first_dispatched_promise.get_future();
+    std::promise<void> second_dispatched_promise;
+    auto second_dispatched_future = second_dispatched_promise.get_future();
+    std::atomic<int> dispatch_count{0};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke(
+            [&dispatch_count, first_p = std::make_shared<std::promise<void>>(std::move(first_dispatched_promise)),
+             second_p = std::make_shared<std::promise<void>>(std::move(second_dispatched_promise))](
+                const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                const int n = dispatch_count.fetch_add(1);
+                if (n == 0) {
+                    const auto message_id = call.at(MESSAGE_ID).get<std::string>();
+                    ocpp::EnhancedMessage<MessageType> malformed;
+                    malformed.messageType = MessageType::PullDynamicScheduleUpdateResponse;
+                    malformed.uniqueId = message_id;
+                    // Required `status` field absent → from_json throws inside the worker's
+                    // CallResult conversion.
+                    malformed.message = json::array({ocpp::MessageTypeId::CALLRESULT, message_id, json::object()});
+                    resp.set_value(malformed);
+                    first_p->set_value();
+                } else {
+                    if (n == 1) {
+                        second_p->set_value();
+                    }
+                    ocpp::EnhancedMessage<MessageType> offline;
+                    offline.offline = true;
+                    resp.set_value(offline);
+                }
+                return resp.get_future();
+            }));
+
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    auto stored_initial = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_initial.size(), 1u);
+    const float initial_setpoint =
+        stored_initial.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f);
+
+    ASSERT_EQ(first_dispatched_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    ASSERT_EQ(second_dispatched_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    auto stored_after = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored_after.size(), 1u);
+    EXPECT_FLOAT_EQ(stored_after.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0).setpoint.value_or(0.0f),
+                    initial_setpoint);
+}
+
+// An exception thrown from set_charging_profiles_callback inside the async pull-response worker
+// must be caught by the worker's own try/catch and NOT escape into the std::future (which is only
+// wait()-ed, never get()-ed). Observable state: the process survives -- the timer keeps dispatching
+// after the throwing tick.
+TEST_F(SmartChargingTestV21, K28_PullResponseWorker_SwallowsCallbackThrow_ProcessSurvives) {
+    enable_dynamic_profiles(device_model);
+
+    std::atomic<int> dispatch_count{0};
+    std::promise<void> second_dispatch_promise;
+    auto second_dispatch_future = second_dispatch_promise.get_future();
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count, snd_p = std::make_shared<std::promise<void>>(std::move(second_dispatch_promise))](
+                       const json& call, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                const int n = dispatch_count.fetch_add(1);
+                if (n == 0) {
+                    const auto message_id = call.at(MESSAGE_ID).get<std::string>();
+                    ChargingScheduleUpdate schedule_update;
+                    schedule_update.setpoint = 7777.0f;
+                    auto enhanced =
+                        make_pull_response_enhanced(message_id, ChargingProfileStatusEnum::Accepted, schedule_update);
+                    resp.set_value(enhanced);
+                } else {
+                    if (n == 1) {
+                        snd_p->set_value();
+                    }
+                    ocpp::EnhancedMessage<MessageType> offline;
+                    offline.offline = true;
+                    resp.set_value(offline);
+                }
+                return resp.get_future();
+            }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    // First callback (fired by the AppliedFieldsCallbackPending branch on the worker thread) throws;
+    // later invocations no-op.
+    std::atomic<bool> callback_threw{false};
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call)
+        .WillOnce(Invoke([&callback_threw]() {
+            callback_threw.store(true);
+            throw std::runtime_error("simulated callback failure in pull-response worker");
+        }))
+        .WillRepeatedly(Return());
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // The throwing callback ran, and the process survived it: a SECOND timer-driven dispatch
+    // happens after the throwing first one (the worker's catch swallowed the exception instead of
+    // letting it escape into the wait()-only future).
+    ASSERT_EQ(second_dispatch_future.wait_for(std::chrono::seconds(5)), std::future_status::ready)
+        << "timer/process did not survive a callback throw inside the pull-response worker";
+    EXPECT_TRUE(callback_threw.load()) << "throwing callback branch never ran";
+}
+
+// Expiry fire-then-commit: a throwing expiry-recompute callback must NOT clear the expire deadline
+// -- the entry is kept so the NEXT timer tick retries the recompute. Observable state: the callback
+// fires again on a later tick (>=2 invocations), which is only possible if the entry survived the
+// throwing tick. Pre-fix the expire field was reset before the callback fired, so a throw left
+// state committed-but-unpublished and the callback fired exactly once.
+TEST_F(SmartChargingTestV21, K28_OnTimerFire_ExpiryCallbackThrows_KeepsEntryAndRetries) {
+    enable_dynamic_profiles(device_model);
+
+    // First expiry callback throws; subsequent ones succeed. Count invocations: a retry (>=2)
+    // proves the expire entry was kept across the throwing tick.
+    std::atomic<int> callback_count{0};
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).WillRepeatedly(Invoke([&callback_count]() {
+        if (callback_count.fetch_add(1) == 0) {
+            throw std::runtime_error("simulated expiry recompute callback failure");
+        }
+    }));
+
+    // Keep the timer alive across ticks via a 1s pull interval; offline responses so no apply runs.
+    std::atomic<int> dispatch_count{0};
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke([&dispatch_count](const json&, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+            dispatch_count.fetch_add(1);
+            std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+            ocpp::EnhancedMessage<MessageType> offline;
+            offline.offline = true;
+            resp.set_value(offline);
+            return resp.get_future();
+        }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    // Dynamic profile: expiry boundary at now+1s AND a 1s pull interval. The first fire (~1s)
+    // detects expiry and fires the callback (throws). With fire-then-commit, the expire field is
+    // kept, so the next tick re-detects expiry and fires the callback again (succeeds), and only
+    // then is the entry cleared.
+    auto periods = create_charging_schedule_periods(0, 1, 1, std::nullopt);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    periods.at(0).setpoint = 10000.0f;
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00"), /*duration=*/1),
+        {}, ChargingProfileKindEnum::Dynamic, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
+        ocpp::DateTime("2034-02-01T13:00:00"));
+    profile.dynUpdateInterval = 1;
+    profile.dynUpdateTime = ocpp::DateTime();
+
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // The expiry callback must fire AGAIN (>=2) after the first throw -- proving the expire entry
+    // was not cleared on the throwing tick and the recompute was retried.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(6);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (callback_count.load() >= 2) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    EXPECT_GE(callback_count.load(), 2)
+        << "expiry callback fired only once -- the expire entry was cleared before the callback, so "
+           "a throw left state committed-but-unpublished with no retry";
+}
+
+// A pull-response future that throws (transient websocket drop) and an offline pull response both
+// return early WITHOUT advancing the pull deadline. Observable state: the timer keeps re-dispatching
+// (deadline stayed due), so dispatch_count climbs past the two seeded responses rather than
+// stalling.
+TEST_F(SmartChargingTestV21, K28_PullResponseWorker_FutureThrowAndOffline_RetriesPromptly) {
+    enable_dynamic_profiles(device_model);
+
+    std::promise<void> future_throw_dispatched;
+    auto future_throw_dispatched_future = future_throw_dispatched.get_future();
+    std::promise<void> offline_dispatched;
+    auto offline_dispatched_future = offline_dispatched.get_future();
+    std::atomic<int> dispatch_count{0};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count, ft_p = std::make_shared<std::promise<void>>(std::move(future_throw_dispatched)),
+                    off_p = std::make_shared<std::promise<void>>(std::move(offline_dispatched))](
+                       const json& /*call*/, bool /*triggered*/) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                const int n = dispatch_count.fetch_add(1);
+                if (n == 0) {
+                    // Future-throw path: the worker's fut.get() rethrows this.
+                    resp.set_exception(std::make_exception_ptr(std::runtime_error("simulated future exception")));
+                    ft_p->set_value();
+                } else {
+                    // Offline path.
+                    ocpp::EnhancedMessage<MessageType> offline;
+                    offline.offline = true;
+                    resp.set_value(offline);
+                    if (n == 1) {
+                        off_p->set_value();
+                    }
+                }
+                return resp.get_future();
+            }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    ASSERT_EQ(future_throw_dispatched_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    ASSERT_EQ(offline_dispatched_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    // Neither the future-throw nor the offline path advances the pull deadline, so the timer keeps
+    // re-dispatching at the 1s interval: dispatch_count climbs past the two seeded responses.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(6);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (dispatch_count.load() >= 3) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    EXPECT_GE(dispatch_count.load(), 3)
+        << "timer stopped re-dispatching after a future-throw + offline -- the pull deadline was "
+           "advanced despite no successful apply";
+}
+
+// ClearChargingProfile drops the deadline tracking for exactly the deleted ids. The DELETE returns
+// the ids it removed, so the handler erases tracking for precisely those -- no mirrored lookup that
+// could drift from the DB filter. Observable state: a pull-tracked Dynamic profile cleared by id is
+// gone from the DB and its deadline entry is erased, so the adaptive timer never dispatches a pull
+// for it afterwards.
+TEST_F(SmartChargingTestV21, K28_ClearChargingProfile_ErasesDeadlineTrackingForDeletedId) {
+    enable_dynamic_profiles(device_model);
+
+    // No pull may ever be dispatched: a far-future interval keeps the deadline un-due before the
+    // clear, and after the clear the tracking entry is erased so it never becomes due.
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _)).Times(0);
+
+    std::optional<ClearChargingProfileResponse> clear_response;
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_))
+        .WillRepeatedly(Invoke([&clear_response](const json& call_result) {
+            clear_response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ClearChargingProfileResponse>();
+        }));
+
+    // Pull-tracked Dynamic profile (deadline entry created), but the next pull is ~1h out so the
+    // timer cannot fire during the test.
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/3600, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    ClearChargingProfileRequest clear_req;
+    clear_req.chargingProfileId = DEFAULT_PROFILE_ID;
+    auto enhanced =
+        request_to_enhanced_message<ClearChargingProfileRequest, MessageType::ClearChargingProfile>(clear_req);
+    smart_charging.handle_message(enhanced);
+
+    // Accepted, and the row is actually gone from the DB.
+    ASSERT_TRUE(clear_response.has_value());
+    EXPECT_EQ(clear_response->status, ClearChargingProfileStatusEnum::Accepted);
+    EXPECT_TRUE(database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID).empty());
+
+    // The deadline entry was erased: rebuilding tracking from the now-empty DB is a no-op, so the
+    // timer stays disarmed and the Times(0) dispatch expectation holds across a short settle.
+    smart_charging.dynamic_schedule_manager->rebuild_from_db();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+}
+
+// Many simultaneously-due Dynamic profiles must all be serviced by the single reaper thread: every
+// Accepted pull response is applied (its setpoint lands in the DB). The mock returns the matching
+// Accepted response for each profile id; the test waits for every per-profile callback to fire,
+// which only happens after each profile's apply path runs on the reaper.
+TEST_F(SmartChargingTestV21, Reaper_SingleThread_HandlesManyDuePulls) {
+    enable_dynamic_profiles(device_model);
+
+    constexpr int profile_count = 8;
+    constexpr float applied_setpoint = 6543.0f;
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([applied_setpoint](const json& call, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                const auto message_id = call.at(MESSAGE_ID).get<std::string>();
+                ChargingScheduleUpdate schedule_update;
+                schedule_update.setpoint = applied_setpoint;
+                auto enhanced =
+                    make_pull_response_enhanced(message_id, ChargingProfileStatusEnum::Accepted, schedule_update);
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                resp.set_value(enhanced);
+                return resp.get_future();
+            }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    // Each profile's apply path fires the callback once it persists. Count distinct applies via the
+    // stored setpoints rather than the callback so re-pulls on later ticks do not skew the result.
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call).WillRepeatedly(Return());
+
+    for (int i = 0; i < profile_count; ++i) {
+        auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID + i, /*interval=*/1, ocpp::DateTime());
+        // Distinct stack levels so all profiles coexist on the same EVSE.
+        profile.stackLevel = DEFAULT_STACK_LEVEL + i;
+        ASSERT_THAT(smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID).status,
+                    testing::Eq(ChargingProfileStatusEnum::Accepted));
+    }
+
+    // Wait until every profile has had the Accepted setpoint applied (all serviced by the reaper).
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    int applied = 0;
+    while (std::chrono::steady_clock::now() < deadline) {
+        applied = 0;
+        auto stored = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+        for (const auto& p : stored) {
+            if (!p.chargingSchedule.empty() && !p.chargingSchedule.at(0).chargingSchedulePeriod.empty()) {
+                const auto& period = p.chargingSchedule.at(0).chargingSchedulePeriod.at(0);
+                if (period.setpoint.has_value() && period.setpoint.value() == applied_setpoint) {
+                    ++applied;
+                }
+            }
+        }
+        if (applied == profile_count) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    EXPECT_EQ(applied, profile_count) << "not all due pulls were serviced by the reaper";
+}
+
+// Single-flight (intentional behavior change): while a profile's pull is still in flight (the
+// CSMS has not responded), the timer's next due-tick must NOT issue a second
+// PullDynamicScheduleUpdateRequest for the same id. The mock holds the response future open (never
+// satisfied) so the pull stays in flight across several 1s ticks; dispatch_call_async must be
+// invoked exactly once.
+TEST_F(SmartChargingTestV21, Reaper_SingleFlight_NoDuplicateDispatch) {
+    enable_dynamic_profiles(device_model);
+
+    std::mutex promises_mtx;
+    std::vector<std::shared_ptr<std::promise<ocpp::EnhancedMessage<MessageType>>>> in_flight;
+    std::atomic<int> dispatch_count{0};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(Invoke([&](const json&, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+            auto p = std::make_shared<std::promise<ocpp::EnhancedMessage<MessageType>>>();
+            auto fut = p->get_future();
+            {
+                std::lock_guard<std::mutex> lk(promises_mtx);
+                in_flight.push_back(std::move(p)); // never satisfied: pull stays in flight
+            }
+            dispatch_count.fetch_add(1, std::memory_order_relaxed);
+            return fut;
+        }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    // Wait for the first dispatch, then let several more 1s ticks elapse. With single-flight the
+    // count must stay at 1 because the first pull never completes.
+    const auto first_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (dispatch_count.load() == 0 && std::chrono::steady_clock::now() < first_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_GE(dispatch_count.load(), 1) << "no pull was dispatched";
+
+    // Span ~4 ticks at the 1s interval; a non-single-flight implementation would emit a fresh
+    // request each tick.
+    std::this_thread::sleep_for(std::chrono::seconds(4));
+    EXPECT_EQ(dispatch_count.load(), 1)
+        << "a second PullDynamicScheduleUpdateRequest was emitted while the first was still in flight";
+
+    // Release the held promises so the reaper drops the future cleanly on teardown.
+    {
+        std::lock_guard<std::mutex> lk(promises_mtx);
+        in_flight.clear();
+    }
+}
+
+// A single due profile's Accepted pull response is applied exactly as before the reaper rework: the
+// schedule update lands in the DB and the apply path fires the set-charging-profiles callback. The
+// callback runs after the database write, so the test reads the stored profile without a sleep.
+TEST_F(SmartChargingTestV21, Reaper_AppliesPullResponse_AsBefore) {
+    enable_dynamic_profiles(device_model);
+
+    std::atomic<int> dispatch_count{0};
+    EXPECT_CALL(mock_dispatcher, dispatch_call_async(_, _))
+        .WillRepeatedly(
+            Invoke([&dispatch_count](const json& call, bool) -> std::future<ocpp::EnhancedMessage<MessageType>> {
+                std::promise<ocpp::EnhancedMessage<MessageType>> resp;
+                if (dispatch_count.fetch_add(1) == 0) {
+                    const auto message_id = call.at(MESSAGE_ID).get<std::string>();
+                    ChargingScheduleUpdate schedule_update;
+                    schedule_update.setpoint = 8888.0f;
+                    auto enhanced =
+                        make_pull_response_enhanced(message_id, ChargingProfileStatusEnum::Accepted, schedule_update);
+                    resp.set_value(enhanced);
+                } else {
+                    ocpp::EnhancedMessage<MessageType> offline;
+                    offline.offline = true;
+                    resp.set_value(offline);
+                }
+                return resp.get_future();
+            }));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).Times(testing::AnyNumber());
+
+    std::promise<void> apply_done_promise;
+    auto apply_done_future = apply_done_promise.get_future();
+    EXPECT_CALL(set_charging_profiles_callback_mock, Call)
+        .WillOnce(Invoke([&apply_done_promise]() { apply_done_promise.set_value(); }))
+        .WillRepeatedly(Return());
+
+    auto profile = make_dynamic_profile_with_interval(DEFAULT_PROFILE_ID, /*interval=*/1, ocpp::DateTime());
+    auto add_response = smart_charging.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    ASSERT_THAT(add_response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
+
+    ASSERT_EQ(apply_done_future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+
+    auto stored = database_handler->get_charging_profiles_for_evse(DEFAULT_EVSE_ID);
+    ASSERT_EQ(stored.size(), 1u);
+    ASSERT_FALSE(stored.front().chargingSchedule.empty());
+    ASSERT_FALSE(stored.front().chargingSchedule.at(0).chargingSchedulePeriod.empty());
+    const auto& period = stored.front().chargingSchedule.at(0).chargingSchedulePeriod.at(0);
+    ASSERT_TRUE(period.setpoint.has_value());
+    EXPECT_FLOAT_EQ(period.setpoint.value(), 8888.0f);
+}
+
+} // namespace ocpp::v2

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -1156,13 +1156,17 @@ void OCPP201::charging_schedules_timer_callback() {
             return;
         }
         {
-            std::lock_guard<std::mutex> guard(recompute_mutex, std::adopt_lock);
-            while (recompute_pending.exchange(false)) {
-                const auto composite_schedule_unit = get_unit_or_default(config.RequestCompositeScheduleUnit);
-                const auto composite_schedules = charge_point->get_all_composite_schedules(
-                    config.RequestCompositeScheduleDurationS, composite_schedule_unit);
-                publish_charging_schedules(composite_schedules);
-                set_external_limits(composite_schedules);
+            try {
+                std::lock_guard<std::mutex> guard(recompute_mutex, std::adopt_lock);
+                while (recompute_pending.exchange(false)) {
+                    const auto composite_schedule_unit = get_unit_or_default(config.RequestCompositeScheduleUnit);
+                    const auto composite_schedules = charge_point->get_all_composite_schedules(
+                        config.RequestCompositeScheduleDurationS, composite_schedule_unit);
+                    publish_charging_schedules(composite_schedules);
+                    set_external_limits(composite_schedules);
+                }
+            } catch (const std::exception& error) {
+                EVLOG_warning << "Composite calculation failed, unable to send external_limits";
             }
         }
     }

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -1141,13 +1141,31 @@ void OCPP201::ready() {
 }
 
 void OCPP201::charging_schedules_timer_callback() {
-    // this callback publishes the schedules within EVerest and applies the schedules for the individual
-    // r_evse_energy_sink
-    const auto composite_schedule_unit = get_unit_or_default(config.RequestCompositeScheduleUnit);
-    const auto composite_schedules =
-        charge_point->get_all_composite_schedules(config.RequestCompositeScheduleDurationS, composite_schedule_unit);
-    publish_charging_schedules(composite_schedules);
-    set_external_limits(composite_schedules);
+    // Single-flight + coalesce: the recompute body publishes schedules within EVerest and applies the
+    // external limits. It now fires concurrently from the interval timer, the libocpp message thread,
+    // and the K28 on_deadline/reaper callbacks, so serialize it here (the convergence point) — concurrent
+    // fires must not apply a stale composite over a fresh one, and a burst collapses into one recompute.
+    recompute_pending.store(true);
+    // Acquire / run / release / re-check: a fire whose store(true) lands after the holder's final
+    // exchange(false) but before it releases the mutex would fail try_lock and otherwise be dropped
+    // until the next trigger. Re-checking the flag after the lock is released runs that pending
+    // request instead of losing it.
+    while (recompute_pending.load()) {
+        if (!recompute_mutex.try_lock()) {
+            // Another thread holds the recompute; it will observe recompute_pending and run our update.
+            return;
+        }
+        {
+            std::lock_guard<std::mutex> guard(recompute_mutex, std::adopt_lock);
+            while (recompute_pending.exchange(false)) {
+                const auto composite_schedule_unit = get_unit_or_default(config.RequestCompositeScheduleUnit);
+                const auto composite_schedules = charge_point->get_all_composite_schedules(
+                    config.RequestCompositeScheduleDurationS, composite_schedule_unit);
+                publish_charging_schedules(composite_schedules);
+                set_external_limits(composite_schedules);
+            }
+        }
+    }
 }
 
 void OCPP201::charging_schedules_timer_start() {

--- a/modules/EVSE/OCPP201/OCPP201.hpp
+++ b/modules/EVSE/OCPP201/OCPP201.hpp
@@ -155,6 +155,10 @@ private:
     int32_t event_id_counter{0};
     std::mutex session_event_mutex;
     std::atomic_bool started{false};
+    // Serialize + coalesce the charging-schedule recompute: it fires concurrently from the interval timer,
+    // the libocpp message thread, and the K28 on_deadline/reaper callbacks.
+    std::mutex recompute_mutex;
+    std::atomic<bool> recompute_pending{false};
     EventQueue event_queue;
     MREC_ERROR_MAP_TYPE mrec_error_map;
     void init_evse_maps();

--- a/tests/ocpp_tests/test_sets/ocpp21/dynamic_charging_profiles.py
+++ b/tests/ocpp_tests/test_sets/ocpp21/dynamic_charging_profiles.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+"""K28 Dynamic Charging Profile integration test.
+
+Verifies that an UpdateDynamicScheduleRequest applied to a Dynamic profile
+propagates through libocpp into the composite schedule returned to the CSMS.
+
+K28 functional-requirement coverage lives in libocpp_unit_tests
+(lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp).
+"""
+
+import asyncio
+import logging
+import math
+from datetime import datetime, timezone
+
+import pytest
+
+# fmt: off
+from everest.testing.core_utils.controller.test_controller_interface import TestController
+
+from ocpp.v21 import call as call21
+from ocpp.v21 import call_result as call_result21
+from ocpp.v21.enums import *
+from ocpp.v21.datatypes import *
+from ocpp.routing import on, create_route_map
+from everest.testing.ocpp_utils.fixtures import *
+from everest_test_utils import *  # overrides v21 Action with v16; reimport below
+from ocpp.v21.enums import (
+    Action,
+    ChargingProfileKindEnumType,
+    ChargingProfilePurposeEnumType,
+    ChargingProfileStatusEnumType,
+    ChargingRateUnitEnumType,
+    ConnectorStatusEnumType,
+    GenericStatusEnumType,
+    OperationModeEnumType,
+)
+from validations import validate_status_notification_201
+from everest.testing.core_utils._configuration.libocpp_configuration_helper import (
+    GenericOCPP2XConfigAdjustment,
+    OCPP2XConfigVariableIdentifier,
+)
+from everest.testing.ocpp_utils.charge_point_utils import wait_for_and_validate, TestUtility
+# fmt: on
+
+log = logging.getLogger("dynamicChargingProfilesTest")
+
+
+# --------------------------------------------------------------------------- #
+# Common config marker                                                        #
+# --------------------------------------------------------------------------- #
+# K01.FR.121 rejects every Dynamic profile when SupportsDynamicProfiles is
+# false. The default ships false (lib/everest/ocpp/config/common/component_config/
+# standardized/SmartChargingCtrlr.json), so every K28 test toggles it on.
+_DYNAMIC_PROFILES_CONFIG = GenericOCPP2XConfigAdjustment(
+    [
+        (
+            OCPP2XConfigVariableIdentifier(
+                "InternalCtrlr", "SupportedOcppVersions", "Actual"
+            ),
+            "ocpp2.1",
+        ),
+        (
+            OCPP2XConfigVariableIdentifier(
+                "SmartChargingCtrlr", "SupportsDynamicProfiles", "Actual"
+            ),
+            "true",
+        ),
+    ]
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+def _build_dynamic_profile(
+    profile_id: int,
+    *,
+    purpose: ChargingProfilePurposeEnumType = ChargingProfilePurposeEnumType.tx_default_profile,
+    limit: float | None = 10000.0,
+    setpoint: float | None = None,
+    operation_mode: OperationModeEnumType | None = None,
+    duration: int | None = None,
+    dyn_update_interval: int | None = None,
+    transaction_id: str | None = None,
+    schedule_periods: list[ChargingSchedulePeriodType] | None = None,
+    kind: ChargingProfileKindEnumType = ChargingProfileKindEnumType.dynamic,
+    stack_level: int = 1,
+) -> ChargingProfileType:
+    """Build a Dynamic ChargingProfile with sensible K28 defaults.
+
+    Defaults to ChargingOnly operationMode, which per the OCPP 2.1 limits/
+    setpoints table requires `limit`. Pass operation_mode=CentralSetpoint plus
+    setpoint=<value> to test the V2X CentralSetpoint flow (Q04).
+    """
+    if schedule_periods is None:
+        period_kwargs: dict = {"start_period": 0}
+        if setpoint is not None:
+            period_kwargs["setpoint"] = setpoint
+        if limit is not None:
+            period_kwargs["limit"] = limit
+        if operation_mode is not None:
+            period_kwargs["operation_mode"] = operation_mode
+        schedule_periods = [ChargingSchedulePeriodType(**period_kwargs)]
+
+    schedule_kwargs: dict = {
+        "id": profile_id,
+        "charging_rate_unit": ChargingRateUnitEnumType.w,
+        "charging_schedule_period": schedule_periods,
+        "duration": duration,
+    }
+    # Absolute / Recurring schedules need a startSchedule; Dynamic does not.
+    if kind == ChargingProfileKindEnumType.absolute:
+        schedule_kwargs["start_schedule"] = datetime.now(timezone.utc).isoformat()
+    schedule = ChargingScheduleType(**schedule_kwargs)
+
+    profile_kwargs: dict = {
+        "id": profile_id,
+        "stack_level": stack_level,
+        "charging_profile_purpose": purpose,
+        "charging_profile_kind": kind,
+        "charging_schedule": [schedule],
+    }
+    if dyn_update_interval is not None:
+        profile_kwargs["dyn_update_interval"] = dyn_update_interval
+        # K28 FR.08: dynUpdateTime sets the anchor for the next pull.
+        profile_kwargs["dyn_update_time"] = datetime.now(timezone.utc).isoformat()
+    if transaction_id is not None:
+        profile_kwargs["transaction_id"] = transaction_id
+
+    return ChargingProfileType(**profile_kwargs)
+
+
+async def _wait_available(test_utility, charge_point):
+    return await wait_for_and_validate(
+        test_utility,
+        charge_point,
+        "StatusNotification",
+        call21.StatusNotification(
+            1, ConnectorStatusEnumType.available, 1, datetime.now().isoformat()
+        ),
+        validate_status_notification_201,
+    )
+
+
+async def _composite_schedule_first_period(charge_point, evse_id: int = 1, duration: int = 30):
+    """Return the first ChargingSchedulePeriod of the composite schedule for the EVSE.
+
+    The python-ocpp library deserializes nested dicts with snake_case keys, so
+    we read `charging_schedule_period`, `operation_mode`, etc., on the returned
+    dict — matching what dataclass-based responses expose to the test.
+    """
+    r: call_result21.GetCompositeSchedule = await charge_point.get_composite_schedule_req(
+        duration=duration,
+        evse_id=evse_id,
+        charging_rate_unit=ChargingRateUnitEnumType.w,
+    )
+    assert r.status == GenericStatusEnumType.accepted, "GetCompositeSchedule rejected"
+    assert r.schedule is not None, "Composite schedule missing in response"
+    periods = (
+        r.schedule.get("charging_schedule_period")
+        or r.schedule.get("chargingSchedulePeriod")
+    )
+    assert periods, f"Composite schedule has no periods: {r.schedule}"
+    return periods[0], r.schedule
+
+
+# --------------------------------------------------------------------------- #
+# 1) Push setpoint update changes the EVSE limit                              #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.1")
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-ocpp201.yaml")
+)
+@pytest.mark.ocpp_config_adaptions(_DYNAMIC_PROFILES_CONFIG)
+@pytest.mark.use_temporary_persistent_store
+async def test_k28_push_setpoint_update_changes_evse_limit(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    """K28.FR.06/.09: UpdateDynamicSchedule with a new limit replaces the profile limit.
+
+    Verified through GetCompositeSchedule, which reflects the active limit the
+    SmartChargingHandler computes for the EVSE.
+    """
+    test_controller.start()
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+    assert await _wait_available(test_utility, charge_point_v21)
+
+    profile_id = 8001
+    profile = _build_dynamic_profile(profile_id, limit=10000.0)
+    set_resp: call_result21.SetChargingProfile = await charge_point_v21.set_charging_profile_req(
+        evse_id=1, charging_profile=profile
+    )
+    assert set_resp.status == ChargingProfileStatusEnumType.accepted
+
+    period, _ = await _composite_schedule_first_period(charge_point_v21)
+    initial = period.get("limit", period.get("setpoint"))
+    assert initial == pytest.approx(10000.0, abs=1.0), f"baseline composite was {initial}"
+
+    update = call21.UpdateDynamicSchedule(
+        charging_profile_id=profile_id,
+        schedule_update=ChargingScheduleUpdateType(limit=5000.0),
+    )
+    upd_resp: call_result21.UpdateDynamicSchedule = await charge_point_v21.call(update)
+    assert upd_resp.status == ChargingProfileStatusEnumType.accepted
+
+    # Allow the handler a brief moment to surface the merged value.
+    await asyncio.sleep(1.0)
+    period, _ = await _composite_schedule_first_period(charge_point_v21)
+    after = period.get("limit", period.get("setpoint"))
+    assert after == pytest.approx(5000.0, abs=1.0), f"updated composite was {after}"
+
+
+# --------------------------------------------------------------------------- #
+# 2) Rapid back-to-back updates converge to the LAST pushed limit             #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.1")
+@pytest.mark.everest_core_config(
+    get_everest_config_path_str("everest-config-ocpp201.yaml")
+)
+@pytest.mark.ocpp_config_adaptions(_DYNAMIC_PROFILES_CONFIG)
+@pytest.mark.use_temporary_persistent_store
+async def test_k28_rapid_updates_converge_to_last_limit(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+):
+    """K28: a rapid burst of UpdateDynamicSchedule messages converges on the LAST limit.
+
+    Sends several updates back-to-back with distinct limits and asserts the composite
+    schedule settles on the LAST pushed value, never an earlier (stale) one — an
+    end-to-end guard that a rapid update burst is processed in order and does not
+    strand an intermediate limit.
+
+    This asserts via GetCompositeSchedule, which reflects libocpp's profile store
+    (mutated synchronously by each UpdateDynamicSchedule) and is therefore independent
+    of the OCPP201 recompute callback. The single-flight + coalescing serialization of
+    that callback — which keeps a concurrent fire from applying a stale composite to the
+    energy sink — is an EVerest-internal change carried by the production logic; this
+    test guards the observable OCPP-level convergence, not the internal apply path.
+    """
+    test_controller.start()
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+    assert await _wait_available(test_utility, charge_point_v21)
+
+    profile_id = 8002
+    profile = _build_dynamic_profile(profile_id, limit=10000.0)
+    set_resp: call_result21.SetChargingProfile = await charge_point_v21.set_charging_profile_req(
+        evse_id=1, charging_profile=profile
+    )
+    assert set_resp.status == ChargingProfileStatusEnumType.accepted
+
+    # Fire a burst of distinct limits back-to-back; 9000 is pushed LAST.
+    burst_limits = [6000.0, 7000.0, 8000.0, 9000.0]
+    for limit in burst_limits:
+        update = call21.UpdateDynamicSchedule(
+            charging_profile_id=profile_id,
+            schedule_update=ChargingScheduleUpdateType(limit=limit),
+        )
+        upd_resp: call_result21.UpdateDynamicSchedule = await charge_point_v21.call(update)
+        assert upd_resp.status == ChargingProfileStatusEnumType.accepted
+
+    final_limit = burst_limits[-1]
+    # Poll for convergence: the coalesced recompute must settle on the LAST limit and
+    # must never expose an intermediate/stale value as the final state.
+    converged = None
+    for _ in range(10):
+        await asyncio.sleep(0.5)
+        period, _schedule = await _composite_schedule_first_period(charge_point_v21)
+        converged = period.get("limit", period.get("setpoint"))
+        if converged == pytest.approx(final_limit, abs=1.0):
+            break
+    assert converged == pytest.approx(final_limit, abs=1.0), (
+        f"final composite was {converged}, expected last pushed limit {final_limit}"
+    )
+
+


### PR DESCRIPTION
Adaptive Dynamic profiles: periodic pull worker, CSMS push handling, deadline tracking via DynamicScheduleManager, expiry filter, and a serialized+coalesced recompute in OCPP201.

## Describe your changes

Implements OCPP 2.1 **K28 Dynamic charging profiles** in libocpp, plus the
OCPP201 module change required to apply the resulting schedules safely.

### libocpp — Dynamic profile support

- New **`DynamicScheduleManager`** that owns the adaptive lifecycle of
  Dynamic charging profiles:
  - a periodic worker that issues `PullDynamicScheduleUpdate` when a
    profile's pull deadline (`dynUpdateTime + dynUpdateInterval`) elapses;
  - handling for CSMS-pushed `UpdateDynamicSchedule` requests;
  - deadline tracking guarded by a monitor, with a single reaper thread that
    polls in-flight pulls and tears them down without a blocking join;
  - per-profile single-flight so a profile with a pull in flight is not
    re-dispatched until it lands or times out.
- `SmartCharging` wiring: validation that a Dynamic profile carries exactly
  one schedule with one period, auto-population of `dynUpdateTime` on accept,
  and an expiry filter that drops a Dynamic profile from the composite
  calculation once its schedule duration has elapsed.
- `profile.cpp` gains single-source helpers for the Dynamic expiry and pull
  deadlines so the manager timer and the composite filter agree on the exact
  boundary instant.

### OCPP201 — serialized recompute

The charging-schedule recompute (`charging_schedules_timer_callback`) now
fires concurrently from three sources: the interval timer, the libocpp
message thread, and the K28 timer/reaper. It is guarded with a single-flight
`try_lock` plus a `recompute_pending` drain loop, so concurrent fires cannot
apply a stale composite over a fresh one and a burst collapses into one
recompute.

This module guard is the safety mechanism for the concurrency the
`DynamicScheduleManager` introduces, so the two land together in this PR by
design — the feature is never separated from the guard that makes it safe.

This stacks on #2278 (`clear` returning deleted ids — which the manager uses
to drop deadline tracking for exactly the cleared profiles). The SQLite
read-robustness change that was beneath both has merged to `main` (#2277), so
this PR now has a single base PR remaining.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements


