### PR TITLE
Do not use wildcard for global error subscription

### DIFF
--- a/lib/everest/framework/lib/error/error_manager_req.cpp
+++ b/lib/everest/framework/lib/error/error_manager_req.cpp
@@ -78,8 +78,12 @@ void ErrorManagerReq::on_error_raised(const Error& error) {
         database->get_errors({ErrorFilter(TypeFilter(error.type)), ErrorFilter(SubTypeFilter(error.sub_type)),
                               ErrorFilter(OriginFilter(error.origin))});
     if (!errors.empty()) {
-        // Error is already raised, ignoring identical new error
-        // FIXME: can we prevent this from happening in the first place?
+        std::stringstream ss;
+        ss << "Error is already raised, type: " << error.type << ", sub_type: ";
+        ss << error.sub_type << ", origin: " << error.origin.module_id << "/";
+        ss << error.origin.implementation_id << ", ignored.";
+        ss << std::endl << "Error object: " << nlohmann::json(error).dump(2);
+        EVLOG_error << ss.str();
         return;
     }
     database->add_error(std::make_shared<Error>(error));

--- a/lib/everest/framework/lib/everest.cpp
+++ b/lib/everest/framework/lib/everest.cpp
@@ -711,10 +711,21 @@ void Everest::subscribe_global_all_errors(const error::ErrorCallback& raise_call
         const json provides = this->config.get_manifests().at(module_name).at("provides");
         for (const auto& impl : provides.items()) {
             const std::string& impl_id = impl.key();
-            const std::string error_topic = fmt::format("{}/error/#", this->config.mqtt_prefix(module_id, impl_id));
-            const std::shared_ptr<TypedHandler> error_token =
-                std::make_shared<TypedHandler>(HandlerType::SubscribeError, std::make_shared<Handler>(error_handler));
-            this->mqtt_abstraction->register_handler(error_topic, error_token, QOS::QOS2);
+
+            const auto& interface_definition = this->config.get_interface_definition(
+                std::string(this->config.get_interfaces().at(module_name).at(impl_id)));
+            for (const auto& error_namespace_it : interface_definition.at("errors").items()) {
+                const auto& error_namespace = error_namespace_it.key();
+                for (const auto& error_name_it : error_namespace_it.value().items()) {
+                    const auto& error_name = error_name_it.key();
+                    const std::string error_type = error_namespace + "/" + error_name;
+                    const std::string error_topic =
+                        fmt::format("{}/error/{}", this->config.mqtt_prefix(module_id, impl_id), error_type);
+                    const std::shared_ptr<TypedHandler> error_token = std::make_shared<TypedHandler>(
+                        HandlerType::SubscribeError, std::make_shared<Handler>(error_handler));
+                    this->mqtt_abstraction->register_handler(error_topic, error_token, QOS::QOS2);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Describe your changes

After the change to mosquitto the usage of wildcard subsscriptions is not that smooth, while topics are overlapping, because of this the global error subscription is changed to manually subscribe to all error topics.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

