### PR TITLE
feat(EvseV2G): Adding telemetry

### DIFF
--- a/docs/source/reference/EVerest_API/telemetry.yaml
+++ b/docs/source/reference/EVerest_API/telemetry.yaml
@@ -1,0 +1,762 @@
+---
+asyncapi: 3.0.0
+id: 'pionix:de:everest:telemetry'
+info:
+  title: 'EVerest telemetry'
+  version: 1.0.0
+  description: >-
+    Typed telemetry payloads and topics emitted by the EVerest framework and EVSE modules.
+
+  license:
+    name: Apache-2.0
+    url: https://opensource.org/licenses/Apache-2.0
+  tags:
+    - name: EVerest
+    - name: telemetry
+servers:
+  default:
+    pathname: 'everest-telemetry'
+    host: 'localhost:1883'
+    description: default local MQTT
+    protocol: mqtt
+defaultContentType: application/json
+
+
+channels:
+  receive_cert_status:
+    address: 'Cert/{telemetry_id}/status'
+    parameters:
+      telemetry_id:
+        description: Telemetry id used by the framework as numeric identifier.
+    messages:
+      receive_cert_status:
+        $ref: '#/components/messages/receive_cert_status'
+  receive_evse_control:
+    address: 'Evse/{telemetry_id}/control'
+    parameters:
+      telemetry_id:
+        description: Telemetry id used by the framework as numeric identifier.
+    messages:
+      receive_evse_control:
+        $ref: '#/components/messages/receive_evse_control'
+  receive_v2g_transport:
+    address: 'V2G/{telemetry_id}/transport'
+    parameters:
+      telemetry_id:
+        description: Telemetry id used by the framework as numeric identifier.
+    messages:
+      receive_v2g_transport:
+        $ref: '#/components/messages/receive_v2g_transport'
+  receive_v2g_ev_electrical:
+    address: 'V2G/{telemetry_id}/ev_electrical'
+    parameters:
+      telemetry_id:
+        description: Telemetry id used by the framework as numeric identifier.
+    messages:
+      receive_v2g_ev_electrical:
+        $ref: '#/components/messages/receive_v2g_ev_electrical'
+  receive_v2g_payment_service:
+    address: 'V2G/{telemetry_id}/payment_service'
+    parameters:
+      telemetry_id:
+        description: Telemetry id used by the framework as numeric identifier.
+    messages:
+      receive_v2g_payment_service:
+        $ref: '#/components/messages/receive_v2g_payment_service'
+  receive_v2g_charger_status:
+    address: 'V2G/{telemetry_id}/charger_status'
+    parameters:
+      telemetry_id:
+        description: Telemetry id used by the framework as numeric identifier.
+    messages:
+      receive_v2g_charger_status:
+        $ref: '#/components/messages/receive_v2g_charger_status'
+
+
+operations:
+  receive_cert_status:
+    title: 'Receive cert status telemetry'
+    summary: 'Direction: EVerest to telemetry consumer'
+    action: receive
+    description: >-
+      The topic payload contains the framework fields `timestamp`, `connector_id`, and `type`
+      plus the `CertTelemetry` struct for the `status` subcategory.
+    channel:
+      $ref: '#/channels/receive_cert_status'
+  receive_evse_control:
+    title: 'Receive EVSE control telemetry'
+    summary: 'Direction: EVerest to telemetry consumer'
+    action: receive
+    description: >-
+      The topic payload contains the framework fields `timestamp`, `connector_id`, and `type`
+      plus the `EvseControlStatus` struct for the `control` subcategory.
+    channel:
+      $ref: '#/channels/receive_evse_control'
+  receive_v2g_transport:
+    title: 'Receive V2G transport telemetry'
+    summary: 'Direction: EVerest to telemetry consumer'
+    action: receive
+    description: >-
+      The topic payload contains the framework fields `timestamp`, `connector_id`, and `type`
+      plus the `V2gTransport` struct for the `transport` subcategory.
+    channel:
+      $ref: '#/channels/receive_v2g_transport'
+  receive_v2g_ev_electrical:
+    title: 'Receive V2G EV electrical telemetry'
+    summary: 'Direction: EVerest to telemetry consumer'
+    action: receive
+    description: >-
+      The topic payload contains the framework fields `timestamp`, `connector_id`, and `type`
+      plus the `V2gEvElectrical` struct for the `ev_electrical` subcategory.
+    channel:
+      $ref: '#/channels/receive_v2g_ev_electrical'
+  receive_v2g_payment_service:
+    title: 'Receive V2G payment service telemetry'
+    summary: 'Direction: EVerest to telemetry consumer'
+    action: receive
+    description: >-
+      The topic payload contains the framework fields `timestamp`, `connector_id`, and `type`
+      plus the `V2gPaymentService` struct for the `payment_service` subcategory.
+    channel:
+      $ref: '#/channels/receive_v2g_payment_service'
+  receive_v2g_charger_status:
+    title: 'Receive V2G charger status telemetry'
+    summary: 'Direction: EVerest to telemetry consumer'
+    action: receive
+    description: >-
+      The topic payload contains the framework fields `timestamp`, `connector_id`, and `type`
+      plus the `V2gChargerStatus` struct for the `charger_status` subcategory.
+    channel:
+      $ref: '#/channels/receive_v2g_charger_status'
+
+
+components:
+  messages:
+    receive_cert_status:
+      name: cert_status
+      title: 'Cert status telemetry'
+      summary: Certificate chain telemetry.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/TelemetryCertStatus'
+    receive_evse_control:
+      name: evse_control
+      title: 'EVSE control telemetry'
+      summary: EVSE control-state telemetry.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/TelemetryEvseControl'
+    receive_v2g_transport:
+      name: v2g_transport
+      title: 'V2G transport telemetry'
+      summary: V2G transport telemetry.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/TelemetryV2gTransport'
+    receive_v2g_ev_electrical:
+      name: v2g_ev_electrical
+      title: 'V2G EV electrical telemetry'
+      summary: EV electrical telemetry.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/TelemetryV2gEvElectrical'
+    receive_v2g_payment_service:
+      name: v2g_payment_service
+      title: 'V2G payment service telemetry'
+      summary: V2G payment service telemetry.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/TelemetryV2gPaymentService'
+    receive_v2g_charger_status:
+      name: v2g_charger_status
+      title: 'V2G charger status telemetry'
+      summary: V2G charger status telemetry.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/TelemetryV2gChargerStatus'
+
+  schemas:
+    TelemetryEnvelope:
+      description: Common fields injected by the framework for all telemetry publications.
+      type: object
+      additionalProperties: true
+      required:
+        - timestamp
+        - connector_id
+        - type
+      properties:
+        timestamp:
+          description: UTC timestamp added by telemetry_publish.
+          type: string
+          format: date-time
+        connector_id:
+          description: Numeric telemetry id injected by telemetry_publish under the connector_id key.
+          type: integer
+        type:
+          description: Telemetry subtype used in the topic publish call.
+          type: string
+
+    TelemetryCertStatus:
+      description: Cert status payload (`Cert/{telemetry_id}/status`) with framework fields.
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: '#/components/schemas/TelemetryEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - status
+        - $ref: '#/components/schemas/CertTelemetry'
+
+    TelemetryEvseControl:
+      description: EVSE control payload (`Evse/{telemetry_id}/control`) with framework fields.
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: '#/components/schemas/TelemetryEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - control
+        - $ref: '#/components/schemas/EvseControlStatus'
+
+    TelemetryV2gTransport:
+      description: V2G transport payload (`V2G/{telemetry_id}/transport`) with framework fields.
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: '#/components/schemas/TelemetryEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - transport
+        - $ref: '#/components/schemas/V2gTransport'
+
+    TelemetryV2gEvElectrical:
+      description: V2G EV electrical payload (`V2G/{telemetry_id}/ev_electrical`) with framework fields.
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: '#/components/schemas/TelemetryEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - ev_electrical
+        - $ref: '#/components/schemas/V2gEvElectrical'
+
+    TelemetryV2gPaymentService:
+      description: V2G payment-service payload (`V2G/{telemetry_id}/payment_service`) with framework fields.
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: '#/components/schemas/TelemetryEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - payment_service
+        - $ref: '#/components/schemas/V2gPaymentService'
+
+    TelemetryV2gChargerStatus:
+      description: V2G charger-status payload (`V2G/{telemetry_id}/charger_status`) with framework fields.
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: '#/components/schemas/TelemetryEnvelope'
+        - type: object
+          properties:
+            type:
+              type: string
+              enum:
+                - charger_status
+        - $ref: '#/components/schemas/V2gChargerStatus'
+
+    CertChainState:
+      description: Cert chain status counters and flags.
+      type: object
+      additionalProperties: true
+      required:
+        - configured
+        - synced
+        - num_files
+        - num_useful_files
+      properties:
+        configured:
+          description: Certificate chain has been configured.
+          type: boolean
+        synced:
+          description: Certificate chain is synced.
+          type: boolean
+        num_files:
+          description: Number of certificate files.
+          type: integer
+        num_useful_files:
+          description: Number of useful certificate files.
+          type: integer
+
+    CertTelemetry:
+      description: Certificate status for SECC and MO root chains.
+      type: object
+      additionalProperties: true
+      required:
+        - config_complete
+        - sync_complete
+        - secc_chain
+        - mo_root
+      properties:
+        config_complete:
+          description: Whether all required certificate groups are configured.
+          type: boolean
+        sync_complete:
+          description: Whether all required certificate groups are synced.
+          type: boolean
+        secc_chain:
+          description: V2G certificate chain state.
+          $ref: '#/components/schemas/CertChainState'
+        mo_root:
+          description: MO root certificate chain state.
+          $ref: '#/components/schemas/CertChainState'
+
+    EvseControlStatus:
+      description: EVSE control state flags.
+      type: object
+      additionalProperties: true
+      required:
+        - authorisation_finished
+        - emergency_stop
+        - error_stop
+        - normal_stop
+        - contract_payment_enabled
+        - free_charging_enabled
+      properties:
+        authorisation_finished:
+          description: Authorization is finished.
+          type: boolean
+        emergency_stop:
+          description: Emergency stop active.
+          type: boolean
+        error_stop:
+          description: Error stop active.
+          type: boolean
+        normal_stop:
+          description: Normal stop active.
+          type: boolean
+        contract_payment_enabled:
+          description: Contract payment enabled.
+          type: boolean
+        free_charging_enabled:
+          description: Free charging enabled.
+          type: boolean
+
+    V2gDin70121CommunicationState:
+      description: DIN 70121 transport communication state.
+      type: string
+      enum:
+        - WaitForSessionSetup
+        - WaitForServiceDiscovery
+        - WaitForPaymentServiceSelection
+        - WaitForAuthorization
+        - WaitForChargeParameterDiscovery
+        - WaitForCableCheck
+        - WaitForPreCharge
+        - WaitForPreChargePowerDelivery
+        - WaitForCurrentDemand
+        - WaitForCurrentDemandPowerDelivery
+        - WaitForWeldingDetectionSessionStop
+        - WaitForSessionStop
+        - WaitForTerminatedSession
+
+    V2gIso15118AcCommunicationState:
+      description: ISO 15118-2 AC transport communication state.
+      type: string
+      enum:
+        - WaitForSessionSetup
+        - WaitForServiceDiscovery
+        - WaitForServiceDetailPaymentServiceSelection
+        - WaitForPaymentDetailsCertificateInstallCertificateUpdate
+        - WaitForPaymentDetails
+        - WaitForAuthorization
+        - WaitForChargeParameterDiscovery
+        - WaitForPowerDelivery
+        - WaitForChargingStatus
+        - WaitForChargingStatusPowerDelivery
+        - WaitForMeteringReceipt
+        - WaitForSessionStop
+        - WaitForTerminatedSession
+
+    V2gIso15118DcCommunicationState:
+      description: ISO 15118-2 DC communication state.
+      type: string
+      enum:
+        - WaitForSessionSetup
+        - WaitForServiceDiscovery
+        - WaitForServiceDetailPaymentServiceSelection
+        - WaitForPaymentDetailsCertificateInstallCertificateUpdate
+        - WaitForPaymentDetails
+        - WaitForAuthorization
+        - WaitForChargeParameterDiscovery
+        - WaitForCableCheck
+        - WaitForPreCharge
+        - WaitForPreChargePowerDelivery
+        - WaitForCurrentDemandPowerDelivery
+        - WaitForCurrentDemand
+        - WaitForMeteringReceipt
+        - WaitForWeldingDetectionSessionStop
+        - WaitForTerminatedSession
+
+    V2gCommunicationState:
+      description: Communication state container. Optional fields are omitted when unset.
+      type: object
+      additionalProperties: true
+      properties:
+        din70121:
+          description: DIN 70121 communication state.
+          $ref: '#/components/schemas/V2gDin70121CommunicationState'
+        iso15118_ac:
+          description: ISO 15118-2 AC communication state.
+          $ref: '#/components/schemas/V2gIso15118AcCommunicationState'
+        iso15118_dc:
+          description: ISO 15118-2 DC communication state.
+          $ref: '#/components/schemas/V2gIso15118DcCommunicationState'
+
+    V2gMessageState:
+      description: ISO 15118 protocol message state.
+      type: string
+      enum:
+        - SupportedAppProtocol
+        - SessionSetup
+        - ServiceDiscovery
+        - ServiceDetail
+        - PaymentServiceSelection
+        - PaymentDetails
+        - Authorization
+        - ChargeParameterDiscovery
+        - MeteringReceipt
+        - CertificateUpdate
+        - CertificateInstallation
+        - ChargingStatus
+        - CableCheck
+        - PreCharge
+        - PowerDelivery
+        - CurrentDemand
+        - WeldingDetection
+        - SessionStop
+        - Unknown
+
+    V2gServerStatus:
+      description: Transport server status.
+      type: string
+      enum:
+        - Inactive
+        - Active
+
+    V2gTransport:
+      description: V2G transport state.
+      type: object
+      additionalProperties: true
+      required:
+        - comm_state
+        - message_state
+        - udp_server_status
+        - tcp_listener_status
+        - tcp_server_status
+        - tcp_connection_established
+        - tcp_discovery_enable
+        - tcp_security_enable
+        - tcp_security_required
+        - tcp_port_number
+        - session_setup_requested
+        - authorization_requested
+        - charge_parameter_discovery_requested
+        - cable_check_requested
+        - pre_charge_requested
+        - current_demand_requested
+        - welding_detection_requested
+      properties:
+        comm_state:
+          description: Communication state object.
+          $ref: '#/components/schemas/V2gCommunicationState'
+        message_state:
+          description: Current message state.
+          $ref: '#/components/schemas/V2gMessageState'
+        udp_server_status:
+          description: UDP server status.
+          $ref: '#/components/schemas/V2gServerStatus'
+        tcp_listener_status:
+          description: TCP listener status.
+          $ref: '#/components/schemas/V2gServerStatus'
+        tcp_server_status:
+          description: TCP server status.
+          $ref: '#/components/schemas/V2gServerStatus'
+        tcp_connection_established:
+          description: TCP connection established.
+          type: boolean
+        tcp_discovery_enable:
+          description: TCP discovery enabled.
+          type: boolean
+        tcp_security_enable:
+          description: TCP security enabled.
+          type: boolean
+        tcp_security_required:
+          description: TCP security required.
+          type: boolean
+        tcp_port_number:
+          description: TCP port number.
+          type: integer
+        session_setup_requested:
+          description: Session setup requested.
+          type: boolean
+        authorization_requested:
+          description: Authorization requested.
+          type: boolean
+        charge_parameter_discovery_requested:
+          description: Charge parameter discovery requested.
+          type: boolean
+        cable_check_requested:
+          description: Cable check requested.
+          type: boolean
+        pre_charge_requested:
+          description: Pre-charge requested.
+          type: boolean
+        current_demand_requested:
+          description: Current demand requested.
+          type: boolean
+        welding_detection_requested:
+          description: Welding detection requested.
+          type: boolean
+
+    ChargeProgress:
+      description: EV charge progress state.
+      type: string
+      enum:
+        - Start
+        - Stop
+        - Renegotiate
+        - Pause
+        - Terminate
+
+    V2gEvElectrical:
+      description: EV electrical telemetry.
+      type: object
+      additionalProperties: true
+      required:
+        - charge_progress
+        - battery_soc_percent
+        - error_code
+        - maximum_current_A
+        - maximum_power_W
+        - maximum_voltage_V
+        - maximum_rated_current_A
+        - maximum_rated_power_W
+        - maximum_rated_voltage_V
+        - target_current_A
+        - target_voltage_V
+        - remaining_time_bulk_min
+        - remaining_time_full_min
+        - energy_request_Wh
+        - energy_capacity_Wh
+      properties:
+        charge_progress:
+          description: Current EV charge progress.
+          $ref: '#/components/schemas/ChargeProgress'
+        battery_soc_percent:
+          description: Battery state of charge.
+          type: integer
+        error_code:
+          description: EV error code.
+          $ref: '#/components/schemas/V2gEvErrorCode'
+        maximum_current_A:
+          description: Maximum allowed current in A.
+          type: number
+        maximum_power_W:
+          description: Maximum allowed power in W.
+          type: number
+        maximum_voltage_V:
+          description: Maximum allowed voltage in V.
+          type: number
+        maximum_rated_current_A:
+          description: Maximum rated current in A.
+          type: number
+        maximum_rated_power_W:
+          description: Maximum rated power in W.
+          type: number
+        maximum_rated_voltage_V:
+          description: Maximum rated voltage in V.
+          type: number
+        target_current_A:
+          description: Target current in A.
+          type: number
+        target_voltage_V:
+          description: Target voltage in V.
+          type: number
+        remaining_time_bulk_min:
+          description: Estimated bulk charge time in minutes.
+          type: integer
+        remaining_time_full_min:
+          description: Estimated full charge time in minutes.
+          type: integer
+        energy_request_Wh:
+          description: Requested energy in Wh.
+          type: number
+        energy_capacity_Wh:
+          description: Battery energy capacity in Wh.
+          type: number
+
+    V2gPaymentService:
+      description: V2G payment-service telemetry flags.
+      type: object
+      additionalProperties: true
+      required:
+        - certificate_install_requested
+        - certificate_update_requested
+        - charging_service_requested
+        - external_payment_requested
+        - contract_payment_requested
+        - contract_payment_approved
+        - contract_payment_error
+        - internet_ftp20_requested
+        - internet_ftp21_requested
+        - internet_http80_requested
+        - internet_https443_requested
+      properties:
+        certificate_install_requested:
+          description: Certificate install requested.
+          type: boolean
+        certificate_update_requested:
+          description: Certificate update requested.
+          type: boolean
+        charging_service_requested:
+          description: Charging service requested.
+          type: boolean
+        external_payment_requested:
+          description: External payment requested.
+          type: boolean
+        contract_payment_requested:
+          description: Contract payment requested.
+          type: boolean
+        contract_payment_approved:
+          description: Contract payment approved.
+          type: boolean
+        contract_payment_error:
+          description: Contract payment error.
+          type: boolean
+        internet_ftp20_requested:
+          description: FTP20 internet request raised.
+          type: boolean
+        internet_ftp21_requested:
+          description: FTP21 internet request raised.
+          type: boolean
+        internet_http80_requested:
+          description: HTTP 80 internet request raised.
+          type: boolean
+        internet_https443_requested:
+          description: HTTPS 443 internet request raised.
+          type: boolean
+
+    V2gChargerStatus:
+      description: V2G charger status telemetry.
+      type: object
+      additionalProperties: true
+      required:
+        - evcc_id
+        - selected_protocol
+        - cable_check_status
+        - param_discovery_finished
+        - isolation_status
+        - dynamic_max_current_A
+        - dynamic_max_power_W
+        - dynamic_max_voltage_V
+      properties:
+        evcc_id:
+          description: EVCC ID.
+          type: string
+        selected_protocol:
+          description: Selected protocol identifier.
+          type: string
+        cable_check_status:
+          description: Cable check status.
+          type: boolean
+        param_discovery_finished:
+          description: Parameter discovery complete.
+          type: boolean
+        isolation_status:
+          description: Isolation status string as reported by module.
+          type: string
+        dynamic_max_current_A:
+          description: Dynamic maximum current in A.
+          type: number
+        dynamic_max_power_W:
+          description: Dynamic maximum power in W.
+          type: number
+        dynamic_max_voltage_V:
+          description: Dynamic maximum voltage in V.
+          type: number
+
+    V2gEvErrorCode:
+      description: V2G error code for EV side.
+      type: string
+      enum:
+        - NO_ERROR
+        - FAILED_RESSTemperatureInhibit
+        - FAILED_EVShiftPosition
+        - FAILED_ChargerConnectorLockFault
+        - FAILED_EVRESSMalfunction
+        - FAILED_ChargingCurrentdifferential
+        - FAILED_ChargingVoltageOutOfRange
+        - Reserved_A
+        - Reserved_B
+        - Reserved_C
+        - FAILED_ChargingSystemIncompatibility
+        - NoData
+
+    V2gEvseElectrical:
+      description: EVSE-side electrical telemetry structure.
+      type: object
+      additionalProperties: true
+      required:
+        - present_current_A
+        - present_voltage_V
+        - maximum_rated_current_A
+        - maximum_rated_power_W
+        - maximum_rated_voltage_V
+        - minimum_rated_current_A
+        - minimum_rated_voltage_V
+        - current_ripple_A
+        - current_tolerance_A
+      properties:
+        present_current_A:
+          description: Present current in A.
+          type: number
+        present_voltage_V:
+          description: Present voltage in V.
+          type: number
+        maximum_rated_current_A:
+          description: Maximum rated current in A.
+          type: number
+        maximum_rated_power_W:
+          description: Maximum rated power in W.
+          type: number
+        maximum_rated_voltage_V:
+          description: Maximum rated voltage in V.
+          type: number
+        minimum_rated_current_A:
+          description: Minimum rated current in A.
+          type: number
+        minimum_rated_voltage_V:
+          description: Minimum rated voltage in V.
+          type: number
+        current_ripple_A:
+          description: Current ripple in A.
+          type: number
+        current_tolerance_A:
+          description: Current tolerance in A.
+          type: number

