### PR TITLE
fix(EvseManager): invalidate powersupply_DC_set cache when switching power supply off

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -2421,6 +2421,10 @@ void EvseManager::powersupply_DC_off() {
         session_log.evse(false, "DC power supply OFF");
         r_powersupply_DC[0]->call_setMode(types::power_supply_DC::Mode::Off, power_supply_DC_charging_phase);
         powersupply_dc_is_on = false;
+        // Invalidate the powersupply_DC_set() cache: the power supply resets its
+        // internal targets on the Off transition, so the cached values are stale now.
+        last_power_supply_voltage = 0.;
+        last_power_supply_current = 0.;
     }
     power_supply_DC_charging_phase = types::power_supply_DC::ChargingPhase::Other;
 }


### PR DESCRIPTION
## Describe your changes

Fixes #2295.

`powersupply_DC_set()` short-circuits when the requested voltage/current match the last requested values, to avoid redundant `setExportVoltageCurrent` calls (cache introduced in #1893). The cache was never invalidated, but power supply implementations reset their internal targets on the `setMode(Off)` transition — so after `powersupply_DC_off()` the cached values are stale.

If a session aborts during CableCheck, the cache stays primed with exactly the voltage/current the next CableCheck will request (cable check voltage is deterministic for the same EV). The next session gets a false cache hit, the power supply never receives a target, output never ramps, and every subsequent session fails with `MREC11CableCheckFault` until the EVerest process is restarted. Cable unplug/replug does not recover. Reproduced and root-caused on DC charger hardware during bench testing — see #2295 for the full analysis and session logs. This fix is contributed by the [Enteligent](https://enteligent.com) engineering team.

This PR resets the cached values in `powersupply_DC_off()`, the common exit path for every flow that switches the power supply off (cable check failure, charger state machine transitions to Idle, unplug, shutdown). The cache keeps suppressing redundant calls within a charging session; only the session-boundary Off transition invalidates it.

## Issue ticket number and link

#2295

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (no documentation changes required)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

