### PR TITLE
Update get-started-sw.rst

### DIFF
--- a/docs/source/how-to-guides/getting-started/get-started-sw.rst
+++ b/docs/source/how-to-guides/getting-started/get-started-sw.rst
@@ -164,8 +164,7 @@ It is used for the communication between the EVerest modules:
 
 .. code-block:: bash
 
-  docker run -d --name mqtt-server --network infranet_network -p 1883:1883 -p 9001:9001 ghcr.io/everest/containers/mosquitto:docker-images-v0.1.0
-
+  docker run -d --name mqtt-server --network infranet_network -p 1883:1883 -p 9001:9001 ghcr.io/everest/everest-demo/mqtt-server:latest
 
 That makes us ready for entering the simulation phase described in the next
 chapter.


### PR DESCRIPTION
Unable to install mosquitto docker image as described.

The following command , gives an error.
```$ docker run -d --name mqtt-server --network infranet_network -p 1883:1883 -p 9001:9001 \
ghcr.io/everest/containers/mosquitto:docker-images-v0.1.0
Unable to find image 'ghcr.io/everest/containers/mosquitto:docker-images-v0.1.0' locally
docker: Error response from daemon: error from registry: denied
denied
```
The fix is to use the docker image from:
```
ghcr.io/everest/everest-demo/mqtt-server:latest
```

(This was the suggestion from ChatGPT.