--- a/lib/everest/everest_api_types/BUILD.bazel
+++ b/lib/everest/everest_api_types/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "everest_api_types",
+    srcs = [
+        "src/everest_api_types/telemetry/codec.cpp",
+        "src/everest_api_types/telemetry/json_codec.cpp",
+    ],
+    hdrs = [
+        "include/everest_api_types/telemetry/API.hpp",
+        "include/everest_api_types/telemetry/codec.hpp",
+        "include/everest_api_types/utilities/constants.hpp",
+        "include/everest_api_types/utilities/deserialize_templates.inc",
+        "private_include/everest_api_types/telemetry/json_codec.hpp",
+        "private_include/everest_api_types/utilities/json_codec_helpers.hpp",
+    ],
+    includes = [
+        "include",
+        "private_include",
+    ],
+    copts = [
+        "-std=c++17",
+        "-Ilib/everest/everest_api_types/include/everest_api_types",
+        "-Ilib/everest/everest_api_types/private_include/everest_api_types",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_nlohmann_json//:json",
+    ],
+)

--- a/lib/everest/everest_api_types/CMakeLists.txt
+++ b/lib/everest/everest_api_types/CMakeLists.txt
@@ -117,6 +117,9 @@ target_sources(everest_api_types
   src/everest_api_types/uk_random_delay/json_codec.cpp
   src/everest_api_types/uk_random_delay/wrapper.cpp
 
+  src/everest_api_types/telemetry/codec.cpp
+  src/everest_api_types/telemetry/json_codec.cpp
+
   src/everest_api_types/generic/codec.cpp
   src/everest_api_types/generic/json_codec.cpp
   src/everest_api_types/generic/string.cpp
@@ -152,5 +155,3 @@ evc_setup_package(
 if(${BUILD_TESTING})
     add_subdirectory(tests)
 endif()
-
-

--- a/lib/everest/everest_api_types/include/everest_api_types/telemetry/API.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/telemetry/API.hpp
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace everest::lib::API::V1_0::types::telemetry {
+
+enum class ChargeProgress {
+    Start,
+    Stop,
+    Renegotiate,
+    Pause,
+    Terminate,
+};
+
+enum class V2gDin70121CommunicationState {
+    WaitForSessionSetup = 0,
+    WaitForServiceDiscovery = 1,
+    WaitForPaymentServiceSelection = 2,
+    WaitForAuthorization = 3,
+    WaitForChargeParameterDiscovery = 4,
+    WaitForCableCheck = 5,
+    WaitForPreCharge = 6,
+    WaitForPreChargePowerDelivery = 7,
+    WaitForCurrentDemand = 8,
+    WaitForCurrentDemandPowerDelivery = 9,
+    WaitForWeldingDetectionSessionStop = 10,
+    WaitForSessionStop = 11,
+    WaitForTerminatedSession = 12,
+};
+
+enum class V2gIso15118AcCommunicationState {
+    WaitForSessionSetup = 0,
+    WaitForServiceDiscovery = 1,
+    WaitForServiceDetailPaymentServiceSelection = 2,
+    WaitForPaymentDetailsCertificateInstallCertificateUpdate = 3,
+    WaitForPaymentDetails = 4,
+    WaitForAuthorization = 5,
+    WaitForChargeParameterDiscovery = 6,
+    WaitForPowerDelivery = 7,
+    WaitForChargingStatus = 8,
+    WaitForChargingStatusPowerDelivery = 9,
+    WaitForMeteringReceipt = 10,
+    WaitForSessionStop = 11,
+    WaitForTerminatedSession = 12,
+};
+
+enum class V2gIso15118DcCommunicationState {
+    WaitForSessionSetup = 0,
+    WaitForServiceDiscovery = 1,
+    WaitForServiceDetailPaymentServiceSelection = 2,
+    WaitForPaymentDetailsCertificateInstallCertificateUpdate = 3,
+    WaitForPaymentDetails = 4,
+    WaitForAuthorization = 5,
+    WaitForChargeParameterDiscovery = 6,
+    WaitForCableCheck = 7,
+    WaitForPreCharge = 8,
+    WaitForPreChargePowerDelivery = 9,
+    WaitForCurrentDemandPowerDelivery = 10,
+    WaitForCurrentDemand = 11,
+    WaitForMeteringReceipt = 12,
+    WaitForWeldingDetectionSessionStop = 13,
+    WaitForTerminatedSession = 14,
+};
+
+struct V2gCommunicationState {
+    std::optional<V2gDin70121CommunicationState> din70121;
+    std::optional<V2gIso15118AcCommunicationState> iso15118_ac;
+    std::optional<V2gIso15118DcCommunicationState> iso15118_dc;
+};
+
+inline bool operator==(V2gCommunicationState const& lhs, V2gCommunicationState const& rhs) {
+    return lhs.din70121 == rhs.din70121 && lhs.iso15118_ac == rhs.iso15118_ac && lhs.iso15118_dc == rhs.iso15118_dc;
+}
+
+inline bool operator!=(V2gCommunicationState const& lhs, V2gCommunicationState const& rhs) {
+    return !(lhs == rhs);
+}
+
+enum class V2gMessageState {
+    SupportedAppProtocol = 0,
+    SessionSetup = 1,
+    ServiceDiscovery = 2,
+    ServiceDetail = 3,
+    PaymentServiceSelection = 4,
+    PaymentDetails = 5,
+    Authorization = 6,
+    ChargeParameterDiscovery = 7,
+    MeteringReceipt = 8,
+    CertificateUpdate = 9,
+    CertificateInstallation = 10,
+    ChargingStatus = 11,
+    CableCheck = 12,
+    PreCharge = 13,
+    PowerDelivery = 14,
+    CurrentDemand = 15,
+    WeldingDetection = 16,
+    SessionStop = 17,
+    Unknown = 18,
+};
+
+enum class V2gServerStatus {
+    Inactive = 0,
+    Active = 1,
+};
+
+enum class V2gEvErrorCode {
+    NO_ERROR = 0,
+    FAILED_RESSTemperatureInhibit = 1,
+    FAILED_EVShiftPosition = 2,
+    FAILED_ChargerConnectorLockFault = 3,
+    FAILED_EVRESSMalfunction = 4,
+    FAILED_ChargingCurrentdifferential = 5,
+    FAILED_ChargingVoltageOutOfRange = 6,
+    Reserved_A = 7,
+    Reserved_B = 8,
+    Reserved_C = 9,
+    FAILED_ChargingSystemIncompatibility = 10,
+    NoData = 11,
+};
+
+struct CertChainState {
+    bool configured{false};
+    bool synced{false};
+    int32_t num_files{0};
+    int32_t num_useful_files{0};
+};
+
+struct CertTelemetry {
+    bool config_complete{false};
+    bool sync_complete{false};
+    CertChainState secc_chain;
+    CertChainState mo_root;
+};
+
+struct EvseControlStatus {
+    bool authorisation_finished{false};
+    bool emergency_stop{false};
+    bool error_stop{false};
+    bool normal_stop{false};
+    bool contract_payment_enabled{false};
+    bool free_charging_enabled{false};
+};
+
+struct V2gTransport {
+    V2gCommunicationState comm_state;
+    V2gMessageState message_state{V2gMessageState::SupportedAppProtocol};
+    V2gServerStatus udp_server_status{V2gServerStatus::Inactive};
+    V2gServerStatus tcp_listener_status{V2gServerStatus::Inactive};
+    V2gServerStatus tcp_server_status{V2gServerStatus::Inactive};
+    bool tcp_connection_established{false};
+    bool tcp_discovery_enable{false};
+    bool tcp_security_enable{false};
+    bool tcp_security_required{false};
+    int32_t tcp_port_number{0};
+    bool session_setup_requested{false};
+    bool authorization_requested{false};
+    bool charge_parameter_discovery_requested{false};
+    bool cable_check_requested{false};
+    bool pre_charge_requested{false};
+    bool current_demand_requested{false};
+    bool welding_detection_requested{false};
+};
+
+struct V2gEvElectrical {
+    ChargeProgress charge_progress{ChargeProgress::Start};
+    int32_t battery_soc_percent{0};
+    V2gEvErrorCode error_code{V2gEvErrorCode::NO_ERROR};
+    float maximum_current_A{0.};
+    float maximum_power_W{0.};
+    float maximum_voltage_V{0.};
+    float maximum_rated_current_A{0.};
+    float maximum_rated_power_W{0.};
+    float maximum_rated_voltage_V{0.};
+    float target_current_A{0.};
+    float target_voltage_V{0.};
+    int32_t remaining_time_bulk_min{0};
+    int32_t remaining_time_full_min{0};
+    float energy_request_Wh{0.};
+    float energy_capacity_Wh{0.};
+};
+
+struct V2gPaymentService {
+    bool certificate_install_requested{false};
+    bool certificate_update_requested{false};
+    bool charging_service_requested{false};
+    bool external_payment_requested{false};
+    bool contract_payment_requested{false};
+    bool contract_payment_approved{false};
+    bool contract_payment_error{false};
+    bool internet_ftp20_requested{false};
+    bool internet_ftp21_requested{false};
+    bool internet_http80_requested{false};
+    bool internet_https443_requested{false};
+};
+
+struct V2gChargerStatus {
+    std::string evcc_id;           // "XX:XX:XX:XX:XX:XX"
+    std::string selected_protocol; // "DIN70121" / "ISO15118-2-2010" / "ISO15118-2-2013"
+    bool cable_check_status{false};
+    bool param_discovery_finished{false};
+    std::string isolation_status;
+    float dynamic_max_current_A{0.};
+    float dynamic_max_power_W{0.};
+    float dynamic_max_voltage_V{0.};
+};
+
+struct V2gEvseElectrical {
+    float present_current_A{0.};
+    float present_voltage_V{0.};
+    float maximum_rated_current_A{0.};
+    float maximum_rated_power_W{0.};
+    float maximum_rated_voltage_V{0.};
+    float minimum_rated_current_A{0.};
+    float minimum_rated_voltage_V{0.};
+    float current_ripple_A{0.};
+    float current_tolerance_A{0.};
+};
+
+} // namespace everest::lib::API::V1_0::types::telemetry

--- a/lib/everest/everest_api_types/include/everest_api_types/telemetry/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/telemetry/codec.hpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include "API.hpp"
+#include <iosfwd>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace everest::lib::API::V1_0::types::telemetry {
+
+std::string serialize(ChargeProgress val) noexcept;
+std::string serialize(V2gDin70121CommunicationState val) noexcept;
+std::string serialize(V2gIso15118AcCommunicationState val) noexcept;
+std::string serialize(V2gIso15118DcCommunicationState val) noexcept;
+std::string serialize(V2gCommunicationState val) noexcept;
+std::string serialize(V2gMessageState val) noexcept;
+std::string serialize(V2gServerStatus val) noexcept;
+std::string serialize(V2gEvErrorCode val) noexcept;
+std::string serialize(CertChainState const& val) noexcept;
+std::string serialize(CertTelemetry const& val) noexcept;
+std::string serialize(EvseControlStatus const& val) noexcept;
+std::string serialize(V2gTransport const& val) noexcept;
+std::string serialize(V2gEvElectrical const& val) noexcept;
+std::string serialize(V2gPaymentService const& val) noexcept;
+std::string serialize(V2gChargerStatus const& val) noexcept;
+std::string serialize(V2gEvseElectrical const& val) noexcept;
+
+std::ostream& operator<<(std::ostream& os, ChargeProgress const& val);
+std::ostream& operator<<(std::ostream& os, V2gCommunicationState const& val);
+std::ostream& operator<<(std::ostream& os, V2gDin70121CommunicationState const& val);
+std::ostream& operator<<(std::ostream& os, V2gIso15118AcCommunicationState const& val);
+std::ostream& operator<<(std::ostream& os, V2gIso15118DcCommunicationState const& val);
+std::ostream& operator<<(std::ostream& os, V2gMessageState const& val);
+std::ostream& operator<<(std::ostream& os, V2gServerStatus const& val);
+std::ostream& operator<<(std::ostream& os, V2gEvErrorCode const& val);
+std::ostream& operator<<(std::ostream& os, CertChainState const& val);
+std::ostream& operator<<(std::ostream& os, CertTelemetry const& val);
+std::ostream& operator<<(std::ostream& os, EvseControlStatus const& val);
+std::ostream& operator<<(std::ostream& os, V2gTransport const& val);
+std::ostream& operator<<(std::ostream& os, V2gEvElectrical const& val);
+std::ostream& operator<<(std::ostream& os, V2gPaymentService const& val);
+std::ostream& operator<<(std::ostream& os, V2gChargerStatus const& val);
+std::ostream& operator<<(std::ostream& os, V2gEvseElectrical const& val);
+
+#include <everest_api_types/utilities/deserialize_templates.inc>
+
+} // namespace everest::lib::API::V1_0::types::telemetry

--- a/lib/everest/everest_api_types/private_include/everest_api_types/telemetry/json_codec.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/telemetry/json_codec.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include "nlohmann/json_fwd.hpp"
+#include <everest_api_types/telemetry/API.hpp>
+
+namespace everest::lib::API::V1_0::types::telemetry {
+
+using json = nlohmann::json;
+
+void to_json(json& j, ChargeProgress const& k) noexcept;
+void from_json(json const& j, ChargeProgress& k);
+
+void to_json(json& j, V2gDin70121CommunicationState const& k) noexcept;
+void from_json(json const& j, V2gDin70121CommunicationState& k);
+
+void to_json(json& j, V2gIso15118AcCommunicationState const& k) noexcept;
+void from_json(json const& j, V2gIso15118AcCommunicationState& k);
+
+void to_json(json& j, V2gIso15118DcCommunicationState const& k) noexcept;
+void from_json(json const& j, V2gIso15118DcCommunicationState& k);
+
+void to_json(json& j, V2gCommunicationState const& k) noexcept;
+void from_json(json const& j, V2gCommunicationState& k);
+
+void to_json(json& j, V2gMessageState const& k) noexcept;
+void from_json(json const& j, V2gMessageState& k);
+
+void to_json(json& j, V2gServerStatus const& k) noexcept;
+void from_json(json const& j, V2gServerStatus& k);
+
+void to_json(json& j, V2gEvErrorCode const& k) noexcept;
+void from_json(json const& j, V2gEvErrorCode& k);
+
+void to_json(json& j, CertChainState const& k) noexcept;
+void from_json(json const& j, CertChainState& k);
+
+void to_json(json& j, CertTelemetry const& k) noexcept;
+void from_json(json const& j, CertTelemetry& k);
+
+void to_json(json& j, EvseControlStatus const& k) noexcept;
+void from_json(json const& j, EvseControlStatus& k);
+
+void to_json(json& j, V2gTransport const& k) noexcept;
+void from_json(json const& j, V2gTransport& k);
+
+void to_json(json& j, V2gEvElectrical const& k) noexcept;
+void from_json(json const& j, V2gEvElectrical& k);
+
+void to_json(json& j, V2gPaymentService const& k) noexcept;
+void from_json(json const& j, V2gPaymentService& k);
+
+void to_json(json& j, V2gChargerStatus const& k) noexcept;
+void from_json(json const& j, V2gChargerStatus& k);
+
+void to_json(json& j, V2gEvseElectrical const& k) noexcept;
+void from_json(json const& j, V2gEvseElectrical& k);
+
+} // namespace everest::lib::API::V1_0::types::telemetry

--- a/lib/everest/everest_api_types/src/everest_api_types/telemetry/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/telemetry/codec.cpp
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "telemetry/codec.hpp"
+#include "telemetry/API.hpp"
+#include "telemetry/json_codec.hpp"
+#include "utilities/json_codec_helpers.hpp"
+#include <ostream>
+#include <string_view>
+
+namespace everest::lib::API::V1_0::types::telemetry {
+
+std::string serialize(ChargeProgress val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gDin70121CommunicationState val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gIso15118AcCommunicationState val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gIso15118DcCommunicationState val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gCommunicationState val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gMessageState val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gServerStatus val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gEvErrorCode val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(CertChainState const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(CertTelemetry const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(EvseControlStatus const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gTransport const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gEvElectrical const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gPaymentService const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gChargerStatus const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(V2gEvseElectrical const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+template <> ChargeProgress deserialize(std::string_view val) {
+    return utilities::parse_json<ChargeProgress>(val);
+}
+
+template <> V2gCommunicationState deserialize(std::string_view val) {
+    return utilities::parse_json<V2gCommunicationState>(val);
+}
+
+template <> V2gDin70121CommunicationState deserialize(std::string_view val) {
+    return utilities::parse_json<V2gDin70121CommunicationState>(val);
+}
+
+template <> V2gIso15118AcCommunicationState deserialize(std::string_view val) {
+    return utilities::parse_json<V2gIso15118AcCommunicationState>(val);
+}
+
+template <> V2gIso15118DcCommunicationState deserialize(std::string_view val) {
+    return utilities::parse_json<V2gIso15118DcCommunicationState>(val);
+}
+
+template <> V2gMessageState deserialize(std::string_view val) {
+    return utilities::parse_json<V2gMessageState>(val);
+}
+
+template <> V2gServerStatus deserialize(std::string_view val) {
+    return utilities::parse_json<V2gServerStatus>(val);
+}
+
+template <> V2gEvErrorCode deserialize(std::string_view val) {
+    return utilities::parse_json<V2gEvErrorCode>(val);
+}
+
+template <> CertChainState deserialize(std::string_view val) {
+    return utilities::parse_json<CertChainState>(val);
+}
+
+template <> CertTelemetry deserialize(std::string_view val) {
+    return utilities::parse_json<CertTelemetry>(val);
+}
+
+template <> EvseControlStatus deserialize(std::string_view val) {
+    return utilities::parse_json<EvseControlStatus>(val);
+}
+
+template <> V2gTransport deserialize(std::string_view val) {
+    return utilities::parse_json<V2gTransport>(val);
+}
+
+template <> V2gEvElectrical deserialize(std::string_view val) {
+    return utilities::parse_json<V2gEvElectrical>(val);
+}
+
+template <> V2gPaymentService deserialize(std::string_view val) {
+    return utilities::parse_json<V2gPaymentService>(val);
+}
+
+template <> V2gChargerStatus deserialize(std::string_view val) {
+    return utilities::parse_json<V2gChargerStatus>(val);
+}
+
+template <> V2gEvseElectrical deserialize(std::string_view val) {
+    return utilities::parse_json<V2gEvseElectrical>(val);
+}
+
+std::ostream& operator<<(std::ostream& os, ChargeProgress const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gCommunicationState const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gDin70121CommunicationState const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gIso15118AcCommunicationState const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gIso15118DcCommunicationState const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gMessageState const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gServerStatus const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gEvErrorCode const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, CertChainState const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, CertTelemetry const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, EvseControlStatus const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gTransport const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gEvElectrical const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gPaymentService const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gChargerStatus const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, V2gEvseElectrical const& val) {
+    os << serialize(val);
+    return os;
+}
+
+} // namespace everest::lib::API::V1_0::types::telemetry

--- a/lib/everest/everest_api_types/src/everest_api_types/telemetry/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/telemetry/json_codec.cpp
@@ -1,0 +1,890 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "telemetry/json_codec.hpp"
+#include "nlohmann/json.hpp"
+#include <stdexcept>
+#include <string>
+
+namespace everest::lib::API::V1_0::types::telemetry {
+
+void to_json(json& j, V2gDin70121CommunicationState const& k) noexcept {
+    switch (k) {
+    case V2gDin70121CommunicationState::WaitForSessionSetup:
+        j = "WaitForSessionSetup";
+        return;
+    case V2gDin70121CommunicationState::WaitForServiceDiscovery:
+        j = "WaitForServiceDiscovery";
+        return;
+    case V2gDin70121CommunicationState::WaitForPaymentServiceSelection:
+        j = "WaitForPaymentServiceSelection";
+        return;
+    case V2gDin70121CommunicationState::WaitForAuthorization:
+        j = "WaitForAuthorization";
+        return;
+    case V2gDin70121CommunicationState::WaitForChargeParameterDiscovery:
+        j = "WaitForChargeParameterDiscovery";
+        return;
+    case V2gDin70121CommunicationState::WaitForCableCheck:
+        j = "WaitForCableCheck";
+        return;
+    case V2gDin70121CommunicationState::WaitForPreCharge:
+        j = "WaitForPreCharge";
+        return;
+    case V2gDin70121CommunicationState::WaitForPreChargePowerDelivery:
+        j = "WaitForPreChargePowerDelivery";
+        return;
+    case V2gDin70121CommunicationState::WaitForCurrentDemand:
+        j = "WaitForCurrentDemand";
+        return;
+    case V2gDin70121CommunicationState::WaitForCurrentDemandPowerDelivery:
+        j = "WaitForCurrentDemandPowerDelivery";
+        return;
+    case V2gDin70121CommunicationState::WaitForWeldingDetectionSessionStop:
+        j = "WaitForWeldingDetectionSessionStop";
+        return;
+    case V2gDin70121CommunicationState::WaitForSessionStop:
+        j = "WaitForSessionStop";
+        return;
+    case V2gDin70121CommunicationState::WaitForTerminatedSession:
+        j = "WaitForTerminatedSession";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::telemetry::V2gDin70121CommunicationState";
+}
+
+void from_json(json const& j, V2gDin70121CommunicationState& k) {
+    std::string s = j;
+    if (s == "WaitForSessionSetup") {
+        k = V2gDin70121CommunicationState::WaitForSessionSetup;
+        return;
+    }
+    if (s == "WaitForServiceDiscovery") {
+        k = V2gDin70121CommunicationState::WaitForServiceDiscovery;
+        return;
+    }
+    if (s == "WaitForPaymentServiceSelection") {
+        k = V2gDin70121CommunicationState::WaitForPaymentServiceSelection;
+        return;
+    }
+    if (s == "WaitForAuthorization") {
+        k = V2gDin70121CommunicationState::WaitForAuthorization;
+        return;
+    }
+    if (s == "WaitForChargeParameterDiscovery") {
+        k = V2gDin70121CommunicationState::WaitForChargeParameterDiscovery;
+        return;
+    }
+    if (s == "WaitForCableCheck") {
+        k = V2gDin70121CommunicationState::WaitForCableCheck;
+        return;
+    }
+    if (s == "WaitForPreCharge") {
+        k = V2gDin70121CommunicationState::WaitForPreCharge;
+        return;
+    }
+    if (s == "WaitForPreChargePowerDelivery") {
+        k = V2gDin70121CommunicationState::WaitForPreChargePowerDelivery;
+        return;
+    }
+    if (s == "WaitForCurrentDemand") {
+        k = V2gDin70121CommunicationState::WaitForCurrentDemand;
+        return;
+    }
+    if (s == "WaitForCurrentDemandPowerDelivery") {
+        k = V2gDin70121CommunicationState::WaitForCurrentDemandPowerDelivery;
+        return;
+    }
+    if (s == "WaitForWeldingDetectionSessionStop") {
+        k = V2gDin70121CommunicationState::WaitForWeldingDetectionSessionStop;
+        return;
+    }
+    if (s == "WaitForSessionStop") {
+        k = V2gDin70121CommunicationState::WaitForSessionStop;
+        return;
+    }
+    if (s == "WaitForTerminatedSession") {
+        k = V2gDin70121CommunicationState::WaitForTerminatedSession;
+        return;
+    }
+    throw std::out_of_range(
+        "Provided string " + s +
+        " could not be converted to enum of type API_V1_0_TYPES_TELEMETRY_V2gDin70121CommunicationState");
+}
+
+void to_json(json& j, V2gIso15118AcCommunicationState const& k) noexcept {
+    switch (k) {
+    case V2gIso15118AcCommunicationState::WaitForSessionSetup:
+        j = "WaitForSessionSetup";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForServiceDiscovery:
+        j = "WaitForServiceDiscovery";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForServiceDetailPaymentServiceSelection:
+        j = "WaitForServiceDetailPaymentServiceSelection";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForPaymentDetailsCertificateInstallCertificateUpdate:
+        j = "WaitForPaymentDetailsCertificateInstallCertificateUpdate";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForPaymentDetails:
+        j = "WaitForPaymentDetails";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForAuthorization:
+        j = "WaitForAuthorization";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForChargeParameterDiscovery:
+        j = "WaitForChargeParameterDiscovery";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForPowerDelivery:
+        j = "WaitForPowerDelivery";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForChargingStatus:
+        j = "WaitForChargingStatus";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForChargingStatusPowerDelivery:
+        j = "WaitForChargingStatusPowerDelivery";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForMeteringReceipt:
+        j = "WaitForMeteringReceipt";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForSessionStop:
+        j = "WaitForSessionStop";
+        return;
+    case V2gIso15118AcCommunicationState::WaitForTerminatedSession:
+        j = "WaitForTerminatedSession";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::telemetry::V2gIso15118AcCommunicationState";
+}
+
+void from_json(json const& j, V2gIso15118AcCommunicationState& k) {
+    std::string s = j;
+    if (s == "WaitForSessionSetup") {
+        k = V2gIso15118AcCommunicationState::WaitForSessionSetup;
+        return;
+    }
+    if (s == "WaitForServiceDiscovery") {
+        k = V2gIso15118AcCommunicationState::WaitForServiceDiscovery;
+        return;
+    }
+    if (s == "WaitForServiceDetailPaymentServiceSelection") {
+        k = V2gIso15118AcCommunicationState::WaitForServiceDetailPaymentServiceSelection;
+        return;
+    }
+    if (s == "WaitForPaymentDetailsCertificateInstallCertificateUpdate") {
+        k = V2gIso15118AcCommunicationState::WaitForPaymentDetailsCertificateInstallCertificateUpdate;
+        return;
+    }
+    if (s == "WaitForPaymentDetails") {
+        k = V2gIso15118AcCommunicationState::WaitForPaymentDetails;
+        return;
+    }
+    if (s == "WaitForAuthorization") {
+        k = V2gIso15118AcCommunicationState::WaitForAuthorization;
+        return;
+    }
+    if (s == "WaitForChargeParameterDiscovery") {
+        k = V2gIso15118AcCommunicationState::WaitForChargeParameterDiscovery;
+        return;
+    }
+    if (s == "WaitForPowerDelivery") {
+        k = V2gIso15118AcCommunicationState::WaitForPowerDelivery;
+        return;
+    }
+    if (s == "WaitForChargingStatus") {
+        k = V2gIso15118AcCommunicationState::WaitForChargingStatus;
+        return;
+    }
+    if (s == "WaitForChargingStatusPowerDelivery") {
+        k = V2gIso15118AcCommunicationState::WaitForChargingStatusPowerDelivery;
+        return;
+    }
+    if (s == "WaitForMeteringReceipt") {
+        k = V2gIso15118AcCommunicationState::WaitForMeteringReceipt;
+        return;
+    }
+    if (s == "WaitForSessionStop") {
+        k = V2gIso15118AcCommunicationState::WaitForSessionStop;
+        return;
+    }
+    if (s == "WaitForTerminatedSession") {
+        k = V2gIso15118AcCommunicationState::WaitForTerminatedSession;
+        return;
+    }
+    throw std::out_of_range(
+        "Provided string " + s +
+        " could not be converted to enum of type API_V1_0_TYPES_TELEMETRY_V2gIso15118AcCommunicationState");
+}
+
+void to_json(json& j, V2gIso15118DcCommunicationState const& k) noexcept {
+    switch (k) {
+    case V2gIso15118DcCommunicationState::WaitForSessionSetup:
+        j = "WaitForSessionSetup";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForServiceDiscovery:
+        j = "WaitForServiceDiscovery";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForServiceDetailPaymentServiceSelection:
+        j = "WaitForServiceDetailPaymentServiceSelection";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForPaymentDetailsCertificateInstallCertificateUpdate:
+        j = "WaitForPaymentDetailsCertificateInstallCertificateUpdate";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForPaymentDetails:
+        j = "WaitForPaymentDetails";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForAuthorization:
+        j = "WaitForAuthorization";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForChargeParameterDiscovery:
+        j = "WaitForChargeParameterDiscovery";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForCableCheck:
+        j = "WaitForCableCheck";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForPreCharge:
+        j = "WaitForPreCharge";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForPreChargePowerDelivery:
+        j = "WaitForPreChargePowerDelivery";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForCurrentDemandPowerDelivery:
+        j = "WaitForCurrentDemandPowerDelivery";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForCurrentDemand:
+        j = "WaitForCurrentDemand";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForMeteringReceipt:
+        j = "WaitForMeteringReceipt";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForWeldingDetectionSessionStop:
+        j = "WaitForWeldingDetectionSessionStop";
+        return;
+    case V2gIso15118DcCommunicationState::WaitForTerminatedSession:
+        j = "WaitForTerminatedSession";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::telemetry::V2gIso15118DcCommunicationState";
+}
+
+void from_json(json const& j, V2gIso15118DcCommunicationState& k) {
+    std::string s = j;
+    if (s == "WaitForSessionSetup") {
+        k = V2gIso15118DcCommunicationState::WaitForSessionSetup;
+        return;
+    }
+    if (s == "WaitForServiceDiscovery") {
+        k = V2gIso15118DcCommunicationState::WaitForServiceDiscovery;
+        return;
+    }
+    if (s == "WaitForServiceDetailPaymentServiceSelection") {
+        k = V2gIso15118DcCommunicationState::WaitForServiceDetailPaymentServiceSelection;
+        return;
+    }
+    if (s == "WaitForPaymentDetailsCertificateInstallCertificateUpdate") {
+        k = V2gIso15118DcCommunicationState::WaitForPaymentDetailsCertificateInstallCertificateUpdate;
+        return;
+    }
+    if (s == "WaitForPaymentDetails") {
+        k = V2gIso15118DcCommunicationState::WaitForPaymentDetails;
+        return;
+    }
+    if (s == "WaitForAuthorization") {
+        k = V2gIso15118DcCommunicationState::WaitForAuthorization;
+        return;
+    }
+    if (s == "WaitForChargeParameterDiscovery") {
+        k = V2gIso15118DcCommunicationState::WaitForChargeParameterDiscovery;
+        return;
+    }
+    if (s == "WaitForCableCheck") {
+        k = V2gIso15118DcCommunicationState::WaitForCableCheck;
+        return;
+    }
+    if (s == "WaitForPreCharge") {
+        k = V2gIso15118DcCommunicationState::WaitForPreCharge;
+        return;
+    }
+    if (s == "WaitForPreChargePowerDelivery") {
+        k = V2gIso15118DcCommunicationState::WaitForPreChargePowerDelivery;
+        return;
+    }
+    if (s == "WaitForCurrentDemandPowerDelivery") {
+        k = V2gIso15118DcCommunicationState::WaitForCurrentDemandPowerDelivery;
+        return;
+    }
+    if (s == "WaitForCurrentDemand") {
+        k = V2gIso15118DcCommunicationState::WaitForCurrentDemand;
+        return;
+    }
+    if (s == "WaitForMeteringReceipt") {
+        k = V2gIso15118DcCommunicationState::WaitForMeteringReceipt;
+        return;
+    }
+    if (s == "WaitForWeldingDetectionSessionStop") {
+        k = V2gIso15118DcCommunicationState::WaitForWeldingDetectionSessionStop;
+        return;
+    }
+    if (s == "WaitForTerminatedSession") {
+        k = V2gIso15118DcCommunicationState::WaitForTerminatedSession;
+        return;
+    }
+    throw std::out_of_range(
+        "Provided string " + s +
+        " could not be converted to enum of type API_V1_0_TYPES_TELEMETRY_V2gIso15118DcCommunicationState");
+}
+
+void to_json(json& j, V2gCommunicationState const& k) noexcept {
+    json state = json::object();
+    if (k.din70121.has_value()) {
+        state["din70121"] = k.din70121.value();
+    }
+    if (k.iso15118_ac.has_value()) {
+        state["iso15118_ac"] = k.iso15118_ac.value();
+    }
+    if (k.iso15118_dc.has_value()) {
+        state["iso15118_dc"] = k.iso15118_dc.value();
+    }
+    j = state;
+}
+
+void from_json(json const& j, V2gCommunicationState& k) {
+    k = {};
+    if (j.contains("din70121")) {
+        k.din70121 = j.at("din70121").get<V2gDin70121CommunicationState>();
+    }
+    if (j.contains("iso15118_ac")) {
+        k.iso15118_ac = j.at("iso15118_ac").get<V2gIso15118AcCommunicationState>();
+    }
+    if (j.contains("iso15118_dc")) {
+        k.iso15118_dc = j.at("iso15118_dc").get<V2gIso15118DcCommunicationState>();
+    }
+}
+
+void to_json(json& j, V2gMessageState const& k) noexcept {
+    switch (k) {
+    case V2gMessageState::SupportedAppProtocol:
+        j = "SupportedAppProtocol";
+        return;
+    case V2gMessageState::SessionSetup:
+        j = "SessionSetup";
+        return;
+    case V2gMessageState::ServiceDiscovery:
+        j = "ServiceDiscovery";
+        return;
+    case V2gMessageState::ServiceDetail:
+        j = "ServiceDetail";
+        return;
+    case V2gMessageState::PaymentServiceSelection:
+        j = "PaymentServiceSelection";
+        return;
+    case V2gMessageState::PaymentDetails:
+        j = "PaymentDetails";
+        return;
+    case V2gMessageState::Authorization:
+        j = "Authorization";
+        return;
+    case V2gMessageState::ChargeParameterDiscovery:
+        j = "ChargeParameterDiscovery";
+        return;
+    case V2gMessageState::MeteringReceipt:
+        j = "MeteringReceipt";
+        return;
+    case V2gMessageState::CertificateUpdate:
+        j = "CertificateUpdate";
+        return;
+    case V2gMessageState::CertificateInstallation:
+        j = "CertificateInstallation";
+        return;
+    case V2gMessageState::ChargingStatus:
+        j = "ChargingStatus";
+        return;
+    case V2gMessageState::CableCheck:
+        j = "CableCheck";
+        return;
+    case V2gMessageState::PreCharge:
+        j = "PreCharge";
+        return;
+    case V2gMessageState::PowerDelivery:
+        j = "PowerDelivery";
+        return;
+    case V2gMessageState::CurrentDemand:
+        j = "CurrentDemand";
+        return;
+    case V2gMessageState::WeldingDetection:
+        j = "WeldingDetection";
+        return;
+    case V2gMessageState::SessionStop:
+        j = "SessionStop";
+        return;
+    case V2gMessageState::Unknown:
+        j = "Unknown";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::telemetry::V2gMessageState";
+}
+
+void from_json(json const& j, V2gMessageState& k) {
+    std::string s = j;
+    if (s == "SupportedAppProtocol") {
+        k = V2gMessageState::SupportedAppProtocol;
+        return;
+    }
+    if (s == "SessionSetup") {
+        k = V2gMessageState::SessionSetup;
+        return;
+    }
+    if (s == "ServiceDiscovery") {
+        k = V2gMessageState::ServiceDiscovery;
+        return;
+    }
+    if (s == "ServiceDetail") {
+        k = V2gMessageState::ServiceDetail;
+        return;
+    }
+    if (s == "PaymentServiceSelection") {
+        k = V2gMessageState::PaymentServiceSelection;
+        return;
+    }
+    if (s == "PaymentDetails") {
+        k = V2gMessageState::PaymentDetails;
+        return;
+    }
+    if (s == "Authorization") {
+        k = V2gMessageState::Authorization;
+        return;
+    }
+    if (s == "ChargeParameterDiscovery") {
+        k = V2gMessageState::ChargeParameterDiscovery;
+        return;
+    }
+    if (s == "MeteringReceipt") {
+        k = V2gMessageState::MeteringReceipt;
+        return;
+    }
+    if (s == "CertificateUpdate") {
+        k = V2gMessageState::CertificateUpdate;
+        return;
+    }
+    if (s == "CertificateInstallation") {
+        k = V2gMessageState::CertificateInstallation;
+        return;
+    }
+    if (s == "ChargingStatus") {
+        k = V2gMessageState::ChargingStatus;
+        return;
+    }
+    if (s == "CableCheck") {
+        k = V2gMessageState::CableCheck;
+        return;
+    }
+    if (s == "PreCharge") {
+        k = V2gMessageState::PreCharge;
+        return;
+    }
+    if (s == "PowerDelivery") {
+        k = V2gMessageState::PowerDelivery;
+        return;
+    }
+    if (s == "CurrentDemand") {
+        k = V2gMessageState::CurrentDemand;
+        return;
+    }
+    if (s == "WeldingDetection") {
+        k = V2gMessageState::WeldingDetection;
+        return;
+    }
+    if (s == "SessionStop") {
+        k = V2gMessageState::SessionStop;
+        return;
+    }
+    if (s == "Unknown") {
+        k = V2gMessageState::Unknown;
+        return;
+    }
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type API_V1_0_TYPES_TELEMETRY_V2gMessageState");
+}
+
+void to_json(json& j, V2gServerStatus const& k) noexcept {
+    switch (k) {
+    case V2gServerStatus::Inactive:
+        j = "Inactive";
+        return;
+    case V2gServerStatus::Active:
+        j = "Active";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::telemetry::V2gServerStatus";
+}
+
+void from_json(json const& j, V2gServerStatus& k) {
+    std::string s = j;
+    if (s == "Inactive") {
+        k = V2gServerStatus::Inactive;
+        return;
+    }
+    if (s == "Active") {
+        k = V2gServerStatus::Active;
+        return;
+    }
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type API_V1_0_TYPES_TELEMETRY_V2gServerStatus");
+}
+
+void to_json(json& j, V2gEvErrorCode const& k) noexcept {
+    switch (k) {
+    case V2gEvErrorCode::NO_ERROR:
+        j = "NO_ERROR";
+        return;
+    case V2gEvErrorCode::FAILED_RESSTemperatureInhibit:
+        j = "FAILED_RESSTemperatureInhibit";
+        return;
+    case V2gEvErrorCode::FAILED_EVShiftPosition:
+        j = "FAILED_EVShiftPosition";
+        return;
+    case V2gEvErrorCode::FAILED_ChargerConnectorLockFault:
+        j = "FAILED_ChargerConnectorLockFault";
+        return;
+    case V2gEvErrorCode::FAILED_EVRESSMalfunction:
+        j = "FAILED_EVRESSMalfunction";
+        return;
+    case V2gEvErrorCode::FAILED_ChargingCurrentdifferential:
+        j = "FAILED_ChargingCurrentdifferential";
+        return;
+    case V2gEvErrorCode::FAILED_ChargingVoltageOutOfRange:
+        j = "FAILED_ChargingVoltageOutOfRange";
+        return;
+    case V2gEvErrorCode::Reserved_A:
+        j = "Reserved_A";
+        return;
+    case V2gEvErrorCode::Reserved_B:
+        j = "Reserved_B";
+        return;
+    case V2gEvErrorCode::Reserved_C:
+        j = "Reserved_C";
+        return;
+    case V2gEvErrorCode::FAILED_ChargingSystemIncompatibility:
+        j = "FAILED_ChargingSystemIncompatibility";
+        return;
+    case V2gEvErrorCode::NoData:
+        j = "NoData";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::telemetry::V2gEvErrorCode";
+}
+
+void from_json(json const& j, V2gEvErrorCode& k) {
+    std::string s = j;
+    if (s == "NO_ERROR") {
+        k = V2gEvErrorCode::NO_ERROR;
+        return;
+    }
+    if (s == "FAILED_RESSTemperatureInhibit") {
+        k = V2gEvErrorCode::FAILED_RESSTemperatureInhibit;
+        return;
+    }
+    if (s == "FAILED_EVShiftPosition") {
+        k = V2gEvErrorCode::FAILED_EVShiftPosition;
+        return;
+    }
+    if (s == "FAILED_ChargerConnectorLockFault") {
+        k = V2gEvErrorCode::FAILED_ChargerConnectorLockFault;
+        return;
+    }
+    if (s == "FAILED_EVRESSMalfunction") {
+        k = V2gEvErrorCode::FAILED_EVRESSMalfunction;
+        return;
+    }
+    if (s == "FAILED_ChargingCurrentdifferential") {
+        k = V2gEvErrorCode::FAILED_ChargingCurrentdifferential;
+        return;
+    }
+    if (s == "FAILED_ChargingVoltageOutOfRange") {
+        k = V2gEvErrorCode::FAILED_ChargingVoltageOutOfRange;
+        return;
+    }
+    if (s == "Reserved_A") {
+        k = V2gEvErrorCode::Reserved_A;
+        return;
+    }
+    if (s == "Reserved_B") {
+        k = V2gEvErrorCode::Reserved_B;
+        return;
+    }
+    if (s == "Reserved_C") {
+        k = V2gEvErrorCode::Reserved_C;
+        return;
+    }
+    if (s == "FAILED_ChargingSystemIncompatibility") {
+        k = V2gEvErrorCode::FAILED_ChargingSystemIncompatibility;
+        return;
+    }
+    if (s == "NoData") {
+        k = V2gEvErrorCode::NoData;
+        return;
+    }
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type API_V1_0_TYPES_TELEMETRY_V2gEvErrorCode");
+}
+
+void to_json(json& j, ChargeProgress const& k) noexcept {
+    switch (k) {
+    case ChargeProgress::Start:
+        j = "Start";
+        return;
+    case ChargeProgress::Stop:
+        j = "Stop";
+        return;
+    case ChargeProgress::Renegotiate:
+        j = "Renegotiate";
+        return;
+    case ChargeProgress::Pause:
+        j = "Pause";
+        return;
+    case ChargeProgress::Terminate:
+        j = "Terminate";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::telemetry::ChargeProgress";
+}
+
+void from_json(json const& j, ChargeProgress& k) {
+    std::string s = j;
+    if (s == "Start") {
+        k = ChargeProgress::Start;
+        return;
+    }
+    if (s == "Stop") {
+        k = ChargeProgress::Stop;
+        return;
+    }
+    if (s == "Renegotiate") {
+        k = ChargeProgress::Renegotiate;
+        return;
+    }
+    if (s == "Pause") {
+        k = ChargeProgress::Pause;
+        return;
+    }
+    if (s == "Terminate") {
+        k = ChargeProgress::Terminate;
+        return;
+    }
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type API_V1_0_TYPES_TELEMETRY_ChargeProgress");
+}
+
+void to_json(json& j, CertChainState const& k) noexcept {
+    j = json{
+        {"configured", k.configured},
+        {"synced", k.synced},
+        {"num_files", k.num_files},
+        {"num_useful_files", k.num_useful_files},
+    };
+}
+
+void from_json(json const& j, CertChainState& k) {
+    k.configured = j.at("configured");
+    k.synced = j.at("synced");
+    k.num_files = j.at("num_files");
+    k.num_useful_files = j.at("num_useful_files");
+}
+
+void to_json(json& j, CertTelemetry const& k) noexcept {
+    j = json{
+        {"config_complete", k.config_complete},
+        {"sync_complete", k.sync_complete},
+        {"secc_chain", k.secc_chain},
+        {"mo_root", k.mo_root},
+    };
+}
+
+void from_json(json const& j, CertTelemetry& k) {
+    k.config_complete = j.at("config_complete");
+    k.sync_complete = j.at("sync_complete");
+    k.secc_chain = j.at("secc_chain");
+    k.mo_root = j.at("mo_root");
+}
+
+void to_json(json& j, EvseControlStatus const& k) noexcept {
+    j = json{
+        {"authorisation_finished", k.authorisation_finished},
+        {"emergency_stop", k.emergency_stop},
+        {"error_stop", k.error_stop},
+        {"normal_stop", k.normal_stop},
+        {"contract_payment_enabled", k.contract_payment_enabled},
+        {"free_charging_enabled", k.free_charging_enabled},
+    };
+}
+
+void from_json(json const& j, EvseControlStatus& k) {
+    k.authorisation_finished = j.at("authorisation_finished");
+    k.emergency_stop = j.at("emergency_stop");
+    k.error_stop = j.at("error_stop");
+    k.normal_stop = j.at("normal_stop");
+    k.contract_payment_enabled = j.at("contract_payment_enabled");
+    k.free_charging_enabled = j.at("free_charging_enabled");
+}
+
+void to_json(json& j, V2gTransport const& k) noexcept {
+    j = json{
+        {"comm_state", k.comm_state},
+        {"message_state", k.message_state},
+        {"udp_server_status", k.udp_server_status},
+        {"tcp_listener_status", k.tcp_listener_status},
+        {"tcp_server_status", k.tcp_server_status},
+        {"tcp_connection_established", k.tcp_connection_established},
+        {"tcp_discovery_enable", k.tcp_discovery_enable},
+        {"tcp_security_enable", k.tcp_security_enable},
+        {"tcp_security_required", k.tcp_security_required},
+        {"tcp_port_number", k.tcp_port_number},
+        {"session_setup_requested", k.session_setup_requested},
+        {"authorization_requested", k.authorization_requested},
+        {"charge_parameter_discovery_requested", k.charge_parameter_discovery_requested},
+        {"cable_check_requested", k.cable_check_requested},
+        {"pre_charge_requested", k.pre_charge_requested},
+        {"current_demand_requested", k.current_demand_requested},
+        {"welding_detection_requested", k.welding_detection_requested},
+    };
+}
+
+void from_json(json const& j, V2gTransport& k) {
+    k.comm_state = j.at("comm_state");
+    k.message_state = j.at("message_state");
+    k.udp_server_status = j.at("udp_server_status");
+    k.tcp_listener_status = j.at("tcp_listener_status");
+    k.tcp_server_status = j.at("tcp_server_status");
+    k.tcp_connection_established = j.at("tcp_connection_established");
+    k.tcp_discovery_enable = j.at("tcp_discovery_enable");
+    k.tcp_security_enable = j.at("tcp_security_enable");
+    k.tcp_security_required = j.at("tcp_security_required");
+    k.tcp_port_number = j.at("tcp_port_number");
+    k.session_setup_requested = j.at("session_setup_requested");
+    k.authorization_requested = j.at("authorization_requested");
+    k.charge_parameter_discovery_requested = j.at("charge_parameter_discovery_requested");
+    k.cable_check_requested = j.at("cable_check_requested");
+    k.pre_charge_requested = j.at("pre_charge_requested");
+    k.current_demand_requested = j.at("current_demand_requested");
+    k.welding_detection_requested = j.at("welding_detection_requested");
+}
+
+void to_json(json& j, V2gEvElectrical const& k) noexcept {
+    j = json{
+        {"charge_progress", k.charge_progress},
+        {"battery_soc_percent", k.battery_soc_percent},
+        {"error_code", k.error_code},
+        {"maximum_current_A", k.maximum_current_A},
+        {"maximum_power_W", k.maximum_power_W},
+        {"maximum_voltage_V", k.maximum_voltage_V},
+        {"maximum_rated_current_A", k.maximum_rated_current_A},
+        {"maximum_rated_power_W", k.maximum_rated_power_W},
+        {"maximum_rated_voltage_V", k.maximum_rated_voltage_V},
+        {"target_current_A", k.target_current_A},
+        {"target_voltage_V", k.target_voltage_V},
+        {"remaining_time_bulk_min", k.remaining_time_bulk_min},
+        {"remaining_time_full_min", k.remaining_time_full_min},
+        {"energy_request_Wh", k.energy_request_Wh},
+        {"energy_capacity_Wh", k.energy_capacity_Wh},
+    };
+}
+
+void from_json(json const& j, V2gEvElectrical& k) {
+    k.charge_progress = j.at("charge_progress");
+    k.battery_soc_percent = j.at("battery_soc_percent");
+    k.error_code = j.at("error_code");
+    k.maximum_current_A = j.at("maximum_current_A");
+    k.maximum_power_W = j.at("maximum_power_W");
+    k.maximum_voltage_V = j.at("maximum_voltage_V");
+    k.maximum_rated_current_A = j.at("maximum_rated_current_A");
+    k.maximum_rated_power_W = j.at("maximum_rated_power_W");
+    k.maximum_rated_voltage_V = j.at("maximum_rated_voltage_V");
+    k.target_current_A = j.at("target_current_A");
+    k.target_voltage_V = j.at("target_voltage_V");
+    k.remaining_time_bulk_min = j.at("remaining_time_bulk_min");
+    k.remaining_time_full_min = j.at("remaining_time_full_min");
+    k.energy_request_Wh = j.at("energy_request_Wh");
+    k.energy_capacity_Wh = j.at("energy_capacity_Wh");
+}
+
+void to_json(json& j, V2gPaymentService const& k) noexcept {
+    j = json{
+        {"certificate_install_requested", k.certificate_install_requested},
+        {"certificate_update_requested", k.certificate_update_requested},
+        {"charging_service_requested", k.charging_service_requested},
+        {"external_payment_requested", k.external_payment_requested},
+        {"contract_payment_requested", k.contract_payment_requested},
+        {"contract_payment_approved", k.contract_payment_approved},
+        {"contract_payment_error", k.contract_payment_error},
+        {"internet_ftp20_requested", k.internet_ftp20_requested},
+        {"internet_ftp21_requested", k.internet_ftp21_requested},
+        {"internet_http80_requested", k.internet_http80_requested},
+        {"internet_https443_requested", k.internet_https443_requested},
+    };
+}
+
+void from_json(json const& j, V2gPaymentService& k) {
+    k.certificate_install_requested = j.at("certificate_install_requested");
+    k.certificate_update_requested = j.at("certificate_update_requested");
+    k.charging_service_requested = j.at("charging_service_requested");
+    k.external_payment_requested = j.at("external_payment_requested");
+    k.contract_payment_requested = j.at("contract_payment_requested");
+    k.contract_payment_approved = j.at("contract_payment_approved");
+    k.contract_payment_error = j.at("contract_payment_error");
+    k.internet_ftp20_requested = j.at("internet_ftp20_requested");
+    k.internet_ftp21_requested = j.at("internet_ftp21_requested");
+    k.internet_http80_requested = j.at("internet_http80_requested");
+    k.internet_https443_requested = j.at("internet_https443_requested");
+}
+
+void to_json(json& j, V2gChargerStatus const& k) noexcept {
+    j = json{
+        {"evcc_id", k.evcc_id},
+        {"selected_protocol", k.selected_protocol},
+        {"cable_check_status", k.cable_check_status},
+        {"param_discovery_finished", k.param_discovery_finished},
+        {"isolation_status", k.isolation_status},
+        {"dynamic_max_current_A", k.dynamic_max_current_A},
+        {"dynamic_max_power_W", k.dynamic_max_power_W},
+        {"dynamic_max_voltage_V", k.dynamic_max_voltage_V},
+    };
+}
+
+void from_json(json const& j, V2gChargerStatus& k) {
+    k.evcc_id = j.at("evcc_id");
+    k.selected_protocol = j.at("selected_protocol");
+    k.cable_check_status = j.at("cable_check_status");
+    k.param_discovery_finished = j.at("param_discovery_finished");
+    k.isolation_status = j.at("isolation_status");
+    k.dynamic_max_current_A = j.at("dynamic_max_current_A");
+    k.dynamic_max_power_W = j.at("dynamic_max_power_W");
+    k.dynamic_max_voltage_V = j.at("dynamic_max_voltage_V");
+}
+
+void to_json(json& j, V2gEvseElectrical const& k) noexcept {
+    j = json{
+        {"present_current_A", k.present_current_A},
+        {"present_voltage_V", k.present_voltage_V},
+        {"maximum_rated_current_A", k.maximum_rated_current_A},
+        {"maximum_rated_power_W", k.maximum_rated_power_W},
+        {"maximum_rated_voltage_V", k.maximum_rated_voltage_V},
+        {"minimum_rated_current_A", k.minimum_rated_current_A},
+        {"minimum_rated_voltage_V", k.minimum_rated_voltage_V},
+        {"current_ripple_A", k.current_ripple_A},
+        {"current_tolerance_A", k.current_tolerance_A},
+    };
+}
+
+void from_json(json const& j, V2gEvseElectrical& k) {
+    k.present_current_A = j.at("present_current_A");
+    k.present_voltage_V = j.at("present_voltage_V");
+    k.maximum_rated_current_A = j.at("maximum_rated_current_A");
+    k.maximum_rated_power_W = j.at("maximum_rated_power_W");
+    k.maximum_rated_voltage_V = j.at("maximum_rated_voltage_V");
+    k.minimum_rated_current_A = j.at("minimum_rated_current_A");
+    k.minimum_rated_voltage_V = j.at("minimum_rated_voltage_V");
+    k.current_ripple_A = j.at("current_ripple_A");
+    k.current_tolerance_A = j.at("current_tolerance_A");
+}
+
+} // namespace everest::lib::API::V1_0::types::telemetry

--- a/lib/everest/everest_api_types/tests/CMakeLists.txt
+++ b/lib/everest/everest_api_types/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ target_include_directories(${TEST_TARGET_NAME} PUBLIC
 target_sources(${TEST_TARGET_NAME} PRIVATE
   manual_tests/serialization/generic.hpp
   manual_tests/serialization/generic.cpp
+  manual_tests/serialization/telemetry.cpp
   manual_tests/source_file_hash_check/source_file_hash_check.cpp
 )
 
@@ -116,13 +117,16 @@ set(
     VERBATIM
 )
 
-add_custom_command(OUTPUT ${GENERATED_TESTS_LOCATION}
+add_custom_command(
+    OUTPUT "${GENERATED_TESTS_LOCATION}CMakeLists.txt"
     COMMAND
     ${GENERATE_COMMAND}
     DEPENDS ${API_FILES} ${TEST_GENERATOR_PY_FILES} ${TEST_DISABLE_FILE} ${SERIALIZATION_TEST_HELPERS_HPP}
 )
 
-add_custom_target(generate_new_tests_on_file_change_only ALL   DEPENDS ${GENERATED_TESTS_LOCATION})
+add_custom_target(generate_new_tests_on_file_change_only ALL
+    DEPENDS "${GENERATED_TESTS_LOCATION}CMakeLists.txt"
+)
 
 add_dependencies(${TEST_TARGET_NAME} generate_new_tests_on_file_change_only generate_actual_hash_csv)
 

--- a/lib/everest/everest_api_types/tests/manual_tests/serialization/telemetry.cpp
+++ b/lib/everest/everest_api_types/tests/manual_tests/serialization/telemetry.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "everest_api_types/telemetry/codec.hpp"
+#include "nlohmann/json.hpp"
+#include <gtest/gtest.h>
+
+using namespace everest::lib::API::V1_0::types::telemetry;
+
+TEST(telemetry, enum_serialization_uses_strings) {
+    EXPECT_EQ(serialize(V2gDin70121CommunicationState::WaitForSessionStop), R"("WaitForSessionStop")");
+    EXPECT_EQ(serialize(V2gIso15118AcCommunicationState::WaitForChargingStatusPowerDelivery),
+              R"("WaitForChargingStatusPowerDelivery")");
+    EXPECT_EQ(serialize(V2gIso15118DcCommunicationState::WaitForCurrentDemandPowerDelivery),
+              R"("WaitForCurrentDemandPowerDelivery")");
+    EXPECT_EQ(serialize(V2gMessageState::PowerDelivery), R"("PowerDelivery")");
+    EXPECT_EQ(serialize(V2gServerStatus::Active), R"("Active")");
+    EXPECT_EQ(serialize(V2gEvErrorCode::FAILED_EVRESSMalfunction), R"("FAILED_EVRESSMalfunction")");
+
+    V2gTransport transport;
+    transport.comm_state.din70121 = V2gDin70121CommunicationState::WaitForTerminatedSession;
+    transport.message_state = V2gMessageState::PowerDelivery;
+    transport.udp_server_status = V2gServerStatus::Active;
+
+    auto transport_json = nlohmann::json::parse(serialize(transport));
+    EXPECT_EQ(transport_json.at("comm_state"), nlohmann::json::parse(R"({"din70121":"WaitForTerminatedSession"})"));
+    EXPECT_EQ(transport_json.at("message_state"), "PowerDelivery");
+    EXPECT_EQ(transport_json.at("udp_server_status"), "Active");
+
+    transport.comm_state = {};
+    transport.comm_state.iso15118_ac = V2gIso15118AcCommunicationState::WaitForSessionSetup;
+    transport_json = nlohmann::json::parse(serialize(transport));
+    EXPECT_TRUE(transport_json.at("comm_state").contains("iso15118_ac"));
+    EXPECT_FALSE(transport_json.at("comm_state").contains("din70121"));
+    EXPECT_FALSE(transport_json.at("comm_state").contains("iso15118_dc"));
+
+    V2gEvElectrical ev_electrical;
+    ev_electrical.error_code = V2gEvErrorCode::FAILED_EVRESSMalfunction;
+
+    auto ev_electrical_json = nlohmann::json::parse(serialize(ev_electrical));
+    EXPECT_EQ(ev_electrical_json.at("error_code"), "FAILED_EVRESSMalfunction");
+}
+
+TEST(telemetry, enum_deserialization_uses_strings) {
+    EXPECT_EQ(deserialize<V2gDin70121CommunicationState>(R"("WaitForSessionStop")"),
+              V2gDin70121CommunicationState::WaitForSessionStop);
+    EXPECT_EQ(
+        deserialize<V2gIso15118AcCommunicationState>(R"("WaitForPaymentDetailsCertificateInstallCertificateUpdate")"),
+        V2gIso15118AcCommunicationState::WaitForPaymentDetailsCertificateInstallCertificateUpdate);
+    EXPECT_EQ(deserialize<V2gIso15118DcCommunicationState>(R"("WaitForCurrentDemand")"),
+              V2gIso15118DcCommunicationState::WaitForCurrentDemand);
+    EXPECT_EQ(deserialize<V2gMessageState>(R"("PowerDelivery")"), V2gMessageState::PowerDelivery);
+    EXPECT_EQ(deserialize<V2gServerStatus>(R"("Active")"), V2gServerStatus::Active);
+    EXPECT_EQ(deserialize<V2gEvErrorCode>(R"("FAILED_EVRESSMalfunction")"), V2gEvErrorCode::FAILED_EVRESSMalfunction);
+
+    auto parsed_din = deserialize<V2gCommunicationState>(R"({"din70121":"WaitForTerminatedSession"})");
+    EXPECT_TRUE(parsed_din.din70121.has_value());
+    EXPECT_FALSE(parsed_din.iso15118_ac.has_value());
+    EXPECT_FALSE(parsed_din.iso15118_dc.has_value());
+    EXPECT_EQ(parsed_din.din70121.value(), V2gDin70121CommunicationState::WaitForTerminatedSession);
+}

--- a/lib/everest/everest_api_types/tests/test_file_autogenerator/enumhelper.py
+++ b/lib/everest/everest_api_types/tests/test_file_autogenerator/enumhelper.py
@@ -9,7 +9,7 @@ from helper import Helper
 
 class EnumHelper(Helper):
     w = Helper.regex_whitespaces
-    regex_enum_field = "(" + w + r"([A-z_0-9]+)(" + w + r")*)"
+    regex_enum_field = "(" + w + r"([A-z_0-9]+)(?:\s*=\s*[^,}]+)?\s*)"
     regex_structure_type = "enum" + w + r"class"
     regex_find_in_file = regex_structure_type + w + \
         r"[A-z_][A-z0-9_]*" + w + r"\{((" + regex_enum_field + r",?" + w + r")*)\};"

--- a/lib/everest/framework/include/framework/everest.hpp
+++ b/lib/everest/framework/include/framework/everest.hpp
@@ -33,7 +33,8 @@ struct cmd {
     ReturnType return_type; ///< The return type
 };
 
-using TelemetryEntry = std::variant<std::string, const char*, bool, int32_t, uint32_t, int64_t, uint64_t, double>;
+using TelemetryEntry =
+    std::variant<std::string, const char*, bool, int32_t, uint32_t, int64_t, uint64_t, double, nlohmann::json>;
 using TelemetryMap = std::map<std::string, TelemetryEntry>;
 using UnsubscribeToken = std::function<void()>;
 

--- a/lib/everest/util/include/everest/util/misc/change_tracker.hpp
+++ b/lib/everest/util/include/everest/util/misc/change_tracker.hpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 - 2026 Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <everest/util/math/comparison.hpp>
+
+#include <type_traits>
+#include <utility>
+
+/**
+ * @file change_tracker.hpp
+ * @brief Tracks incremental changes for a telemetry-like struct during one update cycle.
+ */
+
+namespace everest::lib::util {
+
+/**
+ * @brief Non-owning change tracker for an existing value object.
+ *
+ * The tracker holds a reference to an existing value object and records whether that object changed through one update
+ * transaction. It is intended to be constructed locally, passed to update code, queried once, and then discarded.
+ *
+ * @tparam T Type of the tracked value object.
+ */
+template <typename T> class change_tracker {
+public:
+    /**
+     * @brief Construct a tracker for an existing value.
+     * @param value Reference to the value that should be tracked.
+     */
+    explicit constexpr change_tracker(T& value) : m_value(value) {
+    }
+
+    /**
+     * @brief Copy construction is disabled to keep change state tied to the active tracker.
+     */
+    change_tracker(const change_tracker&) = delete;
+
+    /**
+     * @brief Move construction is disabled to keep change state tied to the active tracker.
+     */
+    change_tracker(change_tracker&&) = delete;
+
+    /**
+     * @brief Copy assignment is disabled to keep change state tied to the active tracker.
+     */
+    change_tracker& operator=(const change_tracker&) = delete;
+
+    /**
+     * @brief Move assignment is disabled to keep change state tied to the active tracker.
+     */
+    change_tracker& operator=(change_tracker&&) = delete;
+
+    /**
+     * @brief Read-only access to the tracked value.
+     * @return Const reference to the currently tracked value.
+     */
+    const T& value() const {
+        return m_value;
+    }
+
+    /**
+     * @brief Get mutable access to the tracked value and mark the transaction as changed.
+     * @return Mutable reference to the tracked value.
+     */
+    T& mutable_value() {
+        mark_changed();
+        return m_value;
+    }
+
+    /**
+     * @brief Set a single member field using exact comparison.
+     * @tparam Field Pointer-to-member type.
+     * @param field Pointer to the member on @p T to update.
+     * @param new_value New value for the member.
+     */
+    template <typename Field, typename NewValue> void set(Field T::*field, NewValue&& new_value) {
+        using ValueType = std::remove_cv_t<std::remove_reference_t<decltype(m_value.*field)>>;
+        ValueType value = static_cast<ValueType>(std::forward<NewValue>(new_value));
+
+        if (m_value.*field != value) {
+            m_value.*field = std::move(value);
+            mark_changed();
+        }
+    }
+
+    /**
+     * @brief Set a floating-point member field with decimal precision tolerance.
+     *
+     * If the current and new values compare equal via @ref almost_eq, the tracked value is left unchanged. This lets
+     * accumulated drift eventually publish relative to the last accepted value instead of the last sampled value.
+     *
+     * @tparam Prec Decimal precision to tolerate as in @ref almost_eq.
+     * @tparam Field Pointer-to-member type.
+     * @param field Pointer to the member on @p T to update.
+     * @param new_value New floating-point value for the member.
+     */
+    template <int Prec, typename Field, typename NewValue> void set_almost_eq(Field T::*field, NewValue&& new_value) {
+        using ValueType = std::remove_cv_t<std::remove_reference_t<decltype(m_value.*field)>>;
+        ValueType value = static_cast<ValueType>(std::forward<NewValue>(new_value));
+
+        if (!everest::lib::util::almost_eq<Prec>(m_value.*field, value)) {
+            m_value.*field = std::move(value);
+            mark_changed();
+        }
+    }
+
+    /**
+     * @brief Explicitly mark the tracked value as changed.
+     */
+    void mark_changed() {
+        m_changed = true;
+    }
+
+    /**
+     * @brief Check whether this update transaction changed any field.
+     * @return true if at least one assignment changed the tracked value in this tracker lifetime.
+     */
+    bool changed() const {
+        return m_changed;
+    }
+
+private:
+    T& m_value;
+    bool m_changed = false;
+};
+
+} // namespace everest::lib::util

--- a/lib/everest/util/tests/CMakeLists.txt
+++ b/lib/everest/util/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(everest_util_tests
   async/thread_pool_tests.cpp
   async/thread_pool_scaling_tests.cpp
   async/wrapper_tests.cpp
+  misc/change_tracker_tests.cpp
   enum/EnumFlagsTest.cpp
   enum/EnumFlagsTest_B.cpp
   math/comparison_tests.cpp

--- a/lib/everest/util/tests/misc/change_tracker_tests.cpp
+++ b/lib/everest/util/tests/misc/change_tracker_tests.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <everest/util/misc/change_tracker.hpp>
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+namespace everest::lib::util {
+
+namespace {
+struct TestTelemetry {
+    int integer_field{0};
+    float float_field{0.f};
+};
+
+static_assert(!std::is_copy_constructible_v<change_tracker<TestTelemetry>>);
+static_assert(!std::is_copy_assignable_v<change_tracker<TestTelemetry>>);
+static_assert(!std::is_move_constructible_v<change_tracker<TestTelemetry>>);
+static_assert(!std::is_move_assignable_v<change_tracker<TestTelemetry>>);
+} // namespace
+
+class ChangeTrackerTests : public ::testing::Test {};
+
+TEST_F(ChangeTrackerTests, ExactSetReportsChangeAndNoChange) {
+    TestTelemetry telemetry;
+    change_tracker<TestTelemetry> tracker{telemetry};
+
+    tracker.set(&TestTelemetry::integer_field, 7);
+    EXPECT_TRUE(tracker.changed());
+
+    TestTelemetry telemetry_same;
+    telemetry_same.integer_field = 7;
+    change_tracker<TestTelemetry> unchanged{telemetry_same};
+    unchanged.set(&TestTelemetry::integer_field, 7);
+    EXPECT_FALSE(unchanged.changed());
+
+    TestTelemetry telemetry_change;
+    telemetry_change.integer_field = 7;
+    change_tracker<TestTelemetry> changed_again{telemetry_change};
+    changed_again.set(&TestTelemetry::integer_field, 7);
+    EXPECT_FALSE(changed_again.changed());
+    changed_again.set(&TestTelemetry::integer_field, 8);
+    EXPECT_TRUE(changed_again.changed());
+}
+
+TEST_F(ChangeTrackerTests, SetAlmostEqSuppressesJitter) {
+    TestTelemetry telemetry_tiny_jitter;
+    change_tracker<TestTelemetry> tiny_jitter_tracker{telemetry_tiny_jitter};
+
+    tiny_jitter_tracker.set_almost_eq<2>(&TestTelemetry::float_field, 1.00f);
+    EXPECT_FLOAT_EQ(tiny_jitter_tracker.value().float_field, 1.0f);
+    EXPECT_TRUE(tiny_jitter_tracker.changed());
+}
+
+TEST_F(ChangeTrackerTests, SetAlmostEqTriggersOnMeaningfulChange) {
+    TestTelemetry telemetry;
+    telemetry.float_field = 1.0f;
+    change_tracker<TestTelemetry> tracker{telemetry};
+
+    tracker.set_almost_eq<2>(&TestTelemetry::float_field, 1.005f);
+    EXPECT_FLOAT_EQ(tracker.value().float_field, 1.0f);
+    EXPECT_FALSE(tracker.changed());
+
+    tracker.set_almost_eq<2>(&TestTelemetry::float_field, 1.02f);
+    EXPECT_FLOAT_EQ(tracker.value().float_field, 1.02f);
+    EXPECT_TRUE(tracker.changed());
+}
+
+TEST_F(ChangeTrackerTests, MutableValueMarksChanged) {
+    TestTelemetry telemetry;
+    change_tracker<TestTelemetry> tracker{telemetry};
+
+    tracker.mutable_value().integer_field = 10;
+    EXPECT_TRUE(tracker.changed());
+    EXPECT_TRUE(tracker.value().integer_field == 10);
+}
+
+TEST_F(ChangeTrackerTests, ValueAccessorReturnsConstRef) {
+    TestTelemetry telemetry;
+    change_tracker<TestTelemetry> tracker{telemetry};
+
+    tracker.set(&TestTelemetry::integer_field, 123);
+    tracker.set(&TestTelemetry::float_field, 42.5f);
+    EXPECT_TRUE(tracker.changed());
+
+    const auto& value = tracker.value();
+    EXPECT_EQ(value.integer_field, 123);
+    EXPECT_FLOAT_EQ(value.float_field, 42.5f);
+}
+
+} // namespace everest::lib::util

--- a/modules/EVSE/EvseManager/BUILD.bazel
+++ b/modules/EVSE/EvseManager/BUILD.bazel
@@ -22,6 +22,7 @@ cc_everest_module(
     ),
     impls = IMPLS,
     deps = [
+        "//lib/everest/everest_api_types:everest_api_types",
         "//lib/everest/helpers",
         "//lib/everest/util",
         "@pugixml",

--- a/modules/EVSE/EvseManager/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(${MODULE_NAME}
 
 target_link_libraries(${MODULE_NAME}
     PRIVATE
+        everest::everest_api_types
         everest::helpers
         everest::util
         Pal::Sigslot

--- a/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EVSE/EvseManager/evse/evse_managerImpl.cpp
@@ -7,6 +7,7 @@
 #include <date/tz.h>
 #include <utils/date.hpp>
 
+#include <everest_api_types/telemetry/json_codec.hpp>
 #include <fmt/core.h>
 
 #include "SessionLog.hpp"
@@ -20,6 +21,29 @@ bool str_to_bool(const std::string& data) {
         return true;
     }
     return false;
+}
+
+void evse_managerImpl::publish_control_telemetry(const ControlStatus& status_snapshot) {
+    if (!this->mod->info.telemetry_enabled) {
+        return;
+    }
+    const nlohmann::json payload = status_snapshot;
+    Everest::TelemetryMap telemetry;
+    for (const auto& [key, value] : payload.items()) {
+        telemetry.emplace(key, value);
+    }
+    this->mod->telemetry.publish("Evse", "control", telemetry);
+}
+
+void evse_managerImpl::update_control_telemetry(const std::function<void(ControlStatus&)>& update_fn) {
+    ControlStatus snapshot;
+    {
+        auto control_status_handle = control_status.handle();
+        update_fn(*control_status_handle);
+        snapshot = *control_status_handle;
+    }
+
+    publish_control_telemetry(snapshot);
 }
 
 void evse_managerImpl::init() {
@@ -77,6 +101,17 @@ void evse_managerImpl::ready() {
 
     // publish evse id at least once
     publish_evse_id(mod->config.evse_id);
+
+    update_control_telemetry([this](ControlStatus& status) {
+        status.contract_payment_enabled = mod->config.payment_enable_contract;
+        status.free_charging_enabled = mod->config.disable_authentication;
+    });
+
+    mod->error_handling->signal_error.connect([this](ErrorHandlingEvents event) {
+        if (event == ErrorHandlingEvents::ForceErrorShutdown) {
+            update_control_telemetry([](ControlStatus& status) { status.error_stop = true; });
+        }
+    });
 
     mod->r_bsp->subscribe_telemetry([this](types::evse_board_support::Telemetry telemetry) {
         // external Nodered interface
@@ -190,6 +225,13 @@ void evse_managerImpl::ready() {
         se.transaction_started.emplace(transaction_started);
         se.uuid = session_uuid;
         publish_session_event(se);
+
+        update_control_telemetry([](ControlStatus& status) {
+            status.authorisation_finished = true;
+            status.normal_stop = false;
+            status.error_stop = false;
+            status.emergency_stop = false;
+        });
     });
 
     mod->charger->signal_transaction_finished_event.connect(
@@ -234,6 +276,22 @@ void evse_managerImpl::ready() {
             se.uuid = session_uuid;
 
             publish_session_event(se);
+
+            switch (finished_reason) {
+            case types::evse_manager::StopTransactionReason::EmergencyStop:
+                update_control_telemetry([](ControlStatus& status) { status.emergency_stop = true; });
+                break;
+            case types::evse_manager::StopTransactionReason::GroundFault:
+            case types::evse_manager::StopTransactionReason::OvercurrentFault:
+            case types::evse_manager::StopTransactionReason::PowerQuality:
+            case types::evse_manager::StopTransactionReason::Timeout:
+            case types::evse_manager::StopTransactionReason::PowerLoss:
+                update_control_telemetry([](ControlStatus& status) { status.error_stop = true; });
+                break;
+            default:
+                update_control_telemetry([](ControlStatus& status) { status.normal_stop = true; });
+                break;
+            }
         });
 
     mod->charger->signal_charging_paused_evse_event.connect(
@@ -297,6 +355,13 @@ void evse_managerImpl::ready() {
         se.uuid = session_uuid;
 
         publish_session_event(se);
+
+        if (e == types::evse_manager::SessionEventEnum::Authorized) {
+            update_control_telemetry([](ControlStatus& status) { status.authorisation_finished = true; });
+        } else if (e == types::evse_manager::SessionEventEnum::Deauthorized ||
+                   e == types::evse_manager::SessionEventEnum::AuthRequired) {
+            update_control_telemetry([](ControlStatus& status) { status.authorisation_finished = false; });
+        }
 
         if (e == types::evse_manager::SessionEventEnum::SessionFinished) {
             this->mod->selected_protocol = "Unknown";

--- a/modules/EVSE/EvseManager/evse/evse_managerImpl.hpp
+++ b/modules/EVSE/EvseManager/evse/evse_managerImpl.hpp
@@ -14,6 +14,9 @@
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
+#include <everest/util/async/monitor.hpp>
+#include <everest_api_types/telemetry/API.hpp>
+#include <functional>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {
@@ -65,8 +68,14 @@ private:
 
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
     // insert your private definitions here
+    using ControlStatus = everest::lib::API::V1_0::types::telemetry::EvseControlStatus;
+
     std::atomic_bool connector_status_changed{false};
     types::evse_manager::Limits limits;
+    everest::lib::util::monitor<ControlStatus> control_status;
+
+    void publish_control_telemetry(const ControlStatus& status_snapshot);
+    void update_control_telemetry(const std::function<void(ControlStatus&)>& update_fn);
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/EVSE/EvseSecurity/BUILD.bazel
+++ b/modules/EVSE/EvseSecurity/BUILD.bazel
@@ -9,7 +9,7 @@ cc_everest_module(
     deps = [
         "//lib/everest/evse_security:libevse-security",
         "//lib:evse_security_conversions",
+        "//lib/everest/everest_api_types:everest_api_types",
     ],
     impls = IMPLS,
 )
-

--- a/modules/EVSE/EvseSecurity/CMakeLists.txt
+++ b/modules/EVSE/EvseSecurity/CMakeLists.txt
@@ -12,6 +12,7 @@ ev_setup_cpp_module()
 
 target_link_libraries(${MODULE_NAME}
     PRIVATE
+        everest::everest_api_types
         everest::evse_security
         everest::evse_security_conversions
 )

--- a/modules/EVSE/EvseSecurity/EvseSecurity.hpp
+++ b/modules/EVSE/EvseSecurity/EvseSecurity.hpp
@@ -34,9 +34,11 @@ struct Conf {
 class EvseSecurity : public Everest::ModuleBase {
 public:
     EvseSecurity() = delete;
-    EvseSecurity(const ModuleInfo& info, std::unique_ptr<evse_securityImplBase> p_main, Conf& config) :
-        ModuleBase(info), p_main(std::move(p_main)), config(config){};
+    EvseSecurity(const ModuleInfo& info, Everest::TelemetryProvider& telemetry,
+                 std::unique_ptr<evse_securityImplBase> p_main, Conf& config) :
+        ModuleBase(info), telemetry(telemetry), p_main(std::move(p_main)), config(config){};
 
+    Everest::TelemetryProvider& telemetry;
     const std::unique_ptr<evse_securityImplBase> p_main;
     const Conf& config;
 

--- a/modules/EVSE/EvseSecurity/main/evse_securityImpl.cpp
+++ b/modules/EVSE/EvseSecurity/main/evse_securityImpl.cpp
@@ -3,6 +3,7 @@
 
 #include "evse_securityImpl.hpp"
 #include <everest/conversions/evse_security/conversions.hpp>
+#include <everest_api_types/telemetry/json_codec.hpp>
 
 namespace module {
 namespace main {
@@ -28,6 +29,7 @@ void evse_securityImpl::init() {
 }
 
 void evse_securityImpl::ready() {
+    publish_cert_telemetry();
 }
 
 types::evse_security::InstallCertificateResult
@@ -41,6 +43,7 @@ evse_securityImpl::handle_install_ca_certificate(std::string& certificate,
             update.operation = types::evse_security::CertificateStoreUpdateOperation::Installed;
             update.ca_certificate_type = certificate_type;
             this->publish_certificate_store_update(update);
+            this->publish_cert_telemetry();
         }
         return response;
     } catch (const std::out_of_range& e) {
@@ -68,6 +71,7 @@ evse_securityImpl::handle_delete_certificate(types::evse_security::CertificateHa
             }
 
             this->publish_certificate_store_update(update);
+            this->publish_cert_telemetry();
         }
 
         return result;
@@ -88,6 +92,7 @@ evse_securityImpl::handle_update_leaf_certificate(std::string& certificate_chain
             update.operation = types::evse_security::CertificateStoreUpdateOperation::Installed;
             update.leaf_certificate_type = certificate_type;
             this->publish_certificate_store_update(update);
+            this->publish_cert_telemetry();
         }
         return response;
     } catch (const std::out_of_range& e) {
@@ -284,6 +289,38 @@ bool evse_securityImpl::handle_verify_file_signature(std::string& file_path, std
         EVLOG_warning << e.what();
         return false;
     }
+}
+
+void evse_securityImpl::publish_cert_telemetry() {
+    if (!this->mod->info.telemetry_enabled || !this->evse_security) {
+        return;
+    }
+
+    everest::lib::API::V1_0::types::telemetry::CertTelemetry payload;
+
+    const int secc_count =
+        this->evse_security->get_count_of_installed_certificates({evse_security::CertificateType::V2GCertificateChain});
+    payload.secc_chain.num_files = secc_count;
+    payload.secc_chain.num_useful_files = secc_count;
+    payload.secc_chain.configured = secc_count > 0;
+    payload.secc_chain.synced = secc_count > 0;
+
+    const int mo_count =
+        this->evse_security->get_count_of_installed_certificates({evse_security::CertificateType::MORootCertificate});
+    payload.mo_root.num_files = mo_count;
+    payload.mo_root.num_useful_files = mo_count;
+    payload.mo_root.configured = mo_count > 0;
+    payload.mo_root.synced = mo_count > 0;
+
+    payload.config_complete = payload.secc_chain.configured && payload.mo_root.configured;
+    payload.sync_complete = payload.secc_chain.synced && payload.mo_root.synced;
+
+    const nlohmann::json json_payload = payload;
+    Everest::TelemetryMap telemetry;
+    for (const auto& [key, value] : json_payload.items()) {
+        telemetry.emplace(key, value);
+    }
+    this->mod->telemetry.publish("Cert", "status", telemetry);
 }
 
 } // namespace main

--- a/modules/EVSE/EvseSecurity/main/evse_securityImpl.hpp
+++ b/modules/EVSE/EvseSecurity/main/evse_securityImpl.hpp
@@ -71,6 +71,7 @@ protected:
 
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here
+    void publish_cert_telemetry();
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
 
 private:

--- a/modules/EVSE/EvseSecurity/manifest.yaml
+++ b/modules/EVSE/EvseSecurity/manifest.yaml
@@ -42,7 +42,7 @@ provides:
   main:
     description: Implementation of the evse_security interface
     interface: evse_security 
-enable_telemetry: false
+enable_telemetry: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/EVSE/EvseV2G/BUILD.bazel
+++ b/modules/EVSE/EvseV2G/BUILD.bazel
@@ -25,6 +25,7 @@ cc_everest_module(
         "//lib/everest/tls",
         "@libevent//:event",
         "@libevent//:event_pthreads",
+        "//lib/everest/everest_api_types:everest_api_types",
     ],
 )
 
@@ -58,6 +59,7 @@ cc_library(
         "//lib/everest/cbv2g:tp",
         "//lib/everest/evse_security:libevse-security",
         "//lib/everest/framework",
+        "//lib/everest/everest_api_types:everest_api_types",
         "//lib/everest/tls",
         "//tests:module_adapter_stub",
         "@everest-core//interfaces:interfaces_lib",

--- a/modules/EVSE/EvseV2G/CMakeLists.txt
+++ b/modules/EVSE/EvseV2G/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(${MODULE_NAME}
 target_link_libraries(${MODULE_NAME}
     PRIVATE
         everest::tls
+        everest::everest_api_types
 )
 target_sources(${MODULE_NAME}
     PRIVATE

--- a/modules/EVSE/EvseV2G/EvseV2G.cpp
+++ b/modules/EVSE/EvseV2G/EvseV2G.cpp
@@ -37,6 +37,9 @@ namespace module {
 
 void EvseV2G::init() {
 
+    telemetry_publisher = std::make_unique<V2gTelemetryPublisher>(telemetry, info.telemetry_enabled,
+                                                                  config.publish_telemetry_only_on_change);
+
     std::vector<ISO15118_vasIntf*> r_vas;
     r_vas.reserve(r_iso15118_vas.size());
     for (const auto& vas : r_iso15118_vas) {
@@ -52,6 +55,7 @@ void EvseV2G::init() {
     (void)openssl::set_log_handler(log_handler);
     tls::Server::configure_signal_handler(SIGUSR1);
     v2g_ctx->tls_server = &tls_server;
+    v2g_ctx->telemetry_publisher = telemetry_publisher.get();
 
     this->r_security->subscribe_certificate_store_update(
         [this](const types::evse_security::CertificateStoreUpdate& update) {
@@ -107,6 +111,8 @@ void EvseV2G::ready() {
 
     invoke_ready(*p_charger);
     invoke_ready(*p_extensions);
+
+    telemetry_publisher->publish_all();
 
     rv = sdp_listen(v2g_ctx);
 

--- a/modules/EVSE/EvseV2G/EvseV2G.hpp
+++ b/modules/EVSE/EvseV2G/EvseV2G.hpp
@@ -20,6 +20,7 @@
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
+#include "telemetry_publisher.hpp"
 #include "v2g_ctx.hpp"
 #include <everest/tls/tls.hpp>
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
@@ -39,21 +40,25 @@ struct Conf {
     int auth_timeout_pnc;
     int auth_timeout_eim;
     bool enable_sdp_server;
+    bool publish_telemetry_only_on_change;
 };
 
 class EvseV2G : public Everest::ModuleBase {
 public:
     EvseV2G() = delete;
-    EvseV2G(const ModuleInfo& info, std::unique_ptr<ISO15118_chargerImplBase> p_charger,
+    EvseV2G(const ModuleInfo& info, Everest::TelemetryProvider& telemetry,
+            std::unique_ptr<ISO15118_chargerImplBase> p_charger,
             std::unique_ptr<iso15118_extensionsImplBase> p_extensions, std::unique_ptr<evse_securityIntf> r_security,
             std::vector<std::unique_ptr<ISO15118_vasIntf>> r_iso15118_vas, Conf& config) :
         ModuleBase(info),
+        telemetry(telemetry),
         p_charger(std::move(p_charger)),
         p_extensions(std::move(p_extensions)),
         r_security(std::move(r_security)),
         r_iso15118_vas(std::move(r_iso15118_vas)),
         config(config){};
 
+    Everest::TelemetryProvider& telemetry;
     const std::unique_ptr<ISO15118_chargerImplBase> p_charger;
     const std::unique_ptr<iso15118_extensionsImplBase> p_extensions;
     const std::unique_ptr<evse_securityIntf> r_security;
@@ -77,6 +82,7 @@ private:
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
     tls::Server tls_server;
+    std::unique_ptr<V2gTelemetryPublisher> telemetry_publisher;
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/EvseV2G/charger/ISO15118_chargerImpl.cpp
@@ -4,9 +4,11 @@
 #include "ISO15118_chargerImpl.hpp"
 #include "log.hpp"
 #include "sdp.hpp"
+#include "telemetry_publisher.hpp"
 #include "tools.hpp"
 #include "v2g_ctx.hpp"
 #include <algorithm>
+#include <everest/util/misc/change_tracker.hpp>
 #include <string.h>
 #include <string_view>
 
@@ -14,6 +16,11 @@ const std::string CERTS_SUB_DIR = "certs"; // relativ path of the certs
 
 using namespace std::chrono_literals;
 using BidiMode = types::iso15118::SaeJ2847BidiMode;
+namespace telemetry_types = everest::lib::API::V1_0::types::telemetry;
+using V2gTransportTracker = everest::lib::util::change_tracker<telemetry_types::V2gTransport>;
+using V2gEvElectricalTracker = everest::lib::util::change_tracker<telemetry_types::V2gEvElectrical>;
+using V2gPaymentServiceTracker = everest::lib::util::change_tracker<telemetry_types::V2gPaymentService>;
+using V2gChargerStatusTracker = everest::lib::util::change_tracker<telemetry_types::V2gChargerStatus>;
 
 namespace module {
 namespace charger {
@@ -319,6 +326,12 @@ void ISO15118_chargerImpl::handle_cable_check_finished(bool& status) {
     } else {
         v2g_ctx->evse_v2g_data.evse_processing[PHASE_ISOLATION] = (uint8_t)iso2_EVSEProcessingType_Ongoing;
     }
+
+    if (v2g_ctx->telemetry_publisher) {
+        v2g_ctx->telemetry_publisher->update_charger_status([&](V2gChargerStatusTracker& charger_status) {
+            charger_status.set(&telemetry_types::V2gChargerStatus::cable_check_status, status);
+        });
+    }
 }
 
 void ISO15118_chargerImpl::handle_receipt_is_required(bool& receipt_required) {
@@ -558,6 +571,17 @@ void ISO15118_chargerImpl::handle_update_dc_maximum_limits(types::iso15118::DcEv
     populate_physical_value_float(&v2g_ctx->evse_v2g_data.evse_maximum_voltage_limit,
                                   maximum_limits.evse_maximum_voltage_limit, 1, iso2_unitSymbolType_V);
     v2g_ctx->evse_v2g_data.evse_maximum_voltage_limit_is_used = 1;
+
+    if (v2g_ctx->telemetry_publisher) {
+        v2g_ctx->telemetry_publisher->update_charger_status([&](V2gChargerStatusTracker& charger_status) {
+            charger_status.set_almost_eq<2>(&telemetry_types::V2gChargerStatus::dynamic_max_current_A,
+                                            maximum_limits.evse_maximum_current_limit);
+            charger_status.set_almost_eq<2>(&telemetry_types::V2gChargerStatus::dynamic_max_power_W,
+                                            maximum_limits.evse_maximum_power_limit);
+            charger_status.set_almost_eq<2>(&telemetry_types::V2gChargerStatus::dynamic_max_voltage_V,
+                                            maximum_limits.evse_maximum_voltage_limit);
+        });
+    }
 }
 
 void ISO15118_chargerImpl::handle_update_dc_minimum_limits(types::iso15118::DcEvseMinimumLimits& minimum_limits) {
@@ -573,6 +597,13 @@ void ISO15118_chargerImpl::handle_update_dc_minimum_limits(types::iso15118::DcEv
 void ISO15118_chargerImpl::handle_update_isolation_status(types::iso15118::IsolationStatus& isolation_status) {
     v2g_ctx->evse_v2g_data.evse_isolation_status = (uint8_t)isolation_status;
     v2g_ctx->evse_v2g_data.evse_isolation_status_is_used = 1;
+
+    if (v2g_ctx->telemetry_publisher) {
+        v2g_ctx->telemetry_publisher->update_charger_status([&](V2gChargerStatusTracker& charger_status) {
+            charger_status.set(&telemetry_types::V2gChargerStatus::isolation_status,
+                               types::iso15118::isolation_status_to_string(isolation_status));
+        });
+    }
 }
 
 void ISO15118_chargerImpl::handle_update_dc_present_values(

--- a/modules/EVSE/EvseV2G/connection/connection.cpp
+++ b/modules/EVSE/EvseV2G/connection/connection.cpp
@@ -4,6 +4,7 @@
 
 #include "connection.hpp"
 #include "log.hpp"
+#include "telemetry_publisher.hpp"
 #include "tls_connection.hpp"
 #include "tools.hpp"
 #include "v2g_server.hpp"
@@ -29,11 +30,19 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <everest/util/misc/change_tracker.hpp>
+
 #define DEFAULT_SOCKET_BACKLOG        3
 #define DEFAULT_TCP_PORT              61341
 #define DEFAULT_TLS_PORT              64109
 #define ERROR_SESSION_ALREADY_STARTED 2
 #define CLIENT_FIN_TIMEOUT            3000
+
+namespace telemetry_types = everest::lib::API::V1_0::types::telemetry;
+using V2gTransportTracker = everest::lib::util::change_tracker<telemetry_types::V2gTransport>;
+using V2gEvElectricalTracker = everest::lib::util::change_tracker<telemetry_types::V2gEvElectrical>;
+using V2gPaymentServiceTracker = everest::lib::util::change_tracker<telemetry_types::V2gPaymentService>;
+using V2gChargerStatusTracker = everest::lib::util::change_tracker<telemetry_types::V2gChargerStatus>;
 
 /*!
  * \brief connection_create_socket This function creates a tcp/tls socket
@@ -192,6 +201,16 @@ int connection_init(struct v2g_context* v2g_ctx) {
                 dlog(DLOG_LEVEL_INFO, "TCP server on %s is listening on port [%s%%%" PRIu32 "]:%" PRIu16,
                      v2g_ctx->if_name, buffer, v2g_ctx->local_tcp_addr->sin6_scope_id,
                      ntohs(v2g_ctx->local_tcp_addr->sin6_port));
+                if (v2g_ctx->telemetry_publisher) {
+                    v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+                        transport.set(&telemetry_types::V2gTransport::tcp_listener_status,
+                                      telemetry_types::V2gServerStatus::Active);
+                        transport.set(&telemetry_types::V2gTransport::tcp_discovery_enable, true);
+                        transport.set(&telemetry_types::V2gTransport::tcp_security_required, false);
+                        transport.set(&telemetry_types::V2gTransport::tcp_port_number,
+                                      ntohs(v2g_ctx->local_tcp_addr->sin6_port));
+                    });
+                }
             } else {
                 dlog(DLOG_LEVEL_ERROR, "TCP server on %s is listening, but inet_ntop failed: %s", v2g_ctx->if_name,
                      strerror(errno));
@@ -220,6 +239,19 @@ int connection_init(struct v2g_context* v2g_ctx) {
                 dlog(DLOG_LEVEL_INFO, "TLS server on %s is listening on port [%s%%%" PRIu32 "]:%" PRIu16,
                      v2g_ctx->if_name, buffer, v2g_ctx->local_tls_addr->sin6_scope_id,
                      ntohs(v2g_ctx->local_tls_addr->sin6_port));
+                if (v2g_ctx->telemetry_publisher) {
+                    v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+                        transport.set(&telemetry_types::V2gTransport::tcp_security_enable, true);
+                        transport.set(&telemetry_types::V2gTransport::tcp_security_required,
+                                      v2g_ctx->tls_security == TLS_SECURITY_FORCE);
+                        if (!v2g_ctx->local_tcp_addr) {
+                            transport.set(&telemetry_types::V2gTransport::tcp_listener_status,
+                                          telemetry_types::V2gServerStatus::Active);
+                            transport.set(&telemetry_types::V2gTransport::tcp_port_number,
+                                          ntohs(v2g_ctx->local_tls_addr->sin6_port));
+                        }
+                    });
+                }
             } else {
                 dlog(DLOG_LEVEL_INFO, "TLS server on %s is listening, but inet_ntop failed: %s", v2g_ctx->if_name,
                      strerror(errno));
@@ -418,6 +450,9 @@ void connection_teardown(struct v2g_connection* conn) {
 
     /* init charging session */
     v2g_ctx_init_charging_session(conn->ctx, true);
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->reset_session_state();
+    }
 
     if (!evse_initiated_stop && (conn->d_link_action == dLinkAction::D_LINK_ACTION_TERMINATE ||
                                  conn->d_link_action == dLinkAction::D_LINK_ACTION_ERROR)) {
@@ -508,6 +543,13 @@ static void* connection_handle_tcp(void* data) {
     }
 
     conn->ctx->connection_initiated = false;
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::tcp_connection_established, false);
+            transport.set(&telemetry_types::V2gTransport::tcp_server_status,
+                          telemetry_types::V2gServerStatus::Inactive);
+        });
+    }
 
     if (rv != ERROR_SESSION_ALREADY_STARTED) {
         /* cleanup and notify lower layers */
@@ -581,10 +623,24 @@ static void* connection_server(void* data) {
             continue;
         }
         ctx->connection_initiated = true;
+        if (ctx->telemetry_publisher) {
+            ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+                transport.set(&telemetry_types::V2gTransport::tcp_connection_established, true);
+                transport.set(&telemetry_types::V2gTransport::tcp_server_status,
+                              telemetry_types::V2gServerStatus::Active);
+            });
+        }
 
         if (pthread_create(&conn->thread_id, &attr, connection_handle_tcp, conn) != 0) {
             dlog(DLOG_LEVEL_ERROR, "pthread_create() failed: %s", strerror(errno));
             ctx->connection_initiated = false;
+            if (ctx->telemetry_publisher) {
+                ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+                    transport.set(&telemetry_types::V2gTransport::tcp_connection_established, false);
+                    transport.set(&telemetry_types::V2gTransport::tcp_server_status,
+                                  telemetry_types::V2gServerStatus::Inactive);
+                });
+            }
             continue;
         }
 

--- a/modules/EVSE/EvseV2G/din_server.cpp
+++ b/modules/EVSE/EvseV2G/din_server.cpp
@@ -4,14 +4,22 @@
 
 #include <cbv2g/din/din_msgDefDatatypes.h>
 
+#include <everest/util/misc/change_tracker.hpp>
 #include <inttypes.h>
 #include <string.h>
 
 #include "din_server.hpp"
 #include "log.hpp"
+#include "telemetry_publisher.hpp"
 #include "tools.hpp"
 #include "v2g_ctx.hpp"
 #include "v2g_server.hpp"
+
+namespace telemetry_types = everest::lib::API::V1_0::types::telemetry;
+using V2gTransportTracker = everest::lib::util::change_tracker<telemetry_types::V2gTransport>;
+using V2gEvElectricalTracker = everest::lib::util::change_tracker<telemetry_types::V2gEvElectrical>;
+using V2gPaymentServiceTracker = everest::lib::util::change_tracker<telemetry_types::V2gPaymentService>;
+using V2gChargerStatusTracker = everest::lib::util::change_tracker<telemetry_types::V2gChargerStatus>;
 
 #define SASCHEDULETUPLEID 1
 
@@ -126,6 +134,14 @@ v2g_event din_validate_response_code(din_responseCodeType* const din_response_co
  * \param din_ev_status the structure the holds the EV Status elements.
  */
 static void publish_DIN_DcEvStatus(struct v2g_context* ctx, const struct din_DC_EVStatusType& din_ev_status) {
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+            telemetry.set(&telemetry_types::V2gEvElectrical::error_code,
+                          static_cast<telemetry_types::V2gEvErrorCode>(din_ev_status.EVErrorCode));
+            telemetry.set(&telemetry_types::V2gEvElectrical::battery_soc_percent, din_ev_status.EVRESSSOC);
+        });
+    }
+
     if ((ctx->ev_v2g_data.din_dc_ev_status.EVErrorCode != din_ev_status.EVErrorCode) ||
         (ctx->ev_v2g_data.din_dc_ev_status.EVReady != din_ev_status.EVReady) ||
         (ctx->ev_v2g_data.din_dc_ev_status.EVRESSSOC != din_ev_status.EVRESSSOC)) {
@@ -164,6 +180,22 @@ publish_din_service_discovery_req(struct v2g_context* ctx,
 static void publish_din_service_payment_selection_req(
     struct v2g_context* ctx, struct din_ServicePaymentSelectionReqType const* const v2g_payment_service_selection_req) {
     // V2G values that can be published: selected_payment_option, SelectedServiceList
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_payment_service([&](V2gPaymentServiceTracker& payment) {
+            payment.set(&telemetry_types::V2gPaymentService::external_payment_requested,
+                        v2g_payment_service_selection_req->SelectedPaymentOption ==
+                            din_paymentOptionType_ExternalPayment);
+            payment.set(&telemetry_types::V2gPaymentService::contract_payment_requested,
+                        v2g_payment_service_selection_req->SelectedPaymentOption == din_paymentOptionType_Contract);
+            for (uint16_t idx = 0;
+                 idx < v2g_payment_service_selection_req->SelectedServiceList.SelectedService.arrayLen; idx++) {
+                if (v2g_payment_service_selection_req->SelectedServiceList.SelectedService.array[idx].ServiceID ==
+                    V2G_SERVICE_ID_CHARGING) {
+                    payment.set(&telemetry_types::V2gPaymentService::charging_service_requested, true);
+                }
+            }
+        });
+    }
 }
 
 /*!
@@ -231,6 +263,40 @@ static void publish_din_charge_parameter_discovery_req(
         float evMaximumVoltageLimit = calc_physical_value(
             v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVMaximumVoltageLimit.Value,
             v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVMaximumVoltageLimit.Multiplier);
+
+        if (ctx->telemetry_publisher) {
+            ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_current_A, evMaximumCurrentLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_power_W, evMaximumPowerLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_voltage_V, evMaximumVoltageLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_rated_current_A,
+                                           evMaximumCurrentLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_rated_power_W,
+                                           evMaximumPowerLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_rated_voltage_V,
+                                           evMaximumVoltageLimit);
+                if (v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyCapacity_isUsed == 1) {
+                    telemetry.set_almost_eq<2>(
+                        &telemetry_types::V2gEvElectrical::energy_capacity_Wh,
+                        calc_physical_value(
+                            v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyCapacity.Value,
+                            v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyCapacity.Multiplier));
+                }
+                if (v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyRequest_isUsed == 1) {
+                    telemetry.set_almost_eq<2>(
+                        &telemetry_types::V2gEvElectrical::energy_request_Wh,
+                        calc_physical_value(
+                            v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyRequest.Value,
+                            v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyRequest.Multiplier));
+                }
+                telemetry.set(&telemetry_types::V2gEvElectrical::error_code,
+                              static_cast<telemetry_types::V2gEvErrorCode>(
+                                  v2g_charge_parameter_discovery_req->DC_EVChargeParameter.DC_EVStatus.EVErrorCode));
+                telemetry.set(&telemetry_types::V2gEvElectrical::battery_soc_percent,
+                              v2g_charge_parameter_discovery_req->DC_EVChargeParameter.DC_EVStatus.EVRESSSOC);
+            });
+        }
+
         publish_dc_ev_maximum_limits(
             ctx, evMaximumCurrentLimit, (unsigned int)1, evMaximumPowerLimit,
             v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVMaximumPowerLimit_isUsed, evMaximumVoltageLimit,
@@ -246,6 +312,14 @@ static void publish_din_charge_parameter_discovery_req(
 static void publish_din_power_delivery_req(struct v2g_context* ctx,
                                            struct din_PowerDeliveryReqType const* const v2g_power_delivery_req) {
     // V2G values that can be published: ReadyToChargeState
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+            telemetry.set(&telemetry_types::V2gEvElectrical::charge_progress,
+                          v2g_power_delivery_req->ReadyToChargeState == 1 ? telemetry_types::ChargeProgress::Start
+                                                                          : telemetry_types::ChargeProgress::Stop);
+        });
+    }
+
     if (v2g_power_delivery_req->DC_EVPowerDeliveryParameter_isUsed == (unsigned int)1) {
         ctx->p_charger->publish_dc_charging_complete(
             v2g_power_delivery_req->DC_EVPowerDeliveryParameter.ChargingComplete);
@@ -264,10 +338,23 @@ static void publish_din_power_delivery_req(struct v2g_context* ctx,
  */
 static void publish_din_precharge_req(struct v2g_context* ctx,
                                       struct din_PreChargeReqType const* const v2g_precharge_req) {
-    publish_dc_ev_target_voltage_current(
-        ctx,
-        calc_physical_value(v2g_precharge_req->EVTargetVoltage.Value, v2g_precharge_req->EVTargetVoltage.Multiplier),
-        calc_physical_value(v2g_precharge_req->EVTargetCurrent.Value, v2g_precharge_req->EVTargetCurrent.Multiplier));
+    const auto target_voltage =
+        calc_physical_value(v2g_precharge_req->EVTargetVoltage.Value, v2g_precharge_req->EVTargetVoltage.Multiplier);
+    const auto target_current =
+        calc_physical_value(v2g_precharge_req->EVTargetCurrent.Value, v2g_precharge_req->EVTargetCurrent.Multiplier);
+
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+            telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::target_voltage_V, target_voltage);
+            telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::target_current_A, target_current);
+            telemetry.set(&telemetry_types::V2gEvElectrical::error_code,
+                          static_cast<telemetry_types::V2gEvErrorCode>(v2g_precharge_req->DC_EVStatus.EVErrorCode));
+            telemetry.set(&telemetry_types::V2gEvElectrical::battery_soc_percent,
+                          v2g_precharge_req->DC_EVStatus.EVRESSSOC);
+        });
+    }
+
+    publish_dc_ev_target_voltage_current(ctx, target_voltage, target_current);
     publish_DIN_DcEvStatus(ctx, v2g_precharge_req->DC_EVStatus);
 }
 
@@ -289,11 +376,12 @@ static void publish_din_current_demand_req(struct v2g_context* ctx,
 
     publish_DIN_DcEvStatus(ctx, v2g_current_demand_req->DC_EVStatus);
 
-    publish_dc_ev_target_voltage_current(ctx,
-                                         calc_physical_value(v2g_current_demand_req->EVTargetVoltage.Value,
-                                                             v2g_current_demand_req->EVTargetVoltage.Multiplier),
-                                         calc_physical_value(v2g_current_demand_req->EVTargetCurrent.Value,
-                                                             v2g_current_demand_req->EVTargetCurrent.Multiplier));
+    const auto target_voltage = calc_physical_value(v2g_current_demand_req->EVTargetVoltage.Value,
+                                                    v2g_current_demand_req->EVTargetVoltage.Multiplier);
+    const auto target_current = calc_physical_value(v2g_current_demand_req->EVTargetCurrent.Value,
+                                                    v2g_current_demand_req->EVTargetCurrent.Multiplier);
+
+    publish_dc_ev_target_voltage_current(ctx, target_voltage, target_current);
 
     float evMaximumCurrentLimit = calc_physical_value(v2g_current_demand_req->EVMaximumCurrentLimit.Value,
                                                       v2g_current_demand_req->EVMaximumCurrentLimit.Multiplier);
@@ -315,6 +403,35 @@ static void publish_din_current_demand_req(struct v2g_context* ctx,
     publish_dc_ev_remaining_time(
         ctx, v2g_dc_ev_remaining_time_to_full_soc, v2g_current_demand_req->RemainingTimeToFullSoC_isUsed,
         v2g_dc_ev_remaining_time_to_bulk_soc, v2g_current_demand_req->RemainingTimeToBulkSoC_isUsed);
+
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+            telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::target_voltage_V, target_voltage);
+            telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::target_current_A, target_current);
+            if (v2g_current_demand_req->EVMaximumCurrentLimit_isUsed == 1) {
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_current_A, evMaximumCurrentLimit);
+            }
+            if (v2g_current_demand_req->EVMaximumPowerLimit_isUsed == 1) {
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_power_W, evMaximumPowerLimit);
+            }
+            if (v2g_current_demand_req->EVMaximumVoltageLimit_isUsed == 1) {
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_voltage_V, evMaximumVoltageLimit);
+            }
+            if (v2g_current_demand_req->RemainingTimeToFullSoC_isUsed == 1) {
+                telemetry.set(&telemetry_types::V2gEvElectrical::remaining_time_full_min,
+                              static_cast<int>(v2g_dc_ev_remaining_time_to_full_soc));
+            }
+            if (v2g_current_demand_req->RemainingTimeToBulkSoC_isUsed == 1) {
+                telemetry.set(&telemetry_types::V2gEvElectrical::remaining_time_bulk_min,
+                              static_cast<int>(v2g_dc_ev_remaining_time_to_bulk_soc));
+            }
+            telemetry.set(
+                &telemetry_types::V2gEvElectrical::error_code,
+                static_cast<telemetry_types::V2gEvErrorCode>(v2g_current_demand_req->DC_EVStatus.EVErrorCode));
+            telemetry.set(&telemetry_types::V2gEvElectrical::battery_soc_percent,
+                          v2g_current_demand_req->DC_EVStatus.EVRESSSOC);
+        });
+    }
 }
 
 //=============================================
@@ -339,6 +456,15 @@ enum v2g_event handle_din_session_setup(struct v2g_connection* conn) {
     const auto mac_addr = to_mac_address_str(&req->EVCCID.bytes[0], req->EVCCID.bytesLen);
 
     conn->ctx->p_charger->publish_evcc_id(mac_addr); // publish EVCC ID
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::session_setup_requested, true);
+        });
+        conn->ctx->telemetry_publisher->update_charger_status([&](V2gChargerStatusTracker& charger_status) {
+            charger_status.set(&telemetry_types::V2gChargerStatus::evcc_id, mac_addr);
+            charger_status.set(&telemetry_types::V2gChargerStatus::param_discovery_finished, false);
+        });
+    }
 
     dlog(DLOG_LEVEL_INFO, "SessionSetupReq.EVCCID: %s",
          (mac_addr.empty()) ? "(zero length provided)" : mac_addr.c_str());
@@ -478,6 +604,11 @@ enum v2g_event states::handle_din_contract_authentication(struct v2g_connection*
         &conn->exi_out.dinEXIDocument->V2G_Message.Body.ContractAuthenticationRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport(
+            [](auto& transport) { transport.set(&telemetry_types::V2gTransport::authorization_requested, true); });
+    }
+
     /* Fill the EVSE response message */
     if (conn->ctx->session.authorization_rejected == true) {
         res->ResponseCode = din_responseCodeType_FAILED;
@@ -512,6 +643,12 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
     struct din_ChargeParameterDiscoveryResType* res =
         &conn->exi_out.dinEXIDocument->V2G_Message.Body.ChargeParameterDiscoveryRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
+
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::charge_parameter_discovery_requested, true);
+        });
+    }
 
     /* At first, publish the received EV request message to the customer MQTT interface */
     publish_din_charge_parameter_discovery_req(conn->ctx, req);
@@ -665,6 +802,13 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
         conn->ctx->state = WAIT_FOR_CHARGEPARAMETERDISCOVERY; // [V2G-DC-498]
     }
 
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_charger_status([&](V2gChargerStatusTracker& charger_status) {
+            charger_status.set(&telemetry_types::V2gChargerStatus::param_discovery_finished,
+                               res->EVSEProcessing == din_EVSEProcessingType_Finished);
+        });
+    }
+
     return nextEvent;
 }
 
@@ -765,6 +909,12 @@ static enum v2g_event handle_din_cable_check(struct v2g_connection* conn) {
     struct din_CableCheckResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.CableCheckRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::cable_check_requested, true);
+        });
+    }
+
     /* At first, publish the received EV request message to the MQTT interface */
     publish_DIN_DcEvStatus(conn->ctx, req->DC_EVStatus);
 
@@ -828,6 +978,12 @@ static enum v2g_event handle_din_pre_charge(struct v2g_connection* conn) {
     struct din_PreChargeResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.PreChargeRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
 
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::pre_charge_requested, true);
+        });
+    }
+
     /* At first, publish the received EV request message to the customer MQTT interface */
     publish_din_precharge_req(conn->ctx, req);
 
@@ -865,6 +1021,12 @@ static enum v2g_event handle_din_current_demand(struct v2g_connection* conn) {
     struct din_CurrentDemandReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.CurrentDemandReq;
     struct din_CurrentDemandResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.CurrentDemandRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
+
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::current_demand_requested, true);
+        });
+    }
 
     /* At first, publish the received EV request message to the MQTT interface */
     publish_din_current_demand_req(conn->ctx, req);
@@ -919,6 +1081,12 @@ static enum v2g_event handle_din_welding_detection(struct v2g_connection* conn) 
     struct din_WeldingDetectionReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.WeldingDetectionReq;
     struct din_WeldingDetectionResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.WeldingDetectionRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
+
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::welding_detection_requested, true);
+        });
+    }
 
     /* At first, publish the received EV request message to the MQTT interface */
     publish_DIN_DcEvStatus(conn->ctx, req->DC_EVStatus);

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <everest/util/misc/change_tracker.hpp>
 #include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
