### PR TITLE
feat(libiso15118): Adding graceful shutdown

### DIFF
--- a/lib/everest/iso15118/include/iso15118/d20/context.hpp
+++ b/lib/everest/iso15118/include/iso15118/d20/context.hpp
@@ -140,6 +140,14 @@ public:
         current_timeout = timeout;
     }
 
+    void request_shutdown() {
+        requested_shutdown = true;
+    }
+
+    [[nodiscard]] bool shutdown_requested() const {
+        return requested_shutdown;
+    }
+
     const session::Feedback feedback;
 
     session::SessionLogger& log;
@@ -170,6 +178,8 @@ private:
     Timeouts& timeouts;
 
     std::optional<TimeoutType> current_timeout{std::nullopt};
+
+    bool requested_shutdown{false};
 };
 
 } // namespace iso15118::d20

--- a/lib/everest/iso15118/include/iso15118/detail/d20/state/power_delivery.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/d20/state/power_delivery.hpp
@@ -8,6 +8,7 @@
 namespace iso15118::d20::state {
 
 message_20::PowerDeliveryResponse handle_request(const message_20::PowerDeliveryRequest& req,
-                                                 const d20::Session& session, bool contactor_error);
+                                                 const d20::Session& session, bool contactor_error,
+                                                 bool shutdown_requested);
 
 } // namespace iso15118::d20::state

