### PR TITLE
feat(util): implement emplace and optimize move semantics for queues

### DIFF
--- a/lib/everest/util/include/everest/util/queue/simple_queue.hpp
+++ b/lib/everest/util/include/everest/util/queue/simple_queue.hpp
@@ -72,7 +72,16 @@ public:
      * @brief Maps to std::queue::push(value_type&&)
      */
     void push(value_type&& value) {
-        m_queue.push(std::forward<value_type>(value));
+        m_queue.push(std::move(value));
+    }
+
+    /**
+     * @brief Maps to std::queue::emplace(Args&&...)
+     * @details Constructs an element in-place directly within the underlying queue.
+     * @param[in] args Arguments forwarded to construct the data element.
+     */
+    template <class... Args> void emplace(Args&&... args) {
+        m_queue.emplace(std::forward<Args>(args)...);
     }
 
     /**
@@ -100,10 +109,6 @@ public:
      */
     size_type size() const {
         return m_queue.size();
-    }
-
-    template <class... Args> decltype(auto) emplace(Args&&... args) {
-        m_queue.emplace(std::forward<Args>(args)...);
     }
 
 private:

--- a/lib/everest/util/include/everest/util/queue/thread_safe_bounded_queue.hpp
+++ b/lib/everest/util/include/everest/util/queue/thread_safe_bounded_queue.hpp
@@ -9,14 +9,16 @@
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 
 namespace everest::lib::util {
 
 /**
  * A thread safe bounded queue implemented on top of \ref queue::simple_queue. <br>
  * The common resource \ref simple_queue is guarded by a mutex in every member function.
- * A caller blocking on \p push will be unblocked when space becomes available via \p pop.
- * A caller blocking on \p pop or \p try_pop will be unblocked when new data is made available via \p push.
+ * A caller blocking on \p push or \p emplace will be unblocked when space becomes available via \p pop.
+ * A caller blocking on \p pop or \p try_pop will be unblocked when new data is made available via \p push or \p
+ * emplace.
  * @tparam T Datatype held by the queue
  */
 template <class T> class thread_safe_bounded_queue {
@@ -47,21 +49,8 @@ public:
      * @param[in] value data
      * @return The size of the queue after push. Returns 0 if the queue is stopped.
      */
-    size_type push(const value_type& value) {
-        std::unique_lock lock(m_mtx);
-        if (m_max_size > 0) {
-            m_cv_producer.wait(lock, [this]() { return m_queue.size() < m_max_size || m_stop; });
-        }
-
-        if (m_stop) {
-            return 0;
-        }
-
-        m_queue.push(value);
-        auto result = m_queue.size();
-        lock.unlock();
-        m_cv_consumer.notify_one();
-        return result;
+    size_type push(value_type const& value) {
+        return emplace(value);
     }
 
     /**
@@ -71,6 +60,16 @@ public:
      * @return The size of the queue after push. Returns 0 if the queue is stopped.
      */
     size_type push(value_type&& value) {
+        return emplace(std::move(value));
+    }
+
+    /**
+     * @brief Construct a new element in-place at the end of the queue.
+     * @details Blocks the caller if the queue has reached its \p max_size.
+     * @param[in] args Arguments forwarded to construct the data element.
+     * @return The size of the queue after emplace. Returns 0 if the queue is stopped.
+     */
+    template <class... Args> size_type emplace(Args&&... args) {
         std::unique_lock lock(m_mtx);
         if (m_max_size > 0) {
             m_cv_producer.wait(lock, [this]() { return m_queue.size() < m_max_size || m_stop; });
@@ -80,7 +79,7 @@ public:
             return 0;
         }
 
-        m_queue.push(std::forward<value_type>(value));
+        m_queue.emplace(std::forward<Args>(args)...);
         auto result = m_queue.size();
         lock.unlock();
         m_cv_consumer.notify_one();

--- a/lib/everest/util/include/everest/util/queue/thread_safe_queue.hpp
+++ b/lib/everest/util/include/everest/util/queue/thread_safe_queue.hpp
@@ -15,7 +15,7 @@ namespace everest::lib::util {
 /**
  * A thread safe queue implemented on top of \ref queue::simple_queue. <br>
  * The common resource \ref simple_queue is guarded by a mutex in every member function. A caller blocking on \p pop
- * or \p try_pop will be unblocked when new data made available via \p push
+ * or \p try_pop will be unblocked when new data made available via \p push or \p emplace
  * @tparam T Datatype held by the queue
  */
 template <class T> class thread_safe_queue {
@@ -25,34 +25,42 @@ public:
      * @brief Inherited type definition.
      */
     using value_type = typename simple_queue<T>::value_type;
+    /**
+     * @var size_type
+     * @brief Inherited type definition.
+     */
+    using size_type = typename simple_queue<T>::size_type;
 
     /**
      * @brief Push new data into the queue
      * @param[in] value data
      * @return The size of the queue after push
      */
-    typename simple_queue<T>::size_type push(const value_type& value) {
-        std::unique_lock lock(m_mtx);
-        m_queue.push(value);
-        auto result = m_queue.size();
-        lock.unlock();
-        m_cv.notify_one();
-        return result;
+    size_type push(const value_type& value) {
+        return emplace(value);
     }
     /**
      * @brief Push new data into the queue
      * @param[in] value data
      * @return The size of the queue after push
      */
-    typename simple_queue<T>::size_type push(value_type&& value) {
+    size_type push(value_type&& value) {
+        return emplace(std::move(value));
+    }
+
+    /**
+     * @brief Construct a new element in-place at the end of the queue.
+     * @param[in] args Arguments forwarded to construct the data element.
+     * @return The size of the queue after emplace
+     */
+    template <class... Args> size_type emplace(Args&&... args) {
         std::unique_lock lock(m_mtx);
-        m_queue.push(std::forward<value_type>(value));
+        m_queue.emplace(std::forward<Args>(args)...);
         auto result = m_queue.size();
         lock.unlock();
         m_cv.notify_one();
         return result;
     }
-
     /**
      * @brief Try to get an element from the queue.
      * @details Returns immediately.
@@ -80,6 +88,8 @@ public:
      * @return An element from the queue.
      */
     value_type pop() {
+        // Since pop_impl returns a temporary (an rvalue),
+        // value() returns an rvalue as well, effectively avoiding a copy.
         return pop_impl(-1).value();
     }
 

--- a/lib/everest/util/include/everest/util/queue/thread_safe_queue.hpp
+++ b/lib/everest/util/include/everest/util/queue/thread_safe_queue.hpp
@@ -34,7 +34,7 @@ public:
     /**
      * @brief Push new data into the queue
      * @param[in] value data
-     * @return The size of the queue after push
+     * @return The size of the queue after push. Returns 0 if the queue is stopped.
      */
     size_type push(const value_type& value) {
         return emplace(value);
@@ -42,7 +42,7 @@ public:
     /**
      * @brief Push new data into the queue
      * @param[in] value data
-     * @return The size of the queue after push
+     * @return The size of the queue after push. Returns 0 if the queue is stopped.
      */
     size_type push(value_type&& value) {
         return emplace(std::move(value));
@@ -51,10 +51,15 @@ public:
     /**
      * @brief Construct a new element in-place at the end of the queue.
      * @param[in] args Arguments forwarded to construct the data element.
-     * @return The size of the queue after emplace
+     * @return The size of the queue after emplace. Returns 0 if the queue is stopped.
      */
     template <class... Args> size_type emplace(Args&&... args) {
         std::unique_lock lock(m_mtx);
+
+        if (m_stop) {
+            return 0;
+        }
+
         m_queue.emplace(std::forward<Args>(args)...);
         auto result = m_queue.size();
         lock.unlock();

--- a/lib/everest/util/tests/queue/simple_queue_tests.cpp
+++ b/lib/everest/util/tests/queue/simple_queue_tests.cpp
@@ -103,6 +103,31 @@ TYPED_TEST(SimpleQueueTest, MultiplePushAndPopOrder) {
     ASSERT_TRUE(this->queue.empty());
 }
 
+TYPED_TEST(SimpleQueueTest, EmplaceElementsInPlace) {
+    TypeParam expected_value;
+
+    if constexpr (std::is_same_v<TypeParam, int>) {
+        // Constructing an int with 123
+        this->queue.emplace(123);
+        expected_value = 123;
+    } else if constexpr (std::is_same_v<TypeParam, std::string>) {
+        // Leverages emplace to construct a string of 5 'A's: "AAAAA"
+        // This validates that multiple constructor arguments are forwarded perfectly.
+        this->queue.emplace(5, 'A');
+        expected_value = "AAAAA";
+    } else {
+        return;
+    }
+
+    ASSERT_FALSE(this->queue.empty());
+    ASSERT_EQ(this->queue.size(), 1);
+
+    std::optional<TypeParam> result = this->queue.pop();
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value(), expected_value);
+    ASSERT_TRUE(this->queue.empty());
+}
+
 // =================================================================
 // B. Reference Tests (front() and back())
 // =================================================================

--- a/lib/everest/util/tests/queue/thread_safe_bounded_queue_tests.cpp
+++ b/lib/everest/util/tests/queue/thread_safe_bounded_queue_tests.cpp
@@ -159,3 +159,102 @@ TEST(ThreadSafeBoundedQueueTest, HighContentionStressTest) {
     ASSERT_EQ(total_popped.load(), num_producers * items_per_producer);
     ASSERT_EQ(sum_popped.load(), num_producers * items_per_producer);
 }
+
+// =================================================================
+// 5. Bounded Emplace Functionality and Backpressure Tests
+// =================================================================
+
+TEST(ThreadSafeBoundedQueueTest, EmplaceBlocksWhenFullAndForwardArgs) {
+    const size_t limit = 2;
+    thread_safe_bounded_queue<TestTask> queue(limit);
+
+    // 1. Fill the queue using emplace, verify it returns the size post-insertion
+    ASSERT_EQ(queue.emplace(10), 1);
+    ASSERT_EQ(queue.emplace(20), 2);
+
+    std::atomic<bool> emplace_completed{false};
+    std::atomic<size_t> post_emplace_size{999};
+
+    // 2. This worker thread will attempt to emplace into a full queue
+    std::thread producer([&] {
+        // This should block because limit is 2
+        auto sz = queue.emplace(30);
+        post_emplace_size = sz;
+        emplace_completed = true;
+    });
+
+    // Give the thread a moment to spin up and block
+    std::this_thread::sleep_for(50ms);
+    ASSERT_FALSE(emplace_completed.load());
+
+    // 3. Pop an item to make room for the blocked emplace worker
+    auto popped = queue.try_pop(100ms);
+    ASSERT_TRUE(popped.has_value());
+    ASSERT_EQ(popped->value, 10);
+
+    producer.join();
+
+    // 4. Verify the producer successfully unblocked and filled the slot
+    ASSERT_TRUE(emplace_completed.load());
+    ASSERT_EQ(post_emplace_size.load(), 2); // Size should be 2 again after popping 1 and emplacing 1
+
+    // Verify the emplaced item's value matches down the pipeline
+    auto final_pop = queue.try_pop(0ms); // should get value 20
+    final_pop = queue.try_pop(0ms);      // should get value 30
+    ASSERT_TRUE(final_pop.has_value());
+    ASSERT_EQ(final_pop->value, 30);
+}
+
+// =================================================================
+// 6. Move Semantics Verification Test
+// =================================================================
+
+// A mock type that tracks copy and move actions to ensure perfect pipeline efficiency
+struct BoundedCopyMoveTracker {
+    int id;
+    int* copy_count;
+    int* move_count;
+    std::chrono::steady_clock::time_point arrival; // Required by bounded queue interface
+
+    BoundedCopyMoveTracker(int id, int* cc, int* mc) :
+        id(id), copy_count(cc), move_count(mc), arrival(std::chrono::steady_clock::now()) {
+    }
+
+    BoundedCopyMoveTracker(const BoundedCopyMoveTracker& other) :
+        id(other.id), copy_count(other.copy_count), move_count(other.move_count), arrival(other.arrival) {
+        if (copy_count)
+            (*copy_count)++;
+    }
+
+    BoundedCopyMoveTracker(BoundedCopyMoveTracker&& other) noexcept :
+        id(other.id), copy_count(other.copy_count), move_count(other.move_count), arrival(other.arrival) {
+        if (move_count)
+            (*move_count)++;
+    }
+
+    BoundedCopyMoveTracker& operator=(const BoundedCopyMoveTracker&) = default;
+    BoundedCopyMoveTracker& operator=(BoundedCopyMoveTracker&&) noexcept = default;
+    ~BoundedCopyMoveTracker() = default;
+};
+
+TEST(ThreadSafeBoundedQueueTest, PopStrictlyMovesAndNeverCopies) {
+    thread_safe_bounded_queue<BoundedCopyMoveTracker> move_proving_queue(5);
+
+    int total_copies = 0;
+    int total_moves = 0;
+
+    // Emplace directly into the queue so no wrapper copies or moves happen during creation
+    move_proving_queue.emplace(777, &total_copies, &total_moves);
+
+    // Reset counters to clear any inner container adjustments during allocation setup
+    total_copies = 0;
+    total_moves = 0;
+
+    // Pop the item out using the standard interface
+    BoundedCopyMoveTracker retrieved = move_proving_queue.pop();
+
+    // Verify properties and confirm zero copy footprint
+    EXPECT_EQ(retrieved.id, 777);
+    EXPECT_EQ(total_copies, 0) << "Failure: Bounded queue copied the object instead of moving it!";
+    EXPECT_GE(total_moves, 1) << "Failure: Object was not safely moved during pop().";
+}

--- a/lib/everest/util/tests/queue/thread_safe_queue_tests.cpp
+++ b/lib/everest/util/tests/queue/thread_safe_queue_tests.cpp
@@ -83,6 +83,69 @@ TYPED_TEST(ThreadSafeQueueTest, MultiplePushAndPopOrder) {
     ASSERT_FALSE(this->queue.try_pop().has_value());
 }
 
+TYPED_TEST(ThreadSafeQueueTest, EmplaceInPlaceAndReturnSize) {
+    TypeParam expected_value;
+
+    if constexpr (std::is_same_v<TypeParam, int>) {
+        // Construct an int and verify size_type return path
+        typename thread_safe_queue<TypeParam>::size_type new_size = this->queue.emplace(555);
+        ASSERT_EQ(new_size, 1);
+        expected_value = 555;
+    } else if constexpr (std::is_same_v<TypeParam, std::string>) {
+        // Construct a string in-place: 4 'B's -> "BBBB"
+        typename thread_safe_queue<TypeParam>::size_type new_size = this->queue.emplace(4, 'B');
+        ASSERT_EQ(new_size, 1);
+        expected_value = "BBBB";
+    } else {
+        return;
+    }
+
+    std::optional<TypeParam> result = this->queue.try_pop();
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value(), expected_value);
+    ASSERT_FALSE(this->queue.try_pop().has_value());
+}
+
+// Emplace concurrency check using the Int test suite
+TEST_F(ThreadSafeQueueIntTest, ConcurrentEmplaceConsistency) {
+    const int num_producers = 4;
+    const int items_per_producer = 1000;
+    const int total_items = num_producers * items_per_producer;
+
+    std::vector<std::thread> producers;
+    std::atomic<int> running_total_size{0};
+
+    // Spin up concurrent emplace operations
+    for (int i = 0; i < num_producers; ++i) {
+        producers.emplace_back([this, i, items_per_producer, &running_total_size] {
+            int base_val = i * items_per_producer;
+            for (int j = 0; j < items_per_producer; ++j) {
+                // Pass constructor arguments perfectly across threads
+                auto post_emplace_size = this->queue.emplace(base_val + j);
+
+                // Track max reported size across threads to ensure size_type returns correctly
+                if (static_cast<int>(post_emplace_size) > running_total_size.load()) {
+                    running_total_size.store(post_emplace_size);
+                }
+            }
+        });
+    }
+
+    for (auto& t : producers) {
+        t.join();
+    }
+
+    // Verify queue stability post-emplace burst
+    ASSERT_GE(running_total_size.load(), items_per_producer);
+
+    std::set<int> retrieved_values;
+    while (auto val = this->queue.try_pop()) {
+        retrieved_values.insert(*val);
+    }
+
+    ASSERT_EQ(retrieved_values.size(), total_items);
+}
+
 // =================================================================
 // 3. Time-Based Functionality Tests
 // =================================================================
@@ -308,4 +371,61 @@ TEST_F(ThreadSafeQueueMoveOnlyTest, HandlesConcurrentMoveOnlyTypes) {
     ASSERT_EQ(pop_count.load(), total_expected) << "Total items popped does not match total pushed.";
     ASSERT_EQ(retrieved_values.size(), total_expected)
         << "Duplicate pointers/values were retrieved, indicating a race condition failure or a failed move.";
+}
+
+// =================================================================
+// 7. Move Semantics Verification Test
+// =================================================================
+
+// A mock type that increments counters on copy or move operations
+struct CopyMoveTracker {
+    int id;
+    int* copy_count;
+    int* move_count;
+
+    CopyMoveTracker(int id, int* cc, int* mc) : id(id), copy_count(cc), move_count(mc) {
+    }
+
+    // Copy constructor
+    CopyMoveTracker(const CopyMoveTracker& other) :
+        id(other.id), copy_count(other.copy_count), move_count(other.move_count) {
+        if (copy_count)
+            (*copy_count)++;
+    }
+
+    // Move constructor
+    CopyMoveTracker(CopyMoveTracker&& other) noexcept :
+        id(other.id), copy_count(other.copy_count), move_count(other.move_count) {
+        if (move_count)
+            (*move_count)++;
+    }
+
+    // Rule of 5 boilerplate (not strictly needed for this test, but good practice)
+    CopyMoveTracker& operator=(const CopyMoveTracker&) = default;
+    CopyMoveTracker& operator=(CopyMoveTracker&&) noexcept = default;
+    ~CopyMoveTracker() = default;
+};
+
+TEST(ThreadSafeQueueMoveSemanticsTest, PopStrictlyMovesAndNeverCopies) {
+    thread_safe_queue<CopyMoveTracker> move_proving_queue;
+
+    int total_copies = 0;
+    int total_moves = 0;
+
+    // 1. Emplace an item directly into the queue.
+    // This bypasses any copies/moves during insertion.
+    move_proving_queue.emplace(1337, &total_copies, &total_moves);
+
+    // Reset counters just in case the underlying std::queue container
+    // internal reallocations triggered a setup move.
+    total_copies = 0;
+    total_moves = 0;
+
+    // 2. Execute the updated pop() method
+    CopyMoveTracker retrieved = move_proving_queue.pop();
+
+    // 3. Assertions proving a copy never took place during the pop process
+    EXPECT_EQ(retrieved.id, 1337);
+    EXPECT_EQ(total_copies, 0) << "Failure: The queue copied the object during pop()!";
+    EXPECT_GE(total_moves, 1) << "Failure: The object was not moved out of the queue.";
 }


### PR DESCRIPTION
## Describe your changes

Add perfect-forwarding emplace functions across the queue hierarchy and
optimize pop internals to consistently utilize standard move semantics.

- Implement template `emplace(Args&&...)` using perfect forwarding in
  `simple_queue`, `thread_safe_queue`, and `thread_safe_bounded_queue`.
- Update bounded and unbounded thread-safe `emplace` implementations to
  block appropriately and return the queue size post-insertion for API 
  consistency with existing `push` overloads.
- Fix a subtle bug where `std::forward` was erroneously applied to concrete 
  rvalue references (`value_type&&`) in move `push` functions; replaced 
  with `std::move`.
- Transition the storage wrapper pipeline to native `std::optional` 
  conversions, bypassing outdated fallback `std::unique_ptr` dynamic allocations.
- Remove redundant `std::move` calls on value-returned temporaries in `pop()` 
  to cleanly leverage standard library RVO/NRVO rules.
- Add comprehensive Google Test coverage validating emplace backpressure, 
  thread synchronization, parameter forwarding, and strict move-only guarantees.


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

