### PR TITLE
fix(Auth): persist EVSE-specific reservations and clear store on cancel

### DIFF
--- a/modules/EVSE/Auth/lib/ReservationHandler.cpp
+++ b/modules/EVSE/Auth/lib/ReservationHandler.cpp
@@ -136,6 +136,7 @@ ReservationHandler::make_reservation(const std::optional<uint32_t> evse_id,
                 EVLOG_info << "Created reservation for evse id " << evse_id.value() << ", connector type "
                            << types::evse_manager::connector_type_enum_to_string(
                                   reservation.connector_type.value_or(types::evse_manager::ConnectorTypeEnum::Unknown));
+                store_reservations();
                 return types::reservation::ReservationResult::Accepted;
             }
 
@@ -155,6 +156,7 @@ ReservationHandler::make_reservation(const std::optional<uint32_t> evse_id,
             EVLOG_info << "Created reservation for evse id " << evse_id.value() << ", connector type "
                        << types::evse_manager::connector_type_enum_to_string(
                               reservation.connector_type.value_or(types::evse_manager::ConnectorTypeEnum::Unknown));
+            store_reservations();
         }
     } else {
         if (reservation.connector_type.has_value() &&
@@ -779,9 +781,10 @@ void ReservationHandler::store_reservations() {
         reservations.push_back(r);
     }
 
-    if (!reservations.empty()) {
-        this->store->call_store(this->kvs_store_key_id, reservations);
-    }
+    // Always persist, even an empty array: cancelling or expiring the last
+    // reservation must clear the stored state. Otherwise the stale entry is
+    // reloaded on the next boot and the cancelled reservation "resurrects".
+    this->store->call_store(this->kvs_store_key_id, reservations);
 }
 
 ReservationEvseStatus ReservationHandler::get_evse_global_reserved_status_and_set_new_status(

--- a/modules/EVSE/Auth/tests/reservation_tests.cpp
+++ b/modules/EVSE/Auth/tests/reservation_tests.cpp
@@ -1222,6 +1222,72 @@ TEST_F(ReservationHandlerTest, store_load_reservations) {
     EXPECT_EQ(r.reservation_id_to_reservation_timeout_timer_map.size(), 2);
 }
 
+TEST_F(ReservationHandlerTest, store_load_evse_specific_reservation_without_global) {
+    // Regression test: an EVSE-specific reservation made without any subsequent global
+    // reservation (or cancellation) must still be persisted. Previously store_reservations()
+    // was only called from the global-reservation branch, so a standalone EVSE-specific
+    // reservation was silently lost across a restart.
+    add_connector(0, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(0, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+    add_connector(1, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(1, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+
+    r.load_reservations();
+    EXPECT_TRUE(r.evse_reservations.empty());
+    EXPECT_TRUE(r.global_reservations.empty());
+
+    // Only an EVSE-specific reservation, with no global reservation to trigger a store.
+    EXPECT_EQ(r.make_reservation(1, create_reservation(types::evse_manager::ConnectorTypeEnum::cCCS2)),
+              ReservationResult::Accepted);
+    EXPECT_EQ(r.evse_reservations.size(), 1);
+    EXPECT_TRUE(r.global_reservations.empty());
+
+    // Simulate a restart: drop in-memory state and reload from storage.
+    r.evse_reservations.clear();
+    r.reservation_id_to_reservation_timeout_timer_map.clear();
+    EXPECT_TRUE(r.evse_reservations.empty());
+
+    r.load_reservations();
+
+    // The EVSE-specific reservation must be restored from storage.
+    EXPECT_EQ(r.evse_reservations.size(), 1);
+    EXPECT_EQ(r.reservation_id_to_reservation_timeout_timer_map.size(), 1);
+}
+
+TEST_F(ReservationHandlerTest, cancelled_reservation_not_resurrected_after_reload) {
+    // Regression test: cancelling the last reservation must clear the stored
+    // state. Previously store_reservations() skipped writing when the set was
+    // empty, leaving the stale entry on disk so the cancelled reservation was
+    // resurrected on the next load_reservations().
+    add_connector(0, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(0, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+    add_connector(1, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
+    add_connector(1, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);
+
+    r.load_reservations();
+    EXPECT_TRUE(r.evse_reservations.empty());
+
+    // Reservation id 0 (create_reservation starts numbering at 0).
+    EXPECT_EQ(r.make_reservation(1, create_reservation(types::evse_manager::ConnectorTypeEnum::cCCS2)),
+              ReservationResult::Accepted);
+    EXPECT_EQ(r.evse_reservations.size(), 1);
+
+    // Cancel the only reservation.
+    r.cancel_reservation(0, false, ReservationEndReason::Cancelled);
+    EXPECT_TRUE(r.evse_reservations.empty());
+
+    // Simulate a restart: drop in-memory state and reload from storage.
+    r.evse_reservations.clear();
+    r.global_reservations.clear();
+    r.reservation_id_to_reservation_timeout_timer_map.clear();
+
+    r.load_reservations();
+
+    // The cancelled reservation must NOT come back.
+    EXPECT_TRUE(r.evse_reservations.empty());
+    EXPECT_TRUE(r.global_reservations.empty());
+}
+
 TEST_F(ReservationHandlerTest, store_load_reservations_connector_unavailable) {
     add_connector(0, 0, types::evse_manager::ConnectorTypeEnum::cCCS2, this->evses);
     add_connector(0, 1, types::evse_manager::ConnectorTypeEnum::cType2, this->evses);


### PR DESCRIPTION
## Describe your changes

Two related reservation-persistence fixes in `ReservationHandler`:

**1. EVSE-specific reservations were never persisted.** `store_reservations()` was only called from the global (no `evse_id`) branch of `make_reservation()`. The two EVSE/connector-specific accept paths returned `Accepted` without calling it, so a standalone EVSE-specific reservation (OCPP 1.6 `connectorId > 0` / OCPP 2.0.1 `ReserveNow` with `evseId` — the common case) was lost across a restart. Fix: call `store_reservations()` in both EVSE-specific accept paths.

**2. Cancelled/expired reservations resurrected on reboot.** `store_reservations()` skipped writing when the set was empty (`if (!reservations.empty())`), so cancelling/expiring the last reservation left the stale entry on disk to be reloaded on the next boot. Fix: always persist the (possibly empty) array. An empty array also loads cleanly (no "reservations is not a json array" warning).

Contradicts the persistence intent from #943 and OCPP reservation semantics (a reservation ends only on expiry, CancelReservation, or use — not on a reboot).

### Tests
- `store_load_evse_specific_reservation_without_global`
- `cancelled_reservation_not_resurrected_after_reload`

## How verified
New unit tests fail before / pass after. Reproduced and verified on hardware (rev1, SIL): EVSE-specific `reserve_now` now writes to the store and reloads after restart; before the fix it wrote 0 rows and was gone.