@@ -22,9 +23,16 @@ using namespace crypto::openssl;
 
 #include "iso_server.hpp"
 #include "log.hpp"
+#include "telemetry_publisher.hpp"
 #include "tools.hpp"
 #include "v2g_ctx.hpp"
 #include "v2g_server.hpp"
+
+namespace telemetry_types = everest::lib::API::V1_0::types::telemetry;
+using V2gTransportTracker = everest::lib::util::change_tracker<telemetry_types::V2gTransport>;
+using V2gEvElectricalTracker = everest::lib::util::change_tracker<telemetry_types::V2gEvElectrical>;
+using V2gPaymentServiceTracker = everest::lib::util::change_tracker<telemetry_types::V2gPaymentService>;
+using V2gChargerStatusTracker = everest::lib::util::change_tracker<telemetry_types::V2gChargerStatus>;
 
 #define MQTT_MAX_PAYLOAD_SIZE         268435455
 #define V2G_SECC_MSG_CERTINSTALL_TIME 4500
@@ -207,6 +215,14 @@ static void check_iso2_charging_profile_values(iso2_PowerDeliveryReqType* req, i
 }
 
 static void publish_DcEvStatus(struct v2g_context* ctx, const struct iso2_DC_EVStatusType& iso2_ev_status) {
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+            telemetry.set(&telemetry_types::V2gEvElectrical::error_code,
+                          static_cast<telemetry_types::V2gEvErrorCode>(iso2_ev_status.EVErrorCode));
+            telemetry.set(&telemetry_types::V2gEvElectrical::battery_soc_percent, iso2_ev_status.EVRESSSOC);
+        });
+    }
+
     if ((ctx->ev_v2g_data.iso2_dc_ev_status.EVErrorCode != iso2_ev_status.EVErrorCode) ||
         (ctx->ev_v2g_data.iso2_dc_ev_status.EVReady != iso2_ev_status.EVReady) ||
         (ctx->ev_v2g_data.iso2_dc_ev_status.EVRESSSOC != iso2_ev_status.EVRESSSOC)) {
@@ -227,6 +243,19 @@ static auto get_emergency_status_code(const struct v2g_context* ctx, uint8_t pha
         return iso2_DC_EVSEStatusCodeType_EVSE_EmergencyShutdown;
     else
         return static_cast<iso2_DC_EVSEStatusCodeType>(ctx->evse_v2g_data.evse_status_code[phase_type]);
+}
+
+static telemetry_types::ChargeProgress to_telemetry_charge_progress(iso2_chargeProgressType progress) {
+    switch (progress) {
+    case iso2_chargeProgressType_Start:
+        return telemetry_types::ChargeProgress::Start;
+    case iso2_chargeProgressType_Stop:
+        return telemetry_types::ChargeProgress::Stop;
+    case iso2_chargeProgressType_Renegotiate:
+        return telemetry_types::ChargeProgress::Renegotiate;
+    default:
+        return telemetry_types::ChargeProgress::Terminate;
+    }
 }
 
 //=============================================
@@ -260,12 +289,43 @@ static void publish_iso_payment_service_selection_req(
     // V2G values that can be published: selected_payment_option, SelectedServiceList
 }
 
+static void publish_iso_payment_service_selection_req(struct v2g_context* ctx,
+                                                      struct iso2_PaymentServiceSelectionReqType const* const req) {
+    publish_iso_payment_service_selection_req(req);
+
+    if (!ctx->telemetry_publisher) {
+        return;
+    }
+
+    ctx->telemetry_publisher->update_payment_service([&](V2gPaymentServiceTracker& payment) {
+        payment.set(&telemetry_types::V2gPaymentService::external_payment_requested,
+                    req->SelectedPaymentOption == iso2_paymentOptionType_ExternalPayment);
+        payment.set(&telemetry_types::V2gPaymentService::contract_payment_requested,
+                    req->SelectedPaymentOption == iso2_paymentOptionType_Contract);
+        for (uint16_t idx = 0; idx < req->SelectedServiceList.SelectedService.arrayLen; idx++) {
+            if (req->SelectedServiceList.SelectedService.array[idx].ServiceID == V2G_SERVICE_ID_CHARGING) {
+                payment.set(&telemetry_types::V2gPaymentService::charging_service_requested, true);
+            }
+        }
+    });
+}
+
 /*!
  * \brief publish_iso_authorization_req This function publishes the publish_iso_authorization_req message to the MQTT
  * interface. \param v2g_authorization_req is the request message.
  */
 static void publish_iso_authorization_req(struct iso2_AuthorizationReqType const* const v2g_authorization_req) {
     // V2G values that can be published: Id, Id_isUsed, GenChallenge, GenChallenge_isUsed
+}
+
+static void publish_iso_authorization_req(struct v2g_context* ctx, struct iso2_AuthorizationReqType const* const req) {
+    publish_iso_authorization_req(req);
+
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::authorization_requested, true);
+        });
+    }
 }
 
 /*!
@@ -396,6 +456,40 @@ static void publish_iso_charge_parameter_discovery_req(
         float evMaximumVoltageLimit = calc_physical_value(
             v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVMaximumVoltageLimit.Value,
             v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVMaximumVoltageLimit.Multiplier);
+
+        if (ctx->telemetry_publisher) {
+            ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_current_A, evMaximumCurrentLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_power_W, evMaximumPowerLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_voltage_V, evMaximumVoltageLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_rated_current_A,
+                                           evMaximumCurrentLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_rated_power_W,
+                                           evMaximumPowerLimit);
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_rated_voltage_V,
+                                           evMaximumVoltageLimit);
+                if (v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyCapacity_isUsed == 1) {
+                    telemetry.set_almost_eq<2>(
+                        &telemetry_types::V2gEvElectrical::energy_capacity_Wh,
+                        calc_physical_value(
+                            v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyCapacity.Value,
+                            v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyCapacity.Multiplier));
+                }
+                if (v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyRequest_isUsed == 1) {
+                    telemetry.set_almost_eq<2>(
+                        &telemetry_types::V2gEvElectrical::energy_request_Wh,
+                        calc_physical_value(
+                            v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyRequest.Value,
+                            v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVEnergyRequest.Multiplier));
+                }
+                telemetry.set(&telemetry_types::V2gEvElectrical::error_code,
+                              static_cast<telemetry_types::V2gEvErrorCode>(
+                                  v2g_charge_parameter_discovery_req->DC_EVChargeParameter.DC_EVStatus.EVErrorCode));
+                telemetry.set(&telemetry_types::V2gEvElectrical::battery_soc_percent,
+                              v2g_charge_parameter_discovery_req->DC_EVChargeParameter.DC_EVStatus.EVRESSSOC);
+            });
+        }
+
         publish_dc_ev_maximum_limits(
             ctx, evMaximumCurrentLimit, (unsigned int)1, evMaximumPowerLimit,
             v2g_charge_parameter_discovery_req->DC_EVChargeParameter.EVMaximumPowerLimit_isUsed, evMaximumVoltageLimit,
@@ -421,10 +515,23 @@ static void publish_iso_charge_parameter_discovery_req(
  */
 static void publish_iso_pre_charge_req(struct v2g_context* ctx,
                                        struct iso2_PreChargeReqType const* const v2g_precharge_req) {
-    publish_dc_ev_target_voltage_current(
-        ctx,
-        calc_physical_value(v2g_precharge_req->EVTargetVoltage.Value, v2g_precharge_req->EVTargetVoltage.Multiplier),
-        calc_physical_value(v2g_precharge_req->EVTargetCurrent.Value, v2g_precharge_req->EVTargetCurrent.Multiplier));
+    const auto target_voltage =
+        calc_physical_value(v2g_precharge_req->EVTargetVoltage.Value, v2g_precharge_req->EVTargetVoltage.Multiplier);
+    const auto target_current =
+        calc_physical_value(v2g_precharge_req->EVTargetCurrent.Value, v2g_precharge_req->EVTargetCurrent.Multiplier);
+
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+            telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::target_voltage_V, target_voltage);
+            telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::target_current_A, target_current);
+            telemetry.set(&telemetry_types::V2gEvElectrical::error_code,
+                          static_cast<telemetry_types::V2gEvErrorCode>(v2g_precharge_req->DC_EVStatus.EVErrorCode));
+            telemetry.set(&telemetry_types::V2gEvElectrical::battery_soc_percent,
+                          v2g_precharge_req->DC_EVStatus.EVRESSSOC);
+        });
+    }
+
+    publish_dc_ev_target_voltage_current(ctx, target_voltage, target_current);
     publish_DcEvStatus(ctx, v2g_precharge_req->DC_EVStatus);
 }
 
