### PR TITLE
feat(libiso15118): Adding config option to select sap namespace based on energy services

### DIFF
--- a/lib/everest/iso15118/include/iso15118/d20/config.hpp
+++ b/lib/everest/iso15118/include/iso15118/d20/config.hpp
@@ -40,6 +40,7 @@ struct EvseSetupConfig {
     std::optional<AcSetupConfig> ac_setup_config{std::nullopt};
     std::optional<BptSetupConfig> bpt_setup_config{std::nullopt};
     d20::DcTransferLimits powersupply_limits;
+    bool selecting_sap_based_on_energy_service{false};
 };
 
 // This should only have EVSE information
@@ -73,6 +74,7 @@ struct SessionConfig {
     std::vector<ControlMobilityNeedsModes> supported_control_mobility_modes;
 
     std::optional<std::string> custom_protocol{std::nullopt};
+    bool selecting_sap_based_on_energy_service{false};
 };
 
 } // namespace iso15118::d20

--- a/lib/everest/iso15118/src/iso15118/d20/config.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/config.cpp
@@ -162,7 +162,8 @@ SessionConfig::SessionConfig(EvseSetupConfig config) :
     ac_limits(std::move(config.ac_limits)),
     powersupply_limits(std::move(config.powersupply_limits)),
     supported_control_mobility_modes(std::move(config.control_mobility_modes)),
