### PR TITLE
OCPP201: Allow remote start with empty evse-id

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/remote_transaction_control.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/remote_transaction_control.hpp
@@ -88,7 +88,7 @@ private:
     /// \param group_id_token   The group id token to check if it is reserved for that group id.
     /// \return The status of the reservation for this evse, id token and group id token.
     ///
-    ReservationCheckStatus is_evse_reserved_for_other(EvseInterface& evse, const IdToken& id_token,
+    ReservationCheckStatus is_evse_reserved_for_other(const EvseInterface& evse, const IdToken& id_token,
                                                       const std::optional<IdToken>& group_id_token) const;
 };
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/remote_transaction_control.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/remote_transaction_control.cpp
@@ -33,7 +33,7 @@ namespace {
 /// \param evse Evse to check.
 /// \return True if at least one connector is not faulted or unavailable.
 ///
-bool is_evse_connector_available(EvseInterface& evse) {
+bool is_evse_connector_available(const EvseInterface& evse) {
     if (evse.has_active_transaction()) {
         // If an EV is connected and has no authorization yet then the status is 'Occupied' and the
         // RemoteStartRequest should still be accepted. So this is the 'occupied' check instead.
@@ -125,10 +125,14 @@ void RemoteTransactionControl::handle_remote_start_transaction_request(Call<Requ
     RequestStartTransactionResponse response;
     response.status = RequestStartStopStatusEnum::Rejected;
 
+    const bool is_smart_charging_enabled =
+        this->context.device_model.get_optional_value<bool>(ControllerComponentVariables::SmartChargingCtrlrEnabled)
+            .value_or(false);
+
     // Check if evse id is given.
     if (msg.evseId.has_value()) {
         const std::int32_t evse_id = msg.evseId.value();
-        auto& evse = this->context.evse_manager.get_evse(evse_id);
+        const auto& evse = this->context.evse_manager.get_evse(evse_id);
 
         // F01.FR.23: Faulted or unavailable. F01.FR.24 / F02.FR.25: Occupied. Send rejected.
         const bool available = is_evse_connector_available(evse);
@@ -158,10 +162,6 @@ void RemoteTransactionControl::handle_remote_start_transaction_request(Call<Requ
         // RequestStartTransactionRequest with an invalid ChargingProfile: The Charging Station SHALL respond
         // with RequestStartTransactionResponse with status = Rejected and optionally with reasonCode =
         // "InvalidProfile" or "InvalidSchedule".
-
-        const bool is_smart_charging_enabled =
-            this->context.device_model.get_optional_value<bool>(ControllerComponentVariables::SmartChargingCtrlrEnabled)
-                .value_or(false);
 
         if (is_smart_charging_enabled) {
             if (msg.chargingProfile.has_value()) {
@@ -193,11 +193,32 @@ void RemoteTransactionControl::handle_remote_start_transaction_request(Call<Requ
             }
         }
     } else {
-        // F01.FR.07 RequestStartTransactionRequest does not contain an evseId. The Charging Station MAY reject the
-        // RequestStartTransactionRequest. We do this for now (send rejected) (TODO: eventually support the charging
-        // station to accept no evse id. If so: add token and remote start id for evse id 0 to
-        // remote_start_id_per_evse, so we know for '0' it means 'all evse id's').
-        EVLOG_warning << "No evse id given. Can not remote start transaction.";
+        // F01.FR.07 RequestStartTransactionRequest does not contain an evseId. Accept the request when at least
+        // one evse can start a new transaction. The token and remote start id are stored for evse id 0, meaning
+        // 'all evse id's': the first transaction event with a matching id token will get trigger reason
+        // 'RemoteStart' and the remote start id, regardless of the evse the transaction starts on.
+        if (is_smart_charging_enabled and msg.chargingProfile.has_value()) {
+            // A charging profile can not be validated and applied without knowing the evse.
+            EVLOG_warning << "No evse id given. Can not remote start transaction with a charging profile.";
+        } else {
+            for (const auto& evse : this->context.evse_manager) {
+                const bool is_reserved = is_evse_reserved_for_other(evse, msg.idToken, msg.groupIdToken) ==
+                                         ocpp::ReservationCheckStatus::ReservedForOtherToken;
+
+                if (is_evse_connector_available(evse) and !is_reserved) {
+                    response.status = RequestStartStopStatusEnum::Accepted;
+                    this->transaction.set_remote_start_id_for_evse(0, msg.idToken, msg.remoteStartId);
+                    break;
+                }
+            }
+
+            if (response.status == RequestStartStopStatusEnum::Rejected) {
+                response.statusInfo = StatusInfo{
+                    "NoEvseAvailable",
+                    " RequestStartTransactionRequest requested without providing an EVSE, but no EVSE is available."};
+                EVLOG_info << "Remote start transaction requested without evse id, but no evse is available.";
+            }
+        }
     }
 
     if (response.status == RequestStartStopStatusEnum::Accepted) {
@@ -433,7 +454,7 @@ void RemoteTransactionControl::handle_trigger_message(Call<TriggerMessageRequest
 }
 
 ReservationCheckStatus
-RemoteTransactionControl::is_evse_reserved_for_other(EvseInterface& evse, const IdToken& id_token,
+RemoteTransactionControl::is_evse_reserved_for_other(const EvseInterface& evse, const IdToken& id_token,
                                                      const std::optional<IdToken>& group_id_token) const {
     if (this->reservation != nullptr) {
         return this->reservation->is_evse_reserved_for_other(evse, id_token, group_id_token);

--- a/lib/everest/ocpp/tests/BUILD.bazel
+++ b/lib/everest/ocpp/tests/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("//third-party/bazel/toolchains:defs.bzl", "CROSS_TEST_INCOMPATIBLE")
+
+cc_test(
+    name = "test_remote_transaction_control",
+    srcs = [
+        "lib/ocpp/common/evse_security_mock.hpp",
+        "lib/ocpp/v2/device_model_test_helper.cpp",
+        "lib/ocpp/v2/device_model_test_helper.hpp",
+        "lib/ocpp/v2/functional_blocks/test_remote_transaction_control.cpp",
+    ] + glob([
+        "lib/ocpp/v2/mocks/*.hpp",
+        "lib/ocpp/common/mocks/*.hpp",
+    ]),
+    data = ["//lib/everest/ocpp:config"],
+    includes = [
+        "lib/ocpp/common",
+        "lib/ocpp/common/mocks",
+        "lib/ocpp/v2",
+        "lib/ocpp/v2/mocks",
+    ],
+    linkstatic = True,
+    local_defines = [
+        'DEVICE_MODEL_MIGRATION_FILES_PATH=\\"lib/everest/ocpp/config/common/device_model_migrations\\"',
+        'DEVICE_MODEL_CONFIG_PATH=\\"lib/everest/ocpp/config/common/component_config\\"',
+    ],
+    target_compatible_with = CROSS_TEST_INCOMPATIBLE,
+    deps = [
+        "//lib/everest/ocpp:libocpp",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/lib/everest/ocpp/tests/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ if(LIBOCPP_ENABLE_V2)
     # Add all v2 tests you don't want to include in the default test executable here.
     list(APPEND SEPARATE_UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/ocpp/v2/functional_blocks/test_authorization.cpp)
     list(APPEND SEPARATE_UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/ocpp/v2/functional_blocks/test_availability.cpp)
+    list(APPEND SEPARATE_UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/ocpp/v2/functional_blocks/test_remote_transaction_control.cpp)
     list(APPEND SEPARATE_UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/ocpp/v2/functional_blocks/test_security.cpp)
     list(APPEND SEPARATE_UNIT_TESTS ${CMAKE_CURRENT_SOURCE_DIR}/lib/ocpp/v2/functional_blocks/test_tariff_and_cost.cpp)
 endif()

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.hpp
@@ -19,8 +19,17 @@
 #include <ocpp/v2/device_model.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>
 
-const static std::string MIGRATION_FILES_PATH = "./resources/v2/device_model_migration_files";
-const static std::string CONFIG_PATH = "./resources/example_config/v2/component_config";
+// The default paths assume the CMake test setup, which copies the resources to the build directory. The bazel
+// test targets override them with the paths of the source files within the runfiles tree.
+#ifndef DEVICE_MODEL_MIGRATION_FILES_PATH
+#define DEVICE_MODEL_MIGRATION_FILES_PATH "./resources/v2/device_model_migration_files"
+#endif
+#ifndef DEVICE_MODEL_CONFIG_PATH
+#define DEVICE_MODEL_CONFIG_PATH "./resources/example_config/v2/component_config"
+#endif
+
+const static std::string MIGRATION_FILES_PATH = DEVICE_MODEL_MIGRATION_FILES_PATH;
+const static std::string CONFIG_PATH = DEVICE_MODEL_CONFIG_PATH;
 const static std::string DEVICE_MODEL_DB_IN_MEMORY_PATH = "file::memory:?cache=shared";
 
 namespace ocpp {

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/CMakeLists.txt
@@ -94,6 +94,49 @@ target_include_directories(libocpp_test_availability PUBLIC
         ${LIBOCPP_TESTS_V2_ROOT_DIR}
 )
 
+set(TEST_REMOTE_TRANSACTION_CONTROL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../device_model_test_helper.cpp
+            ${TEST_FUNCTIONAL_BLOCK_CONTEXT_SOURCES}
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/functional_blocks/remote_transaction_control.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/ctrlr_component_variables.cpp
+            # smart_charging.cpp defines the stream operator for ProfileValidationResultEnum, which the smart
+            # charging mock needs; profile.cpp and the charging profile related messages are its dependencies.
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/functional_blocks/smart_charging.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/profile.cpp
+            # smart_charging.cpp references the DynamicScheduleManager and its v2.1 messages.
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/dynamic_schedule_manager.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v21/messages/PullDynamicScheduleUpdate.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v21/messages/UpdateDynamicSchedule.cpp
+            # ChangeAvailability and Get15118EVCertificate are not used by the tests directly, but the mocks of
+            # the availability and security interfaces need their vtables and stream operators.
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/ChangeAvailability.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/ClearChargingProfile.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/Get15118EVCertificate.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/GetChargingProfiles.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/GetCompositeSchedule.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/LogStatusNotification.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/NotifyEVChargingNeeds.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/ReportChargingProfiles.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/RequestStartTransaction.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/RequestStopTransaction.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/SetChargingProfile.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/TriggerMessage.cpp
+            ${LIBOCPP_LIB_PATH}/ocpp/v2/messages/UnlockConnector.cpp
+            ${LIBOCPP_TEST_INCLUDE_COMMON_SOURCES}
+            ${LIBOCPP_TEST_INCLUDE_V2_SOURCES}
+)
+
+target_sources(libocpp_test_remote_transaction_control PRIVATE
+        ${TEST_REMOTE_TRANSACTION_CONTROL_SOURCES}
+)
+
+target_include_directories(libocpp_test_remote_transaction_control PUBLIC
+        ${LIBOCPP_INCLUDE_PATH}
+        ${LIBOCPP_3RDPARTY_PATH}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../mocks
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../common/mocks
+        ${LIBOCPP_TESTS_V2_ROOT_DIR}
+)
+
 set(TEST_TARIFF_AND_COST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../device_model_test_helper.cpp
             ${TEST_FUNCTIONAL_BLOCK_CONTEXT_SOURCES}
             ${LIBOCPP_LIB_PATH}/ocpp/v2/functional_blocks/tariff_and_cost.cpp

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_remote_transaction_control.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/functional_blocks/test_remote_transaction_control.cpp
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <ocpp/v2/functional_blocks/remote_transaction_control.hpp>
+
+#include <ocpp/v2/connector.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model.hpp>
+#include <ocpp/v2/functional_blocks/availability.hpp>
+#include <ocpp/v2/functional_blocks/firmware_update.hpp>
+#include <ocpp/v2/functional_blocks/functional_block_context.hpp>
+#include <ocpp/v2/functional_blocks/provisioning.hpp>
+#include <ocpp/v2/functional_blocks/security.hpp>
+#include <ocpp/v2/functional_blocks/transaction.hpp>
+
+#include <ocpp/v2/messages/Get15118EVCertificate.hpp>
+#include <ocpp/v2/messages/RequestStartTransaction.hpp>
+#include <ocpp/v2/messages/UnlockConnector.hpp>
+
+#include "component_state_manager_mock.hpp"
+#include "connectivity_manager_mock.hpp"
+#include "device_model_test_helper.hpp"
+#include "evse_manager_fake.hpp"
+#include "evse_mock.hpp"
+#include "evse_security_mock.hpp"
+#include "message_dispatcher_mock.hpp"
+#include "meter_values_mock.hpp"
+#include "mocks/database_handler_mock.hpp"
+#include "smart_charging_mock.hpp"
+
+using namespace ocpp::v2;
+using testing::_;
+using testing::Invoke;
+using testing::MockFunction;
+using testing::NiceMock;
+using testing::Return;
+
+namespace {
+class AvailabilityMock : public AvailabilityInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, status_notification_req, (std::int32_t, std::int32_t, ConnectorStatusEnum, bool), (override));
+    MOCK_METHOD(void, heartbeat_req, (bool), (override));
+    MOCK_METHOD(void, handle_scheduled_change_availability_requests, (std::int32_t), (override));
+    MOCK_METHOD(void, set_scheduled_change_availability_requests, (std::int32_t, AvailabilityChange), (override));
+    MOCK_METHOD(void, set_heartbeat_timer_interval, (const std::chrono::seconds&), (override));
+    MOCK_METHOD(void, stop_heartbeat_timer, (), (override));
+    MOCK_METHOD(ChangeAvailabilityResponse, change_availability_req, (bool&, const ChangeAvailabilityRequest&),
+                (override));
+    MOCK_METHOD(void, action_change_availability_req,
+                (bool, const ChangeAvailabilityRequest&, const ChangeAvailabilityResponse&), (override));
+};
+
+class SecurityMock : public SecurityInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, security_event_notification_req,
+                (const ocpp::CiString<50>&, const std::optional<ocpp::CiString<255>>&, bool, bool,
+                 const std::optional<ocpp::DateTime>&),
+                (override));
+    MOCK_METHOD(void, sign_certificate_req, (const ocpp::CertificateSigningUseEnum&, bool), (override));
+    MOCK_METHOD(void, stop_certificate_signed_timer, (), (override));
+    MOCK_METHOD(void, init_certificate_expiration_check_timers, (), (override));
+    MOCK_METHOD(void, stop_certificate_expiration_check_timers, (), (override));
+    MOCK_METHOD(Get15118EVCertificateResponse, on_get_15118_ev_certificate_request,
+                (const Get15118EVCertificateRequest&), (override));
+};
+
+class TransactionBlockMock : public TransactionInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, on_transaction_started,
+                (std::int32_t, std::int32_t, const std::string&, const ocpp::DateTime&, TriggerReasonEnum,
+                 const MeterValue&, const std::optional<IdToken>&, const std::optional<IdToken>&,
+                 const std::optional<std::int32_t>&, const std::optional<std::int32_t>&, ChargingStateEnum),
+                (override));
+    MOCK_METHOD(void, on_transaction_finished,
+                (std::int32_t, const ocpp::DateTime&, const MeterValue&, ReasonEnum, TriggerReasonEnum,
+                 const std::optional<IdToken>&, const std::optional<std::string>&, ChargingStateEnum,
+                 const std::optional<SignedMeterValue>&),
+                (override));
+    MOCK_METHOD(void, transaction_event_req,
+                (const TransactionEventEnum&, const ocpp::DateTime&, const Transaction&, const TriggerReasonEnum&,
+                 std::int32_t, const std::optional<std::int32_t>&, const std::optional<EVSE>&,
+                 const std::optional<IdToken>&, const std::optional<std::vector<MeterValue>>&,
+                 const std::optional<std::int32_t>&, bool, const std::optional<std::int32_t>&, bool),
+                (override));
+    MOCK_METHOD(void, set_remote_start_id_for_evse, (std::int32_t, IdToken, std::int32_t), (override));
+    MOCK_METHOD(void, schedule_reset, (std::optional<std::int32_t>), (override));
+};
+
+class FirmwareUpdateMock : public FirmwareUpdateInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, on_firmware_update_status_notification, (std::int32_t, const FirmwareStatusEnum&, const bool),
+                (override));
+    MOCK_METHOD(void, on_firmware_status_notification_request, (), (override));
+};
+
+class ProvisioningMock : public ProvisioningInterface {
+public:
+    MOCK_METHOD(void, handle_message, (const ocpp::EnhancedMessage<MessageType>&), (override));
+    MOCK_METHOD(void, boot_notification_req, (const BootReasonEnum&, bool), (override));
+    MOCK_METHOD(void, stop_bootnotification_timer, (), (override));
+    MOCK_METHOD(void, on_variable_changed, (const SetVariableData&), (override));
+    MOCK_METHOD(std::vector<GetVariableResult>, get_variables, (const std::vector<GetVariableData>&), (override));
+    MOCK_METHOD((std::map<SetVariableData, SetVariableResult>), set_variables,
+                (const std::vector<SetVariableData>&, const std::string&), (override));
+};
+} // namespace
+
+class RemoteTransactionControlTest : public ::testing::Test {
+protected: // Members
+    DeviceModelTestHelper device_model_test_helper;
+    NiceMock<MockMessageDispatcher> mock_dispatcher;
+    DeviceModel* device_model;
+    NiceMock<ocpp::ConnectivityManagerMock> connectivity_manager;
+    NiceMock<DatabaseHandlerMock> database_handler_mock;
+    ocpp::EvseSecurityMock evse_security;
+    EvseManagerFake evse_manager;
+    std::shared_ptr<NiceMock<ComponentStateManagerMock>> component_state_manager;
+    std::atomic<ocpp::OcppProtocolVersion> ocpp_version;
+    FunctionalBlockContext functional_block_context;
+
+    NiceMock<TransactionBlockMock> transaction;
+    NiceMock<SmartChargingMock> smart_charging;
+    NiceMock<MeterValuesMock> meter_values;
+    NiceMock<AvailabilityMock> availability;
+    NiceMock<FirmwareUpdateMock> firmware_update;
+    NiceMock<SecurityMock> security;
+    NiceMock<ProvisioningMock> provisioning;
+
+    MockFunction<UnlockConnectorResponse(const std::int32_t evse_id, const std::int32_t connector_id)>
+        unlock_connector_callback;
+    MockFunction<RequestStartStopStatusEnum(const RequestStartTransactionRequest& request,
+                                            const bool authorize_remote_start)>
+        remote_start_transaction_callback;
+    MockFunction<RequestStartStopStatusEnum(const std::int32_t evse_id, const ReasonEnum& stop_reason)>
+        stop_transaction_callback;
+
+    std::atomic<RegistrationStatusEnum> registration_status;
+    std::atomic<UploadLogStatusEnum> upload_log_status;
+    std::atomic<std::int32_t> upload_log_status_id;
+
+    // One connector per evse, owned here because EvseMock::get_connector returns a raw pointer.
+    Connector connector_evse_1;
+    Connector connector_evse_2;
+
+    std::unique_ptr<RemoteTransactionControl> remote_transaction_control;
+
+protected: // Functions
+    RemoteTransactionControlTest() :
+        device_model_test_helper(),
+        mock_dispatcher(),
+        device_model(device_model_test_helper.get_device_model()),
+        connectivity_manager(),
+        database_handler_mock(),
+        evse_security(),
+        evse_manager(2),
+        component_state_manager(std::make_shared<NiceMock<ComponentStateManagerMock>>()),
+        ocpp_version(ocpp::OcppProtocolVersion::v201),
+        functional_block_context{
+            this->mock_dispatcher,       *this->device_model, this->connectivity_manager,     this->evse_manager,
+            this->database_handler_mock, this->evse_security, *this->component_state_manager, this->ocpp_version},
+        registration_status(RegistrationStatusEnum::Accepted),
+        upload_log_status(UploadLogStatusEnum::Idle),
+        upload_log_status_id(0),
+        connector_evse_1(1, 1, component_state_manager),
+        connector_evse_2(2, 1, component_state_manager),
+        remote_transaction_control(std::make_unique<RemoteTransactionControl>(
+            functional_block_context, transaction, smart_charging, meter_values, availability, firmware_update,
+            security, nullptr, provisioning, unlock_connector_callback.AsStdFunction(),
+            remote_start_transaction_callback.AsStdFunction(), stop_transaction_callback.AsStdFunction(),
+            registration_status, upload_log_status, upload_log_status_id)) {
+        set_evse_connector_status(1, ConnectorStatusEnum::Available);
+        set_evse_connector_status(2, ConnectorStatusEnum::Available);
+    }
+
+    void set_evse_connector_status(const std::int32_t evse_id, const ConnectorStatusEnum status) {
+        auto& evse_mock = evse_manager.get_mock(evse_id);
+        ON_CALL(evse_mock, get_number_of_connectors()).WillByDefault(Return(1));
+        ON_CALL(evse_mock, get_connector(1))
+            .WillByDefault(Return(evse_id == 1 ? &this->connector_evse_1 : &this->connector_evse_2));
+        ON_CALL(*component_state_manager, get_connector_effective_status(evse_id, 1)).WillByDefault(Return(status));
+    }
+
+    void set_evse_occupied(const std::int32_t evse_id) {
+        ON_CALL(evse_manager.get_mock(evse_id), has_active_transaction()).WillByDefault(Return(true));
+    }
+
+    void set_smart_charging_enabled(const bool enabled) {
+        const auto& cv = ControllerComponentVariables::SmartChargingCtrlrEnabled;
+        this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual,
+                                      enabled ? "true" : "false", "test", true);
+    }
+
+    ocpp::EnhancedMessage<MessageType>
+    create_remote_start_request(const std::optional<std::int32_t> evse_id,
+                                const std::optional<ChargingProfile>& charging_profile = std::nullopt) {
+        RequestStartTransactionRequest request;
+        request.evseId = evse_id;
+        request.remoteStartId = 123;
+        request.idToken.idToken = "REMOTE_TOKEN";
+        request.idToken.type = IdTokenEnumStringType::Central;
+        request.chargingProfile = charging_profile;
+
+        ocpp::Call<RequestStartTransactionRequest> call(request);
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.messageType = MessageType::RequestStartTransaction;
+        enhanced_message.message = call;
+        return enhanced_message;
+    }
+
+    ChargingProfile create_tx_profile() {
+        ChargingSchedulePeriod period;
+        period.startPeriod = 0;
+        period.limit = 16.0f;
+
+        ChargingSchedule schedule;
+        schedule.id = 1;
+        schedule.chargingRateUnit = ChargingRateUnitEnum::A;
+        schedule.chargingSchedulePeriod = {period};
+
+        ChargingProfile profile;
+        profile.id = 1;
+        profile.stackLevel = 1;
+        profile.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+        profile.chargingProfileKind = ChargingProfileKindEnum::Relative;
+        profile.chargingSchedule = {schedule};
+        return profile;
+    }
+
+    void expect_response_status(const RequestStartStopStatusEnum status) {
+        EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([status](const json& call_result) {
+            const auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<RequestStartTransactionResponse>();
+            EXPECT_EQ(response.status, status);
+        }));
+    }
+};
+
+TEST_F(RemoteTransactionControlTest, RemoteStartWithoutEvseIdAcceptedWhenEvseAvailable) {
+    // Evse 1 is occupied, evse 2 is free: the request must be accepted and the remote start id must
+    // be registered for evse id 0, meaning 'all evse ids'.
+    set_evse_occupied(1);
+
+    EXPECT_CALL(transaction, set_remote_start_id_for_evse(0, _, 123));
+    EXPECT_CALL(remote_start_transaction_callback, Call(_, _))
+        .WillOnce(Invoke([](const RequestStartTransactionRequest& request, bool /*authorize_remote_start*/) {
+            EXPECT_FALSE(request.evseId.has_value());
+            EXPECT_EQ(request.idToken.idToken.get(), "REMOTE_TOKEN");
+            return RequestStartStopStatusEnum::Accepted;
+        }));
+    expect_response_status(RequestStartStopStatusEnum::Accepted);
+
+    remote_transaction_control->handle_message(create_remote_start_request(std::nullopt));
+}
+
+TEST_F(RemoteTransactionControlTest, RemoteStartWithoutEvseIdRejectedWhenAllEvsesOccupied) {
+    set_evse_occupied(1);
+    set_evse_occupied(2);
+
+    EXPECT_CALL(transaction, set_remote_start_id_for_evse(_, _, _)).Times(0);
+    EXPECT_CALL(remote_start_transaction_callback, Call(_, _)).Times(0);
+    expect_response_status(RequestStartStopStatusEnum::Rejected);
+
+    remote_transaction_control->handle_message(create_remote_start_request(std::nullopt));
+}
+
+TEST_F(RemoteTransactionControlTest, RemoteStartWithoutEvseIdRejectedWhenAllConnectorsUnavailable) {
+    set_evse_connector_status(1, ConnectorStatusEnum::Unavailable);
+    set_evse_connector_status(2, ConnectorStatusEnum::Faulted);
+
+    EXPECT_CALL(transaction, set_remote_start_id_for_evse(_, _, _)).Times(0);
+    EXPECT_CALL(remote_start_transaction_callback, Call(_, _)).Times(0);
+    expect_response_status(RequestStartStopStatusEnum::Rejected);
+
+    remote_transaction_control->handle_message(create_remote_start_request(std::nullopt));
+}
+
+TEST_F(RemoteTransactionControlTest, RemoteStartWithoutEvseIdRejectedWithProfileWhenSmartChargingEnabled) {
+    // A charging profile can not be validated and applied without knowing the evse.
+    set_smart_charging_enabled(true);
+
+    EXPECT_CALL(transaction, set_remote_start_id_for_evse(_, _, _)).Times(0);
+    EXPECT_CALL(remote_start_transaction_callback, Call(_, _)).Times(0);
+    expect_response_status(RequestStartStopStatusEnum::Rejected);
+
+    remote_transaction_control->handle_message(create_remote_start_request(std::nullopt, create_tx_profile()));
+}
+
+TEST_F(RemoteTransactionControlTest, RemoteStartWithoutEvseIdAcceptedWithProfileWhenSmartChargingDisabled) {
+    // With smart charging disabled the profile is ignored, like in the branch with an evse id.
+    set_smart_charging_enabled(false);
+
+    EXPECT_CALL(transaction, set_remote_start_id_for_evse(0, _, 123));
+    EXPECT_CALL(remote_start_transaction_callback, Call(_, _)).WillOnce(Return(RequestStartStopStatusEnum::Accepted));
+    expect_response_status(RequestStartStopStatusEnum::Accepted);
+
+    remote_transaction_control->handle_message(create_remote_start_request(std::nullopt, create_tx_profile()));
+}
+
+TEST_F(RemoteTransactionControlTest, RemoteStartWithEvseIdAcceptedForSpecificEvse) {
+    // Regression test for the existing path: with an evse id, the remote start id is registered for
+    // that specific evse.
+    EXPECT_CALL(transaction, set_remote_start_id_for_evse(2, _, 123));
+    EXPECT_CALL(remote_start_transaction_callback, Call(_, _))
+        .WillOnce(Invoke([](const RequestStartTransactionRequest& request, bool /*authorize_remote_start*/) {
+            EXPECT_EQ(request.evseId, 2);
+            return RequestStartStopStatusEnum::Accepted;
+        }));
+    expect_response_status(RequestStartStopStatusEnum::Accepted);
+
+    remote_transaction_control->handle_message(create_remote_start_request(2));
+}

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/mocks/smart_charging_mock.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/mocks/smart_charging_mock.hpp
@@ -20,5 +20,10 @@ public:
                  AddChargingProfileSource source_of_request));
     MOCK_METHOD(ProfileValidationResultEnum, conform_and_validate_profile,
                 (ChargingProfile & profile, std::int32_t evse_id, AddChargingProfileSource source_of_request));
+    MOCK_METHOD(EnhancedCompositeScheduleResponse, get_composite_schedule,
+                (const GetCompositeScheduleRequest& request));
+    MOCK_METHOD(std::optional<EnhancedCompositeSchedule>, get_composite_schedule,
+                (std::int32_t evse_id, std::chrono::seconds duration, ChargingRateUnitEnum unit));
+    MOCK_METHOD(void, notify_ev_charging_needs_req, (const NotifyEVChargingNeedsRequest& req));
 };
 } // namespace ocpp::v2

--- a/tests/ocpp_tests/test_sets/ocpp201/remote_control.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/remote_control.py
@@ -125,9 +125,9 @@ async def test_F01_F02_F03(
         validate_status_notification_201,
     )
 
-    # send RequestStartTransaction while EVSE in unavailable and expect rejected
+    # send RequestStartTransaction targeting the unavailable EVSE and expect rejected (F01.FR.23)
     await charge_point_v201.request_start_transaction_req(
-        id_token=id_token, remote_start_id=remote_start_id
+        id_token=id_token, remote_start_id=remote_start_id, evse_id=evse_id
     )
     assert await wait_for_and_validate(
         test_utility,
@@ -157,22 +157,11 @@ async def test_F01_F02_F03(
 
     await asyncio.sleep(2)
 
-    # send RequestStartTransaction without evse_id and expect Rejected
+    # send RequestStartTransaction without evse_id and expect Accepted: with no evse_id given the
+    # request is accepted as long as at least one EVSE can start a transaction (F01.FR.07). The
+    # transaction is then started on the first available EVSE once the vehicle is plugged in.
     await charge_point_v201.request_start_transaction_req(
         id_token=id_token, remote_start_id=remote_start_id
-    )
-    assert await wait_for_and_validate(
-        test_utility,
-        charge_point_v201,
-        "RequestStartTransaction",
-        call_result201.RequestStartTransaction(
-            status=RequestStartStopStatusEnumType.rejected
-        ),
-    )
-
-    # send RequestStartTransaction and expect Accepted
-    await charge_point_v201.request_start_transaction_req(
-        id_token=id_token, remote_start_id=remote_start_id, evse_id=evse_id
     )
     assert await wait_for_and_validate(
         test_utility,


### PR DESCRIPTION
## Describe your changes

Adds support for the `RequestStartTransaction` without an evse-id. In this case we leave the connector list empty and leave the decision which connector to pick to the auth manager