@@ -435,6 +542,13 @@ static void publish_iso_pre_charge_req(struct v2g_context* ctx,
 static void publish_iso_power_delivery_req(struct v2g_context* ctx,
                                            struct iso2_PowerDeliveryReqType const* const v2g_power_delivery_req) {
     // V2G values that can be published: ChargeProgress, SAScheduleTupleID
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+            telemetry.set(&telemetry_types::V2gEvElectrical::charge_progress,
+                          to_telemetry_charge_progress(v2g_power_delivery_req->ChargeProgress));
+        });
+    }
+
     if (v2g_power_delivery_req->DC_EVPowerDeliveryParameter_isUsed == (unsigned int)1) {
         ctx->p_charger->publish_dc_charging_complete(
             v2g_power_delivery_req->DC_EVPowerDeliveryParameter.ChargingComplete);
@@ -464,11 +578,12 @@ static void publish_iso_current_demand_req(struct v2g_context* ctx,
 
     publish_DcEvStatus(ctx, v2g_current_demand_req->DC_EVStatus);
 
-    publish_dc_ev_target_voltage_current(ctx,
-                                         calc_physical_value(v2g_current_demand_req->EVTargetVoltage.Value,
-                                                             v2g_current_demand_req->EVTargetVoltage.Multiplier),
-                                         calc_physical_value(v2g_current_demand_req->EVTargetCurrent.Value,
-                                                             v2g_current_demand_req->EVTargetCurrent.Multiplier));
+    const auto target_voltage = calc_physical_value(v2g_current_demand_req->EVTargetVoltage.Value,
+                                                    v2g_current_demand_req->EVTargetVoltage.Multiplier);
+    const auto target_current = calc_physical_value(v2g_current_demand_req->EVTargetCurrent.Value,
+                                                    v2g_current_demand_req->EVTargetCurrent.Multiplier);
+
+    publish_dc_ev_target_voltage_current(ctx, target_voltage, target_current);
 
     float evMaximumCurrentLimit = calc_physical_value(v2g_current_demand_req->EVMaximumCurrentLimit.Value,
                                                       v2g_current_demand_req->EVMaximumCurrentLimit.Multiplier);
@@ -490,6 +605,35 @@ static void publish_iso_current_demand_req(struct v2g_context* ctx,
     publish_dc_ev_remaining_time(
         ctx, v2g_dc_ev_remaining_time_to_full_soc, v2g_current_demand_req->RemainingTimeToFullSoC_isUsed,
         v2g_dc_ev_remaining_time_to_bulk_soc, v2g_current_demand_req->RemainingTimeToBulkSoC_isUsed);
+
+    if (ctx->telemetry_publisher) {
+        ctx->telemetry_publisher->update_ev_electrical([&](V2gEvElectricalTracker& telemetry) {
+            telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::target_voltage_V, target_voltage);
+            telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::target_current_A, target_current);
+            if (v2g_current_demand_req->EVMaximumCurrentLimit_isUsed == 1) {
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_current_A, evMaximumCurrentLimit);
+            }
+            if (v2g_current_demand_req->EVMaximumPowerLimit_isUsed == 1) {
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_power_W, evMaximumPowerLimit);
+            }
+            if (v2g_current_demand_req->EVMaximumVoltageLimit_isUsed == 1) {
+                telemetry.set_almost_eq<2>(&telemetry_types::V2gEvElectrical::maximum_voltage_V, evMaximumVoltageLimit);
+            }
+            if (v2g_current_demand_req->RemainingTimeToFullSoC_isUsed == 1) {
+                telemetry.set(&telemetry_types::V2gEvElectrical::remaining_time_full_min,
+                              static_cast<int>(v2g_dc_ev_remaining_time_to_full_soc));
+            }
+            if (v2g_current_demand_req->RemainingTimeToBulkSoC_isUsed == 1) {
+                telemetry.set(&telemetry_types::V2gEvElectrical::remaining_time_bulk_min,
+                              static_cast<int>(v2g_dc_ev_remaining_time_to_bulk_soc));
+            }
+            telemetry.set(
+                &telemetry_types::V2gEvElectrical::error_code,
+                static_cast<telemetry_types::V2gEvErrorCode>(v2g_current_demand_req->DC_EVStatus.EVErrorCode));
+            telemetry.set(&telemetry_types::V2gEvElectrical::battery_soc_percent,
+                          v2g_current_demand_req->DC_EVStatus.EVRESSSOC);
+        });
+    }
 }
 /*!
  * \brief publish_iso_metering_receipt_req This function publishes the iso_metering_receipt_req message to the MQTT
@@ -556,6 +700,15 @@ static enum v2g_event handle_iso_session_setup(struct v2g_connection* conn) {
     const auto mac_addr = to_mac_address_str(&req->EVCCID.bytes[0], req->EVCCID.bytesLen);
 
     conn->ctx->p_charger->publish_evcc_id(mac_addr); // publish EVCC ID
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::session_setup_requested, true);
+        });
+        conn->ctx->telemetry_publisher->update_charger_status([&](V2gChargerStatusTracker& charger_status) {
+            charger_status.set(&telemetry_types::V2gChargerStatus::evcc_id, mac_addr);
+            charger_status.set(&telemetry_types::V2gChargerStatus::param_discovery_finished, false);
+        });
+    }
 
     dlog(DLOG_LEVEL_INFO, "SessionSetupReq.EVCCID: %s",
          (mac_addr.empty()) ? "(zero length provided)" : mac_addr.c_str());
@@ -835,7 +988,7 @@ static enum v2g_event handle_iso_payment_service_selection(struct v2g_connection
     bool list_element_found = false;
 
     /* At first, publish the received ev request message to the customer mqtt interface */
