### PR TITLE
fix(iso15118): change from PreCharge to PowerDelivery only after "Finished"

### DIFF
--- a/lib/everest/iso15118/src/iso15118/d20/state/dc_pre_charge.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/dc_pre_charge.cpp
@@ -66,7 +66,11 @@ Result DC_PreCharge::feed(Event ev) {
             return {};
         }
 
-        return m_ctx.create_state<PowerDelivery>();
+        if (req->processing == dt::Processing::Finished) {
+            return m_ctx.create_state<PowerDelivery>();
+        }
+
+        return {};
 
     } else if (const auto req = variant->get_if<message_20::SessionStopRequest>()) {
         const auto res = handle_request(*req, m_ctx.session);

--- a/lib/everest/iso15118/src/iso15118/d20/state/power_delivery.cpp
+++ b/lib/everest/iso15118/src/iso15118/d20/state/power_delivery.cpp
@@ -105,20 +105,7 @@ Result PowerDelivery::feed(Event ev) {
 
     const auto variant = m_ctx.pull_request();
 
-    if (const auto req = variant->get_if<message_20::DC_PreChargeRequest>()) {
-        const auto res = handle_request(*req, m_ctx.session, present_voltage);
-
-        m_ctx.feedback.dc_pre_charge_target_voltage(dt::from_RationalNumber(req->target_voltage));
-
-        m_ctx.respond(res);
-
-        if (res.response_code >= dt::ResponseCode::FAILED) {
-            m_ctx.session_stopped = true;
-            return {};
-        }
-
-        return {};
-    } else if (const auto req = variant->get_if<message_20::PowerDeliveryRequest>()) {
+    if (const auto req = variant->get_if<message_20::PowerDeliveryRequest>()) {
 
         const auto shutdown_requested = m_ctx.shutdown_requested();
 
@@ -174,7 +161,7 @@ Result PowerDelivery::feed(Event ev) {
         return {};
 
     } else {
-        m_ctx.log("Expected DC_PreChargeReq or PowerDeliveryReq! But code type id: %d", variant->get_type());
+        m_ctx.log("Expected PowerDeliveryReq! But code type id: %d", variant->get_type());
 
         // Sequence Error
         const message_20::Type req_type = variant->get_type();

--- a/lib/everest/iso15118/test/iso15118/fsm/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/fsm/CMakeLists.txt
@@ -16,6 +16,7 @@ endfunction()
 
 create_fsm_test_target(session_setup)
 create_fsm_test_target(service_detail)
+create_fsm_test_target(dc_pre_charge)
 
 add_executable(test_d20_transitions d20_transitions.cpp)
 

--- a/lib/everest/iso15118/test/iso15118/fsm/dc_pre_charge.cpp
+++ b/lib/everest/iso15118/test/iso15118/fsm/dc_pre_charge.cpp
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_test_macros.hpp>
+
+#include "helper.hpp"
+
+#include <iso15118/d20/state/dc_pre_charge.hpp>
+#include <iso15118/d20/state/power_delivery.hpp>
+
+#include <iso15118/message/dc_pre_charge.hpp>
+#include <iso15118/message/session_setup.hpp>
+#include <iso15118/message/session_stop.hpp>
+
+using namespace iso15118;
+
+namespace dt = message_20::datatypes;
+
+SCENARIO("ISO15118-20 dc pre charge state transitions") {
+
+    const d20::EvseSetupConfig evse_setup = create_default_evse_setup();
+    std::optional<d20::PauseContext> pause_ctx{std::nullopt};
+    session::feedback::Callbacks callbacks{};
+
+    auto state_helper = FsmStateHelper(d20::SessionConfig(evse_setup), pause_ctx, callbacks);
+    auto ctx = state_helper.get_context();
+    ctx.session = d20::Session();
+
+    GIVEN("Bad Case - Unknown session") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::DC_PreCharge>()};
+
+        ctx.session_config.supported_energy_transfer_services = {dt::ServiceCategory::DC};
+        ctx.session_config.supported_vas_services = {};
+        ctx.session_ev_info.ev_energy_services = {};
+
+        message_20::DC_PreChargeRequest req;
+        req.header.session_id = d20::Session().get_id();
+        req.header.timestamp = 1691411798;
+        req.processing = dt::Processing::Ongoing;
+        req.present_voltage = {0, 0};
+        req.target_voltage = {400, 0};
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == false);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::DC_PreCharge);
+            REQUIRE(ctx.session_stopped == true);
+
+            const auto response_message = ctx.get_response<message_20::DC_PreChargeResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& res = response_message.value();
+            REQUIRE(res.response_code == dt::ResponseCode::FAILED_UnknownSession);
+            REQUIRE(res.present_voltage.value == 0);
+            REQUIRE(res.present_voltage.exponent == 0);
+        }
+    }
+
+    GIVEN("Good Case - Ongoing") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::DC_PreCharge>()};
+
+        ctx.session_config.supported_energy_transfer_services = {dt::ServiceCategory::DC};
+
+        // Set control event for present voltage (400.1V)
+        state_helper.set_active_control_event(d20::PresentVoltageCurrent{400.1f, 0.0f});
+        fsm.feed(d20::Event::CONTROL_MESSAGE);
+
+        message_20::DC_PreChargeRequest req;
+        req.header.session_id = ctx.session.get_id();
+        req.header.timestamp = 1691411798;
+        req.processing = dt::Processing::Ongoing;
+        req.present_voltage = {0, 0};
+        req.target_voltage = {400, 0};
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition and response") {
+            REQUIRE(result.transitioned() == false);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::DC_PreCharge);
+
+            const auto response_message = ctx.get_response<message_20::DC_PreChargeResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& res = response_message.value();
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            // 400.1 = 4001 * 10^-1
+            REQUIRE(res.present_voltage.value == 4001);
+            REQUIRE(res.present_voltage.exponent == -1);
+        }
+    }
+
+    GIVEN("Good Case - Finished") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::DC_PreCharge>()};
+
+        ctx.session_config.supported_energy_transfer_services = {dt::ServiceCategory::DC};
+
+        // Set control event for present voltage (400.1V)
+        state_helper.set_active_control_event(d20::PresentVoltageCurrent{400.1f, 0.0f});
+        fsm.feed(d20::Event::CONTROL_MESSAGE);
+
+        message_20::DC_PreChargeRequest req;
+        req.header.session_id = ctx.session.get_id();
+        req.header.timestamp = 1691411798;
+        req.processing = dt::Processing::Finished;
+        req.present_voltage = {0, 0};
+        req.target_voltage = {400, 0};
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition and response") {
+            REQUIRE(result.transitioned() == true);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::PowerDelivery);
+
+            const auto response_message = ctx.get_response<message_20::DC_PreChargeResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& res = response_message.value();
+            REQUIRE(res.response_code == dt::ResponseCode::OK);
+            // 400.1 = 4001 * 10^-1
+            REQUIRE(res.present_voltage.value == 4001);
+            REQUIRE(res.present_voltage.exponent == -1);
+        }
+    }
+
+    GIVEN("Event then other V2GTP_MESSAGE") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::DC_PreCharge>()};
+        const auto result = fsm.feed(d20::Event::FAILED);
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == false);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::DC_PreCharge);
+        }
+    }
+
+    GIVEN("SessionStopReq") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::DC_PreCharge>()};
+
+        ctx.session_config.cert_install_service = false;
+        ctx.session_config.authorization_services = {dt::Authorization::EIM};
+
+        message_20::SessionStopRequest req;
+        req.header.session_id = ctx.session.get_id();
+        req.header.timestamp = 1691411798;
+        req.charging_session = dt::ChargingSession::Terminate;
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == false);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::DC_PreCharge);
+
+            const auto response_message = ctx.get_response<message_20::SessionStopResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& session_stop_res = response_message.value();
+            REQUIRE(session_stop_res.response_code == dt::ResponseCode::OK);
+        }
+    }
+
+    GIVEN("Sequence Error") {
+        fsm::v2::FSM<d20::StateBase> fsm{ctx.create_state<d20::state::DC_PreCharge>()};
+
+        ctx.session_config.cert_install_service = false;
+        ctx.session_config.authorization_services = {dt::Authorization::EIM};
+
+        message_20::SessionSetupRequest req;
+        req.header.session_id = ctx.session.get_id();
+        req.header.timestamp = 1691411798;
+        req.evccid = "WMIV1234567890ABCDEX";
+
+        state_helper.handle_request(req);
+        const auto result = fsm.feed(d20::Event::V2GTP_MESSAGE);
+
+        THEN("Check state transition") {
+            REQUIRE(result.transitioned() == false);
+            REQUIRE(fsm.get_current_state_id() == d20::StateID::DC_PreCharge);
+
+            const auto response_message = ctx.get_response<message_20::SessionSetupResponse>();
+            REQUIRE(response_message.has_value());
+
+            const auto& session_setup_res = response_message.value();
+            REQUIRE(session_setup_res.response_code == dt::ResponseCode::FAILED_SequenceError);
+        }
+    }
+}

