### PR TITLE
Bazel: stage module runtime data files into their share directory

### DIFF
--- a/lib/everest/framework/bazel/everest_env.bzl
+++ b/lib/everest/framework/bazel/everest_env.bzl
@@ -46,21 +46,25 @@ def _everest_env(ctx):
         ][0]
         prefix = manifest.dirname
 
-        symlinks.update(
-            {
-                "libexec/everest/modules/{0}{1}".format(
-                    mod.label.name,
-                    file.path.removeprefix(prefix),
-                ): file
-                for file in mod[DefaultInfo].data_runfiles.files.to_list()
-                if file.path.startswith(prefix)
-            },
-        )
-        [
-            files.append(file)
-            for file in mod[DefaultInfo].default_runfiles.files.to_list()
-            if not file.path.startswith(prefix)
-        ]
+        for file in mod[DefaultInfo].data_runfiles.files.to_list():
+            # Only consider files staged inside the module subdir (next to the
+            # manifest). The trailing "/" avoids matching siblings such as the
+            # raw `<name>__binary` output.
+            if not file.path.startswith(prefix + "/"):
+                continue
+            rel = file.path.removeprefix(prefix + "/")
+
+            # The module binary and its manifest are loaded from libexec; every
+            # other staged module file (e.g. a `models/` folder) belongs in the
+            # module's share directory, where the framework looks it up at
+            # runtime as `data_dir/modules/<name>/...` (see runtime.cpp).
+            if file.basename in ["manifest.yaml", "manifest.yml"] or file.basename == mod.label.name:
+                symlinks["libexec/everest/modules/{0}/{1}".format(mod.label.name, rel)] = file
+            else:
+                symlinks["share/everest/modules/{0}/{1}".format(mod.label.name, rel)] = file
+        for file in mod[DefaultInfo].default_runfiles.files.to_list():
+            if not file.path.startswith(prefix):
+                files.append(file)
 
     config_file = ctx.attr.config_file[DefaultInfo].files.to_list()[0]
     config_path = "etc/everest/{0}".format(config_file.basename)

--- a/modules/HardwareDrivers/PowerMeters/GenericPowermeter/BUILD.bazel
+++ b/modules/HardwareDrivers/PowerMeters/GenericPowermeter/BUILD.bazel
@@ -6,6 +6,7 @@ IMPLS = [
 
 cc_everest_module(
     name = "GenericPowermeter",
+    data = glob(["models/**"]),
     deps = [],
     impls = IMPLS,
 )

--- a/modules/module.bzl
+++ b/modules/module.bzl
@@ -105,11 +105,34 @@ def cc_everest_module(
               "cp $(location {}) $(RULEDIR)/{}/".format(manifest, name),
     )
 
+    # `data` entries given as plain (package-relative) paths -- e.g.
+    # `glob(["models/**"])` -- are runtime files that the framework loads from
+    # the module's share directory at runtime (`share/everest/modules/<name>/`,
+    # see everest_env.bzl and runtime.cpp). We stage them into the module
+    # subdir next to the manifest, preserving their relative path, so the env
+    # rule can place them deterministically. Entries that are targets
+    # (`:foo`, `//pkg`, `@repo//...`) are left untouched.
+    data_targets = [d for d in data if d.startswith((":", "//", "@"))]
+    data_files = [d for d in data if d not in data_targets]
+    data_subdir = []
+    if data_files:
+        data_subdir = ["{}/{}".format(name, f) for f in data_files]
+        native.genrule(
+            name = "copy_data_to_subdir",
+            srcs = data_files,
+            outs = data_subdir,
+            cmd = " && ".join([
+                ("mkdir -p $$(dirname $(RULEDIR)/{name}/{f}) && " +
+                 "cp $(location {f}) $(RULEDIR)/{name}/{f}").format(name = name, f = f)
+                for f in data_files
+            ]),
+        )
+
     native.filegroup(
         name = name,
         srcs = [
             ":copy_to_subdir",
-        ] + data,  # Include data files in the filegroup
+        ] + data_subdir + data_targets,  # Stage runtime files into the module subdir
         data = [":" + binary],  # Include the binary to get its runfiles
         visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
  Bazel-built EVerest modules had no way to ship auxiliary runtime data files
  into their share directory (`share/everest/modules/<name>/`), which is where the
  framework resolves them at runtime. The `everest_env` rule only
  symlinked files under the module prefix into `libexec/` and nothing into `share/`.

  `powermeterImpl` loads its models from `mod->info.paths.share / "models"`, and CMake already installs `models/` to `share/everest/modules/GenericPowermeter/models/`. Under Bazel those files never reached the sysroot, so no model could be loaded.
  
  Co-authored-by: Usame Islamoglu <uis@qwello.eu>

  ## Describe your changes

Adds a generic way for Bazel-built EVerest modules to include runtime data files in their module share directory:

`share/everest/modules/<name>/`

This matches the path used by the framework at runtime and the location where CMake already installs these files.

`cc_everest_module` now stages package-relative data files into the module’s share directory. everest_env puts the binary and manifest under `libexec/`, while routing all other files to `share/`.

GenericPowermeter now uses this so its register-map models are available at runtime when built with Bazel.

  ## Checklist before requesting a review

  - [x] I have performed a self-review of my code
  - [ ] I have made corresponding changes to the documentation
  - [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