-    publish_iso_payment_service_selection_req(req);
+    publish_iso_payment_service_selection_req(conn->ctx, req);
 
     res->ResponseCode = iso2_responseCodeType_OK;
 
@@ -1133,6 +1286,15 @@ static enum v2g_event handle_iso_payment_details(struct v2g_connection* conn) {
 
 error_out:
 
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_payment_service([&](V2gPaymentServiceTracker& payment_service) {
+            payment_service.set(&telemetry_types::V2gPaymentService::contract_payment_approved,
+                                res->ResponseCode == iso2_responseCodeType_OK);
+            payment_service.set(&telemetry_types::V2gPaymentService::contract_payment_error,
+                                res->ResponseCode >= iso2_responseCodeType_FAILED);
+        });
+    }
+
     /* Check the current response code and check if no external error has occurred */
     nextEvent = iso_validate_response_code(&res->ResponseCode, conn);
 
@@ -1157,7 +1319,7 @@ static enum v2g_event handle_iso_authorization(struct v2g_connection* conn) {
     bool is_payment_option_contract = conn->ctx->session.iso_selected_payment_option == iso2_paymentOptionType_Contract;
 
     /* At first, publish the received ev request message to the customer mqtt interface */
-    publish_iso_authorization_req(req);
+    publish_iso_authorization_req(conn->ctx, req);
 
     res->ResponseCode = iso2_responseCodeType_OK;
 
@@ -1250,6 +1412,12 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
     struct iso2_ChargeParameterDiscoveryResType* res =
         &conn->exi_out.iso2EXIDocument->V2G_Message.Body.ChargeParameterDiscoveryRes;
     enum v2g_event next_event = V2G_EVENT_NO_EVENT;
+
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::charge_parameter_discovery_requested, true);
+        });
+    }
 
     /* At first, publish the received ev request message to the MQTT interface */
     publish_iso_charge_parameter_discovery_req(conn->ctx, req);