--- a/lib/everest/iso15118/test/iso15118/fsm/helper.hpp
+++ b/lib/everest/iso15118/test/iso15118/fsm/helper.hpp
@@ -21,6 +21,25 @@
 
 using namespace iso15118;
 
+namespace dt = message_20::datatypes;
+
+inline d20::EvseSetupConfig create_default_evse_setup() {
+    const auto evse_id = std::string("everest se");
+    const std::vector<dt::ServiceCategory> supported_energy_services = {dt::ServiceCategory::DC};
+    const auto cert_install = false;
+    const std::vector<uint16_t> vas_services{}; // TODO(SL): Add Custom service
+    const std::vector<dt::Authorization> auth_services = {dt::Authorization::EIM};
+    const d20::DcTransferLimits dc_limits;
+    const d20::AcTransferLimits ac_limits;
+    const d20::DcTransferLimits powersupply_limits;
+    const std::vector<d20::ControlMobilityNeedsModes> control_mobility_modes = {
+        {dt::ControlMode::Scheduled, dt::MobilityNeedsMode::ProvidedByEvcc}};
+
+    return d20::EvseSetupConfig{
+        evse_id,   supported_energy_services, auth_services, vas_services, cert_install, dc_limits,
+        ac_limits, control_mobility_modes,    std::nullopt,  std::nullopt, std::nullopt, powersupply_limits};
+}
+
 class FsmStateHelper {
 public:
     FsmStateHelper(const d20::SessionConfig& config, std::optional<d20::PauseContext>& pause_ctx_,
@@ -44,6 +63,10 @@ public:
 
     template <typename RequestType> void handle_request(const RequestType& request) {
         msg_exch.set_request(std::make_unique<message_20::Variant>(request));
+    }
+
+    void set_active_control_event(const std::optional<d20::ControlEvent>& event) {
+        active_control_event = event;
     }
 
 private:


### PR DESCRIPTION
The D20 state machine was going from DCPreCharge to PowerDelivery without first checking that DCPreCharge had EVProcessing = "Finished". It thereby accepted premature PowerDelivery from the EV, which should be a sequence error.

ISO 15118-20:2022, Table 62, description of DC_PreChargeReq::EVProcessing: Parameter that indicates the stop of the DC_PreCharge process by the EV. When the EV wants to continue in the Sequence, the EVProcessing is set to "Finished", while still running it is set to "Ongoing".

IEC 61851-23-3 (MCS) also specifies this more explicitly.

Note: PyEvJosev violates this requirement as well (goes to PowerDelivery after DCPreCharge with EVProcessing = "Ongoing"), which is why this combination succeeds in the SIL.

Fixes https://github.com/EVerest/EVerest/issues/2305

Co-authored-by: Martin Lukas <martin.lukas@chargebyte.com>
## Describe your changes

## Issue ticket number and link
https://github.com/EVerest/EVerest/issues/2305

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