--- a/lib/everest/iso15118/include/iso15118/io/sdp_server.hpp
+++ b/lib/everest/iso15118/include/iso15118/io/sdp_server.hpp
@@ -31,6 +31,8 @@ class SdpServer {
 public:
     explicit SdpServer(const std::string& interface_name);
     ~SdpServer();
+
+    void close();
     PeerRequestContext get_peer_request();
     void send_response(const PeerRequestContext&, const Ipv6EndPoint&);
 

--- a/lib/everest/iso15118/include/iso15118/session/iso.hpp
+++ b/lib/everest/iso15118/include/iso15118/session/iso.hpp
@@ -46,6 +46,8 @@ public:
 
     void close();
 
+    void request_shutdown();
+
 private:
     std::unique_ptr<io::IConnection> connection;
     session::SessionLogger log;

--- a/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
+++ b/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
@@ -2,7 +2,7 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
-#include <list>
+#include <atomic>
 #include <memory>
 #include <optional>
 #include <string>
@@ -31,8 +31,11 @@ struct TbdConfig {
 class TbdController {
 public:
     TbdController(TbdConfig, session::feedback::Callbacks, d20::EvseSetupConfig);
+    ~TbdController();
 
     void loop();
+
+    void shutdown();
 
     void send_control_event(const d20::ControlEvent&);
 
@@ -52,6 +55,8 @@ private:
     std::unique_ptr<io::SdpServer> sdp_server;
 
     std::unique_ptr<Session> session;
+
+    std::atomic_bool shutdown_active{false};
 
     // callbacks for sdp server
     void handle_sdp_server_input();

--- a/lib/everest/iso15118/src/iso15118/d20/state/ac_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/ac_charge_loop.cpp
@@ -200,7 +200,10 @@ Result AC_ChargeLoop::feed(Event ev) {
     const auto variant = m_ctx.pull_request();
 
     if (const auto req = variant->get_if<message_20::PowerDeliveryRequest>()) {
-        const auto res = handle_request(*req, m_ctx.session, false);
+
+        const auto shutdown_requested = m_ctx.shutdown_requested();
+
+        const auto res = handle_request(*req, m_ctx.session, false, shutdown_requested);
 
         m_ctx.respond(res);
 
@@ -210,7 +213,7 @@ Result AC_ChargeLoop::feed(Event ev) {
         }
 
         // V2G20-1623 -> state machine direct transition (skipped PowerDelivery)
-        if (req->charge_progress == dt::Progress::Stop) {
+        if (req->charge_progress == dt::Progress::Stop or shutdown_requested) {
             m_ctx.feedback.signal(session::feedback::Signal::CHARGE_LOOP_FINISHED);
             m_ctx.feedback.signal(session::feedback::Signal::AC_OPEN_CONTACTOR);
             return m_ctx.create_state<SessionStop>();

--- a/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/dc_charge_loop.cpp
@@ -219,7 +219,10 @@ Result DC_ChargeLoop::feed(Event ev) {
     const auto variant = m_ctx.pull_request();
 
     if (const auto req = variant->get_if<message_20::PowerDeliveryRequest>()) {
-        const auto res = handle_request(*req, m_ctx.session, false);
+
+        const auto shutdown_requested = m_ctx.shutdown_requested();
+
+        const auto res = handle_request(*req, m_ctx.session, false, shutdown_requested);
 
         m_ctx.respond(res);
 
@@ -233,7 +236,7 @@ Result DC_ChargeLoop::feed(Event ev) {
 
         // Todo(sl): React properly to Start, Stop, Standby and ScheduleRenegotiation
         // TODO(Sl): How to check if the EV wants do a pause in dynamic mode (This should not happen)
-        if (req->charge_progress == dt::Progress::Stop) {
+        if (req->charge_progress == dt::Progress::Stop or shutdown_requested) {
             m_ctx.feedback.signal(session::feedback::Signal::CHARGE_LOOP_FINISHED);
             m_ctx.feedback.signal(session::feedback::Signal::DC_OPEN_CONTACTOR);
             return m_ctx.create_state<DC_WeldingDetection>();

--- a/lib/everest/iso15118/src/iso15118/d20/state/power_delivery.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/power_delivery.cpp
@@ -2,6 +2,7 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #include <iso15118/d20/state/ac_charge_loop.hpp>
 #include <iso15118/d20/state/dc_charge_loop.hpp>
+#include <iso15118/d20/state/dc_welding_detection.hpp>
 #include <iso15118/d20/state/power_delivery.hpp>
 #include <iso15118/d20/state/session_stop.hpp>
 #include <iso15118/d20/timeout.hpp>
@@ -16,16 +17,23 @@ namespace iso15118::d20::state {
 namespace dt = message_20::datatypes;
 
 message_20::PowerDeliveryResponse handle_request(const message_20::PowerDeliveryRequest& req,
-                                                 const d20::Session& session, bool contactor_error) {
+                                                 const d20::Session& session, bool contactor_error,
+                                                 bool shutdown_requested) {
 
     message_20::PowerDeliveryResponse res;
 
-    if (validate_and_setup_header(res.header, session, req.header.session_id) == false) {
+    if (not validate_and_setup_header(res.header, session, req.header.session_id)) {
         return response_with_code(res, dt::ResponseCode::FAILED_UnknownSession);
     }
 
     if (contactor_error) {
         return response_with_code(res, dt::ResponseCode::FAILED_ContactorError);
+    }
+
+    if (shutdown_requested) {
+        auto& notification = res.status.emplace();
+        notification.notification = dt::EvseNotification::Terminate;
+        notification.notification_max_delay = 0;
     }
 
     // TODO(sl): Check Req PowerProfile & ChannelSelection
@@ -65,7 +73,7 @@ Result PowerDelivery::feed(Event ev) {
                 return {};
             }
 
-            const auto& res = handle_request(previous_req.value(), m_ctx.session, false);
+            const auto& res = handle_request(previous_req.value(), m_ctx.session, false, false);
             m_ctx.respond(res);
 
             if (res.response_code >= dt::ResponseCode::FAILED) {
@@ -84,7 +92,7 @@ Result PowerDelivery::feed(Event ev) {
         if (timeout and *timeout == d20::TimeoutType::CONTACTOR) {
             // TODO(SL): Check if value_or is the correct way
             const auto& res =
-                handle_request(previous_req.value_or(message_20::PowerDeliveryRequest{}), m_ctx.session, true);
+                handle_request(previous_req.value_or(message_20::PowerDeliveryRequest{}), m_ctx.session, true, false);
             m_ctx.respond(res);
             m_ctx.session_stopped = true;
         }
@@ -111,28 +119,46 @@ Result PowerDelivery::feed(Event ev) {
 
         return {};
     } else if (const auto req = variant->get_if<message_20::PowerDeliveryRequest>()) {
-        if (req->charge_progress == dt::Progress::Start) {
-            m_ctx.feedback.signal(session::feedback::Signal::SETUP_FINISHED);
+
+        const auto shutdown_requested = m_ctx.shutdown_requested();
+
+        if (not shutdown_requested) {
+
+            if (req->charge_progress == dt::Progress::Start) {
+                m_ctx.feedback.signal(session::feedback::Signal::SETUP_FINISHED);
+            }
+
+            if (m_ctx.session.is_ac_charger() and ac_connector_closed == false and
+                req->charge_progress == dt::Progress::Start) {
+                // Save req
+                previous_req = *req;
+                // Close the AC contactor so that charging can start
+                m_ctx.feedback.signal(session::feedback::Signal::AC_CLOSE_CONTACTOR);
+                m_ctx.start_timeout(d20::TimeoutType::CONTACTOR, 3000);
+                logf_info("Waiting for contactor is closed");
+                return {};
+            }
         }
 
-        if (m_ctx.session.is_ac_charger() and ac_connector_closed == false and
-            req->charge_progress == dt::Progress::Start) {
-            // Save req
-            previous_req = *req;
-            // Close the AC contactor so that charging can start
-            m_ctx.feedback.signal(session::feedback::Signal::AC_CLOSE_CONTACTOR);
-            m_ctx.start_timeout(d20::TimeoutType::CONTACTOR, 3000);
-            logf_info("Waiting for contactor is closed");
-            return {};
-        }
-
-        const auto& res = handle_request(*req, m_ctx.session, false);
+        const auto& res = handle_request(*req, m_ctx.session, false, shutdown_requested);
 
         m_ctx.respond(res);
 
         if (res.response_code >= dt::ResponseCode::FAILED) {
             m_ctx.session_stopped = true;
             return {};
+        }
+
+        if (shutdown_requested) {
+            m_ctx.feedback.signal(session::feedback::Signal::CHARGE_LOOP_FINISHED);
+            if (m_ctx.session.is_ac_charger()) {
+                m_ctx.feedback.signal(session::feedback::Signal::AC_OPEN_CONTACTOR);
+                return m_ctx.create_state<SessionStop>();
+            }
+            if (m_ctx.session.is_dc_charger()) {
+                m_ctx.feedback.signal(session::feedback::Signal::DC_OPEN_CONTACTOR);
+                return m_ctx.create_state<DC_WeldingDetection>();
+            }
         }
 
         if (m_ctx.session.is_ac_charger()) {

--- a/lib/everest/iso15118/src/iso15118/io/sdp_server.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/sdp_server.cpp
@@ -99,7 +99,19 @@ SdpServer::~SdpServer() {
     // FIXME (aw): rather use some RAII class for this!
     logf_info("Shutting down SDP server!");
     if (fd != -1) {
-        close(fd);
+        close();
+    }
+}
+
+void SdpServer::close() {
+    logf_info("Closing Sdp Server");
+
+    const auto close_sdp = ::close(fd);
+    if (close_sdp == -1) {
+        logf_error("Sdp server close() failed");
+    } else {
+        logf_info("Sdp server closed gracefully");
+        fd = -1;
     }
 }
 

--- a/lib/everest/iso15118/src/iso15118/session/iso.cpp
+++ b/lib/everest/iso15118/src/iso15118/session/iso.cpp
@@ -325,4 +325,16 @@ void Session::close() {
     ctx.session_stopped = true;
 }
 
+void Session::request_shutdown() {
+    if (not state.connected) {
+        logf_info("Shutdown requested before an EV connected");
+        ctx.session_stopped = true;
+        connection->close();
+        ctx.feedback.signal(session::feedback::Signal::DLINK_TERMINATE);
+    } else {
+        push_control_event(d20::StopCharging{true}); // Stopping active charge loop
+        ctx.request_shutdown();
+    }
+}
+
 } // namespace iso15118

--- a/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
+++ b/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
@@ -34,8 +34,18 @@ TbdController::TbdController(TbdConfig config_, session::feedback::Callbacks cal
     }
 }
 
+TbdController::~TbdController() {
+    if (config.enable_sdp_server) {
+        poll_manager.unregister_fd(sdp_server->get_fd());
+        sdp_server->close();
+    }
+}
+
 void TbdController::loop() {
     static constexpr auto POLL_MANAGER_TIMEOUT_MS = 50;
+
+    shutdown_active.store(false);
+    bool shutdown_signaled{false};
 
     if (not config.enable_sdp_server) {
         auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, interface_name);
@@ -45,7 +55,7 @@ void TbdController::loop() {
 
     auto next_event = get_current_time_point();
 
-    while (true) {
+    while (session or not shutdown_active.load()) {
         const auto poll_timeout_ms = get_timeout_ms_until(next_event, POLL_MANAGER_TIMEOUT_MS);
 
         try {
@@ -66,6 +76,11 @@ void TbdController::loop() {
             callbacks.signal(session::feedback::Signal::DLINK_ERROR);
         }
 
+        if (session and shutdown_active.load() and not shutdown_signaled) {
+            session->request_shutdown(); // Stopping the session
+            shutdown_signaled = true;
+        }
+
         if (session) {
             try {
                 const auto next_session_event = session->poll();
@@ -79,7 +94,7 @@ void TbdController::loop() {
             if (session->is_finished()) {
                 session.reset();
 
-                if (not config.enable_sdp_server) {
+                if (not shutdown_active.load() and not config.enable_sdp_server) {
                     auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, interface_name);
                     session = std::make_unique<Session>(std::move(connection), d20::SessionConfig(evse_setup),
                                                         callbacks, pause_ctx);
@@ -87,6 +102,12 @@ void TbdController::loop() {
             }
         }
     }
+    logf_info("Exiting TbdController loop gracefully");
+}
+
+void TbdController::shutdown() {
+    logf_info("Trigger graceful shutdown");
+    shutdown_active.store(true);
 }
 
 void TbdController::send_control_event(const d20::ControlEvent& event) {
@@ -164,6 +185,11 @@ void TbdController::handle_sdp_server_input() {
 
     if (not sdp_server->is_dlink_ready()) {
         logf_info("Ignoring SDP request because dlink is not ready");
+        return;
+    }
+
+    if (shutdown_active.load()) {
+        logf_warning("Ignoring sdp request message because the TbdController loop is being shutdown");
         return;
     }
 

--- a/lib/everest/iso15118/test/iso15118/states/power_delivery.cpp
+++ b/lib/everest/iso15118/test/iso15118/states/power_delivery.cpp
@@ -19,7 +19,7 @@ SCENARIO("Power delivery state handling") {
         req.processing = dt::Processing::Ongoing;
         req.charge_progress = dt::Progress::Start;
 
-        const auto res = d20::state::handle_request(req, d20::Session(), false);
+        const auto res = d20::state::handle_request(req, d20::Session(), false, false);
 
         THEN("ResponseCode: FAILED_UnknownSession, mandatory fields should be set") {
             REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
@@ -36,7 +36,7 @@ SCENARIO("Power delivery state handling") {
         req.processing = dt::Processing::Ongoing;
         req.charge_progress = dt::Progress::Standby;
 
-        const auto res = d20::state::handle_request(req, session, false);
+        const auto res = d20::state::handle_request(req, session, false, false);
 
         // Right now standby ist not supported
 
@@ -70,13 +70,32 @@ SCENARIO("Power delivery state handling") {
         req.processing = dt::Processing::Ongoing;
         req.charge_progress = dt::Progress::Start;
 
-        const auto res = d20::state::handle_request(req, session, true);
+        const auto res = d20::state::handle_request(req, session, true, false);
 
         THEN("ResponseCode: FAILED_ContactorError, mandatory fields should be set") {
             REQUIRE(res.response_code == dt::ResponseCode::FAILED_ContactorError);
             REQUIRE(res.status.has_value() == false);
         }
     } // TODO(sl): AC stuff
+
+    GIVEN("Good case - shutdown requested") {
+        d20::Session session = d20::Session();
+
+        message_20::PowerDeliveryRequest req;
+        req.header.session_id = session.get_id();
+        req.header.timestamp = 1691411798;
+
+        req.processing = dt::Processing::Ongoing;
+        req.charge_progress = dt::Progress::Start;
+
+        const auto res = d20::state::handle_request(req, session, false, true);
+
+        THEN("ResponseCode: OK") {
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            REQUIRE(res.status.has_value());
+            REQUIRE(res.status.value().notification == message_20::datatypes::EvseNotification::Terminate);
+        }
+    }
 
     // GIVEN("Bad Case - sequence error") {} // TODO(sl): not here
 


### PR DESCRIPTION
## Describe your changes
Adding the ability to gracefully exit the infinite `loop()` from the `TbdController`. During an active session, either the PowerDelivery state or the active charge loop is terminated. If no session is active, the loop() is exited immediately.

I have actively decided against terminating the session in every state based on a failed response code. Theoretically, terminating the session before the PowerDelivery state is not an error, and therefore, as the standard specifies, the session should be terminated in the PowerDelivery state.

## Issue ticket number and link
Before the changes there was no way to stop the endless `loop()` from the `TbdController` and shutdown gracefully the whole `libiso15118`.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