@@ -1506,6 +1674,13 @@ static enum v2g_event handle_iso_charge_parameter_discovery(struct v2g_connectio
         res->DC_EVSEChargeParameter.EVSEEnergyToBeDelivered_isUsed = 0;
         res->DC_EVSEChargeParameter.DC_EVSEStatus.EVSEIsolationStatus_isUsed = 0;
         res->SAScheduleList_isUsed = 0;
+    }
+
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_charger_status([&](V2gChargerStatusTracker& charger_status) {
+            charger_status.set(&telemetry_types::V2gChargerStatus::param_discovery_finished,
+                               res->EVSEProcessing == iso2_EVSEProcessingType_Finished);
+        });
     }
 
     return next_event;
@@ -1816,6 +1991,12 @@ static enum v2g_event handle_iso_metering_receipt(struct v2g_connection* conn) {
  */
 static enum v2g_event handle_iso_certificate_update(struct v2g_connection* conn) {
     // TODO: implement CertificateUpdate handling
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_payment_service([&](V2gPaymentServiceTracker& payment_service) {
+            payment_service.set(&telemetry_types::V2gPaymentService::certificate_update_requested, true);
+        });
+    }
+
     return V2G_EVENT_NO_EVENT;
 }
 
@@ -1832,6 +2013,13 @@ static enum v2g_event handle_iso_certificate_installation(struct v2g_connection*
     enum v2g_event nextEvent = V2G_EVENT_SEND_AND_TERMINATE;
     struct timespec ts_abs_timeout;
     int rv = 0;
+
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_payment_service([&](V2gPaymentServiceTracker& payment_service) {
+            payment_service.set(&telemetry_types::V2gPaymentService::certificate_install_requested, true);
+        });
+    }
+
     /* At first, publish the received EV request message to the customer MQTT interface */
     if (publish_iso_certificate_installation_exi_req(conn->ctx, conn->buffer + V2GTP_HEADER_LENGTH,
                                                      conn->stream.data_size - V2GTP_HEADER_LENGTH) == false) {
@@ -1904,6 +2092,12 @@ static enum v2g_event handle_iso_cable_check(struct v2g_connection* conn) {
     struct iso2_CableCheckResType* res = &conn->exi_out.iso2EXIDocument->V2G_Message.Body.CableCheckRes;
     enum v2g_event next_event = V2G_EVENT_NO_EVENT;
 
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::cable_check_requested, true);
+        });
+    }
+
     /* At first, publish the received EV request message to the MQTT interface */
     publish_DcEvStatus(conn->ctx, req->DC_EVStatus);
 
