### PR TITLE
feat(sqlite): enable WAL journal mode on file databases

### DIFF
--- a/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
+++ b/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
@@ -86,22 +86,23 @@ bool Connection::open_connection() {
     sqlite3_busy_timeout(this->db, busy_timeout_ms);
 
     // Enable WAL journal mode on file-based databases so concurrent readers and a single writer
-    // stop serializing. WAL-or-fail: if WAL cannot be established we refuse to open the connection.
+    // stop serializing. Best-effort: if WAL cannot be established (e.g. on a filesystem that does
+    // not support it) we log and continue with whatever journal mode SQLite reports rather than
+    // failing the open.
     if (!in_memory) {
         auto statement = this->new_statement("PRAGMA journal_mode=WAL");
         if (statement->step() != SQLITE_ROW) {
-            EVLOG_error << "Failed to enable WAL journal mode on " << this->database_file_path << ": "
-                        << this->get_error_message();
-            return false;
-        }
-        const std::string journal_mode = statement->column_text(0);
-        std::string lowered = journal_mode;
-        std::transform(lowered.begin(), lowered.end(), lowered.begin(),
-                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-        if (lowered != "wal") {
-            EVLOG_error << "Expected WAL journal mode on " << this->database_file_path << " but got '" << journal_mode
-                        << "'";
-            return false;
+            EVLOG_warning << "Could not query journal mode while enabling WAL on " << this->database_file_path << ": "
+                          << this->get_error_message();
+        } else {
+            const std::string journal_mode = statement->column_text(0);
+            std::string lowered = journal_mode;
+            std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                           [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            if (lowered != "wal") {
+                EVLOG_warning << "Could not enable WAL journal mode on " << this->database_file_path
+                              << ", continuing with '" << journal_mode << "'";
+            }
         }
     }
 

--- a/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
+++ b/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 
+#include <algorithm>
+#include <cctype>
 #include <chrono>
 
 #include <everest/database/exceptions.hpp>
@@ -64,10 +66,11 @@ bool Connection::open_connection() {
     }
 
     // Add special exception for databases in ram; we don't need to create a path
-    // for them
-    if (this->database_file_path.string().find(":memory:") == std::string::npos and
-        this->database_file_path.string().find("mode=memory") == std::string::npos and
-        !fs::exists(this->database_file_path.parent_path())) {
+    // for them and we must not attempt to enable WAL on them.
+    const bool in_memory = this->database_file_path.string().find(":memory:") != std::string::npos ||
+                           this->database_file_path.string().find("mode=memory") != std::string::npos;
+
+    if (!in_memory && !fs::exists(this->database_file_path.parent_path())) {
         fs::create_directories(this->database_file_path.parent_path());
     }
 
@@ -81,6 +84,27 @@ bool Connection::open_connection() {
     // transient SQLITE_BUSY to the caller.
     constexpr int busy_timeout_ms = 5000;
     sqlite3_busy_timeout(this->db, busy_timeout_ms);
+
+    // Enable WAL journal mode on file-based databases so concurrent readers and a single writer
+    // stop serializing. WAL-or-fail: if WAL cannot be established we refuse to open the connection.
+    if (!in_memory) {
+        auto statement = this->new_statement("PRAGMA journal_mode=WAL");
+        if (statement->step() != SQLITE_ROW) {
+            EVLOG_error << "Failed to enable WAL journal mode on " << this->database_file_path << ": "
+                        << this->get_error_message();
+            return false;
+        }
+        const std::string journal_mode = statement->column_text(0);
+        std::string lowered = journal_mode;
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (lowered != "wal") {
+            EVLOG_error << "Expected WAL journal mode on " << this->database_file_path << " but got '" << journal_mode
+                        << "'";
+            return false;
+        }
+    }
+
     EVLOG_debug << "Established connection to database: " << this->database_file_path;
     return true;
 }

--- a/lib/everest/sqlite/tests/CMakeLists.txt
+++ b/lib/everest/sqlite/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(GTEST_LIBRARIES GTest::gmock_main GTest::gtest_main)
 add_executable(${TEST_TARGET_NAME})
 
 target_sources(${TEST_TARGET_NAME} PRIVATE
+    test_connection.cpp
     test_database_schema_updater.cpp
     test_sqlite_statement.cpp
 )

--- a/lib/everest/sqlite/tests/test_connection.cpp
+++ b/lib/everest/sqlite/tests/test_connection.cpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include <everest/database/sqlite/connection.hpp>
+#include <everest/database/sqlite/statement.hpp>
+#include <gtest/gtest.h>
+#include <sqlite3.h>
+
+#include <filesystem>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace everest::db::sqlite {
+
+class ConnectionWalTest : public ::testing::Test {
+protected:
+    fs::path db_path;
+
+    void SetUp() override {
+        const auto unique = "everest_sqlite_conn_test_" + std::to_string(reinterpret_cast<std::uintptr_t>(this)) + "_" +
+                            std::to_string(::testing::UnitTest::GetInstance()->random_seed()) + ".db";
+        db_path = fs::temp_directory_path() / unique;
+        std::error_code ec;
+        fs::remove(db_path, ec);
+        fs::remove(db_path.string() + "-wal", ec);
+        fs::remove(db_path.string() + "-shm", ec);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove(db_path, ec);
+        fs::remove(db_path.string() + "-wal", ec);
+        fs::remove(db_path.string() + "-shm", ec);
+    }
+};
+
+TEST_F(ConnectionWalTest, FileDatabaseUsesWalJournalMode) {
+    Connection db(db_path);
+    ASSERT_TRUE(db.open_connection());
+
+    {
+        auto stmt = db.new_statement("PRAGMA journal_mode");
+        ASSERT_EQ(stmt->step(), SQLITE_ROW);
+        EXPECT_EQ(stmt->column_text(0), "wal");
+    }
+
+    db.close_connection();
+}
+
+TEST_F(ConnectionWalTest, InMemoryDatabaseOpensWithoutWalFailure) {
+    Connection db(fs::path("file::memory:?cache=shared"));
+    ASSERT_TRUE(db.open_connection());
+    db.close_connection();
+}
+
+TEST_F(ConnectionWalTest, ExistingRollbackDatabaseMigratesToWal) {
+    sqlite3* raw = nullptr;
+    ASSERT_EQ(sqlite3_open_v2(db_path.c_str(), &raw, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr), SQLITE_OK);
+    ASSERT_EQ(sqlite3_exec(raw, "PRAGMA journal_mode=DELETE; CREATE TABLE t(id INTEGER);", nullptr, nullptr, nullptr),
+              SQLITE_OK);
+    sqlite3_close(raw);
+
+    Connection db(db_path);
+    ASSERT_TRUE(db.open_connection());
+
+    {
+        auto stmt = db.new_statement("PRAGMA journal_mode");
+        ASSERT_EQ(stmt->step(), SQLITE_ROW);
+        EXPECT_EQ(stmt->column_text(0), "wal");
+    }
+
+    db.close_connection();
+}
+
+} // namespace everest::db::sqlite


### PR DESCRIPTION

## Describe your changes

Set PRAGMA journal_mode=WAL when opening file-based connections so concurrent readers and a single writer stop serializing against each other. The mode is read back and the open fails if WAL cannot be established (WAL-or-fail); in-memory databases are detected via a single reused flag and skip WAL.

Add ConnectionWalTest covering WAL on a file database, in-memory open, and migration of a pre-existing rollback-journal database.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

