### PR TITLE
fix(iso15118): namespace SAE DER datatypes

### DIFF
--- a/lib/everest/cbv2g/lib/cbv2g/iso_20/iso20_AC_DER_SAE_Decoder.c
+++ b/lib/everest/cbv2g/lib/cbv2g/iso_20/iso20_AC_DER_SAE_Decoder.c
@@ -4062,8 +4062,8 @@ static int decode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
         switch (grammar_id)
         {
         case 67:
-            // Grammar: ID=67; read/write bits=2; START (CurveDataPoint), END Element
-            error = exi_basetypes_decoder_nbit_uint(stream, 2, &eventCode);
+            // Grammar: ID=67; read/write bits=1; START (CurveDataPoint)
+            error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
             if (error == 0)
             {
                 switch (eventCode)
@@ -4080,12 +4080,11 @@ static int decode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
                         // static array not large enough, only iso20_ac_der_sae_DataTupleType_10_ARRAY_SIZE elements
                         error = EXI_ERROR__ARRAY_OUT_OF_BOUNDS;
                     }
-                    grammar_id = 68;
-                    break;
-                case 1:
-                    // Event: END Element; next=3
-                    done = 1;
-                    grammar_id = 3;
+
+                    if (CurveDataPointsListType->CurveDataPoint.arrayLen >= 2)
+                    {
+                        grammar_id = 68;
+                    }
                     break;
                 default:
                     error = EXI_ERROR__UNKNOWN_EVENT_CODE;
@@ -4094,8 +4093,8 @@ static int decode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
             }
             break;
         case 68:
-            // Grammar: ID=68; read/write bits=1; LOOP (CurveDataPoint)
-            error = exi_basetypes_decoder_nbit_uint(stream, 1, &eventCode);
+            // Grammar: ID=68; read/write bits=2; LOOP (CurveDataPoint), END Element
+            error = exi_basetypes_decoder_nbit_uint(stream, 2, &eventCode);
             if (error == 0)
             {
                 switch (eventCode)
@@ -4119,8 +4118,13 @@ static int decode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
                     }
                     else
                     {
-                        grammar_id = -1;
+                        grammar_id = 2;
                     }
+                    break;
+                case 1:
+                    // Event: END Element; next=3
+                    done = 1;
+                    grammar_id = 3;
                     break;
                 default:
                     error = EXI_ERROR__UNKNOWN_EVENT_CODE;

--- a/lib/everest/cbv2g/lib/cbv2g/iso_20/iso20_AC_DER_SAE_Encoder.c
+++ b/lib/everest/cbv2g/lib/cbv2g/iso_20/iso20_AC_DER_SAE_Encoder.c
@@ -3690,13 +3690,36 @@ static int encode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
         switch (grammar_id)
         {
         case 67:
-            // Grammar: ID=67; read/write bits=2; START (CurveDataPoint), END Element
+            // Grammar: ID=67; read/write bits=1; START (CurveDataPoint)
+            if (CurveDataPoint_currentIndex < CurveDataPointsListType->CurveDataPoint.arrayLen)
+            {
+                error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
+                if (error == EXI_ERROR__NO_ERROR)
+                {
+                    // Event: START (DataTupleType); next=67, 68
+                    error = encode_iso20_ac_der_sae_DataTupleType(stream, &CurveDataPointsListType->CurveDataPoint.array[CurveDataPoint_currentIndex++]);
+                    if (error == EXI_ERROR__NO_ERROR)
+                    {
+                        if (CurveDataPoint_currentIndex >= 2)
+                        {
+                            grammar_id = 68;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                error = EXI_ERROR__UNKNOWN_EVENT_CODE;
+            }
+            break;
+        case 68:
+            // Grammar: ID=68; read/write bits=2; LOOP (CurveDataPoint), END Element
             if (CurveDataPoint_currentIndex < CurveDataPointsListType->CurveDataPoint.arrayLen)
             {
                 error = exi_basetypes_encoder_nbit_uint(stream, 2, 0);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (DataTupleType); next=68
+                    // Event: LOOP (DataTupleType); next=68
                     error = encode_iso20_ac_der_sae_DataTupleType(stream, &CurveDataPointsListType->CurveDataPoint.array[CurveDataPoint_currentIndex++]);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
@@ -3713,26 +3736,6 @@ static int encode_iso20_ac_der_sae_CurveDataPointsListType(exi_bitstream_t* stre
                     done = 1;
                     grammar_id = 3;
                 }
-            }
-            break;
-        case 68:
-            // Grammar: ID=68; read/write bits=1; LOOP (CurveDataPoint)
-            if (CurveDataPoint_currentIndex < CurveDataPointsListType->CurveDataPoint.arrayLen)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 1, 0);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: LOOP (DataTupleType); next=68
-                    error = encode_iso20_ac_der_sae_DataTupleType(stream, &CurveDataPointsListType->CurveDataPoint.array[CurveDataPoint_currentIndex++]);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 68;
-                    }
-                }
-            }
-            else
-            {
-                error = EXI_ERROR__UNKNOWN_EVENT_CODE;
             }
             break;
         case 2:

--- a/lib/everest/iso15118/include/iso15118/message/ac_der_sae_charge_loop.hpp
+++ b/lib/everest/iso15118/include/iso15118/message/ac_der_sae_charge_loop.hpp
@@ -11,6 +11,7 @@
 namespace iso15118::message_20 {
 
 namespace datatypes {
+namespace sae {
 
 // EVApparentPower struct based on EVApparentPowerType from XSD
 struct EVApparentPower {
@@ -180,6 +181,7 @@ struct DER_Dynamic_AC_CLResControlMode : Dynamic_AC_CLResControlMode {
     std::optional<GridConnectionMode> grid_connection_mode;
 };
 
+} // namespace sae
 } // namespace datatypes
 
 struct DER_SAE_AC_ChargeLoopRequest {
@@ -190,7 +192,8 @@ struct DER_SAE_AC_ChargeLoopRequest {
     std::optional<datatypes::DisplayParameters> display_parameters;
     bool meter_info_requested;
 
-    std::variant<datatypes::DER_Scheduled_AC_CLReqControlMode, datatypes::DER_Dynamic_AC_CLReqControlMode> control_mode;
+    std::variant<datatypes::sae::DER_Scheduled_AC_CLReqControlMode, datatypes::sae::DER_Dynamic_AC_CLReqControlMode>
+        control_mode;
 };
 
 struct DER_SAE_AC_ChargeLoopResponse {
@@ -205,9 +208,8 @@ struct DER_SAE_AC_ChargeLoopResponse {
 
     std::optional<datatypes::RationalNumber> target_frequency;
 
-    std::variant<datatypes::DER_Scheduled_AC_CLResControlMode, datatypes::DER_Dynamic_AC_CLResControlMode> control_mode{
-        datatypes::DER_Scheduled_AC_CLResControlMode()};
+    std::variant<datatypes::sae::DER_Scheduled_AC_CLResControlMode, datatypes::sae::DER_Dynamic_AC_CLResControlMode>
+        control_mode{datatypes::sae::DER_Scheduled_AC_CLResControlMode()};
 };
 
 } // namespace iso15118::message_20
-

--- a/lib/everest/iso15118/include/iso15118/message/ac_der_sae_charge_parameter_discovery.hpp
+++ b/lib/everest/iso15118/include/iso15118/message/ac_der_sae_charge_parameter_discovery.hpp
@@ -12,6 +12,7 @@
 namespace iso15118::message_20 {
 
 namespace datatypes {
+namespace sae {
 
 // Type aliases for string-based XSD types
 using InverterSwVersion = std::string;
@@ -196,17 +197,18 @@ struct DER_SAE_AC_CPDResEnergyTransferMode : AC_CPDResEnergyTransferMode {
     uint64_t update_time;
 };
 
+} // namespace sae
 } // namespace datatypes
 
 struct DER_SAE_AC_ChargeParameterDiscoveryRequest {
     Header header;
-    datatypes::DER_SAE_AC_CPDReqEnergyTransferMode transfer_mode;
+    datatypes::sae::DER_SAE_AC_CPDReqEnergyTransferMode transfer_mode;
 };
 
 struct DER_SAE_AC_ChargeParameterDiscoveryResponse {
     Header header;
     datatypes::ResponseCode response_code{};
-    datatypes::DER_SAE_AC_CPDResEnergyTransferMode transfer_mode;
+    datatypes::sae::DER_SAE_AC_CPDResEnergyTransferMode transfer_mode;
 };
 
 } // namespace iso15118::message_20

--- a/lib/everest/iso15118/include/iso15118/message/ac_der_sae_types.hpp
+++ b/lib/everest/iso15118/include/iso15118/message/ac_der_sae_types.hpp
@@ -9,7 +9,7 @@
 
 #include "common_types.hpp"
 
-namespace iso15118::message_20::datatypes {
+namespace iso15118::message_20::datatypes::sae {
 
 enum class PowerFactorExcitation : std::uint8_t {
     OverExcited,
@@ -200,4 +200,4 @@ struct FrequencyTrip {
     std::optional<DERCurve> under_frequency_may_trip_curve;
 };
 
-} // namespace iso15118::message_20::datatypes
+} // namespace iso15118::message_20::datatypes::sae

--- a/lib/everest/iso15118/src/iso15118/message/ac_der_sae_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/ac_der_sae_charge_parameter_discovery.cpp
@@ -9,11 +9,11 @@
 
 namespace iso15118::message_20 {
 
-using DER_AC_ModeReq = datatypes::DER_SAE_AC_CPDReqEnergyTransferMode;
-using DER_AC_ModeRes = datatypes::DER_SAE_AC_CPDResEnergyTransferMode;
+using DER_AC_ModeReq = datatypes::sae::DER_SAE_AC_CPDReqEnergyTransferMode;
+using DER_AC_ModeRes = datatypes::sae::DER_SAE_AC_CPDResEnergyTransferMode;
 
 template <>
-void convert(const struct iso20_ac_der_sae_EVApparentPowerLimitsType& in, datatypes::EVApparentPowerLimits& out) {
+void convert(const struct iso20_ac_der_sae_EVApparentPowerLimitsType& in, datatypes::sae::EVApparentPowerLimits& out) {
     convert(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption,
             out.maximum_apparent_power_during_charging_and_var_absorption);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L2,
@@ -41,7 +41,7 @@ void convert(const struct iso20_ac_der_sae_EVApparentPowerLimitsType& in, dataty
 }
 
 template <>
-void convert(const datatypes::EVApparentPowerLimits& in, struct iso20_ac_der_sae_EVApparentPowerLimitsType& out) {
+void convert(const datatypes::sae::EVApparentPowerLimits& in, struct iso20_ac_der_sae_EVApparentPowerLimitsType& out) {
     init_iso20_ac_der_sae_EVApparentPowerLimitsType(&out);
     convert(in.maximum_apparent_power_during_charging_and_var_absorption,
             out.EVMaximumApparentPowerDuringChargingAndVarAbsorption);
@@ -70,7 +70,7 @@ void convert(const datatypes::EVApparentPowerLimits& in, struct iso20_ac_der_sae
 }
 
 template <>
-void convert(const struct iso20_ac_der_sae_EVReactivePowerLimitsType& in, datatypes::EVReactivePowerLimits& out) {
+void convert(const struct iso20_ac_der_sae_EVReactivePowerLimitsType& in, datatypes::sae::EVReactivePowerLimits& out) {
     convert(in.EVMaximumVarAbsorptionDuringCharging, out.maximum_var_absorption_during_charging);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringCharging_L2, out.maximum_var_absorption_during_charging_L2);
     CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringCharging_L3, out.maximum_var_absorption_during_charging_L3);
@@ -109,7 +109,7 @@ void convert(const struct iso20_ac_der_sae_EVReactivePowerLimitsType& in, dataty
 }
 
 template <>
-void convert(const datatypes::EVReactivePowerLimits& in, struct iso20_ac_der_sae_EVReactivePowerLimitsType& out) {
+void convert(const datatypes::sae::EVReactivePowerLimits& in, struct iso20_ac_der_sae_EVReactivePowerLimitsType& out) {
     init_iso20_ac_der_sae_EVReactivePowerLimitsType(&out);
     convert(in.maximum_var_absorption_during_charging, out.EVMaximumVarAbsorptionDuringCharging);
     CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_charging_L2, out.EVMaximumVarAbsorptionDuringCharging_L2);
@@ -148,7 +148,8 @@ void convert(const datatypes::EVReactivePowerLimits& in, struct iso20_ac_der_sae
     CPP2CB_CONVERT_IF_USED(in.reactive_susceptance_L3, out.EVReactiveSusceptance_L3);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_EVExcitationLimitsType& in, datatypes::EVExcitationLimits& out) {
+template <>
+void convert(const struct iso20_ac_der_sae_EVExcitationLimitsType& in, datatypes::sae::EVExcitationLimits& out) {
     convert(in.EVSpecifiedOverExcitedPowerFactor, out.specified_over_excited_power_factor);
     CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor_L2, out.specified_over_excited_power_factor_L2);
     CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor_L3, out.specified_over_excited_power_factor_L3);
@@ -163,7 +164,8 @@ template <> void convert(const struct iso20_ac_der_sae_EVExcitationLimitsType& i
     CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedDischargePower_L3, out.specified_under_excited_discharge_power_L3);
 }
 
-template <> void convert(const datatypes::EVExcitationLimits& in, struct iso20_ac_der_sae_EVExcitationLimitsType& out) {
+template <>
+void convert(const datatypes::sae::EVExcitationLimits& in, struct iso20_ac_der_sae_EVExcitationLimitsType& out) {
     init_iso20_ac_der_sae_EVExcitationLimitsType(&out);
     convert(in.specified_over_excited_power_factor, out.EVSpecifiedOverExcitedPowerFactor);
     CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor_L2, out.EVSpecifiedOverExcitedPowerFactor_L2);
@@ -179,7 +181,8 @@ template <> void convert(const datatypes::EVExcitationLimits& in, struct iso20_a
     CPP2CB_CONVERT_IF_USED(in.specified_under_excited_discharge_power_L3, out.EVSpecifiedUnderExcitedDischargePower_L3);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_EVInverterDetailsType& in, datatypes::EVInverterDetails& out) {
+template <>
+void convert(const struct iso20_ac_der_sae_EVInverterDetailsType& in, datatypes::sae::EVInverterDetails& out) {
     out.inverter_sw_version = CB2CPP_STRING(in.EVInverterSwVersion);
     CB2CPP_STRING_IF_USED(in.EVInverterHwVersion, out.inverter_hw_version);
     out.inverter_manufacturer = CB2CPP_STRING(in.EVInverterManufacturer);
@@ -187,7 +190,8 @@ template <> void convert(const struct iso20_ac_der_sae_EVInverterDetailsType& in
     out.inverter_serial_number = CB2CPP_STRING(in.EVInverterSerialNumber);
 }
 
-template <> void convert(const datatypes::EVInverterDetails& in, struct iso20_ac_der_sae_EVInverterDetailsType& out) {
+template <>
+void convert(const datatypes::sae::EVInverterDetails& in, struct iso20_ac_der_sae_EVInverterDetailsType& out) {
     init_iso20_ac_der_sae_EVInverterDetailsType(&out);
     CPP2CB_STRING(in.inverter_sw_version, out.EVInverterSwVersion);
     CPP2CB_STRING_IF_USED(in.inverter_hw_version, out.EVInverterHwVersion);
@@ -249,7 +253,7 @@ template <> void insert_type(VariantAccess& va, const struct iso20_ac_der_sae_AC
 }
 
 template <>
-void convert(const datatypes::DER_SAE_AC_CPDReqEnergyTransferMode& in,
+void convert(const datatypes::sae::DER_SAE_AC_CPDReqEnergyTransferMode& in,
              struct iso20_ac_der_sae_DER_AC_CPDReqEnergyTransferModeType& out) {
     init_iso20_ac_der_sae_DER_AC_CPDReqEnergyTransferModeType(&out);
 
@@ -312,7 +316,8 @@ template <> size_t serialize(const DER_SAE_AC_ChargeParameterDiscoveryRequest& i
 }
 
 template <>
-void convert(const struct iso20_ac_der_sae_ActivePowerSupportCPDResType& in, datatypes::ActivePowerSupportCPDRes& out) {
+void convert(const struct iso20_ac_der_sae_ActivePowerSupportCPDResType& in,
+             datatypes::sae::ActivePowerSupportCPDRes& out) {
     convert(in.FrequencyDroop, out.frequency_droop);
     convert(in.VoltWatt, out.volt_watt);
     convert(in.ConstantWatt, out.constant_watt);
@@ -320,7 +325,8 @@ void convert(const struct iso20_ac_der_sae_ActivePowerSupportCPDResType& in, dat
 }
 
 template <>
-void convert(const datatypes::ActivePowerSupportCPDRes& in, struct iso20_ac_der_sae_ActivePowerSupportCPDResType& out) {
+void convert(const datatypes::sae::ActivePowerSupportCPDRes& in,
+             struct iso20_ac_der_sae_ActivePowerSupportCPDResType& out) {
     init_iso20_ac_der_sae_ActivePowerSupportCPDResType(&out);
     convert(in.frequency_droop, out.FrequencyDroop);
     convert(in.volt_watt, out.VoltWatt);
@@ -330,7 +336,7 @@ void convert(const datatypes::ActivePowerSupportCPDRes& in, struct iso20_ac_der_
 
 template <>
 void convert(const struct iso20_ac_der_sae_ReactivePowerSupportCPDResType& in,
-             datatypes::ReactivePowerSupportCPDRes& out) {
+             datatypes::sae::ReactivePowerSupportCPDRes& out) {
     convert(in.ConstantPowerFactor, out.constant_power_factor);
     convert(in.VoltVar, out.volt_var);
     convert(in.WattVar, out.watt_var);
@@ -338,7 +344,7 @@ void convert(const struct iso20_ac_der_sae_ReactivePowerSupportCPDResType& in,
 }
 
 template <>
-void convert(const datatypes::ReactivePowerSupportCPDRes& in,
+void convert(const datatypes::sae::ReactivePowerSupportCPDRes& in,
              struct iso20_ac_der_sae_ReactivePowerSupportCPDResType& out) {
     init_iso20_ac_der_sae_ReactivePowerSupportCPDResType(&out);
     convert(in.constant_power_factor, out.ConstantPowerFactor);
@@ -347,7 +353,8 @@ void convert(const datatypes::ReactivePowerSupportCPDRes& in,
     convert(in.constant_var, out.ConstantVar);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_EnterServiceCPDResType& in, datatypes::EnterServiceCPDRes& out) {
+template <>
+void convert(const struct iso20_ac_der_sae_EnterServiceCPDResType& in, datatypes::sae::EnterServiceCPDRes& out) {
     out.permit_service = in.PermitService;
     convert(in.EnterServiceVoltageHigh, out.enter_service_voltage_high);
     convert(in.EnterServiceVoltageLow, out.enter_service_voltage_low);
@@ -358,7 +365,8 @@ template <> void convert(const struct iso20_ac_der_sae_EnterServiceCPDResType& i
     CB2CPP_CONVERT_IF_USED(in.EnterServiceRampTime, out.enter_service_ramp_time);
 }
 
-template <> void convert(const datatypes::EnterServiceCPDRes& in, struct iso20_ac_der_sae_EnterServiceCPDResType& out) {
+template <>
+void convert(const datatypes::sae::EnterServiceCPDRes& in, struct iso20_ac_der_sae_EnterServiceCPDResType& out) {
     init_iso20_ac_der_sae_EnterServiceCPDResType(&out);
     out.PermitService = in.permit_service;
     convert(in.enter_service_voltage_high, out.EnterServiceVoltageHigh);
@@ -370,7 +378,8 @@ template <> void convert(const datatypes::EnterServiceCPDRes& in, struct iso20_a
     CPP2CB_CONVERT_IF_USED(in.enter_service_ramp_time, out.EnterServiceRampTime);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_DERControlCPDResType& in, datatypes::DERControlCPDRes& out) {
+template <>
+void convert(const struct iso20_ac_der_sae_DERControlCPDResType& in, datatypes::sae::DERControlCPDRes& out) {
     convert(in.VoltageTrip, out.voltage_trip);
     convert(in.FrequencyTrip, out.frequency_trip);
     convert(in.EnterServiceCPDRes, out.enter_service_cpd_res);
@@ -378,7 +387,8 @@ template <> void convert(const struct iso20_ac_der_sae_DERControlCPDResType& in,
     convert(in.ActivePowerSupportCPDRes, out.active_power_support_cpd_res);
 }
 
-template <> void convert(const datatypes::DERControlCPDRes& in, struct iso20_ac_der_sae_DERControlCPDResType& out) {
+template <>
+void convert(const datatypes::sae::DERControlCPDRes& in, struct iso20_ac_der_sae_DERControlCPDResType& out) {
     init_iso20_ac_der_sae_DERControlCPDResType(&out);
     convert(in.voltage_trip, out.VoltageTrip);
     convert(in.frequency_trip, out.FrequencyTrip);
@@ -388,7 +398,8 @@ template <> void convert(const datatypes::DERControlCPDRes& in, struct iso20_ac_
 }
 
 template <>
-void convert(const struct iso20_ac_der_sae_EVSEReactivePowerLimitsType& in, datatypes::EVSEReactivePowerLimits& out) {
+void convert(const struct iso20_ac_der_sae_EVSEReactivePowerLimitsType& in,
+             datatypes::sae::EVSEReactivePowerLimits& out) {
     convert(in.EVSEMaximumVarAbsorptionDuringCharging, out.maximum_var_absorption_during_charging);
     CB2CPP_CONVERT_IF_USED(in.EVSEMaximumVarAbsorptionDuringCharging_L2, out.maximum_var_absorption_during_charging_L2);
     CB2CPP_CONVERT_IF_USED(in.EVSEMaximumVarAbsorptionDuringCharging_L3, out.maximum_var_absorption_during_charging_L3);
@@ -408,7 +419,8 @@ void convert(const struct iso20_ac_der_sae_EVSEReactivePowerLimitsType& in, data
 }
 
 template <>
-void convert(const datatypes::EVSEReactivePowerLimits& in, struct iso20_ac_der_sae_EVSEReactivePowerLimitsType& out) {
+void convert(const datatypes::sae::EVSEReactivePowerLimits& in,
+             struct iso20_ac_der_sae_EVSEReactivePowerLimitsType& out) {
     init_iso20_ac_der_sae_EVSEReactivePowerLimitsType(&out);
     convert(in.maximum_var_absorption_during_charging, out.EVSEMaximumVarAbsorptionDuringCharging);
     CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_charging_L2, out.EVSEMaximumVarAbsorptionDuringCharging_L2);
@@ -428,7 +440,7 @@ void convert(const datatypes::EVSEReactivePowerLimits& in, struct iso20_ac_der_s
                            out.EVSEMaximumVarInjectionDuringDischarging_L3);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_GridLimitsType& in, datatypes::GridLimits& out) {
+template <> void convert(const struct iso20_ac_der_sae_GridLimitsType& in, datatypes::sae::GridLimits& out) {
     convert(in.GridNominalFrequency, out.nominal_frequency);
     convert(in.GridNominalVoltage, out.nominal_voltage);
     convert(in.GridNominalVoltageOffset, out.nominal_voltage_offset);
@@ -438,7 +450,7 @@ template <> void convert(const struct iso20_ac_der_sae_GridLimitsType& in, datat
     convert(in.GridMinimumVoltage, out.minimum_voltage);
 }
 
-template <> void convert(const datatypes::GridLimits& in, struct iso20_ac_der_sae_GridLimitsType& out) {
+template <> void convert(const datatypes::sae::GridLimits& in, struct iso20_ac_der_sae_GridLimitsType& out) {
     init_iso20_ac_der_sae_GridLimitsType(&out);
     convert(in.nominal_frequency, out.GridNominalFrequency);
     convert(in.nominal_voltage, out.GridNominalVoltage);

--- a/lib/everest/iso15118/src/iso15118/message/ac_der_sae_types.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/ac_der_sae_types.cpp
@@ -10,28 +10,28 @@
 
 namespace iso15118::message_20 {
 
-template <> void convert(const struct iso20_ac_der_sae_DataTupleType& in, datatypes::DataTuple& out) {
+template <> void convert(const struct iso20_ac_der_sae_DataTupleType& in, datatypes::sae::DataTuple& out) {
     convert(in.xValue, out.x_value);
     convert(in.yValue, out.y_value);
 }
 
-template <> void convert(const datatypes::DataTuple& in, struct iso20_ac_der_sae_DataTupleType& out) {
+template <> void convert(const datatypes::sae::DataTuple& in, struct iso20_ac_der_sae_DataTupleType& out) {
     convert(in.x_value, out.xValue);
     convert(in.y_value, out.yValue);
 }
 
 template <>
-void convert(const struct iso20_ac_der_sae_CurveDataPointsListType& in, datatypes::CurveDataPointsList& out) {
+void convert(const struct iso20_ac_der_sae_CurveDataPointsListType& in, datatypes::sae::CurveDataPointsList& out) {
     out.clear();
     for (size_t i = 0; i < in.CurveDataPoint.arrayLen; ++i) {
-        datatypes::DataTuple tuple;
+        datatypes::sae::DataTuple tuple;
         convert(in.CurveDataPoint.array[i], tuple);
         out.push_back(tuple);
     }
 }
 
 template <>
-void convert(const datatypes::CurveDataPointsList& in, struct iso20_ac_der_sae_CurveDataPointsListType& out) {
+void convert(const datatypes::sae::CurveDataPointsList& in, struct iso20_ac_der_sae_CurveDataPointsListType& out) {
     init_iso20_ac_der_sae_CurveDataPointsListType(&out);
     out.CurveDataPoint.arrayLen = in.size();
     for (size_t i = 0; i < in.size(); i++) {
@@ -39,7 +39,7 @@ void convert(const datatypes::CurveDataPointsList& in, struct iso20_ac_der_sae_C
     }
 }
 
-template <> void convert(const struct iso20_ac_der_sae_DERCurveType& in, datatypes::DERCurve& out) {
+template <> void convert(const struct iso20_ac_der_sae_DERCurveType& in, datatypes::sae::DERCurve& out) {
     out.enable = static_cast<bool>(in.Enable);
     CB2CPP_ASSIGN_IF_USED(in.Priority, out.priority);
     cb_convert_enum(in.xUnit, out.x_unit);
@@ -49,7 +49,7 @@ template <> void convert(const struct iso20_ac_der_sae_DERCurveType& in, datatyp
     CB2CPP_CONVERT_IF_USED(in.CurveDataPoints_L3, out.curve_data_points_L3);
 }
 
-template <> void convert(const datatypes::DERCurve& in, struct iso20_ac_der_sae_DERCurveType& out) {
+template <> void convert(const datatypes::sae::DERCurve& in, struct iso20_ac_der_sae_DERCurveType& out) {
     init_iso20_ac_der_sae_DERCurveType(&out);
     out.Enable = in.enable;
     CPP2CB_ASSIGN_IF_USED(in.priority, out.Priority);
@@ -61,7 +61,8 @@ template <> void convert(const datatypes::DERCurve& in, struct iso20_ac_der_sae_
 }
 
 template <>
-void convert(const struct iso20_ac_der_sae_FrequencyDroopSettingsType& in, datatypes::FrequencyDroopSettings& out) {
+void convert(const struct iso20_ac_der_sae_FrequencyDroopSettingsType& in,
+             datatypes::sae::FrequencyDroopSettings& out) {
     convert(in.db, out.db);
     convert(in.DroopFactor, out.droop_factor);
     CB2CPP_CONVERT_IF_USED(in.DroopFactor_L2, out.droop_factor_L2);
@@ -77,7 +78,8 @@ void convert(const struct iso20_ac_der_sae_FrequencyDroopSettingsType& in, datat
 }
 
 template <>
-void convert(const datatypes::FrequencyDroopSettings& in, struct iso20_ac_der_sae_FrequencyDroopSettingsType& out) {
+void convert(const datatypes::sae::FrequencyDroopSettings& in,
+             struct iso20_ac_der_sae_FrequencyDroopSettingsType& out) {
     init_iso20_ac_der_sae_FrequencyDroopSettingsType(&out);
     convert(in.db, out.db);
     convert(in.droop_factor, out.DroopFactor);
@@ -95,14 +97,14 @@ void convert(const datatypes::FrequencyDroopSettings& in, struct iso20_ac_der_sa
     convert(in.open_loop_response_time, out.OpenLoopResponseTime);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_FrequencyDroopType& in, datatypes::FrequencyDroop& out) {
+template <> void convert(const struct iso20_ac_der_sae_FrequencyDroopType& in, datatypes::sae::FrequencyDroop& out) {
     out.enable = static_cast<bool>(in.Enable);
     CB2CPP_ASSIGN_IF_USED(in.Priority, out.priority);
     CB2CPP_CONVERT_IF_USED(in.OverFrequencyDroop, out.over_frequency_droop);
     CB2CPP_CONVERT_IF_USED(in.UnderFrequencyDroop, out.under_frequency_droop);
 }
 
-template <> void convert(const datatypes::FrequencyDroop& in, struct iso20_ac_der_sae_FrequencyDroopType& out) {
+template <> void convert(const datatypes::sae::FrequencyDroop& in, struct iso20_ac_der_sae_FrequencyDroopType& out) {
     init_iso20_ac_der_sae_FrequencyDroopType(&out);
     out.Enable = in.enable;
     CPP2CB_ASSIGN_IF_USED(in.priority, out.Priority);
@@ -110,7 +112,7 @@ template <> void convert(const datatypes::FrequencyDroop& in, struct iso20_ac_de
     CPP2CB_CONVERT_IF_USED(in.under_frequency_droop, out.UnderFrequencyDroop);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_VoltWattType& in, datatypes::VoltWatt& out) {
+template <> void convert(const struct iso20_ac_der_sae_VoltWattType& in, datatypes::sae::VoltWatt& out) {
     out.enable = static_cast<bool>(in.Enable);
     CB2CPP_ASSIGN_IF_USED(in.Priority, out.priority);
     cb_convert_enum(in.xUnit, out.x_unit);
@@ -122,7 +124,7 @@ template <> void convert(const struct iso20_ac_der_sae_VoltWattType& in, datatyp
     CB2CPP_ASSIGN_IF_USED(in.TimeConstantPT1, out.time_constant_pt1);
 }
 
-template <> void convert(const datatypes::VoltWatt& in, struct iso20_ac_der_sae_VoltWattType& out) {
+template <> void convert(const datatypes::sae::VoltWatt& in, struct iso20_ac_der_sae_VoltWattType& out) {
     init_iso20_ac_der_sae_VoltWattType(&out);
     out.Enable = in.enable;
     CPP2CB_ASSIGN_IF_USED(in.priority, out.Priority);
@@ -135,7 +137,7 @@ template <> void convert(const datatypes::VoltWatt& in, struct iso20_ac_der_sae_
     CPP2CB_ASSIGN_IF_USED(in.time_constant_pt1, out.TimeConstantPT1);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_ConstantWattType& in, datatypes::ConstantWatt& out) {
+template <> void convert(const struct iso20_ac_der_sae_ConstantWattType& in, datatypes::sae::ConstantWatt& out) {
     out.enable = static_cast<bool>(in.Enable);
     CB2CPP_ASSIGN_IF_USED(in.Priority, out.priority);
     convert(in.WattSetpoint, out.watt_setpoint);
@@ -144,7 +146,7 @@ template <> void convert(const struct iso20_ac_der_sae_ConstantWattType& in, dat
     cb_convert_enum(in.Unit, out.unit);
 }
 
-template <> void convert(const datatypes::ConstantWatt& in, struct iso20_ac_der_sae_ConstantWattType& out) {
+template <> void convert(const datatypes::sae::ConstantWatt& in, struct iso20_ac_der_sae_ConstantWattType& out) {
     init_iso20_ac_der_sae_ConstantWattType(&out);
     out.Enable = in.enable;
     CPP2CB_ASSIGN_IF_USED(in.priority, out.Priority);
@@ -155,7 +157,8 @@ template <> void convert(const datatypes::ConstantWatt& in, struct iso20_ac_der_
 }
 
 template <>
-void convert(const struct iso20_ac_der_sae_LimitMaxDischargePowerType& in, datatypes::LimitMaxDischargePower& out) {
+void convert(const struct iso20_ac_der_sae_LimitMaxDischargePowerType& in,
+             datatypes::sae::LimitMaxDischargePower& out) {
     out.enable = static_cast<bool>(in.Enable);
     CB2CPP_ASSIGN_IF_USED(in.Priority, out.priority);
     out.percentage_value = in.PercentageValue;
@@ -165,7 +168,8 @@ void convert(const struct iso20_ac_der_sae_LimitMaxDischargePowerType& in, datat
 }
 
 template <>
-void convert(const datatypes::LimitMaxDischargePower& in, struct iso20_ac_der_sae_LimitMaxDischargePowerType& out) {
+void convert(const datatypes::sae::LimitMaxDischargePower& in,
+             struct iso20_ac_der_sae_LimitMaxDischargePowerType& out) {
     init_iso20_ac_der_sae_LimitMaxDischargePowerType(&out);
     out.Enable = in.enable;
     CPP2CB_ASSIGN_IF_USED(in.priority, out.Priority);
@@ -176,7 +180,7 @@ void convert(const datatypes::LimitMaxDischargePower& in, struct iso20_ac_der_sa
 }
 
 template <>
-void convert(const struct iso20_ac_der_sae_ConstantPowerFactorType& in, datatypes::ConstantPowerFactor& out) {
+void convert(const struct iso20_ac_der_sae_ConstantPowerFactorType& in, datatypes::sae::ConstantPowerFactor& out) {
     out.enable = static_cast<bool>(in.Enable);
     CB2CPP_ASSIGN_IF_USED(in.Priority, out.priority);
     convert(in.PowerFactorValue, out.power_factor_value);
@@ -192,7 +196,7 @@ void convert(const struct iso20_ac_der_sae_ConstantPowerFactorType& in, datatype
 }
 
 template <>
-void convert(const datatypes::ConstantPowerFactor& in, struct iso20_ac_der_sae_ConstantPowerFactorType& out) {
+void convert(const datatypes::sae::ConstantPowerFactor& in, struct iso20_ac_der_sae_ConstantPowerFactorType& out) {
     init_iso20_ac_der_sae_ConstantPowerFactorType(&out);
     out.Enable = in.enable;
     CPP2CB_ASSIGN_IF_USED(in.priority, out.Priority);
@@ -210,7 +214,7 @@ void convert(const datatypes::ConstantPowerFactor& in, struct iso20_ac_der_sae_C
     }
 }
 
-template <> void convert(const struct iso20_ac_der_sae_WattVarType& in, datatypes::WattVar& out) {
+template <> void convert(const struct iso20_ac_der_sae_WattVarType& in, datatypes::sae::WattVar& out) {
     out.enable = in.Enable;
     CB2CPP_ASSIGN_IF_USED(in.Priority, out.priority);
     cb_convert_enum(in.xUnit, out.x_unit);
@@ -222,7 +226,7 @@ template <> void convert(const struct iso20_ac_der_sae_WattVarType& in, datatype
     CB2CPP_ASSIGN_IF_USED(in.TimeConstantPT1, out.time_constant_pt1);
 }
 
-template <> void convert(const datatypes::WattVar& in, struct iso20_ac_der_sae_WattVarType& out) {
+template <> void convert(const datatypes::sae::WattVar& in, struct iso20_ac_der_sae_WattVarType& out) {
     init_iso20_ac_der_sae_WattVarType(&out);
     out.Enable = in.enable;
     CPP2CB_ASSIGN_IF_USED(in.priority, out.Priority);
@@ -235,7 +239,7 @@ template <> void convert(const datatypes::WattVar& in, struct iso20_ac_der_sae_W
     CPP2CB_ASSIGN_IF_USED(in.time_constant_pt1, out.TimeConstantPT1);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_VoltVarType& in, datatypes::VoltVar& out) {
+template <> void convert(const struct iso20_ac_der_sae_VoltVarType& in, datatypes::sae::VoltVar& out) {
     out.enable = in.Enable;
     CB2CPP_ASSIGN_IF_USED(in.Priority, out.priority);
     cb_convert_enum(in.xUnit, out.x_unit);
@@ -250,7 +254,7 @@ template <> void convert(const struct iso20_ac_der_sae_VoltVarType& in, datatype
     out.reference_voltage_adjustment_time_constant = in.ReferenceVoltageAdjustmentTimeConstant;
 }
 
-template <> void convert(const datatypes::VoltVar& in, struct iso20_ac_der_sae_VoltVarType& out) {
+template <> void convert(const datatypes::sae::VoltVar& in, struct iso20_ac_der_sae_VoltVarType& out) {
     init_iso20_ac_der_sae_VoltVarType(&out);
     out.Enable = in.enable;
     CPP2CB_ASSIGN_IF_USED(in.priority, out.Priority);
@@ -266,7 +270,7 @@ template <> void convert(const datatypes::VoltVar& in, struct iso20_ac_der_sae_V
     out.ReferenceVoltageAdjustmentTimeConstant = in.reference_voltage_adjustment_time_constant;
 }
 
-template <> void convert(const struct iso20_ac_der_sae_ConstantVarType& in, datatypes::ConstantVar& out) {
+template <> void convert(const struct iso20_ac_der_sae_ConstantVarType& in, datatypes::sae::ConstantVar& out) {
     out.enable = in.Enable;
     CB2CPP_ASSIGN_IF_USED(in.Priority, out.priority);
     convert(in.VarSetpoint, out.var_setpoint);
@@ -275,7 +279,7 @@ template <> void convert(const struct iso20_ac_der_sae_ConstantVarType& in, data
     cb_convert_enum(in.Unit, out.unit);
 }
 
-template <> void convert(const datatypes::ConstantVar& in, struct iso20_ac_der_sae_ConstantVarType& out) {
+template <> void convert(const datatypes::sae::ConstantVar& in, struct iso20_ac_der_sae_ConstantVarType& out) {
     init_iso20_ac_der_sae_ConstantVarType(&out);
     out.Enable = in.enable;
     CPP2CB_ASSIGN_IF_USED(in.priority, out.Priority);
@@ -285,7 +289,7 @@ template <> void convert(const datatypes::ConstantVar& in, struct iso20_ac_der_s
     cb_convert_enum(in.unit, out.Unit);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_VoltageTripType& in, datatypes::VoltageTrip& out) {
+template <> void convert(const struct iso20_ac_der_sae_VoltageTripType& in, datatypes::sae::VoltageTrip& out) {
     convert(in.OverVoltageMustTripCurve, out.over_voltage_must_trip_curve);
     convert(in.UnderVoltageMustTripCurve, out.under_voltage_must_trip_curve);
     CB2CPP_CONVERT_IF_USED(in.OverVoltageMomentaryCessationTripCurve, out.over_voltage_momentary_cessation_trip_curve);
@@ -295,7 +299,7 @@ template <> void convert(const struct iso20_ac_der_sae_VoltageTripType& in, data
     CB2CPP_CONVERT_IF_USED(in.UnderVoltageMayTripCurve, out.under_voltage_may_trip_curve);
 }
 
-template <> void convert(const datatypes::VoltageTrip& in, struct iso20_ac_der_sae_VoltageTripType& out) {
+template <> void convert(const datatypes::sae::VoltageTrip& in, struct iso20_ac_der_sae_VoltageTripType& out) {
     init_iso20_ac_der_sae_VoltageTripType(&out);
     convert(in.over_voltage_must_trip_curve, out.OverVoltageMustTripCurve);
     convert(in.under_voltage_must_trip_curve, out.UnderVoltageMustTripCurve);
@@ -306,14 +310,14 @@ template <> void convert(const datatypes::VoltageTrip& in, struct iso20_ac_der_s
     CPP2CB_CONVERT_IF_USED(in.under_voltage_may_trip_curve, out.UnderVoltageMayTripCurve);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_FrequencyTripType& in, datatypes::FrequencyTrip& out) {
+template <> void convert(const struct iso20_ac_der_sae_FrequencyTripType& in, datatypes::sae::FrequencyTrip& out) {
     convert(in.OverFrequencyMustTripCurve, out.over_frequency_must_trip_curve);
     convert(in.UnderFrequencyMustTripCurve, out.under_frequency_must_trip_curve);
     CB2CPP_CONVERT_IF_USED(in.OverFrequencyMayTripCurve, out.over_frequency_may_trip_curve);
     CB2CPP_CONVERT_IF_USED(in.UnderFrequencyMayTripCurve, out.under_frequency_may_trip_curve);
 }
 
-template <> void convert(const datatypes::FrequencyTrip& in, struct iso20_ac_der_sae_FrequencyTripType& out) {
+template <> void convert(const datatypes::sae::FrequencyTrip& in, struct iso20_ac_der_sae_FrequencyTripType& out) {
     init_iso20_ac_der_sae_FrequencyTripType(&out);
     convert(in.over_frequency_must_trip_curve, out.OverFrequencyMustTripCurve);
     convert(in.under_frequency_must_trip_curve, out.UnderFrequencyMustTripCurve);


### PR DESCRIPTION
IEC and SAE DER types shared message_20::datatypes with different layouts (e.g. DataTuple), multiple definitions for the same struct name corrupted fixed_vector<DataTuple> curve handling. Move the SAE datatypes into a datatypes::sae sub-namespace.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