@@ -1953,6 +2147,12 @@ static enum v2g_event handle_iso_pre_charge(struct v2g_connection* conn) {
     struct iso2_PreChargeResType* res = &conn->exi_out.iso2EXIDocument->V2G_Message.Body.PreChargeRes;
     enum v2g_event next_event = V2G_EVENT_NO_EVENT;
 
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::pre_charge_requested, true);
+        });
+    }
+
     /* At first, publish the received EV request message to the MQTT interface */
     publish_iso_pre_charge_req(conn->ctx, req);
 
@@ -1990,6 +2190,12 @@ static enum v2g_event handle_iso_current_demand(struct v2g_connection* conn) {
     struct iso2_CurrentDemandReqType* req = &conn->exi_in.iso2EXIDocument->V2G_Message.Body.CurrentDemandReq;
     struct iso2_CurrentDemandResType* res = &conn->exi_out.iso2EXIDocument->V2G_Message.Body.CurrentDemandRes;
     enum v2g_event next_event = V2G_EVENT_NO_EVENT;
+
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::current_demand_requested, true);
+        });
+    }
 
     /* At first, publish the received EV request message to the MQTT interface */
     publish_iso_current_demand_req(conn->ctx, req);
@@ -2136,6 +2342,12 @@ static enum v2g_event handle_iso_welding_detection(struct v2g_connection* conn) 
     struct iso2_WeldingDetectionReqType* req = &conn->exi_in.iso2EXIDocument->V2G_Message.Body.WeldingDetectionReq;
     struct iso2_WeldingDetectionResType* res = &conn->exi_out.iso2EXIDocument->V2G_Message.Body.WeldingDetectionRes;
     enum v2g_event next_event = V2G_EVENT_NO_EVENT;
+
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::welding_detection_requested, true);
+        });
+    }
 
     /* At first, publish the received EV request message to the MQTT interface */
     publish_iso_welding_detection_req(conn->ctx, req);

--- a/modules/EVSE/EvseV2G/manifest.yaml
+++ b/modules/EVSE/EvseV2G/manifest.yaml
@@ -75,6 +75,11 @@ config:
       Enable the built-in SDP server
     type: boolean
     default: true
+  publish_telemetry_only_on_change:
+    description: >-
+      Only publish telemetry blocks when values changed.
+    type: boolean
+    default: true
 provides:
   charger:
     interface: ISO15118_charger
@@ -93,6 +98,7 @@ requires:
     interface: ISO15118_vas
     min_connections: 0
     max_connections: 128
+enable_telemetry: true
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/EVSE/EvseV2G/sdp.cpp
+++ b/modules/EVSE/EvseV2G/sdp.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2022-2023 Contributors to EVerest
 #include "sdp.hpp"
 #include "log.hpp"
+#include "telemetry_publisher.hpp"
 #include "tools.hpp"
 
 #include <arpa/inet.h>
@@ -19,6 +20,8 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include <everest/util/misc/change_tracker.hpp>
 
 #define DEBUG 1
 
@@ -40,6 +43,12 @@
 /* link-local multicast address ff02::1 aka ip6-allnodes */
 #define IN6ADDR_ALLNODES                                                                                               \
     { 0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 }
+
+namespace telemetry_types = everest::lib::API::V1_0::types::telemetry;
+using V2gTransportTracker = everest::lib::util::change_tracker<telemetry_types::V2gTransport>;
+using V2gEvElectricalTracker = everest::lib::util::change_tracker<telemetry_types::V2gEvElectrical>;
+using V2gPaymentServiceTracker = everest::lib::util::change_tracker<telemetry_types::V2gPaymentService>;
+using V2gChargerStatusTracker = everest::lib::util::change_tracker<telemetry_types::V2gChargerStatus>;
 
 /* bundles various aspects of a SDP query */
 struct sdp_query {
@@ -258,6 +267,12 @@ int sdp_init(struct v2g_context* v2g_ctx) {
 
     dlog(DLOG_LEVEL_TRACE, "joined multicast group");
 
+    if (v2g_ctx->telemetry_publisher) {
+        v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::udp_server_status, telemetry_types::V2gServerStatus::Active);
+        });
+    }
+
     return 0;
 }
 
@@ -335,6 +350,15 @@ int sdp_listen(struct v2g_context* v2g_ctx) {
             sdp_query.security_requested = (sdp_security)buffer[SDP_HEADER_LEN + 0];
             sdp_query.proto_requested = (sdp_transport_protocol)buffer[SDP_HEADER_LEN + 1];
 
+            if (v2g_ctx->telemetry_publisher) {
+                v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+                    transport.set(&telemetry_types::V2gTransport::tcp_discovery_enable,
+                                  sdp_query.proto_requested == SDP_TRANSPORT_PROTOCOL_TCP);
+                    transport.set(&telemetry_types::V2gTransport::tcp_security_enable,
+                                  sdp_query.security_requested == SDP_SECURITY_TLS);
+                });
+            }
+
             dlog(DLOG_LEVEL_INFO, "Received packet from [%s]:%" PRIu16 " with security 0x%02x and protocol 0x%02x",
                  addr, ntohs(sdp_query.remote_addr.sin6_port), sdp_query.security_requested, sdp_query.proto_requested);
 
