### PR TITLE
Feature/everest api types codec improvements

### DIFF
--- a/lib/everest/everest_api_types/include/everest_api_types/auth/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/auth/codec.hpp
@@ -6,6 +6,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::auth {
 
@@ -39,21 +40,6 @@ std::ostream& operator<<(std::ostream& os, ValidationResult const& val);
 std::ostream& operator<<(std::ostream& os, ValidationResultUpdate const& val);
 std::ostream& operator<<(std::ostream& os, WithdrawAuthorizationRequest const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::auth

--- a/lib/everest/everest_api_types/include/everest_api_types/dc_external_derate/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/dc_external_derate/codec.hpp
@@ -5,6 +5,7 @@
 
 #include "API.hpp"
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::dc_external_derate {
 
@@ -12,21 +13,6 @@ std::string serialize(ExternalDerating const& val) noexcept;
 
 std::ostream& operator<<(std::ostream& os, ExternalDerating const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::dc_external_derate

--- a/lib/everest/everest_api_types/include/everest_api_types/display_message/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/display_message/codec.hpp
@@ -32,21 +32,6 @@ std::ostream& operator<<(std::ostream& os, GetDisplayMessageResponse const& val)
 std::ostream& operator<<(std::ostream& os, ClearDisplayMessageRequest const& val);
 std::ostream& operator<<(std::ostream& os, ClearDisplayMessageResponse const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::display_message

--- a/lib/everest/everest_api_types/include/everest_api_types/energy/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/energy/codec.hpp
@@ -6,6 +6,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::energy {
 
@@ -37,21 +38,6 @@ std::ostream& operator<<(std::ostream& os, ExternalLimits const& val);
 std::ostream& operator<<(std::ostream& os, EnforcedLimits const& val);
 std::ostream& operator<<(std::ostream& os, CapabilityLimits const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::energy

--- a/lib/everest/everest_api_types/include/everest_api_types/entrypoint/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/entrypoint/codec.hpp
@@ -15,21 +15,6 @@ std::ostream& operator<<(std::ostream& os, ApiParameter const& val);
 std::ostream& operator<<(std::ostream& os, ApiDiscoverResponse const& val);
 std::ostream& operator<<(std::ostream& os, CommunicationParameters const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::entrypoint

--- a/lib/everest/everest_api_types/include/everest_api_types/error_history/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/error_history/codec.hpp
@@ -6,6 +6,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::error_history {
 
@@ -27,21 +28,6 @@ std::ostream& operator<<(std::ostream& os, FilterArguments const& val);
 std::ostream& operator<<(std::ostream& os, ErrorObject const& val);
 std::ostream& operator<<(std::ostream& os, ErrorList const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::error_history

--- a/lib/everest/everest_api_types/include/everest_api_types/ev_board_support/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/ev_board_support/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::ev_board_support {
 
@@ -14,21 +15,6 @@ std::string serialize(BspMeasurement const& val) noexcept;
 std::ostream& operator<<(std::ostream& os, EvCpState const& val);
 std::ostream& operator<<(std::ostream& os, BspMeasurement const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::ev_board_support

--- a/lib/everest/everest_api_types/include/everest_api_types/evse_board_support/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/evse_board_support/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::evse_board_support {
 
@@ -30,21 +31,6 @@ std::ostream& operator<<(std::ostream& os, PowerOnOff const& val);
 std::ostream& operator<<(std::ostream& os, Ampacity const& val);
 std::ostream& operator<<(std::ostream& os, ProximityPilot const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::evse_board_support

--- a/lib/everest/everest_api_types/include/everest_api_types/evse_manager/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/evse_manager/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::evse_manager {
 
@@ -76,22 +77,6 @@ std::ostream& operator<<(std::ostream& os, PauseChargingEVSEReasonEnum const& va
 std::ostream& operator<<(std::ostream& os, ChargingPausedEVSEReasons const& val);
 std::ostream& operator<<(std::ostream& os, HlcSessionFailedReasonEnum const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) noexcept {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::evse_manager

--- a/lib/everest/everest_api_types/include/everest_api_types/evse_security/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/evse_security/codec.hpp
@@ -29,21 +29,6 @@ std::ostream& operator<<(std::ostream& os, CertificateOCSP const& val);
 std::ostream& operator<<(std::ostream& os, CertificateInfo const& val);
 std::ostream& operator<<(std::ostream& os, GetCertificateInfoResult const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::evse_security

--- a/lib/everest/everest_api_types/include/everest_api_types/generic/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/generic/codec.hpp
@@ -6,6 +6,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::generic {
 
@@ -23,21 +24,6 @@ std::ostream& operator<<(std::ostream& os, RequestReply const& val);
 std::ostream& operator<<(std::ostream& os, const Error& val);
 std::ostream& operator<<(std::ostream& os, const ErrorEnum& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::generic

--- a/lib/everest/everest_api_types/include/everest_api_types/iso15118_charger/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/iso15118_charger/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::iso15118_charger {
 
@@ -26,22 +27,6 @@ std::ostream& operator<<(std::ostream& os, ResponseExiStreamStatus const& val);
 std::ostream& operator<<(std::ostream& os, CertificateHashDataInfo const& val);
 std::ostream& operator<<(std::ostream& os, EnergyTransferModeList const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) noexcept {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::iso15118_charger

--- a/lib/everest/everest_api_types/include/everest_api_types/isolation_monitor/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/isolation_monitor/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::isolation_monitor {
 
@@ -16,21 +17,6 @@ std::ostream& operator<<(std::ostream& os, IsolationMeasurement const& val);
 std::ostream& operator<<(std::ostream& os, const Error& val);
 std::ostream& operator<<(std::ostream& os, const ErrorEnum& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::isolation_monitor

--- a/lib/everest/everest_api_types/include/everest_api_types/money/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/money/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::money {
 
@@ -18,21 +19,6 @@ std::ostream& operator<<(std::ostream& os, Currency const& val);
 std::ostream& operator<<(std::ostream& os, MoneyAmount const& val);
 std::ostream& operator<<(std::ostream& os, Price const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::money

--- a/lib/everest/everest_api_types/include/everest_api_types/ocpp/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/ocpp/codec.hpp
@@ -6,6 +6,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::ocpp {
 
@@ -54,21 +55,6 @@ create_serialize_interface(Message);
 
 #undef create_serialize_interface
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::ocpp

--- a/lib/everest/everest_api_types/include/everest_api_types/over_voltage_monitor/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/over_voltage_monitor/codec.hpp
@@ -6,6 +6,7 @@
 #include <everest_api_types/over_voltage_monitor/API.hpp>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::over_voltage_monitor {
 
@@ -19,21 +20,6 @@ std::ostream& operator<<(std::ostream& os, const ErrorEnum& val);
 std::ostream& operator<<(std::ostream& os, const ErrorSeverityEnum& val);
 std::ostream& operator<<(std::ostream& os, const OverVoltageLimits& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::over_voltage_monitor

--- a/lib/everest/everest_api_types/include/everest_api_types/power_supply_DC/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/power_supply_DC/codec.hpp
@@ -6,6 +6,7 @@
 #include <everest_api_types/power_supply_DC/API.hpp>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::power_supply_DC {
 
@@ -25,21 +26,6 @@ std::ostream& operator<<(std::ostream& os, const VoltageCurrent& val);
 std::ostream& operator<<(std::ostream& os, const Error& val);
 std::ostream& operator<<(std::ostream& os, const ErrorEnum& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::power_supply_DC

--- a/lib/everest/everest_api_types/include/everest_api_types/powermeter/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/powermeter/codec.hpp
@@ -6,6 +6,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::powermeter {
 
@@ -57,21 +58,6 @@ std::ostream& operator<<(std::ostream& os, ReplyStartTransaction const& val);
 std::ostream& operator<<(std::ostream& os, ReplyStopTransaction const& val);
 std::ostream& operator<<(std::ostream& os, RequestStartTransaction const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) noexcept {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::powermeter

--- a/lib/everest/everest_api_types/include/everest_api_types/session_cost/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/session_cost/codec.hpp
@@ -6,6 +6,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::session_cost {
 
@@ -29,21 +30,6 @@ std::ostream& operator<<(std::ostream& os, SessionCostChunk const& val);
 std::ostream& operator<<(std::ostream& os, SessionStatus const& val);
 std::ostream& operator<<(std::ostream& os, SessionCost const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::session_cost

--- a/lib/everest/everest_api_types/include/everest_api_types/slac/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/slac/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::slac {
 
@@ -12,22 +13,6 @@ std::string serialize(State val) noexcept;
 
 std::ostream& operator<<(std::ostream& os, State const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) noexcept {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::slac

--- a/lib/everest/everest_api_types/include/everest_api_types/system/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/system/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::system {
 
@@ -34,21 +35,6 @@ std::ostream& operator<<(std::ostream& os, FirmwareUpdateStatus const& val);
 std::ostream& operator<<(std::ostream& os, UploadLogsResponse const& val);
 std::ostream& operator<<(std::ostream& os, ResetRequest const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::system

--- a/lib/everest/everest_api_types/include/everest_api_types/text_message/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/text_message/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::text_message {
 
@@ -14,21 +15,6 @@ std::string serialize(MessageContent const& val) noexcept;
 std::ostream& operator<<(std::ostream& os, MessageFormat const& val);
 std::ostream& operator<<(std::ostream& os, MessageContent const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::text_message

--- a/lib/everest/everest_api_types/include/everest_api_types/uk_random_delay/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/uk_random_delay/codec.hpp
@@ -5,6 +5,7 @@
 #include "API.hpp"
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::uk_random_delay {
 
@@ -12,21 +13,6 @@ std::string serialize(CountDown const& val) noexcept;
 
 std::ostream& operator<<(std::ostream& os, CountDown const& val);
 
-template <class T> T deserialize(std::string const& val);
-template <class T> std::optional<T> try_deserialize(std::string const& val) {
-    try {
-        return deserialize<T>(val);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-template <class T> bool adl_deserialize(std::string const& json_data, T& obj) {
-    auto opt = try_deserialize<T>(json_data);
-    if (opt) {
-        obj = opt.value();
-        return true;
-    }
-    return false;
-}
+#include <everest_api_types/utilities/deserialize_templates.inc>
 
 } // namespace everest::lib::API::V1_0::types::uk_random_delay

--- a/lib/everest/everest_api_types/include/everest_api_types/utilities/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/utilities/codec.hpp
@@ -4,18 +4,19 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API {
 
-template <class T> bool deserialize(std::string const& json_data, T& obj) {
+template <class T> bool deserialize(std::string_view json_data, T& obj) {
     return adl_deserialize(json_data, obj);
 }
 
-template <> bool deserialize(std::string const& data, bool& obj);
-template <> bool deserialize(std::string const& data, int& obj);
-template <> bool deserialize(std::string const& data, size_t& obj);
-template <> bool deserialize(std::string const& data, double& obj);
-template <> bool deserialize(std::string const& data, float& obj);
-template <> bool deserialize(std::string const& data, std::string& obj);
+template <> bool deserialize(std::string_view data, bool& obj);
+template <> bool deserialize(std::string_view data, int& obj);
+template <> bool deserialize(std::string_view data, size_t& obj);
+template <> bool deserialize(std::string_view data, double& obj);
+template <> bool deserialize(std::string_view data, float& obj);
+template <> bool deserialize(std::string_view data, std::string& obj);
 
 } // namespace everest::lib::API

--- a/lib/everest/everest_api_types/include/everest_api_types/utilities/constants.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/utilities/constants.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 
+#pragma once
+
 namespace everest::lib::API {
 #ifndef EVEREST_API_JSON_INDENT
 #define EVEREST_API_JSON_INDENT 4

--- a/lib/everest/everest_api_types/include/everest_api_types/utilities/deserialize_templates.inc
+++ b/lib/everest/everest_api_types/include/everest_api_types/utilities/deserialize_templates.inc
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+//
+// Include this fragment inside an everest_api_types type namespace.
+
+template <class T> T deserialize(std::string_view val);
+
+template <class T> std::optional<T> try_deserialize(std::string_view val) noexcept {
+    try {
+        return deserialize<T>(val);
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+template <class T> bool adl_deserialize(std::string_view json_data, T& obj) noexcept {
+    try {
+        obj = deserialize<T>(json_data);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}

--- a/lib/everest/everest_api_types/private_include/everest_api_types/evse_security/json_codec.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/evse_security/json_codec.hpp
@@ -3,12 +3,8 @@
 
 #pragma once
 
+#include "nlohmann/json_fwd.hpp"
 #include <everest_api_types/evse_security/API.hpp>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wignored-qualifiers"
-#pragma GCC diagnostic ignored "-Wunused-function"
-#include "generated/types/evse_security.hpp"
-#pragma GCC diagnostic pop
 
 namespace everest::lib::API::V1_0::types::evse_security {
 

--- a/lib/everest/everest_api_types/private_include/everest_api_types/money/json_codec.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/money/json_codec.hpp
@@ -3,12 +3,8 @@
 
 #pragma once
 
+#include "nlohmann/json_fwd.hpp"
 #include <everest_api_types/money/API.hpp>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wignored-qualifiers"
-#pragma GCC diagnostic ignored "-Wunused-function"
-#include "generated/types/money.hpp"
-#pragma GCC diagnostic pop
 
 namespace everest::lib::API::V1_0::types::money {
 

--- a/lib/everest/everest_api_types/private_include/everest_api_types/session_cost/json_codec.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/session_cost/json_codec.hpp
@@ -3,12 +3,8 @@
 
 #pragma once
 
+#include "nlohmann/json_fwd.hpp"
 #include <everest_api_types/session_cost/API.hpp>
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wignored-qualifiers"
-#pragma GCC diagnostic ignored "-Wunused-function"
-#include "generated/types/session_cost.hpp"
-#pragma GCC diagnostic pop
 
 namespace everest::lib::API::V1_0::types::session_cost {
 

--- a/lib/everest/everest_api_types/private_include/everest_api_types/utilities/json_codec_helpers.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/utilities/json_codec_helpers.hpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include "nlohmann/json.hpp"
+#include "utilities/constants.hpp"
+
+#include <string>
+#include <string_view>
+
+namespace everest::lib::API::V1_0::types::utilities {
+
+template <class T> std::string dump_json(T const& val) noexcept {
+    return nlohmann::json(val).dump(json_indent);
+}
+
+template <class T> T parse_json(std::string_view val) {
+    return nlohmann::json::parse(val.begin(), val.end());
+}
+
+} // namespace everest::lib::API::V1_0::types::utilities

--- a/lib/everest/everest_api_types/src/everest_api_types/auth/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/auth/codec.cpp
@@ -6,65 +6,67 @@
 #include "auth/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::auth {
 
 std::string serialize(AuthorizationStatus val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(CertificateStatus val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(TokenValidationStatus val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SelectionAlgorithm val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(AuthorizationType val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(IdTokenType val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(CustomIdToken const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(IdToken const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(WithdrawAuthorizationResult val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ProvidedIdToken const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(TokenValidationStatusMessage const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ValidationResult const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ValidationResultUpdate const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(WithdrawAuthorizationRequest const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, AuthorizationStatus const& val) {
@@ -137,60 +139,60 @@ std::ostream& operator<<(std::ostream& os, WithdrawAuthorizationRequest const& v
     return os;
 }
 
-template <> AuthorizationStatus deserialize(std::string const& val) {
-    return json::parse(val);
+template <> AuthorizationStatus deserialize(std::string_view val) {
+    return utilities::parse_json<AuthorizationStatus>(val);
 }
 
-template <> CertificateStatus deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> CertificateStatus deserialize(std::string_view val) {
+    return utilities::parse_json<CertificateStatus>(val);
 }
 
-template <> TokenValidationStatus deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> TokenValidationStatus deserialize(std::string_view val) {
+    return utilities::parse_json<TokenValidationStatus>(val);
 }
 
-template <> SelectionAlgorithm deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> SelectionAlgorithm deserialize(std::string_view val) {
+    return utilities::parse_json<SelectionAlgorithm>(val);
 }
 
-template <> AuthorizationType deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> AuthorizationType deserialize(std::string_view val) {
+    return utilities::parse_json<AuthorizationType>(val);
 }
 
-template <> IdTokenType deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> IdTokenType deserialize(std::string_view val) {
+    return utilities::parse_json<IdTokenType>(val);
 }
 
-template <> WithdrawAuthorizationResult deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> WithdrawAuthorizationResult deserialize(std::string_view val) {
+    return utilities::parse_json<WithdrawAuthorizationResult>(val);
 }
 
-template <> CustomIdToken deserialize<>(const std::string& val) {
-    return json::parse(val);
+template <> CustomIdToken deserialize(std::string_view val) {
+    return utilities::parse_json<CustomIdToken>(val);
 }
 
-template <> IdToken deserialize<>(const std::string& val) {
-    return json::parse(val);
+template <> IdToken deserialize(std::string_view val) {
+    return utilities::parse_json<IdToken>(val);
 }
 
-template <> ProvidedIdToken deserialize<>(const std::string& val) {
-    return json::parse(val);
+template <> ProvidedIdToken deserialize(std::string_view val) {
+    return utilities::parse_json<ProvidedIdToken>(val);
 }
 
-template <> TokenValidationStatusMessage deserialize<>(const std::string& val) {
-    return json::parse(val);
+template <> TokenValidationStatusMessage deserialize(std::string_view val) {
+    return utilities::parse_json<TokenValidationStatusMessage>(val);
 }
 
-template <> ValidationResult deserialize<>(const std::string& val) {
-    return json::parse(val);
+template <> ValidationResult deserialize(std::string_view val) {
+    return utilities::parse_json<ValidationResult>(val);
 }
 
-template <> ValidationResultUpdate deserialize<>(const std::string& val) {
-    return json::parse(val);
+template <> ValidationResultUpdate deserialize(std::string_view val) {
+    return utilities::parse_json<ValidationResultUpdate>(val);
 }
 
-template <> WithdrawAuthorizationRequest deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> WithdrawAuthorizationRequest deserialize(std::string_view val) {
+    return utilities::parse_json<WithdrawAuthorizationRequest>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::auth

--- a/lib/everest/everest_api_types/src/everest_api_types/dc_external_derate/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/dc_external_derate/codec.cpp
@@ -6,11 +6,12 @@
 #include "dc_external_derate/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 
 namespace everest::lib::API::V1_0::types::dc_external_derate {
 
 std::string serialize(ExternalDerating const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, ExternalDerating const& val) {
@@ -18,8 +19,8 @@ std::ostream& operator<<(std::ostream& os, ExternalDerating const& val) {
     return os;
 }
 
-template <> ExternalDerating deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ExternalDerating deserialize(std::string_view val) {
+    return utilities::parse_json<ExternalDerating>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::dc_external_derate

--- a/lib/everest/everest_api_types/src/everest_api_types/display_message/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/display_message/codec.cpp
@@ -5,55 +5,56 @@
 #include "display_message/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 
 namespace everest::lib::API::V1_0::types::display_message {
 
 std::string serialize(MessagePriorityEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(MessageStateEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(DisplayMessageStatusEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ClearMessageResponseEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Identifier_type val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(DisplayMessage const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SetDisplayMessageRequest const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SetDisplayMessageResponse const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(GetDisplayMessageRequest const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(GetDisplayMessageResponse const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ClearDisplayMessageRequest const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ClearDisplayMessageResponse const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, MessagePriorityEnum const& val) {
@@ -116,52 +117,52 @@ std::ostream& operator<<(std::ostream& os, ClearDisplayMessageResponse const& va
     return os;
 }
 
-template <> MessagePriorityEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> MessagePriorityEnum deserialize(std::string_view val) {
+    return utilities::parse_json<MessagePriorityEnum>(val);
 }
 
-template <> MessageStateEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> MessageStateEnum deserialize(std::string_view val) {
+    return utilities::parse_json<MessageStateEnum>(val);
 }
 
-template <> DisplayMessageStatusEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> DisplayMessageStatusEnum deserialize(std::string_view val) {
+    return utilities::parse_json<DisplayMessageStatusEnum>(val);
 }
 
-template <> ClearMessageResponseEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ClearMessageResponseEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ClearMessageResponseEnum>(val);
 }
 
-template <> Identifier_type deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Identifier_type deserialize(std::string_view val) {
+    return utilities::parse_json<Identifier_type>(val);
 }
 
-template <> DisplayMessage deserialize(std::string const& val) {
-    return json::parse(val);
+template <> DisplayMessage deserialize(std::string_view val) {
+    return utilities::parse_json<DisplayMessage>(val);
 }
 
-template <> SetDisplayMessageRequest deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SetDisplayMessageRequest deserialize(std::string_view val) {
+    return utilities::parse_json<SetDisplayMessageRequest>(val);
 }
 
-template <> SetDisplayMessageResponse deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SetDisplayMessageResponse deserialize(std::string_view val) {
+    return utilities::parse_json<SetDisplayMessageResponse>(val);
 }
 
-template <> GetDisplayMessageRequest deserialize(std::string const& val) {
-    return json::parse(val);
+template <> GetDisplayMessageRequest deserialize(std::string_view val) {
+    return utilities::parse_json<GetDisplayMessageRequest>(val);
 }
 
-template <> GetDisplayMessageResponse deserialize(std::string const& val) {
-    return json::parse(val);
+template <> GetDisplayMessageResponse deserialize(std::string_view val) {
+    return utilities::parse_json<GetDisplayMessageResponse>(val);
 }
 
-template <> ClearDisplayMessageRequest deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ClearDisplayMessageRequest deserialize(std::string_view val) {
+    return utilities::parse_json<ClearDisplayMessageRequest>(val);
 }
 
-template <> ClearDisplayMessageResponse deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ClearDisplayMessageResponse deserialize(std::string_view val) {
+    return utilities::parse_json<ClearDisplayMessageResponse>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::display_message

--- a/lib/everest/everest_api_types/src/everest_api_types/energy/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/energy/codec.cpp
@@ -6,59 +6,60 @@
 #include "energy/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 
 namespace everest::lib::API::V1_0::types::energy {
 
 std::string serialize(NumberWithSource const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(IntegerWithSource const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(FrequencyWattPoint const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SetpointType const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(PricePerkWh const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(LimitsReq const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(LimitsRes const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ScheduleReqEntry const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ScheduleResEntry const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ScheduleSetpointEntry const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ExternalLimits const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(EnforcedLimits const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(CapabilityLimits const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, NumberWithSource const& val) {
@@ -126,56 +127,56 @@ std::ostream& operator<<(std::ostream& os, CapabilityLimits const& val) {
     return os;
 }
 
-template <> NumberWithSource deserialize(std::string const& val) {
-    return json::parse(val);
+template <> NumberWithSource deserialize(std::string_view val) {
+    return utilities::parse_json<NumberWithSource>(val);
 }
 
-template <> IntegerWithSource deserialize(std::string const& val) {
-    return json::parse(val);
+template <> IntegerWithSource deserialize(std::string_view val) {
+    return utilities::parse_json<IntegerWithSource>(val);
 }
 
-template <> FrequencyWattPoint deserialize(std::string const& val) {
-    return json::parse(val);
+template <> FrequencyWattPoint deserialize(std::string_view val) {
+    return utilities::parse_json<FrequencyWattPoint>(val);
 }
 
-template <> SetpointType deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SetpointType deserialize(std::string_view val) {
+    return utilities::parse_json<SetpointType>(val);
 }
 
-template <> PricePerkWh deserialize(std::string const& val) {
-    return json::parse(val);
+template <> PricePerkWh deserialize(std::string_view val) {
+    return utilities::parse_json<PricePerkWh>(val);
 }
 
-template <> LimitsReq deserialize(std::string const& val) {
-    return json::parse(val);
+template <> LimitsReq deserialize(std::string_view val) {
+    return utilities::parse_json<LimitsReq>(val);
 }
 
-template <> LimitsRes deserialize(std::string const& val) {
-    return json::parse(val);
+template <> LimitsRes deserialize(std::string_view val) {
+    return utilities::parse_json<LimitsRes>(val);
 }
 
-template <> ScheduleReqEntry deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ScheduleReqEntry deserialize(std::string_view val) {
+    return utilities::parse_json<ScheduleReqEntry>(val);
 }
 
-template <> ScheduleResEntry deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ScheduleResEntry deserialize(std::string_view val) {
+    return utilities::parse_json<ScheduleResEntry>(val);
 }
 
-template <> ScheduleSetpointEntry deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ScheduleSetpointEntry deserialize(std::string_view val) {
+    return utilities::parse_json<ScheduleSetpointEntry>(val);
 }
 
-template <> ExternalLimits deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ExternalLimits deserialize(std::string_view val) {
+    return utilities::parse_json<ExternalLimits>(val);
 }
 
-template <> EnforcedLimits deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EnforcedLimits deserialize(std::string_view val) {
+    return utilities::parse_json<EnforcedLimits>(val);
 }
 
-template <> CapabilityLimits deserialize(std::string const& val) {
-    return json::parse(val);
+template <> CapabilityLimits deserialize(std::string_view val) {
+    return utilities::parse_json<CapabilityLimits>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::energy

--- a/lib/everest/everest_api_types/src/everest_api_types/entrypoint/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/entrypoint/codec.cpp
@@ -5,21 +5,22 @@
 #include "entrypoint/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 
 #include <iostream>
 
 namespace everest::lib::API::V1_0::types::entrypoint {
 
 std::string serialize(ApiParameter val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ApiDiscoverResponse val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(CommunicationParameters val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, ApiParameter const& val) {
@@ -37,16 +38,16 @@ std::ostream& operator<<(std::ostream& os, CommunicationParameters const& val) {
     return os;
 }
 
-template <> ApiParameter deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ApiParameter deserialize(std::string_view val) {
+    return utilities::parse_json<ApiParameter>(val);
 }
 
-template <> ApiDiscoverResponse deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ApiDiscoverResponse deserialize(std::string_view val) {
+    return utilities::parse_json<ApiDiscoverResponse>(val);
 }
 
-template <> CommunicationParameters deserialize(std::string const& val) {
-    return json::parse(val);
+template <> CommunicationParameters deserialize(std::string_view val) {
+    return utilities::parse_json<CommunicationParameters>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::entrypoint

--- a/lib/everest/everest_api_types/src/everest_api_types/error_history/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/error_history/codec.cpp
@@ -6,41 +6,43 @@
 #include "error_history/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::error_history {
 
 std::string serialize(State val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SeverityFilter val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Severity val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ImplementationIdentifier const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(TimeperiodFilter const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(FilterArguments const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ErrorObject const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ErrorList const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, State const& val) {
@@ -83,36 +85,36 @@ std::ostream& operator<<(std::ostream& os, ErrorList const& val) {
     return os;
 }
 
-template <> State deserialize(std::string const& val) {
-    return json::parse(val);
+template <> State deserialize(std::string_view val) {
+    return utilities::parse_json<State>(val);
 }
 
-template <> SeverityFilter deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> SeverityFilter deserialize(std::string_view val) {
+    return utilities::parse_json<SeverityFilter>(val);
 }
 
-template <> Severity deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> Severity deserialize(std::string_view val) {
+    return utilities::parse_json<Severity>(val);
 }
 
-template <> ImplementationIdentifier deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> ImplementationIdentifier deserialize(std::string_view val) {
+    return utilities::parse_json<ImplementationIdentifier>(val);
 }
 
-template <> TimeperiodFilter deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> TimeperiodFilter deserialize(std::string_view val) {
+    return utilities::parse_json<TimeperiodFilter>(val);
 }
 
-template <> FilterArguments deserialize<>(std::string const& val) {
-    return json::parse(val);
+template <> FilterArguments deserialize(std::string_view val) {
+    return utilities::parse_json<FilterArguments>(val);
 }
 
-template <> ErrorObject deserialize<>(const std::string& val) {
-    return json::parse(val);
+template <> ErrorObject deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorObject>(val);
 }
 
-template <> ErrorList deserialize<>(const std::string& val) {
-    return json::parse(val);
+template <> ErrorList deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorList>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::error_history

--- a/lib/everest/everest_api_types/src/everest_api_types/ev_board_support/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/ev_board_support/codec.cpp
@@ -6,16 +6,18 @@
 #include "ev_board_support/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::ev_board_support {
 
 std::string serialize(EvCpState val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(BspMeasurement const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, EvCpState const& val) {
@@ -28,12 +30,12 @@ std::ostream& operator<<(std::ostream& os, const BspMeasurement& val) {
     return os;
 }
 
-template <> EvCpState deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EvCpState deserialize(std::string_view val) {
+    return utilities::parse_json<EvCpState>(val);
 }
 
-template <> BspMeasurement deserialize(std::string const& val) {
-    return json::parse(val);
+template <> BspMeasurement deserialize(std::string_view val) {
+    return utilities::parse_json<BspMeasurement>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::ev_board_support

--- a/lib/everest/everest_api_types/src/everest_api_types/evse_board_support/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/evse_board_support/codec.cpp
@@ -6,48 +6,50 @@
 #include "evse_board_support/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::evse_board_support {
 
 std::string serialize(Event val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(BspEvent const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ErrorEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Error const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Connector_type val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(HardwareCapabilities const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Reason val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(PowerOnOff const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Ampacity val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ProximityPilot const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, Event const& val) {
@@ -100,44 +102,44 @@ std::ostream& operator<<(std::ostream& os, const ProximityPilot& val) {
     return os;
 }
 
-template <> Event deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Event deserialize(std::string_view val) {
+    return utilities::parse_json<Event>(val);
 }
 
-template <> BspEvent deserialize(std::string const& val) {
-    return json::parse(val);
+template <> BspEvent deserialize(std::string_view val) {
+    return utilities::parse_json<BspEvent>(val);
 }
 
-template <> ErrorEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ErrorEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorEnum>(val);
 }
 
-template <> Error deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Error deserialize(std::string_view val) {
+    return utilities::parse_json<Error>(val);
 }
 
-template <> Connector_type deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Connector_type deserialize(std::string_view val) {
+    return utilities::parse_json<Connector_type>(val);
 }
 
-template <> HardwareCapabilities deserialize(std::string const& val) {
-    return json::parse(val);
+template <> HardwareCapabilities deserialize(std::string_view val) {
+    return utilities::parse_json<HardwareCapabilities>(val);
 }
 
-template <> Reason deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Reason deserialize(std::string_view val) {
+    return utilities::parse_json<Reason>(val);
 }
 
-template <> PowerOnOff deserialize(std::string const& val) {
-    return json::parse(val);
+template <> PowerOnOff deserialize(std::string_view val) {
+    return utilities::parse_json<PowerOnOff>(val);
 }
 
-template <> Ampacity deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Ampacity deserialize(std::string_view val) {
+    return utilities::parse_json<Ampacity>(val);
 }
 
-template <> ProximityPilot deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ProximityPilot deserialize(std::string_view val) {
+    return utilities::parse_json<ProximityPilot>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::evse_board_support

--- a/lib/everest/everest_api_types/src/everest_api_types/evse_manager/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/evse_manager/codec.cpp
@@ -6,140 +6,142 @@
 #include "evse_manager/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::evse_manager {
 
 std::string serialize(StopTransactionReason val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(StopTransactionRequest const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(StartSessionReason val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SessionEventEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SessionEvent const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Limits const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(EVInfo const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(CarManufacturer val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SessionStarted const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SessionFinished const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(TransactionStarted const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(TransactionFinished const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ChargingStateChangedEvent const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(AuthorizationEvent const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ErrorSeverity val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ErrorState val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ErrorOrigin const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Error const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ConnectorTypeEnum const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Connector const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Evse const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(EnableSourceEnum const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(EnableStateEnum const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(EnableDisableSource const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(EnableDisableRequest const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(AuthorizeResponseArgs const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(PlugAndChargeConfiguration const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(EvseStateEnum const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SessionInfo const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(PauseChargingEVSEReasonEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ChargingPausedEVSEReasons const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(HlcSessionFailedReasonEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(HlcSessionFailedEvent const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, StopTransactionReason const& val) {
@@ -306,136 +308,136 @@ std::ostream& operator<<(std::ostream& os, HlcSessionFailedEvent const& val) {
     return os;
 }
 
-template <> StopTransactionReason deserialize(std::string const& val) {
-    return json::parse(val);
+template <> StopTransactionReason deserialize(std::string_view val) {
+    return utilities::parse_json<StopTransactionReason>(val);
 }
 
-template <> StopTransactionRequest deserialize(std::string const& val) {
-    return json::parse(val);
+template <> StopTransactionRequest deserialize(std::string_view val) {
+    return utilities::parse_json<StopTransactionRequest>(val);
 }
 
-template <> StartSessionReason deserialize(std::string const& val) {
-    return json::parse(val);
+template <> StartSessionReason deserialize(std::string_view val) {
+    return utilities::parse_json<StartSessionReason>(val);
 }
 
-template <> SessionEventEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SessionEventEnum deserialize(std::string_view val) {
+    return utilities::parse_json<SessionEventEnum>(val);
 }
 
-template <> SessionEvent deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SessionEvent deserialize(std::string_view val) {
+    return utilities::parse_json<SessionEvent>(val);
 }
 
-template <> Limits deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Limits deserialize(std::string_view val) {
+    return utilities::parse_json<Limits>(val);
 }
 
-template <> EVInfo deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EVInfo deserialize(std::string_view val) {
+    return utilities::parse_json<EVInfo>(val);
 }
 
-template <> CarManufacturer deserialize(std::string const& val) {
-    return json::parse(val);
+template <> CarManufacturer deserialize(std::string_view val) {
+    return utilities::parse_json<CarManufacturer>(val);
 }
 
-template <> SessionStarted deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SessionStarted deserialize(std::string_view val) {
+    return utilities::parse_json<SessionStarted>(val);
 }
 
-template <> SessionFinished deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SessionFinished deserialize(std::string_view val) {
+    return utilities::parse_json<SessionFinished>(val);
 }
 
-template <> TransactionStarted deserialize(std::string const& val) {
-    return json::parse(val);
+template <> TransactionStarted deserialize(std::string_view val) {
+    return utilities::parse_json<TransactionStarted>(val);
 }
 
-template <> TransactionFinished deserialize(std::string const& val) {
-    return json::parse(val);
+template <> TransactionFinished deserialize(std::string_view val) {
+    return utilities::parse_json<TransactionFinished>(val);
 }
 
-template <> ChargingStateChangedEvent deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ChargingStateChangedEvent deserialize(std::string_view val) {
+    return utilities::parse_json<ChargingStateChangedEvent>(val);
 }
 
-template <> AuthorizationEvent deserialize(std::string const& val) {
-    return json::parse(val);
+template <> AuthorizationEvent deserialize(std::string_view val) {
+    return utilities::parse_json<AuthorizationEvent>(val);
 }
 
-template <> ErrorSeverity deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ErrorSeverity deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorSeverity>(val);
 }
 
-template <> ErrorState deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ErrorState deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorState>(val);
 }
 
-template <> ErrorOrigin deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ErrorOrigin deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorOrigin>(val);
 }
 
-template <> Error deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Error deserialize(std::string_view val) {
+    return utilities::parse_json<Error>(val);
 }
 
-template <> ConnectorTypeEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ConnectorTypeEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ConnectorTypeEnum>(val);
 }
 
-template <> Connector deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Connector deserialize(std::string_view val) {
+    return utilities::parse_json<Connector>(val);
 }
 
-template <> Evse deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Evse deserialize(std::string_view val) {
+    return utilities::parse_json<Evse>(val);
 }
 
-template <> EnableSourceEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EnableSourceEnum deserialize(std::string_view val) {
+    return utilities::parse_json<EnableSourceEnum>(val);
 }
 
-template <> EnableStateEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EnableStateEnum deserialize(std::string_view val) {
+    return utilities::parse_json<EnableStateEnum>(val);
 }
 
-template <> EnableDisableSource deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EnableDisableSource deserialize(std::string_view val) {
+    return utilities::parse_json<EnableDisableSource>(val);
 }
 
-template <> EnableDisableRequest deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EnableDisableRequest deserialize(std::string_view val) {
+    return utilities::parse_json<EnableDisableRequest>(val);
 }
 
-template <> AuthorizeResponseArgs deserialize(std::string const& val) {
-    return json::parse(val);
+template <> AuthorizeResponseArgs deserialize(std::string_view val) {
+    return utilities::parse_json<AuthorizeResponseArgs>(val);
 }
 
-template <> PlugAndChargeConfiguration deserialize(std::string const& val) {
-    return json::parse(val);
+template <> PlugAndChargeConfiguration deserialize(std::string_view val) {
+    return utilities::parse_json<PlugAndChargeConfiguration>(val);
 }
 
-template <> EvseStateEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EvseStateEnum deserialize(std::string_view val) {
+    return utilities::parse_json<EvseStateEnum>(val);
 }
 
-template <> SessionInfo deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SessionInfo deserialize(std::string_view val) {
+    return utilities::parse_json<SessionInfo>(val);
 }
 
-template <> PauseChargingEVSEReasonEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> PauseChargingEVSEReasonEnum deserialize(std::string_view val) {
+    return utilities::parse_json<PauseChargingEVSEReasonEnum>(val);
 }
 
-template <> ChargingPausedEVSEReasons deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ChargingPausedEVSEReasons deserialize(std::string_view val) {
+    return utilities::parse_json<ChargingPausedEVSEReasons>(val);
 }
 
-template <> HlcSessionFailedReasonEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> HlcSessionFailedReasonEnum deserialize(std::string_view val) {
+    return utilities::parse_json<HlcSessionFailedReasonEnum>(val);
 }
 
-template <> HlcSessionFailedEvent deserialize(std::string const& val) {
-    return json::parse(val);
+template <> HlcSessionFailedEvent deserialize(std::string_view val) {
+    return utilities::parse_json<HlcSessionFailedEvent>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::evse_manager

--- a/lib/everest/everest_api_types/src/everest_api_types/evse_security/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/evse_security/codec.cpp
@@ -6,8 +6,10 @@
 #include "evse_security/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::evse_security {
 
@@ -93,62 +95,62 @@ std::ostream& operator<<(std::ostream& os, GetCertificateInfoResult const& val) 
     return os;
 }
 
-template <> CaCertificateType deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> CaCertificateType deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     CaCertificateType obj = data;
     return obj;
 }
 
-template <> LeafCertificateType deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> LeafCertificateType deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     LeafCertificateType obj = data;
     return obj;
 }
 
-template <> EncodingFormat deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> EncodingFormat deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     EncodingFormat obj = data;
     return obj;
 }
 
-template <> GetLeafCertificateInfoRequest deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> GetLeafCertificateInfoRequest deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     GetLeafCertificateInfoRequest obj = data;
     return obj;
 }
 
-template <> GetCertificateInfoStatus deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> GetCertificateInfoStatus deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     GetCertificateInfoStatus obj = data;
     return obj;
 }
 
-template <> HashAlgorithm deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> HashAlgorithm deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     HashAlgorithm obj = data;
     return obj;
 }
 
-template <> CertificateHashData deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> CertificateHashData deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     CertificateHashData obj = data;
     return obj;
 }
 
-template <> CertificateOCSP deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> CertificateOCSP deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     CertificateOCSP obj = data;
     return obj;
 }
 
-template <> CertificateInfo deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> CertificateInfo deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     CertificateInfo obj = data;
     return obj;
 }
 
-template <> GetCertificateInfoResult deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> GetCertificateInfoResult deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     GetCertificateInfoResult obj = data;
     return obj;
 }

--- a/lib/everest/everest_api_types/src/everest_api_types/generic/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/generic/codec.cpp
@@ -6,35 +6,37 @@
 #include "generic/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 using json = nlohmann::json;
 
 namespace everest::lib::API::V1_0::types::generic {
 
 std::string serialize(bool val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(int val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(size_t val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(double val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(float val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(std::string const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(RequestReply const& val) {
@@ -42,11 +44,11 @@ std::string serialize(RequestReply const& val) {
 }
 
 std::string serialize(ErrorEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Error const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, RequestReply const& val) {
@@ -64,40 +66,40 @@ std::ostream& operator<<(std::ostream& os, const Error& val) {
     return os;
 }
 
-template <> bool deserialize(std::string const& val) {
-    return json::parse(val);
+template <> bool deserialize(std::string_view val) {
+    return utilities::parse_json<bool>(val);
 }
 
-template <> int deserialize(std::string const& val) {
-    return json::parse(val);
+template <> int deserialize(std::string_view val) {
+    return utilities::parse_json<int>(val);
 }
 
-template <> size_t deserialize(std::string const& val) {
-    return json::parse(val);
+template <> size_t deserialize(std::string_view val) {
+    return utilities::parse_json<size_t>(val);
 }
 
-template <> double deserialize(std::string const& val) {
-    return json::parse(val);
+template <> double deserialize(std::string_view val) {
+    return utilities::parse_json<double>(val);
 }
 
-template <> float deserialize(std::string const& val) {
-    return json::parse(val);
+template <> float deserialize(std::string_view val) {
+    return utilities::parse_json<float>(val);
 }
 
-template <> std::string deserialize(std::string const& val) {
-    return json::parse(val);
+template <> std::string deserialize(std::string_view val) {
+    return utilities::parse_json<std::string>(val);
 }
 
-template <> RequestReply deserialize(std::string const& val) {
-    return json::parse(val);
+template <> RequestReply deserialize(std::string_view val) {
+    return utilities::parse_json<RequestReply>(val);
 }
 
-template <> ErrorEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ErrorEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorEnum>(val);
 }
 
-template <> Error deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Error deserialize(std::string_view val) {
+    return utilities::parse_json<Error>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::generic

--- a/lib/everest/everest_api_types/src/everest_api_types/iso15118_charger/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/iso15118_charger/codec.cpp
@@ -6,41 +6,43 @@
 #include "iso15118_charger/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::iso15118_charger {
 
 std::string serialize(CertificateActionEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(EnergyTransferMode val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Status val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(HashAlgorithm val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(RequestExiStreamSchema const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ResponseExiStreamStatus const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(CertificateHashDataInfo const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(EnergyTransferModeList const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, CertificateActionEnum const& val) {
@@ -83,36 +85,36 @@ std::ostream& operator<<(std::ostream& os, EnergyTransferModeList const& val) {
     return os;
 }
 
-template <> CertificateActionEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> CertificateActionEnum deserialize(std::string_view val) {
+    return utilities::parse_json<CertificateActionEnum>(val);
 }
 
-template <> EnergyTransferMode deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EnergyTransferMode deserialize(std::string_view val) {
+    return utilities::parse_json<EnergyTransferMode>(val);
 }
 
-template <> Status deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Status deserialize(std::string_view val) {
+    return utilities::parse_json<Status>(val);
 }
 
-template <> HashAlgorithm deserialize(std::string const& val) {
-    return json::parse(val);
+template <> HashAlgorithm deserialize(std::string_view val) {
+    return utilities::parse_json<HashAlgorithm>(val);
 }
 
-template <> RequestExiStreamSchema deserialize(std::string const& val) {
-    return json::parse(val);
+template <> RequestExiStreamSchema deserialize(std::string_view val) {
+    return utilities::parse_json<RequestExiStreamSchema>(val);
 }
 
-template <> ResponseExiStreamStatus deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ResponseExiStreamStatus deserialize(std::string_view val) {
+    return utilities::parse_json<ResponseExiStreamStatus>(val);
 }
 
-template <> CertificateHashDataInfo deserialize(std::string const& val) {
-    return json::parse(val);
+template <> CertificateHashDataInfo deserialize(std::string_view val) {
+    return utilities::parse_json<CertificateHashDataInfo>(val);
 }
 
-template <> EnergyTransferModeList deserialize(std::string const& val) {
-    return json::parse(val);
+template <> EnergyTransferModeList deserialize(std::string_view val) {
+    return utilities::parse_json<EnergyTransferModeList>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::iso15118_charger

--- a/lib/everest/everest_api_types/src/everest_api_types/isolation_monitor/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/isolation_monitor/codec.cpp
@@ -6,20 +6,22 @@
 #include "isolation_monitor/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::isolation_monitor {
 
 std::string serialize(IsolationMeasurement const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ErrorEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Error const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, IsolationMeasurement const& val) {
@@ -37,16 +39,16 @@ std::ostream& operator<<(std::ostream& os, const Error& val) {
     return os;
 }
 
-template <> IsolationMeasurement deserialize(std::string const& val) {
-    return json::parse(val);
+template <> IsolationMeasurement deserialize(std::string_view val) {
+    return utilities::parse_json<IsolationMeasurement>(val);
 }
 
-template <> ErrorEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ErrorEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorEnum>(val);
 }
 
-template <> Error deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Error deserialize(std::string_view val) {
+    return utilities::parse_json<Error>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::isolation_monitor

--- a/lib/everest/everest_api_types/src/everest_api_types/money/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/money/codec.cpp
@@ -6,22 +6,24 @@
 #include "money/json_codec.hpp"
 #include "nlohmann/json.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::money {
 
 std::string serialize(CurrencyCode val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(Currency val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(MoneyAmount val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(Price val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::ostream& operator<<(std::ostream& os, CurrencyCode const& val) {
     os << serialize(val);
@@ -40,19 +42,19 @@ std::ostream& operator<<(std::ostream& os, Price const& val) {
     return os;
 }
 
-template <> CurrencyCode deserialize(std::string const& val) {
-    return json::parse(val);
+template <> CurrencyCode deserialize(std::string_view val) {
+    return utilities::parse_json<CurrencyCode>(val);
 }
 
-template <> Currency deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Currency deserialize(std::string_view val) {
+    return utilities::parse_json<Currency>(val);
 }
 
-template <> MoneyAmount deserialize(std::string const& val) {
-    return json::parse(val);
+template <> MoneyAmount deserialize(std::string_view val) {
+    return utilities::parse_json<MoneyAmount>(val);
 }
-template <> Price deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Price deserialize(std::string_view val) {
+    return utilities::parse_json<Price>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::money

--- a/lib/everest/everest_api_types/src/everest_api_types/ocpp/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/ocpp/codec.cpp
@@ -6,18 +6,20 @@
 #include "ocpp/API.hpp"
 #include "ocpp/json_codec.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::ocpp {
 
 #define create_serialize_impl(A)                                                                                       \
-    std::string serialize(A const& val) noexcept { return nlohmann::json(val).dump(json_indent); }                     \
+    std::string serialize(A const& val) noexcept { return utilities::dump_json(val); }                                 \
     std::ostream& operator<<(std::ostream& os, A const& val) {                                                         \
         os << serialize(val);                                                                                          \
         return os;                                                                                                     \
     }                                                                                                                  \
-    template <> A deserialize(std::string const& val) { return json::parse(val); }
+    template <> A deserialize(std::string_view val) { return utilities::parse_json<A>(val); }
 
 create_serialize_impl(AttributeEnum);
 create_serialize_impl(GetVariableStatusEnumType);

--- a/lib/everest/everest_api_types/src/everest_api_types/over_voltage_monitor/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/over_voltage_monitor/codec.cpp
@@ -6,41 +6,43 @@
 #include "over_voltage_monitor/API.hpp"
 #include "over_voltage_monitor/json_codec.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::over_voltage_monitor {
 
 std::string serialize(ErrorEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ErrorSeverityEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Error const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(OverVoltageLimits const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
-template <> ErrorEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ErrorEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorEnum>(val);
 }
 
-template <> ErrorSeverityEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ErrorSeverityEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorSeverityEnum>(val);
 }
 
-template <> Error deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Error deserialize(std::string_view val) {
+    return utilities::parse_json<Error>(val);
 }
 
-template <> OverVoltageLimits deserialize(std::string const& val) {
-    return json::parse(val);
+template <> OverVoltageLimits deserialize(std::string_view val) {
+    return utilities::parse_json<OverVoltageLimits>(val);
 }
 
 std::ostream& operator<<(std::ostream& os, const ErrorEnum& val) {

--- a/lib/everest/everest_api_types/src/everest_api_types/power_supply_DC/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/power_supply_DC/codec.cpp
@@ -6,65 +6,67 @@
 #include "power_supply_DC/API.hpp"
 #include "power_supply_DC/json_codec.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::power_supply_DC {
 
 std::string serialize(Capabilities const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Mode val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ChargingPhase val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ModeRequest val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(VoltageCurrent const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ErrorEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Error const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
-template <> Capabilities deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Capabilities deserialize(std::string_view val) {
+    return utilities::parse_json<Capabilities>(val);
 }
 
-template <> Mode deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Mode deserialize(std::string_view val) {
+    return utilities::parse_json<Mode>(val);
 }
 
-template <> ChargingPhase deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ChargingPhase deserialize(std::string_view val) {
+    return utilities::parse_json<ChargingPhase>(val);
 }
 
-template <> ModeRequest deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ModeRequest deserialize(std::string_view val) {
+    return utilities::parse_json<ModeRequest>(val);
 }
 
-template <> VoltageCurrent deserialize(std::string const& val) {
-    return json::parse(val);
+template <> VoltageCurrent deserialize(std::string_view val) {
+    return utilities::parse_json<VoltageCurrent>(val);
 }
 
-template <> ErrorEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ErrorEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ErrorEnum>(val);
 }
 
-template <> Error deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Error deserialize(std::string_view val) {
+    return utilities::parse_json<Error>(val);
 }
 
 std::ostream& operator<<(std::ostream& os, const Capabilities& k) {

--- a/lib/everest/everest_api_types/src/everest_api_types/powermeter/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/powermeter/codec.cpp
@@ -6,193 +6,195 @@
 #include "powermeter/API.hpp"
 #include "powermeter/json_codec.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::powermeter {
 
 std::string serialize(OCMFUserIdentificationStatus val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(OCMFIdentificationFlags val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(OCMFIdentificationType val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(OCMFIdentificationLevel val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Current const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Voltage const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Frequency const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Power const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Energy const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ReactivePower const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SignedMeterValue const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SignedCurrent const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SignedVoltage const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SignedFrequency const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SignedPower const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SignedEnergy const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(SignedReactivePower const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(PowermeterValues const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(Temperature const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(TransactionStatus val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ReplyStartTransaction const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ReplyStopTransaction const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(RequestStartTransaction const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
-template <> OCMFUserIdentificationStatus deserialize(std::string const& val) {
-    return json::parse(val);
+template <> OCMFUserIdentificationStatus deserialize(std::string_view val) {
+    return utilities::parse_json<OCMFUserIdentificationStatus>(val);
 }
 
-template <> OCMFIdentificationFlags deserialize(std::string const& val) {
-    return json::parse(val);
+template <> OCMFIdentificationFlags deserialize(std::string_view val) {
+    return utilities::parse_json<OCMFIdentificationFlags>(val);
 }
 
-template <> OCMFIdentificationType deserialize(std::string const& val) {
-    return json::parse(val);
+template <> OCMFIdentificationType deserialize(std::string_view val) {
+    return utilities::parse_json<OCMFIdentificationType>(val);
 }
 
-template <> OCMFIdentificationLevel deserialize(std::string const& val) {
-    return json::parse(val);
+template <> OCMFIdentificationLevel deserialize(std::string_view val) {
+    return utilities::parse_json<OCMFIdentificationLevel>(val);
 }
 
-template <> Current deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Current deserialize(std::string_view val) {
+    return utilities::parse_json<Current>(val);
 }
 
-template <> Voltage deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Voltage deserialize(std::string_view val) {
+    return utilities::parse_json<Voltage>(val);
 }
 
-template <> Frequency deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Frequency deserialize(std::string_view val) {
+    return utilities::parse_json<Frequency>(val);
 }
 
-template <> Power deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Power deserialize(std::string_view val) {
+    return utilities::parse_json<Power>(val);
 }
 
-template <> Energy deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Energy deserialize(std::string_view val) {
+    return utilities::parse_json<Energy>(val);
 }
 
-template <> ReactivePower deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ReactivePower deserialize(std::string_view val) {
+    return utilities::parse_json<ReactivePower>(val);
 }
 
-template <> SignedMeterValue deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SignedMeterValue deserialize(std::string_view val) {
+    return utilities::parse_json<SignedMeterValue>(val);
 }
 
-template <> SignedCurrent deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SignedCurrent deserialize(std::string_view val) {
+    return utilities::parse_json<SignedCurrent>(val);
 }
 
-template <> SignedVoltage deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SignedVoltage deserialize(std::string_view val) {
+    return utilities::parse_json<SignedVoltage>(val);
 }
 
-template <> SignedFrequency deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SignedFrequency deserialize(std::string_view val) {
+    return utilities::parse_json<SignedFrequency>(val);
 }
 
-template <> SignedPower deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SignedPower deserialize(std::string_view val) {
+    return utilities::parse_json<SignedPower>(val);
 }
 
-template <> SignedEnergy deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SignedEnergy deserialize(std::string_view val) {
+    return utilities::parse_json<SignedEnergy>(val);
 }
 
-template <> SignedReactivePower deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SignedReactivePower deserialize(std::string_view val) {
+    return utilities::parse_json<SignedReactivePower>(val);
 }
 
-template <> Temperature deserialize(std::string const& val) {
-    return json::parse(val);
+template <> Temperature deserialize(std::string_view val) {
+    return utilities::parse_json<Temperature>(val);
 }
 
-template <> PowermeterValues deserialize(std::string const& val) {
-    return json::parse(val);
+template <> PowermeterValues deserialize(std::string_view val) {
+    return utilities::parse_json<PowermeterValues>(val);
 }
 
-template <> TransactionStatus deserialize(std::string const& val) {
-    return json::parse(val);
+template <> TransactionStatus deserialize(std::string_view val) {
+    return utilities::parse_json<TransactionStatus>(val);
 }
 
-template <> ReplyStartTransaction deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ReplyStartTransaction deserialize(std::string_view val) {
+    return utilities::parse_json<ReplyStartTransaction>(val);
 }
 
-template <> ReplyStopTransaction deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ReplyStopTransaction deserialize(std::string_view val) {
+    return utilities::parse_json<ReplyStopTransaction>(val);
 }
 
-template <> RequestStartTransaction deserialize(std::string const& val) {
-    return json::parse(val);
+template <> RequestStartTransaction deserialize(std::string_view val) {
+    return utilities::parse_json<RequestStartTransaction>(val);
 }
 
 std::ostream& operator<<(std::ostream& os, OCMFUserIdentificationStatus const& val) {

--- a/lib/everest/everest_api_types/src/everest_api_types/session_cost/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/session_cost/codec.cpp
@@ -6,8 +6,10 @@
 #include "session_cost/API.hpp"
 #include "session_cost/json_codec.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::session_cost {
 
@@ -16,28 +18,28 @@ std::string serialize(DefaultPrice val) noexcept {
     return result.dump(json_indent);
 }
 std::string serialize(TariffMessage val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(IdlePrice val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(CostCategory val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(ChargingPriceComponent val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(NextPeriodPrice val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(SessionCostChunk val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(SessionStatus val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 std::string serialize(SessionCost val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, DefaultPrice const& val) {
@@ -77,38 +79,38 @@ std::ostream& operator<<(std::ostream& os, SessionCost const& val) {
     return os;
 }
 
-template <> DefaultPrice deserialize(std::string const& val) {
-    auto data = json::parse(val);
+template <> DefaultPrice deserialize(std::string_view val) {
+    auto data = json::parse(val.begin(), val.end());
     DefaultPrice obj = data;
     return obj;
 }
 
-template <> TariffMessage deserialize(std::string const& val) {
-    return json::parse(val);
+template <> TariffMessage deserialize(std::string_view val) {
+    return utilities::parse_json<TariffMessage>(val);
 }
 
-template <> IdlePrice deserialize(std::string const& val) {
-    return json::parse(val);
+template <> IdlePrice deserialize(std::string_view val) {
+    return utilities::parse_json<IdlePrice>(val);
 }
-template <> CostCategory deserialize(std::string const& val) {
-    return json::parse(val);
+template <> CostCategory deserialize(std::string_view val) {
+    return utilities::parse_json<CostCategory>(val);
 }
-template <> ChargingPriceComponent deserialize(std::string const& val) {
-    return json::parse(val);
-}
-
-template <> NextPeriodPrice deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ChargingPriceComponent deserialize(std::string_view val) {
+    return utilities::parse_json<ChargingPriceComponent>(val);
 }
 
-template <> SessionCostChunk deserialize(std::string const& val) {
-    return json::parse(val);
+template <> NextPeriodPrice deserialize(std::string_view val) {
+    return utilities::parse_json<NextPeriodPrice>(val);
 }
-template <> SessionStatus deserialize(std::string const& val) {
-    return json::parse(val);
+
+template <> SessionCostChunk deserialize(std::string_view val) {
+    return utilities::parse_json<SessionCostChunk>(val);
 }
-template <> SessionCost deserialize(std::string const& val) {
-    return json::parse(val);
+template <> SessionStatus deserialize(std::string_view val) {
+    return utilities::parse_json<SessionStatus>(val);
+}
+template <> SessionCost deserialize(std::string_view val) {
+    return utilities::parse_json<SessionCost>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::session_cost

--- a/lib/everest/everest_api_types/src/everest_api_types/slac/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/slac/codec.cpp
@@ -6,12 +6,14 @@
 #include "slac/API.hpp"
 #include "slac/json_codec.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::slac {
 
 std::string serialize(State val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, State const& val) {
@@ -19,7 +21,7 @@ std::ostream& operator<<(std::ostream& os, State const& val) {
     return os;
 }
 
-template <> State deserialize(std::string const& val) {
-    return json::parse(val);
+template <> State deserialize(std::string_view val) {
+    return utilities::parse_json<State>(val);
 }
 } // namespace everest::lib::API::V1_0::types::slac

--- a/lib/everest/everest_api_types/src/everest_api_types/system/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/system/codec.cpp
@@ -6,58 +6,60 @@
 #include "system/API.hpp"
 #include "system/json_codec.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::system {
 
 std::string serialize(UpdateFirmwareResponse val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(UploadLogsStatus val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(LogStatusEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(FirmwareUpdateStatusEnum val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ResetType val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(BootReason val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(FirmwareUpdateRequest const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(UploadLogsRequest const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(UploadLogsResponse const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(LogStatus const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(FirmwareUpdateStatus const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(ResetRequest const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, UpdateFirmwareResponse const& val) {
@@ -120,52 +122,52 @@ std::ostream& operator<<(std::ostream& os, ResetRequest const& val) {
     return os;
 }
 
-template <> UpdateFirmwareResponse deserialize(std::string const& val) {
-    return json::parse(val);
+template <> UpdateFirmwareResponse deserialize(std::string_view val) {
+    return utilities::parse_json<UpdateFirmwareResponse>(val);
 }
 
-template <> UploadLogsStatus deserialize(std::string const& val) {
-    return json::parse(val);
+template <> UploadLogsStatus deserialize(std::string_view val) {
+    return utilities::parse_json<UploadLogsStatus>(val);
 }
 
-template <> LogStatusEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> LogStatusEnum deserialize(std::string_view val) {
+    return utilities::parse_json<LogStatusEnum>(val);
 }
 
-template <> FirmwareUpdateStatusEnum deserialize(std::string const& val) {
-    return json::parse(val);
+template <> FirmwareUpdateStatusEnum deserialize(std::string_view val) {
+    return utilities::parse_json<FirmwareUpdateStatusEnum>(val);
 }
 
-template <> ResetType deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ResetType deserialize(std::string_view val) {
+    return utilities::parse_json<ResetType>(val);
 }
 
-template <> BootReason deserialize(std::string const& val) {
-    return json::parse(val);
+template <> BootReason deserialize(std::string_view val) {
+    return utilities::parse_json<BootReason>(val);
 }
 
-template <> FirmwareUpdateRequest deserialize(std::string const& val) {
-    return json::parse(val);
+template <> FirmwareUpdateRequest deserialize(std::string_view val) {
+    return utilities::parse_json<FirmwareUpdateRequest>(val);
 }
 
-template <> UploadLogsRequest deserialize(std::string const& val) {
-    return json::parse(val);
+template <> UploadLogsRequest deserialize(std::string_view val) {
+    return utilities::parse_json<UploadLogsRequest>(val);
 }
 
-template <> UploadLogsResponse deserialize(std::string const& val) {
-    return json::parse(val);
+template <> UploadLogsResponse deserialize(std::string_view val) {
+    return utilities::parse_json<UploadLogsResponse>(val);
 }
 
-template <> LogStatus deserialize(std::string const& val) {
-    return json::parse(val);
+template <> LogStatus deserialize(std::string_view val) {
+    return utilities::parse_json<LogStatus>(val);
 }
 
-template <> FirmwareUpdateStatus deserialize(std::string const& val) {
-    return json::parse(val);
+template <> FirmwareUpdateStatus deserialize(std::string_view val) {
+    return utilities::parse_json<FirmwareUpdateStatus>(val);
 }
 
-template <> ResetRequest deserialize(std::string const& val) {
-    return json::parse(val);
+template <> ResetRequest deserialize(std::string_view val) {
+    return utilities::parse_json<ResetRequest>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::system

--- a/lib/everest/everest_api_types/src/everest_api_types/text_message/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/text_message/codec.cpp
@@ -6,18 +6,20 @@
 #include "text_message/API.hpp"
 #include "text_message/json_codec.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::text_message {
 
 std::string serialize(MessageFormat val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::string serialize(MessageContent const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, MessageFormat const& val) {
@@ -30,12 +32,12 @@ std::ostream& operator<<(std::ostream& os, MessageContent const& val) {
     return os;
 }
 
-template <> MessageFormat deserialize(std::string const& val) {
-    return json::parse(val);
+template <> MessageFormat deserialize(std::string_view val) {
+    return utilities::parse_json<MessageFormat>(val);
 }
 
-template <> MessageContent deserialize(std::string const& val) {
-    return json::parse(val);
+template <> MessageContent deserialize(std::string_view val) {
+    return utilities::parse_json<MessageContent>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::text_message

--- a/lib/everest/everest_api_types/src/everest_api_types/uk_random_delay/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/uk_random_delay/codec.cpp
@@ -6,14 +6,16 @@
 #include "uk_random_delay/API.hpp"
 #include "uk_random_delay/json_codec.hpp"
 #include "utilities/constants.hpp"
+#include "utilities/json_codec_helpers.hpp"
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace everest::lib::API::V1_0::types::uk_random_delay {
 
 std::string serialize(CountDown const& val) noexcept {
-    return nlohmann::json(val).dump(json_indent);
+    return utilities::dump_json(val);
 }
 
 std::ostream& operator<<(std::ostream& os, CountDown const& val) {
@@ -21,8 +23,8 @@ std::ostream& operator<<(std::ostream& os, CountDown const& val) {
     return os;
 }
 
-template <> CountDown deserialize(std::string const& val) {
-    return json::parse(val);
+template <> CountDown deserialize(std::string_view val) {
+    return utilities::parse_json<CountDown>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::uk_random_delay

--- a/lib/everest/everest_api_types/src/everest_api_types/utilities/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/utilities/codec.cpp
@@ -6,27 +6,27 @@
 
 namespace everest::lib::API {
 
-template <> bool deserialize(std::string const& data, bool& obj) {
+template <> bool deserialize(std::string_view data, bool& obj) {
     return everest::lib::API::V1_0::types::generic::adl_deserialize(data, obj);
 }
 
-template <> bool deserialize(std::string const& data, int& obj) {
+template <> bool deserialize(std::string_view data, int& obj) {
     return everest::lib::API::V1_0::types::generic::adl_deserialize(data, obj);
 }
 
-template <> bool deserialize(std::string const& data, size_t& obj) {
+template <> bool deserialize(std::string_view data, size_t& obj) {
     return everest::lib::API::V1_0::types::generic::adl_deserialize(data, obj);
 }
 
-template <> bool deserialize(std::string const& data, double& obj) {
+template <> bool deserialize(std::string_view data, double& obj) {
     return everest::lib::API::V1_0::types::generic::adl_deserialize(data, obj);
 }
 
-template <> bool deserialize(std::string const& data, float& obj) {
+template <> bool deserialize(std::string_view data, float& obj) {
     return everest::lib::API::V1_0::types::generic::adl_deserialize(data, obj);
 }
 
-template <> bool deserialize(std::string const& data, std::string& obj) {
+template <> bool deserialize(std::string_view data, std::string& obj) {
     return everest::lib::API::V1_0::types::generic::adl_deserialize(data, obj);
 }
 

--- a/lib/everest/everest_api_types/tests/manual_tests/serialization/generic.cpp
+++ b/lib/everest/everest_api_types/tests/manual_tests/serialization/generic.cpp
@@ -5,6 +5,7 @@
 #include "everest_api_types/generic/codec.hpp"
 #include "nlohmann/json.hpp"
 #include <gtest/gtest.h>
+#include <string_view>
 
 using namespace everest::lib::API::V1_0::types::generic;
 
@@ -100,4 +101,15 @@ TEST(generic, RequestReply_back_and_forth_2) {
     EXPECT_EQ(rr.payload, des.payload);
     EXPECT_EQ(rr.replyTo, des2.replyTo);
     EXPECT_EQ(rr.payload, des2.payload);
+}
+
+TEST(generic, deserialize_accepts_string_view_subrange) {
+    std::string payload = "xxtrueyy";
+    std::string_view json_data(payload.data() + 2, 4);
+
+    EXPECT_TRUE(deserialize<bool>(json_data));
+
+    bool result = false;
+    EXPECT_TRUE(everest::lib::API::deserialize(json_data, result));
+    EXPECT_TRUE(result);
 }


### PR DESCRIPTION
## Summary

  Refactors lib/everest/everest_api_types codec helpers to remove repeated deserialize boilerplate and support non-owning JSON input.

###  Changes

  - Centralized repeated deserialize, try_deserialize, and adl_deserialize templates in a shared include.
  - Made try_deserialize and adl_deserialize noexcept.
  - Simplified adl_deserialize to assign directly from deserialize<T>(...), avoiding the intermediate std::optional<T> move/copy path.
  - Added shared JSON codec helpers:
      - dump_json(...)
      - parse_json(...)

  - Replaced repeated nlohmann::json(val).dump(json_indent) and simple json::parse(...) patterns with the helpers.
  - Kept RequestReply serialization as a deliberate special case because invalid payload JSON must still throw.
  - Changed deserialize APIs from std::string const& to std::string_view.
  - Parse JSON from std::string_view using iterator ranges, so inputs do not need to be owned or null-terminated.
  - Added regression coverage for deserializing from a std::string_view subrange.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

