### PR TITLE
fix(cbv2g): correct SAE DER curve list grammar

### DIFF
--- a/lib/everest/cbv2g/lib/cbv2g/iso_20/iso20_AC_DER_SAE_Decoder.c
+++ b/lib/everest/cbv2g/lib/cbv2g/iso_20/iso20_AC_DER_SAE_Decoder.c
@@ -4062,8 +4062,8 @@ static int decode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
         switch (grammar_id)
         {
         case 67:
-            // Grammar: ID=67; read/write bits=2; START (CurveDataPoint), END Element
-            error = exi_basetypes_decoder_nbit_uint(stream, 2, &eventCode);
+            // Grammar: ID=67; read/write bits=1; START (CurveDataPoint)
+            error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
             if (error == 0)
             {
                 switch (eventCode)
@@ -4080,12 +4080,11 @@ static int decode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
                         // static array not large enough, only iso20_ac_der_sae_DataTupleType_10_ARRAY_SIZE elements
                         error = EXI_ERROR__ARRAY_OUT_OF_BOUNDS;
                     }
-                    grammar_id = 68;
-                    break;
-                case 1:
-                    // Event: END Element; next=3
-                    done = 1;
-                    grammar_id = 3;
+
+                    if (CurveDataPointsListType->CurveDataPoint.arrayLen >= 2)
+                    {
+                        grammar_id = 68;
+                    }
                     break;
                 default:
                     error = EXI_ERROR__UNKNOWN_EVENT_CODE;
@@ -4094,8 +4093,8 @@ static int decode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
             }
             break;
         case 68:
-            // Grammar: ID=68; read/write bits=1; LOOP (CurveDataPoint)
-            error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
+            // Grammar: ID=68; read/write bits=2; LOOP (CurveDataPoint), END Element
+            error = exi_basetypes_decoder_nbit_uint(stream, 2, &eventCode);
             if (error == 0)
             {
                 switch (eventCode)
@@ -4119,8 +4118,13 @@ static int decode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
                     }
                     else
                     {
-                        grammar_id = -1;
+                        grammar_id = 2;
                     }
+                    break;
+                case 1:
+                    // Event: END Element; next=3
+                    done = 1;
+                    grammar_id = 3;
                     break;
                 default:
                     error = EXI_ERROR__UNKNOWN_EVENT_CODE;

--- a/lib/everest/cbv2g/lib/cbv2g/iso_20/iso20_AC_DER_SAE_Encoder.c
+++ b/lib/everest/cbv2g/lib/cbv2g/iso_20/iso20_AC_DER_SAE_Encoder.c
@@ -3690,13 +3690,36 @@ static int encode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
         switch (grammar_id)
         {
         case 67:
-            // Grammar: ID=67; read/write bits=2; START (CurveDataPoint), END Element
+            // Grammar: ID=67; read/write bits=1; START (CurveDataPoint)
+            if (CurveDataPoint_currentIndex < CurveDataPointsListType->CurveDataPoint.arrayLen)
+            {
+                error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
+                if (error == EXI_ERROR__NO_ERROR)
+                {
+                    // Event: START (DataTupleType); next=67, 68
+                    error = encode_iso20_ac_der_sae_DataTupleType(stream, &CurveDataPointsListType->CurveDataPoint.array[CurveDataPoint_currentIndex++]);
+                    if (error == EXI_ERROR__NO_ERROR)
+                    {
+                        if (CurveDataPoint_currentIndex >= 2)
+                        {
+                            grammar_id = 68;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                error = EXI_ERROR__UNKNOWN_EVENT_CODE;
+            }
+            break;
+        case 68:
+            // Grammar: ID=68; read/write bits=2; LOOP (CurveDataPoint), END Element
             if (CurveDataPoint_currentIndex < CurveDataPointsListType->CurveDataPoint.arrayLen)
             {
                 error = exi_basetypes_encoder_nbit_uint(stream, 2, 0);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (DataTupleType); next=68
+                    // Event: LOOP (DataTupleType); next=68
                     error = encode_iso20_ac_der_sae_DataTupleType(stream, &CurveDataPointsListType->CurveDataPoint.array[CurveDataPoint_currentIndex++]);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
@@ -3713,26 +3736,6 @@ static int encode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
                     done = 1;
                     grammar_id = 3;
                 }
-            }
-            break;
-        case 68:
-            // Grammar: ID=68; read/write bits=1; LOOP (CurveDataPoint)
-            if (CurveDataPoint_currentIndex < CurveDataPointsListType->CurveDataPoint.arrayLen)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: LOOP (DataTupleType); next=68
-                    error = encode_iso20_ac_der_sae_DataTupleType(stream, &CurveDataPointsListType->CurveDataPoint.array[CurveDataPoint_currentIndex++]);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 68;
-                    }
-                }
-            }
-            else
-            {
-                error = EXI_ERROR__UNKNOWN_EVENT_CODE;
             }
             break;
         case 2:


### PR DESCRIPTION
CurveDataPointsListType (minOccurs=2) was generated with a 2-bit optional-first event code and a loop state lacking an END production, desyncing curve EXI (decode -151, encode -150). Mirror the IEC grammar: 1-bit mandatory START until arrayLen>=2, then 2-bit {LOOP, END}.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