@@ -349,6 +373,12 @@ int sdp_listen(struct v2g_context* v2g_ctx) {
 
     if (close(v2g_ctx->sdp_socket) == -1) {
         dlog(DLOG_LEVEL_ERROR, "close() failed: %s", strerror(errno));
+    }
+    if (v2g_ctx->telemetry_publisher) {
+        v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+            transport.set(&telemetry_types::V2gTransport::udp_server_status,
+                          telemetry_types::V2gServerStatus::Inactive);
+        });
     }
 
     return 0;

--- a/modules/EVSE/EvseV2G/telemetry_publisher.hpp
+++ b/modules/EVSE/EvseV2G/telemetry_publisher.hpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <everest/util/misc/change_tracker.hpp>
+#include <everest_api_types/telemetry/json_codec.hpp>
+#include <framework/everest.hpp>
+#include <mutex>
+
+namespace module {
+
+namespace telemetry_types = everest::lib::API::V1_0::types::telemetry;
+using V2gTransportTracker = everest::lib::util::change_tracker<telemetry_types::V2gTransport>;
+using V2gEvElectricalTracker = everest::lib::util::change_tracker<telemetry_types::V2gEvElectrical>;
+using V2gPaymentServiceTracker = everest::lib::util::change_tracker<telemetry_types::V2gPaymentService>;
+using V2gChargerStatusTracker = everest::lib::util::change_tracker<telemetry_types::V2gChargerStatus>;
+
+// Owns the V2G telemetry status structs and publishes them through the
+// Everest TelemetryProvider channel. One instance per EvseV2G module.
+// Each struct is published as its own block under category "V2G".
+class V2gTelemetryPublisher {
+public:
+    V2gTelemetryPublisher(Everest::TelemetryProvider& telemetry, bool enabled, bool publish_only_on_change) :
+        m_telemetry(telemetry), m_enabled(enabled), m_publish_only_on_change(publish_only_on_change) {
+    }
+
+    template <typename F> void update_transport(F&& update_fn) {
+        std::lock_guard<std::mutex> lock(m_publish_mutex);
+        V2gTransportTracker tracker{m_transport};
+        update_fn(tracker);
+        maybe_publish_block_no_lock("transport", tracker);
+    }
+
+    template <typename F> void update_ev_electrical(F&& update_fn) {
+        std::lock_guard<std::mutex> lock(m_publish_mutex);
+        V2gEvElectricalTracker tracker{m_ev_electrical};
+        update_fn(tracker);
+        maybe_publish_block_no_lock("ev_electrical", tracker);
+    }
+
+    template <typename F> void update_payment_service(F&& update_fn) {
+        std::lock_guard<std::mutex> lock(m_publish_mutex);
+        V2gPaymentServiceTracker tracker{m_payment_service};
+        update_fn(tracker);
+        maybe_publish_block_no_lock("payment_service", tracker);
+    }
+
+    template <typename F> void update_charger_status(F&& update_fn) {
+        std::lock_guard<std::mutex> lock(m_publish_mutex);
+        V2gChargerStatusTracker tracker{m_charger_status};
+        update_fn(tracker);
+        maybe_publish_block_no_lock("charger_status", tracker);
+    }
+
+    // Reset session-scoped telemetry values but keep persistent transport settings.
+    void reset_session_state() {
+        std::lock_guard<std::mutex> lock(m_publish_mutex);
+
+        const auto transport_persistent = m_transport;
+        m_transport = telemetry_types::V2gTransport{};
+        m_transport.udp_server_status = transport_persistent.udp_server_status;
+        m_transport.tcp_listener_status = transport_persistent.tcp_listener_status;
+        m_transport.tcp_server_status = transport_persistent.tcp_server_status;
+        m_transport.tcp_connection_established = transport_persistent.tcp_connection_established;
+        m_transport.tcp_discovery_enable = transport_persistent.tcp_discovery_enable;
+        m_transport.tcp_security_enable = transport_persistent.tcp_security_enable;
+        m_transport.tcp_security_required = transport_persistent.tcp_security_required;
+        m_transport.tcp_port_number = transport_persistent.tcp_port_number;
+
+        m_ev_electrical = telemetry_types::V2gEvElectrical{};
+        m_payment_service = telemetry_types::V2gPaymentService{};
+        m_charger_status = telemetry_types::V2gChargerStatus{};
+
+        publish_transport_no_lock();
+        publish_ev_electrical_no_lock();
+        publish_payment_service_no_lock();
+        publish_charger_status_no_lock();
+    }
+
+    void publish_transport() {
+        publish_block("transport", m_transport);
+    }
+    void publish_ev_electrical() {
+        publish_block("ev_electrical", m_ev_electrical);
+    }
+    void publish_payment_service() {
+        publish_block("payment_service", m_payment_service);
+    }
+    void publish_charger_status() {
+        publish_block("charger_status", m_charger_status);
+    }
+
+    void publish_all() {
+        publish_transport();
+        publish_ev_electrical();
+        publish_payment_service();
+        publish_charger_status();
+    }
+
+private:
+    template <typename T> void publish_block(const std::string& block, T const& payload) {
+        if (!m_enabled) {
+            return;
+        }
+        std::lock_guard<std::mutex> lock(m_publish_mutex);
+        publish_block_no_lock(block, payload);
+    }
+
+    template <typename T> void publish_block_no_lock(const std::string& block, T const& payload) {
+        if (!m_enabled) {
+            return;
+        }
+        const nlohmann::json json_payload = payload;
+        Everest::TelemetryMap telemetry;
+        for (const auto& [key, value] : json_payload.items()) {
+            telemetry.emplace(key, value);
+        }
+        m_telemetry.publish("V2G", block, telemetry);
+    }
+
+    void publish_transport_no_lock() {
+        publish_block_no_lock("transport", m_transport);
+    }
+    void publish_ev_electrical_no_lock() {
+        publish_block_no_lock("ev_electrical", m_ev_electrical);
+    }
+    void publish_payment_service_no_lock() {
+        publish_block_no_lock("payment_service", m_payment_service);
+    }
+    void publish_charger_status_no_lock() {
+        publish_block_no_lock("charger_status", m_charger_status);
+    }
+
+    template <typename T>
+    void maybe_publish_block_no_lock(const std::string& block, const everest::lib::util::change_tracker<T>& tracker) {
+        if (!m_publish_only_on_change || tracker.changed()) {
+            publish_block_no_lock(block, tracker.value());
+        }
+    }
+
+    Everest::TelemetryProvider& m_telemetry;
+    bool m_enabled;
+    bool m_publish_only_on_change;
+    std::mutex m_publish_mutex;
+
+    telemetry_types::V2gTransport m_transport{};
+    telemetry_types::V2gEvElectrical m_ev_electrical{};
+    telemetry_types::V2gPaymentService m_payment_service{};
+    telemetry_types::V2gChargerStatus m_charger_status{};
+};
+
+} // namespace module

--- a/modules/EVSE/EvseV2G/tests/CMakeLists.txt
+++ b/modules/EVSE/EvseV2G/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(${TLS_GTEST_NAME} PRIVATE
     everest::framework
     everest::evse_security
     everest::tls
+    everest::everest_api_types
 )
 
 set(V2G_MAIN_NAME v2g_server)
@@ -90,6 +91,7 @@ target_link_libraries(${V2G_MAIN_NAME} PRIVATE
     everest::framework
     everest::evse_security
     everest::tls
+    everest::everest_api_types
     -levent -lpthread -levent_pthreads
 )
 
@@ -132,6 +134,7 @@ target_link_libraries(${DIN_SERVER_NAME}
         everest::framework
         everest::evse_security
         everest::tls
+        everest::everest_api_types
 )
 
 add_test(${DIN_SERVER_NAME} ${DIN_SERVER_NAME})
@@ -164,6 +167,7 @@ target_link_libraries(${SDP_NAME}
         cbv2g::tp
         everest::framework
         everest::tls
+        everest::everest_api_types
 )
 
 add_test(${SDP_NAME} ${SDP_NAME})
@@ -204,6 +208,7 @@ target_link_libraries(${V2GCTX_NAME}
         everest::framework
         everest::evse_security
         everest::tls
+        everest::everest_api_types
         -levent -lpthread -levent_pthreads
 )
 

--- a/modules/EVSE/EvseV2G/v2g.hpp
+++ b/modules/EVSE/EvseV2G/v2g.hpp
@@ -27,6 +27,10 @@
 #include <event2/event.h>
 #include <event2/thread.h>
 
+namespace module {
+class V2gTelemetryPublisher;
+} // namespace module
+
 /* timeouts in milliseconds */
 #define V2G_SEQUENCE_TIMEOUT_60S              60000 /* [V2G2-443] et.al. */
 #define V2G_SEQUENCE_TIMEOUT_10S              10000
@@ -224,6 +228,8 @@ struct v2g_context {
         int fd;
     } tls_socket;
     tls::Server* tls_server;
+
+    module::V2gTelemetryPublisher* telemetry_publisher;
 
     bool tls_key_logging;
 

--- a/modules/EVSE/EvseV2G/v2g_server.cpp
+++ b/modules/EVSE/EvseV2G/v2g_server.cpp
@@ -22,9 +22,177 @@
 #include "din_server.hpp"
 #include "iso_server.hpp"
 #include "log.hpp"
+#include "telemetry_publisher.hpp"
 #include "tools.hpp"
 
 #define MAX_RES_TIME 98
+
+namespace telemetry_types = everest::lib::API::V1_0::types::telemetry;
+using V2gTransportTracker = everest::lib::util::change_tracker<telemetry_types::V2gTransport>;
+using V2gEvElectricalTracker = everest::lib::util::change_tracker<telemetry_types::V2gEvElectrical>;
+using V2gPaymentServiceTracker = everest::lib::util::change_tracker<telemetry_types::V2gPaymentService>;
+using V2gChargerStatusTracker = everest::lib::util::change_tracker<telemetry_types::V2gChargerStatus>;
+
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::SupportedAppProtocol) ==
+                  static_cast<int>(V2G_SUPPORTED_APP_PROTOCOL_MSG),
+              "telemetry: SupportedAppProtocol should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::SessionSetup) ==
+                  static_cast<int>(V2G_SESSION_SETUP_MSG),
+              "telemetry: SessionSetup should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::ServiceDiscovery) ==
+                  static_cast<int>(V2G_SERVICE_DISCOVERY_MSG),
+              "telemetry: ServiceDiscovery should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::ServiceDetail) ==
+                  static_cast<int>(V2G_SERVICE_DETAIL_MSG),
+              "telemetry: ServiceDetail should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::PaymentServiceSelection) ==
+                  static_cast<int>(V2G_PAYMENT_SERVICE_SELECTION_MSG),
+              "telemetry: PaymentServiceSelection should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::PaymentDetails) ==
+                  static_cast<int>(V2G_PAYMENT_DETAILS_MSG),
+              "telemetry: PaymentDetails should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::Authorization) ==
+                  static_cast<int>(V2G_AUTHORIZATION_MSG),
+              "telemetry: Authorization should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::ChargeParameterDiscovery) ==
+                  static_cast<int>(V2G_CHARGE_PARAMETER_DISCOVERY_MSG),
+              "telemetry: ChargeParameterDiscovery should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::MeteringReceipt) ==
+                  static_cast<int>(V2G_METERING_RECEIPT_MSG),
+              "telemetry: MeteringReceipt should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::CertificateUpdate) ==
+                  static_cast<int>(V2G_CERTIFICATE_UPDATE_MSG),
+              "telemetry: CertificateUpdate should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::CertificateInstallation) ==
+                  static_cast<int>(V2G_CERTIFICATE_INSTALLATION_MSG),
+              "telemetry: CertificateInstallation should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::ChargingStatus) ==
+                  static_cast<int>(V2G_CHARGING_STATUS_MSG),
+              "telemetry: ChargingStatus should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::CableCheck) == static_cast<int>(V2G_CABLE_CHECK_MSG),
+              "telemetry: CableCheck should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::PreCharge) == static_cast<int>(V2G_PRE_CHARGE_MSG),
+              "telemetry: PreCharge should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::PowerDelivery) ==
+                  static_cast<int>(V2G_POWER_DELIVERY_MSG),
+              "telemetry: PowerDelivery should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::CurrentDemand) ==
+                  static_cast<int>(V2G_CURRENT_DEMAND_MSG),
+              "telemetry: CurrentDemand should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::WeldingDetection) ==
+                  static_cast<int>(V2G_WELDING_DETECTION_MSG),
+              "telemetry: WeldingDetection should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::SessionStop) == static_cast<int>(V2G_SESSION_STOP_MSG),
+              "telemetry: SessionStop should match protocol enum value");
+static_assert(static_cast<int>(telemetry_types::V2gMessageState::Unknown) == static_cast<int>(V2G_UNKNOWN_MSG),
+              "telemetry: Unknown should match protocol enum value");
+
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::NO_ERROR) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_NO_ERROR),
+              "telemetry: NO_ERROR should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_RESSTemperatureInhibit) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_FAILED_RESSTemperatureInhibit),
+              "telemetry: FAILED_RESSTemperatureInhibit should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_EVShiftPosition) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_FAILED_EVShiftPosition),
+              "telemetry: FAILED_EVShiftPosition should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_ChargerConnectorLockFault) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_FAILED_ChargerConnectorLockFault),
+              "telemetry: FAILED_ChargerConnectorLockFault should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_EVRESSMalfunction) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_FAILED_EVRESSMalfunction),
+              "telemetry: FAILED_EVRESSMalfunction should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_ChargingCurrentdifferential) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_FAILED_ChargingCurrentdifferential),
+              "telemetry: FAILED_ChargingCurrentdifferential should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_ChargingVoltageOutOfRange) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_FAILED_ChargingVoltageOutOfRange),
+              "telemetry: FAILED_ChargingVoltageOutOfRange should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::Reserved_A) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_Reserved_A),
+              "telemetry: Reserved_A should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::Reserved_B) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_Reserved_B),
+              "telemetry: Reserved_B should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::Reserved_C) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_Reserved_C),
+              "telemetry: Reserved_C should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_ChargingSystemIncompatibility) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_FAILED_ChargingSystemIncompatibility),
+              "telemetry: FAILED_ChargingSystemIncompatibility should match DIN DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::NoData) ==
+                  static_cast<int>(din_DC_EVErrorCodeType_NoData),
+              "telemetry: NoData should match DIN DC EV error enum value");
+
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::NO_ERROR) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_NO_ERROR),
+              "telemetry: NO_ERROR should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_RESSTemperatureInhibit) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_FAILED_RESSTemperatureInhibit),
+              "telemetry: FAILED_RESSTemperatureInhibit should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_EVShiftPosition) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_FAILED_EVShiftPosition),
+              "telemetry: FAILED_EVShiftPosition should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_ChargerConnectorLockFault) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_FAILED_ChargerConnectorLockFault),
+              "telemetry: FAILED_ChargerConnectorLockFault should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_EVRESSMalfunction) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_FAILED_EVRESSMalfunction),
+              "telemetry: FAILED_EVRESSMalfunction should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_ChargingCurrentdifferential) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_FAILED_ChargingCurrentdifferential),
+              "telemetry: FAILED_ChargingCurrentdifferential should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_ChargingVoltageOutOfRange) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_FAILED_ChargingVoltageOutOfRange),
+              "telemetry: FAILED_ChargingVoltageOutOfRange should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::Reserved_A) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_Reserved_A),
+              "telemetry: Reserved_A should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::Reserved_B) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_Reserved_B),
+              "telemetry: Reserved_B should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::Reserved_C) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_Reserved_C),
+              "telemetry: Reserved_C should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::FAILED_ChargingSystemIncompatibility) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_FAILED_ChargingSystemIncompatibility),
+              "telemetry: FAILED_ChargingSystemIncompatibility should match ISO2 DC EV error enum value");
+static_assert(static_cast<int>(telemetry_types::V2gEvErrorCode::NoData) ==
+                  static_cast<int>(iso2_DC_EVErrorCodeType_NoData),
+              "telemetry: NoData should match ISO2 DC EV error enum value");
+
+static_assert(static_cast<int>(telemetry_types::V2gDin70121CommunicationState::WaitForSessionSetup) == 0,
+              "telemetry: V2gDin70121CommunicationState should start at protocol state 0");
+static_assert(static_cast<int>(telemetry_types::V2gIso15118AcCommunicationState::WaitForSessionSetup) == 0,
+              "telemetry: V2gIso15118AcCommunicationState should start at protocol state 0");
+static_assert(static_cast<int>(telemetry_types::V2gIso15118DcCommunicationState::WaitForSessionSetup) == 0,
+              "telemetry: V2gIso15118DcCommunicationState should start at protocol state 0");
+static_assert(static_cast<int>(telemetry_types::V2gDin70121CommunicationState::WaitForTerminatedSession) ==
+                  static_cast<int>(din_state_id::WAIT_FOR_TERMINATED_SESSION),
+              "telemetry: V2gDin70121CommunicationState::WaitForTerminatedSession should map DIN terminal state");
+static_assert(static_cast<int>(telemetry_types::V2gIso15118AcCommunicationState::WaitForTerminatedSession) ==
+                  static_cast<int>(iso_ac_state_id::WAIT_FOR_TERMINATED_SESSION),
+              "telemetry: V2gIso15118AcCommunicationState::WaitForTerminatedSession should map ISO AC terminal state");
+static_assert(static_cast<int>(telemetry_types::V2gIso15118DcCommunicationState::WaitForTerminatedSession) ==
+                  static_cast<int>(iso_dc_state_id::WAIT_FOR_TERMINATED_SESSION),
+              "telemetry: V2gIso15118DcCommunicationState::WaitForTerminatedSession should map ISO DC terminal state");
+
+static telemetry_types::V2gCommunicationState get_v2g_communication_state(v2g_context const& ctx) {
+    telemetry_types::V2gCommunicationState communication_state{};
+
+    if (ctx.selected_protocol == V2G_PROTO_DIN70121) {
+        communication_state.din70121 = static_cast<telemetry_types::V2gDin70121CommunicationState>(ctx.state);
+    } else if (ctx.selected_protocol == V2G_PROTO_ISO15118_2010 || ctx.selected_protocol == V2G_PROTO_ISO15118_2013 ||
+               ctx.selected_protocol == V2G_PROTO_ISO15118_2015) {
+        if (ctx.is_dc_charger == true) {
+            communication_state.iso15118_dc = static_cast<telemetry_types::V2gIso15118DcCommunicationState>(ctx.state);
+        } else {
+            communication_state.iso15118_ac = static_cast<telemetry_types::V2gIso15118AcCommunicationState>(ctx.state);
+        }
+    }
+
+    return communication_state;
+}
 
 static types::iso15118::V2gMessageId get_v2g_message_id(enum V2gMsgTypeId v2g_msg, enum v2g_protocol selected_protocol,
                                                         bool is_req) {
@@ -327,6 +495,11 @@ static enum v2g_event v2g_handle_apphandshake(struct v2g_connection* conn) {
     if (conn->ctx->debugMode == true) {
         conn->ctx->p_charger->publish_selected_protocol(selected_protocol_str);
     }
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->update_charger_status([&](V2gChargerStatusTracker& charger_status) {
+            charger_status.set(&telemetry_types::V2gChargerStatus::selected_protocol, selected_protocol_str);
+        });
+    }
 
     if (conn->ctx->is_connection_terminated == true) {
         dlog(DLOG_LEVEL_ERROR, "Connection is terminated. Abort charging");
@@ -363,6 +536,9 @@ int v2g_handle_connection(struct v2g_connection* conn) {
     int64_t start_time = 0; // in ms
 
     enum v2g_protocol selected_protocol = V2G_UNKNOWN_PROTOCOL;
+    if (conn->ctx->telemetry_publisher) {
+        conn->ctx->telemetry_publisher->reset_session_state();
+    }
     v2g_ctx_init_charging_state(conn->ctx, false);
     conn->buffer = static_cast<uint8_t*>(malloc(DEFAULT_BUFFER_SIZE));
     if (!conn->buffer)
@@ -523,6 +699,14 @@ int v2g_handle_connection(struct v2g_connection* conn) {
             break;
         default:
             goto error_out; //     if protocol is unknown
+        }
+
+        if (conn->ctx->telemetry_publisher) {
+            conn->ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+                transport.set(&telemetry_types::V2gTransport::comm_state, get_v2g_communication_state(*conn->ctx));
+                transport.set(&telemetry_types::V2gTransport::message_state,
+                              static_cast<telemetry_types::V2gMessageState>(conn->ctx->current_v2g_msg));
+            });
         }
 
         /* form the content of V2G_Message type and publish the request*/


### PR DESCRIPTION
## Describe your changes

  Adds EVSE/V2G telemetry support for EvseManager, EvseSecurity, and EvseV2G.

  - Adds telemetry API types and JSON codecs in `everest_api_types`.
  - Publishes typed telemetry payloads through the existing EVerest telemetry wrapper path.
  - Extends framework telemetry values to support `nlohmann::json` entries.
  - Adds EvseManager control telemetry and EvseSecurity certificate status telemetry.
  - Adds V2G transport, EV electrical, payment service, and charger status telemetry.
  - Guards V2G telemetry state updates with a publisher-owned mutex.
  - Resets session-scoped V2G telemetry between sessions.
  - Reports DIN authorization requests consistently with ISO authorization telemetry.

  Verification:
  - `cmake --build build/TESTING --target EvseV2G din_server_test v2g_ctx_test sdp_test -j24`
  - `ctest --test-dir build/TESTING -R "din_server_test|v2g_ctx_test|sdp_test" --output-on-failure`

  ## Issue ticket number and link

  N/A

  ## Checklist before requesting a review
  - [x] I have performed a self-review of my code
  - [ ] I have made corresponding changes to the documentation
  - [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