-    custom_protocol(std::move(config.custom_protocol)) {
+    custom_protocol(std::move(config.custom_protocol)),
+    selecting_sap_based_on_energy_service(config.selecting_sap_based_on_energy_service) {
 
     // TODO(SL): How to handle this probaly
     const auto is_dc_bpt_service = [](dt::ServiceCategory service) {

--- a/lib/everest/iso15118/src/iso15118/d20/state/supported_app_protocol.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/supported_app_protocol.cpp
@@ -2,6 +2,8 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #include <iso15118/d20/state/supported_app_protocol.hpp>
 
+#include <algorithm>
+#include <array>
 #include <map>
 #include <optional>
 
@@ -16,21 +18,39 @@ namespace iso15118::d20::state {
 
 constexpr auto ISO20_DC_NAMESPACE = "urn:iso:std:iso:15118:-20:DC";
 constexpr auto ISO20_AC_NAMESPACE = "urn:iso:std:iso:15118:-20:AC";
+// constexpr auto ISO20_DER_IEC_NAMESPACE = "urn:iso:std:iso:15118:-20:AC-DER-IEC";
+// constexpr auto ISO20_DER_SAE_NAMESPACE = "urn:iso:std:iso:15118:-20:AC-DER-SAE";
+
+constexpr std::array AcNamespaces = {ISO20_AC_NAMESPACE};
 
 using ResponseCode = message_20::SupportedAppProtocolResponse::ResponseCode;
 
+struct SupportedEnergyModes {
+    bool ac{false};
+    bool dc{false};
+    bool acdp{false};
+    bool wpt{false};
+};
+
+namespace {
+
 message_20::SupportedAppProtocolResponse handle_request(const message_20::SupportedAppProtocolRequest& req,
+                                                        const SupportedEnergyModes& modes,
                                                         const std::optional<std::string>& custom_protocol_namespace) {
     message_20::SupportedAppProtocolResponse res;
 
     std::map<uint8_t, uint8_t> ev_supported_protocols{}; // key: priority, value: schema_id
 
     for (const auto& protocol : req.app_protocol) {
-        if (protocol.protocol_namespace.compare(ISO20_DC_NAMESPACE) == 0) {
-            ev_supported_protocols[protocol.priority] = protocol.schema_id;
-        } else if (protocol.protocol_namespace.compare(ISO20_AC_NAMESPACE) == 0) {
-            ev_supported_protocols[protocol.priority] = protocol.schema_id;
-        } else if (protocol.protocol_namespace.compare(custom_protocol_namespace.value_or("")) == 0) {
+        const auto is_dc = protocol.protocol_namespace == ISO20_DC_NAMESPACE and modes.dc;
+        const auto is_ac =
+            (std::find(AcNamespaces.begin(), AcNamespaces.end(), protocol.protocol_namespace) != AcNamespaces.end()) and
+            modes.ac;
+        const auto is_custom = custom_protocol_namespace.has_value()
+                                   ? protocol.protocol_namespace == custom_protocol_namespace.value()
+                                   : false;
+
+        if (is_dc or is_ac or is_custom) {
             ev_supported_protocols[protocol.priority] = protocol.schema_id;
         }
     }
@@ -42,6 +62,8 @@ message_20::SupportedAppProtocolResponse handle_request(const message_20::Suppor
     res.schema_id = ev_supported_protocols.begin()->second; // [V2G20-167] Highest Prio: 1, Lowest Prio: 20
     return response_with_code(res, ResponseCode::OK_SuccessfulNegotiation);
 }
+
+} // namespace
 
 void SupportedAppProtocol::enter() {
     m_ctx.log.enter_state("SupportedAppProtocol");
@@ -56,14 +78,38 @@ Result SupportedAppProtocol::feed(Event ev) {
 
     if (const auto req = variant->get_if<message_20::SupportedAppProtocolRequest>()) {
 
-        const auto res = handle_request(*req, m_ctx.session_config.custom_protocol);
+        auto energy_modes = SupportedEnergyModes{false, false, false, false};
+        const auto supported_energy_services = m_ctx.session_config.supported_energy_transfer_services;
+
+        if (m_ctx.session_config.selecting_sap_based_on_energy_service) {
+            logf_info("Selecting supported app protocol namespace based on the supported energy services");
+            for (const auto& service : supported_energy_services) {
+                if (service == dt::ServiceCategory::AC or service == dt::ServiceCategory::AC_BPT) {
+                    energy_modes.ac = true;
+                } else if (service == dt::ServiceCategory::DC or service == dt::ServiceCategory::DC_BPT or
+                           service == dt::ServiceCategory::MCS or service == dt::ServiceCategory::MCS_BPT) {
+                    energy_modes.dc = true;
+                } else if (service == dt::ServiceCategory::DC_ACDP or service == dt::ServiceCategory::DC_ACDP_BPT) {
+                    energy_modes.acdp = true;
+                } else if (service == dt::ServiceCategory::WPT) {
+                    energy_modes.wpt = true;
+                }
+            }
+        } else {
+            energy_modes = SupportedEnergyModes{true, true, true, true};
+        }
+
+        const auto res = handle_request(*req, energy_modes, m_ctx.session_config.custom_protocol);
         m_ctx.respond(res);
 
         m_ctx.ev_info.ev_supported_app_protocols = req->app_protocol;
 
         if (res.response_code == ResponseCode::Failed_NoNegotiation) {
-            m_ctx.log("unsupported app protocol: [%s]",
-                      req->app_protocol.size() ? req->app_protocol[0].protocol_namespace.c_str() : "unknown");
+            std::string ev_supported_namespaces{};
+            for (const auto& protocol : req->app_protocol) {
+                ev_supported_namespaces.append(protocol.protocol_namespace + ";");
+            }
+            logf_error("Selecting a protocol namespace failed. Ev offered: %s", ev_supported_namespaces.c_str());
             return {};
         }
 
@@ -71,12 +117,13 @@ Result SupportedAppProtocol::feed(Event ev) {
             if (protocol.schema_id == res.schema_id) {
                 m_ctx.ev_info.selected_app_protocol = protocol;
 
-                if (protocol.protocol_namespace.compare(ISO20_DC_NAMESPACE) == 0) {
+                if (protocol.protocol_namespace == ISO20_DC_NAMESPACE) {
                     m_ctx.feedback.selected_protocol("ISO15118-20:DC");
-                } else if (protocol.protocol_namespace.compare(ISO20_AC_NAMESPACE) == 0) {
+                } else if (std::find(AcNamespaces.begin(), AcNamespaces.end(), protocol.protocol_namespace) !=
+                           AcNamespaces.end()) {
                     m_ctx.feedback.selected_protocol("ISO15118-20:AC");
-                } else if (protocol.protocol_namespace.compare(m_ctx.session_config.custom_protocol.value_or("")) ==
-                           0) {
+                } else if (m_ctx.session_config.custom_protocol.has_value() and
+                           m_ctx.session_config.custom_protocol.value() == protocol.protocol_namespace) {
                     m_ctx.feedback.selected_protocol(m_ctx.session_config.custom_protocol.value());
                     logf_warning(
                         "EV and EVSE have agreed on a custom protocol namespace. Problems or aborts can occur in the "
@@ -85,12 +132,11 @@ Result SupportedAppProtocol::feed(Event ev) {
             }
         }
         return m_ctx.create_state<SessionSetup>();
-    } else {
-        m_ctx.log("expected SupportedAppProtocolReq! But code type id: %d", variant->get_type());
-
-        m_ctx.session_stopped = true;
-        return {};
     }
+    m_ctx.log("expected SupportedAppProtocolReq! But code type id: %d", variant->get_type());
+
+    m_ctx.session_stopped = true;
+    return {};
 }
 
 } // namespace iso15118::d20::state

--- a/lib/everest/iso15118/test/iso15118/fsm/d20_transitions.cpp
+++ b/lib/everest/iso15118/test/iso15118/fsm/d20_transitions.cpp
@@ -29,7 +29,8 @@ SCENARIO("ISO15118-20 supported app protocol state transitions") {
 
     const d20::EvseSetupConfig evse_setup{
         evse_id,   supported_energy_services, auth_services,    vas_services, cert_install, dc_limits,
-        ac_limits, control_mobility_modes,    custom_namespace, std::nullopt, std::nullopt, powersupply_limits};
+        ac_limits, control_mobility_modes,    custom_namespace, std::nullopt, std::nullopt, powersupply_limits,
+        false};
 
     std::optional<d20::PauseContext> pause_ctx{std::nullopt};
 
@@ -181,6 +182,44 @@ SCENARIO("ISO15118-20 supported app protocol state transitions") {
 
             REQUIRE(supported_app_res.response_code ==
                     message_20::SupportedAppProtocolResponse::ResponseCode::Failed_NoNegotiation);
+        }
+    }
+
+    GIVEN("Good case - Selecting namespace based on supported energy services") {
+        ctx.session_config.selecting_sap_based_on_energy_service = true;
+
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::SupportedAppProtocol>()};
+
+        message_20::SupportedAppProtocolRequest req;
+        auto& ap_dc = req.app_protocol.emplace_back();
+        ap_dc.priority = 2;
+        ap_dc.protocol_namespace = "urn:iso:std:iso:15118:-20:DC";
+        ap_dc.schema_id = 2;
+        ap_dc.version_number_major = 1;
+        ap_dc.version_number_minor = 0;
+
+        auto& ap_ac = req.app_protocol.emplace_back();
+        ap_ac.priority = 1;
+        ap_ac.protocol_namespace = "urn:iso:std:iso:15118:-20:AC";
+        ap_ac.schema_id = 1;
+        ap_ac.version_number_major = 1;
+        ap_ac.version_number_minor = 0;
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == true);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::SessionSetup);
+
+            const auto response_message = ctx.get_response<message_20::SupportedAppProtocolResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& supported_app_res = response_message.value();
+
+            REQUIRE(supported_app_res.response_code ==
+                    message_20::SupportedAppProtocolResponse::ResponseCode::OK_SuccessfulNegotiation);
+            REQUIRE(supported_app_res.schema_id.value_or(0) == 2);
         }
     }
 }

--- a/modules/EVSE/Evse15118D20/Evse15118D20.hpp
+++ b/modules/EVSE/Evse15118D20/Evse15118D20.hpp
@@ -38,6 +38,7 @@ struct Conf {
     bool supported_scheduled_mode;
     std::string custom_protocol_namespace;
     bool negative_bidirectional_limits;
+    bool selecting_sap_based_on_energy_service;
 };
 
 class Evse15118D20 : public Everest::ModuleBase {

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -233,6 +233,8 @@ void ISO15118_chargerImpl::ready() {
         setup_config.custom_protocol.emplace(mod->config.custom_protocol_namespace);
     }
 
+    setup_config.selecting_sap_based_on_energy_service = mod->config.selecting_sap_based_on_energy_service;
+
     controller = std::make_unique<iso15118::TbdController>(tbd_config, callbacks, setup_config);
 
     // if the vas providers report their supported vas services before the controller exists,

--- a/modules/EVSE/Evse15118D20/manifest.yaml
+++ b/modules/EVSE/Evse15118D20/manifest.yaml
@@ -69,6 +69,15 @@ config:
       can be converted using this option.
     type: boolean
     default: false
+  selecting_sap_based_on_energy_service:
+    description: >-
+      Based on ISO15118-20 AMD1, selecting the SAP namespace does not imply a final selection.
+      The final decision on which service to select is made later in the D20 service states.
+      However, since AMD1 is relatively new, it is possible that EVs will only support certain energy services
+      after the SAP namespace has been selected. If this is the case, this option should be set to true
+      so that libiso15118 will select the sap namespace based on the supported energy services.
+    type: boolean
+    default: false
 provides:
   charger:
     interface: ISO15118_charger


### PR DESCRIPTION
## Describe your changes
Adding config option selecting sap namespace based on supported energy services.

## Issue ticket number and link
Based on ISO15118-20 AMD1, selecting the SAP namespace does not imply a final selection. The final decision on which service to select is made later in the D20 service states.  However, since AMD1 is relatively new, it is possible that EVs will only support certain energy services after the SAP namespace has been selected.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

