### PR TITLE
feat(iso15118): SAE ChargeLoop Res convert + tests

### DIFF
--- a/lib/everest/iso15118/include/iso15118/message/payload_type.hpp
+++ b/lib/everest/iso15118/include/iso15118/message/payload_type.hpp
@@ -43,7 +43,7 @@ CREATE_TYPE_TRAIT(AC_ChargeLoopResponse, Part20AC);
 CREATE_TYPE_TRAIT(DER_AC_ChargeParameterDiscoveryResponse, Part20DerIec);
 CREATE_TYPE_TRAIT(DER_AC_ChargeLoopResponse, Part20DerIec);
 CREATE_TYPE_TRAIT(DER_SAE_AC_ChargeParameterDiscoveryResponse, Part20DerSae);
-// CREATE_TYPE_TRAIT(DER_SAE_AC_ChargeLoopResponse, Part20DerSae);
+CREATE_TYPE_TRAIT(DER_SAE_AC_ChargeLoopResponse, Part20DerSae);
 
 #ifdef CREATE_TYPE_TRAIT_PUSHED
 #define CREATE_TYPE_TRAIT CREATE_TYPE_TRAIT_PUSHED

--- a/lib/everest/iso15118/src/iso15118/message/ac_der_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/ac_der_charge_loop.cpp
@@ -208,7 +208,7 @@ struct ReqControlModeVisitor {
     using DER_ScheduledCM = datatypes::DER_Scheduled_AC_CLReqControlMode;
     using DER_DynamicCM = datatypes::DER_Dynamic_AC_CLReqControlMode;
 
-    ReqControlModeVisitor(iso20_ac_der_iec_AC_ChargeLoopReqType& req_) : req(req_) {};
+    ReqControlModeVisitor(iso20_ac_der_iec_AC_ChargeLoopReqType& req_) : req(req_){};
 
     void operator()(const DER_ScheduledCM& in) {
         auto& out = req.DER_Scheduled_AC_CLReqControlMode;
@@ -503,7 +503,7 @@ struct ControlModeVisitor {
     using DER_ScheduledCM = datatypes::DER_Scheduled_AC_CLResControlMode;
     using DER_DynamicCM = datatypes::DER_Dynamic_AC_CLResControlMode;
 
-    ControlModeVisitor(iso20_ac_der_iec_AC_ChargeLoopResType& res_) : res(res_) {};
+    ControlModeVisitor(iso20_ac_der_iec_AC_ChargeLoopResType& res_) : res(res_){};
 
     void operator()(const DER_ScheduledCM& in) {
         auto& out = res.DER_Scheduled_AC_CLResControlMode;

--- a/lib/everest/iso15118/src/iso15118/message/ac_der_sae_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/ac_der_sae_charge_loop.cpp
@@ -9,6 +9,10 @@
 
 namespace iso15118::message_20 {
 
+namespace dts = datatypes::sae;
+
+// Response
+
 template <> void convert(const struct iso20_ac_der_sae_DisplayParametersType& in, datatypes::DisplayParameters& out) {
     CB2CPP_ASSIGN_IF_USED(in.PresentSOC, out.present_soc);
     CB2CPP_ASSIGN_IF_USED(in.MinimumSOC, out.min_soc);
@@ -41,448 +45,314 @@ template <> void convert(const datatypes::DisplayParameters& in, struct iso20_ac
     CPP2CB_ASSIGN_IF_USED(in.inlet_hot, out.InletHot);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_EVApparentPowerType& in, datatypes::EVApparentPower& out) {
-    convert(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption,
-            out.maximum_apparent_power_during_charging_and_var_absorption);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L2,
-                           out.maximum_apparent_power_during_charging_and_var_absorption_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L3,
-                           out.maximum_apparent_power_during_charging_and_var_absorption_L3);
-    convert(in.EVMaximumApparentPowerDuringChargingAndVarInjection,
-            out.maximum_apparent_power_during_charging_and_var_injection);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarInjection_L2,
-                           out.maximum_apparent_power_during_charging_and_var_injection_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarInjection_L3,
-                           out.maximum_apparent_power_during_charging_and_var_injection_L3);
-    convert(in.EVMaximumApparentPowerDuringDischargingAndVarAbsorption,
-            out.maximum_apparent_power_during_discharging_and_var_absorption);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L2,
-                           out.maximum_apparent_power_during_discharging_and_var_absorption_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L3,
-                           out.maximum_apparent_power_during_discharging_and_var_absorption_L3);
-    convert(in.EVMaximumApparentPowerDuringDischargingAndVarInjection,
-            out.maximum_apparent_power_during_discharging_and_var_injection);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarInjection_L2,
-                           out.maximum_apparent_power_during_discharging_and_var_injection_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarInjection_L3,
-                           out.maximum_apparent_power_during_discharging_and_var_injection_L3);
+template <> void convert(const datatypes::DetailedCost& in, struct iso20_ac_der_sae_DetailedCostType& out) {
+    init_iso20_ac_der_sae_DetailedCostType(&out);
+    convert(in.amount, out.Amount);
+    convert(in.cost_per_unit, out.CostPerUnit);
 }
 
-template <> void convert(const datatypes::EVApparentPower& in, struct iso20_ac_der_sae_EVApparentPowerType& out) {
-    init_iso20_ac_der_sae_EVApparentPowerType(&out);
-    convert(in.maximum_apparent_power_during_charging_and_var_absorption,
-            out.EVMaximumApparentPowerDuringChargingAndVarAbsorption);
-    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_absorption_L2,
-                           out.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_absorption_L3,
-                           out.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L3);
-    convert(in.maximum_apparent_power_during_charging_and_var_injection,
-            out.EVMaximumApparentPowerDuringChargingAndVarInjection);
-    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_injection_L2,
-                           out.EVMaximumApparentPowerDuringChargingAndVarInjection_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_injection_L3,
-                           out.EVMaximumApparentPowerDuringChargingAndVarInjection_L3);
-    convert(in.maximum_apparent_power_during_discharging_and_var_absorption,
-            out.EVMaximumApparentPowerDuringDischargingAndVarAbsorption);
-    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_absorption_L2,
-                           out.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_absorption_L3,
-                           out.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L3);
-    convert(in.maximum_apparent_power_during_discharging_and_var_injection,
-            out.EVMaximumApparentPowerDuringDischargingAndVarInjection);
-    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_injection_L2,
-                           out.EVMaximumApparentPowerDuringDischargingAndVarInjection_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_injection_L3,
-                           out.EVMaximumApparentPowerDuringDischargingAndVarInjection_L3);
+template <> void convert(const struct iso20_ac_der_sae_DetailedCostType& in, datatypes::DetailedCost& out) {
+    convert(in.Amount, out.amount);
+    convert(in.CostPerUnit, out.cost_per_unit);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_EVReactivePowerType& in, datatypes::EVReactivePower& out) {
-    convert(in.EVMaximumVarAbsorptionDuringCharging, out.maximum_var_absorption_during_charging);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringCharging_L2, out.maximum_var_absorption_during_charging_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringCharging_L3, out.maximum_var_absorption_during_charging_L3);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringCharging, out.minimum_var_absorption_during_charging);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringCharging_L2, out.minimum_var_absorption_during_charging_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringCharging_L3, out.minimum_var_absorption_during_charging_L3);
-    convert(in.EVMaximumVarInjectionDuringCharging, out.maximum_var_injection_during_charging);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringCharging_L2, out.maximum_var_injection_during_charging_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringCharging_L3, out.maximum_var_injection_during_charging_L3);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringCharging, out.minimum_var_injection_during_charging);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringCharging_L2, out.minimum_var_injection_during_charging_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringCharging_L3, out.minimum_var_injection_during_charging_L3);
-    convert(in.EVMaximumVarAbsorptionDuringDischarging, out.maximum_var_absorption_during_discharging);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringDischarging_L2,
-                           out.maximum_var_absorption_during_discharging_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringDischarging_L3,
-                           out.maximum_var_absorption_during_discharging_L3);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringDischarging, out.minimum_var_absorption_during_discharging);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringDischarging_L2,
-                           out.minimum_var_absorption_during_discharging_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringDischarging_L3,
-                           out.minimum_var_absorption_during_discharging_L3);
-    convert(in.EVMaximumVarInjectionDuringDischarging, out.maximum_var_injection_during_discharging);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringDischarging_L2,
-                           out.maximum_var_injection_during_discharging_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringDischarging_L3,
-                           out.maximum_var_injection_during_discharging_L3);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringDischarging, out.minimum_var_injection_during_discharging);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringDischarging_L2,
-                           out.minimum_var_injection_during_discharging_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringDischarging_L3,
-                           out.minimum_var_injection_during_discharging_L3);
+template <> void convert(const datatypes::DetailedTax& in, struct iso20_ac_der_sae_DetailedTaxType& out) {
+    init_iso20_ac_der_sae_DetailedTaxType(&out);
+    out.TaxRuleID = in.tax_rule_id;
+    convert(in.amount, out.Amount);
 }
 
-template <> void convert(const datatypes::EVReactivePower& in, struct iso20_ac_der_sae_EVReactivePowerType& out) {
-    init_iso20_ac_der_sae_EVReactivePowerType(&out);
-    convert(in.maximum_var_absorption_during_charging, out.EVMaximumVarAbsorptionDuringCharging);
-    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_charging_L2, out.EVMaximumVarAbsorptionDuringCharging_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_charging_L3, out.EVMaximumVarAbsorptionDuringCharging_L3);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_charging, out.EVMinimumVarAbsorptionDuringCharging);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_charging_L2, out.EVMinimumVarAbsorptionDuringCharging_L2);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_charging_L3, out.EVMinimumVarAbsorptionDuringCharging_L3);
-    convert(in.maximum_var_injection_during_charging, out.EVMaximumVarInjectionDuringCharging);
-    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_charging_L2, out.EVMaximumVarInjectionDuringCharging_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_charging_L3, out.EVMaximumVarInjectionDuringCharging_L3);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_charging, out.EVMinimumVarInjectionDuringCharging);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_charging_L2, out.EVMinimumVarInjectionDuringCharging_L2);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_charging_L3, out.EVMinimumVarInjectionDuringCharging_L3);
-    convert(in.maximum_var_absorption_during_discharging, out.EVMaximumVarAbsorptionDuringDischarging);
-    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_discharging_L2,
-                           out.EVMaximumVarAbsorptionDuringDischarging_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_discharging_L3,
-                           out.EVMaximumVarAbsorptionDuringDischarging_L3);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_discharging, out.EVMinimumVarAbsorptionDuringDischarging);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_discharging_L2,
-                           out.EVMinimumVarAbsorptionDuringDischarging_L2);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_discharging_L3,
-                           out.EVMinimumVarAbsorptionDuringDischarging_L3);
-    convert(in.maximum_var_injection_during_discharging, out.EVMaximumVarInjectionDuringDischarging);
-    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_discharging_L2,
-                           out.EVMaximumVarInjectionDuringDischarging_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_discharging_L3,
-                           out.EVMaximumVarInjectionDuringDischarging_L3);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_discharging, out.EVMinimumVarInjectionDuringDischarging);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_discharging_L2,
-                           out.EVMinimumVarInjectionDuringDischarging_L2);
-    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_discharging_L3,
-                           out.EVMinimumVarInjectionDuringDischarging_L3);
+template <> void convert(const struct iso20_ac_der_sae_DetailedTaxType& in, datatypes::DetailedTax& out) {
+    out.tax_rule_id = in.TaxRuleID;
+    convert(in.Amount, out.amount);
 }
 
-template <> void convert(const struct iso20_ac_der_sae_EVExcitationType& in, datatypes::EVExcitation& out) {
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor, out.specified_over_excited_power_factor);
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor_L2, out.specified_over_excited_power_factor_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor_L3, out.specified_over_excited_power_factor_L3);
-    convert(in.EVSpecifiedOverExcitedDischargePower, out.specified_over_excited_discharge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedDischargePower_L2, out.specified_over_excited_discharge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedDischargePower_L3, out.specified_over_excited_discharge_power_L3);
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedPowerFactor, out.specified_under_excited_power_factor);
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedPowerFactor_L2, out.specified_under_excited_power_factor_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedPowerFactor_L3, out.specified_under_excited_power_factor_L3);
-    convert(in.EVSpecifiedUnderExcitedDischargePower, out.specified_under_excited_discharge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedDischargePower_L2, out.specified_under_excited_discharge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedDischargePower_L3, out.specified_under_excited_discharge_power_L3);
+template <> void convert(const datatypes::Receipt& in, struct iso20_ac_der_sae_ReceiptType& out) {
+    init_iso20_ac_der_sae_ReceiptType(&out);
+
+    out.TimeAnchor = in.time_anchor;
+    CPP2CB_CONVERT_IF_USED(in.energy_costs, out.EnergyCosts);
+    CPP2CB_CONVERT_IF_USED(in.occupancy_costs, out.OccupancyCosts);
+    CPP2CB_CONVERT_IF_USED(in.additional_service_costs, out.AdditionalServicesCosts);
+    CPP2CB_CONVERT_IF_USED(in.overstay_costs, out.OverstayCosts);
+
+    if (sizeof(out.TaxCosts.array) < in.tax_costs.size()) {
+        throw std::runtime_error("tax costs array is too large");
+    }
+    for (std::size_t i = 0; i < in.tax_costs.size(); ++i) {
+        convert(in.tax_costs[i], out.TaxCosts.array[i]);
+    }
+    out.TaxCosts.arrayLen = in.tax_costs.size();
 }
 
-template <> void convert(const datatypes::EVExcitation& in, struct iso20_ac_der_sae_EVExcitationType& out) {
-    init_iso20_ac_der_sae_EVExcitationType(&out);
-    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor, out.EVSpecifiedOverExcitedPowerFactor);
-    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor_L2, out.EVSpecifiedOverExcitedPowerFactor_L2);
-    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor_L3, out.EVSpecifiedOverExcitedPowerFactor_L3);
-    convert(in.specified_over_excited_discharge_power, out.EVSpecifiedOverExcitedDischargePower);
-    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_discharge_power_L2, out.EVSpecifiedOverExcitedDischargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_discharge_power_L3, out.EVSpecifiedOverExcitedDischargePower_L3);
-    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_power_factor, out.EVSpecifiedUnderExcitedPowerFactor);
-    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_power_factor_L2, out.EVSpecifiedUnderExcitedPowerFactor_L2);
-    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_power_factor_L3, out.EVSpecifiedUnderExcitedPowerFactor_L3);
-    convert(in.specified_under_excited_discharge_power, out.EVSpecifiedUnderExcitedDischargePower);
-    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_discharge_power_L2, out.EVSpecifiedUnderExcitedDischargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_discharge_power_L3, out.EVSpecifiedUnderExcitedDischargePower_L3);
+template <> void convert(const struct iso20_ac_der_sae_ReceiptType& in, datatypes::Receipt& out) {
+    out.time_anchor = in.TimeAnchor;
+
+    CB2CPP_CONVERT_IF_USED(in.EnergyCosts, out.energy_costs);
+    CB2CPP_CONVERT_IF_USED(in.OccupancyCosts, out.occupancy_costs);
+    CB2CPP_CONVERT_IF_USED(in.AdditionalServicesCosts, out.additional_service_costs);
+    CB2CPP_CONVERT_IF_USED(in.OverstayCosts, out.overstay_costs);
+
+    if (in.TaxCosts.arrayLen > 10) {
+        throw std::runtime_error("tax costs array is too large");
+    }
+    out.tax_costs.clear();
+    for (std::size_t i = 0; i < in.TaxCosts.arrayLen; ++i) {
+        convert(in.TaxCosts.array[i], out.tax_costs.emplace_back());
+    }
+}
+
+template <> void convert(const struct iso20_ac_der_sae_EnterServiceCLResType& in, dts::EnterServiceCLRes& out) {
+    out.permit_service = in.PermitService;
+    CB2CPP_CONVERT_IF_USED(in.EnterServiceVoltageHigh, out.enter_service_voltage_high);
+    CB2CPP_CONVERT_IF_USED(in.EnterServiceVoltageLow, out.enter_service_voltage_low);
+    CB2CPP_CONVERT_IF_USED(in.EnterServiceFrequencyHigh, out.enter_service_frequency_high);
+    CB2CPP_CONVERT_IF_USED(in.EnterServiceFrequencyLow, out.enter_service_frequency_low);
+    CB2CPP_CONVERT_IF_USED(in.EnterServiceDelay, out.enter_service_delay);
+    CB2CPP_CONVERT_IF_USED(in.EnterServiceRandomizedDelay, out.enter_service_randomized_delay);
+    CB2CPP_CONVERT_IF_USED(in.EnterServiceRampTime, out.enter_service_ramp_time);
+}
+
+template <> void convert(const dts::EnterServiceCLRes& in, struct iso20_ac_der_sae_EnterServiceCLResType& out) {
+    init_iso20_ac_der_sae_EnterServiceCLResType(&out);
+    out.PermitService = in.permit_service;
+    CPP2CB_CONVERT_IF_USED(in.enter_service_voltage_high, out.EnterServiceVoltageHigh);
+    CPP2CB_CONVERT_IF_USED(in.enter_service_voltage_low, out.EnterServiceVoltageLow);
+    CPP2CB_CONVERT_IF_USED(in.enter_service_frequency_high, out.EnterServiceFrequencyHigh);
+    CPP2CB_CONVERT_IF_USED(in.enter_service_frequency_low, out.EnterServiceFrequencyLow);
+    CPP2CB_CONVERT_IF_USED(in.enter_service_delay, out.EnterServiceDelay);
+    CPP2CB_CONVERT_IF_USED(in.enter_service_randomized_delay, out.EnterServiceRandomizedDelay);
+    CPP2CB_CONVERT_IF_USED(in.enter_service_ramp_time, out.EnterServiceRampTime);
 }
 
 template <>
-void convert(const datatypes::DER_Dynamic_AC_CLReqControlMode& in,
-             struct iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType& out) {
-    init_iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType(&out);
+void convert(const struct iso20_ac_der_sae_ReactivePowerSupportCLResType& in, dts::ReactivePowerSupportCLRes& out) {
+    CB2CPP_CONVERT_IF_USED(in.ConstantPowerFactor, out.constant_power_factor);
+    CB2CPP_CONVERT_IF_USED(in.VoltVar, out.volt_var);
+    CB2CPP_CONVERT_IF_USED(in.WattVar, out.watt_var);
+    CB2CPP_CONVERT_IF_USED(in.ConstantVar, out.constant_var);
+}
+
+template <>
+void convert(const dts::ReactivePowerSupportCLRes& in, struct iso20_ac_der_sae_ReactivePowerSupportCLResType& out) {
+    init_iso20_ac_der_sae_ReactivePowerSupportCLResType(&out);
+    CPP2CB_CONVERT_IF_USED(in.constant_power_factor, out.ConstantPowerFactor);
+    CPP2CB_CONVERT_IF_USED(in.volt_var, out.VoltVar);
+    CPP2CB_CONVERT_IF_USED(in.watt_var, out.WattVar);
+    CPP2CB_CONVERT_IF_USED(in.constant_var, out.ConstantVar);
+}
+
+template <>
+void convert(const struct iso20_ac_der_sae_ActivePowerSupportCLResType& in, dts::ActivePowerSupportCLRes& out) {
+    CB2CPP_CONVERT_IF_USED(in.FrequencyDroop, out.frequency_droop);
+    CB2CPP_CONVERT_IF_USED(in.VoltWatt, out.volt_watt);
+    CB2CPP_CONVERT_IF_USED(in.ConstantWatt, out.constant_watt);
+    CB2CPP_CONVERT_IF_USED(in.LimitMaxDischargePower, out.limit_max_discharge_power);
+}
+
+template <>
+void convert(const dts::ActivePowerSupportCLRes& in, struct iso20_ac_der_sae_ActivePowerSupportCLResType& out) {
+    init_iso20_ac_der_sae_ActivePowerSupportCLResType(&out);
+    CPP2CB_CONVERT_IF_USED(in.frequency_droop, out.FrequencyDroop);
+    CPP2CB_CONVERT_IF_USED(in.volt_watt, out.VoltWatt);
+    CPP2CB_CONVERT_IF_USED(in.constant_watt, out.ConstantWatt);
+    CPP2CB_CONVERT_IF_USED(in.limit_max_discharge_power, out.LimitMaxDischargePower);
+}
+
+template <> void convert(const struct iso20_ac_der_sae_DERControlCLResType& in, dts::DERControlCLRes& out) {
+    CB2CPP_CONVERT_IF_USED(in.VoltageTrip, out.voltage_trip);
+    CB2CPP_CONVERT_IF_USED(in.FrequencyTrip, out.frequency_trip);
+    convert(in.EnterServiceCLRes, out.enter_service_cl_res);
+    CB2CPP_CONVERT_IF_USED(in.ReactivePowerSupportCLRes, out.reactive_power_support_cl_res);
+    CB2CPP_CONVERT_IF_USED(in.ActivePowerSupportCLRes, out.active_power_support_cl_res);
+}
+
+template <> void convert(const dts::DERControlCLRes& in, struct iso20_ac_der_sae_DERControlCLResType& out) {
+    init_iso20_ac_der_sae_DERControlCLResType(&out);
+    CPP2CB_CONVERT_IF_USED(in.voltage_trip, out.VoltageTrip);
+    CPP2CB_CONVERT_IF_USED(in.frequency_trip, out.FrequencyTrip);
+    convert(in.enter_service_cl_res, out.EnterServiceCLRes);
+    CPP2CB_CONVERT_IF_USED(in.reactive_power_support_cl_res, out.ReactivePowerSupportCLRes);
+    CPP2CB_CONVERT_IF_USED(in.active_power_support_cl_res, out.ActivePowerSupportCLRes);
+}
+
+template <>
+void convert(const struct iso20_ac_der_sae_DER_Scheduled_AC_CLResControlModeType& in,
+             dts::DER_Scheduled_AC_CLResControlMode& out) {
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetActivePower, out.target_active_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetActivePower_L2, out.target_active_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetActivePower_L3, out.target_active_power_L3);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetReactivePower, out.target_reactive_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetReactivePower_L2, out.target_reactive_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetReactivePower_L3, out.target_reactive_power_L3);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSEPresentActivePower, out.present_active_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSEPresentActivePower_L2, out.present_active_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSEPresentActivePower_L3, out.present_active_power_L3);
+
+    convert(in.DERControlCLRes, out.der_control_cl_res);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumChargePower, out.evse_maximum_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumChargePower_L2, out.evse_maximum_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumChargePower_L3, out.evse_maximum_charge_power_L3);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumDischargePower, out.evse_maximum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumDischargePower_L2, out.evse_maximum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumDischargePower_L3, out.evse_maximum_discharge_power_L3);
+
+    if (in.RequiredDEROperatingMode_isUsed) {
+        cb_convert_enum(in.RequiredDEROperatingMode, out.required_der_operating_mode.emplace());
+    }
+    if (in.GridConnectionMode_isUsed) {
+        cb_convert_enum(in.GridConnectionMode, out.grid_connection_mode.emplace());
+    }
+}
+
+template <>
+void convert(const dts::DER_Scheduled_AC_CLResControlMode& in,
+             struct iso20_ac_der_sae_DER_Scheduled_AC_CLResControlModeType& out) {
+    init_iso20_ac_der_sae_DER_Scheduled_AC_CLResControlModeType(&out);
+
+    CPP2CB_CONVERT_IF_USED(in.target_active_power, out.EVSETargetActivePower);
+    CPP2CB_CONVERT_IF_USED(in.target_active_power_L2, out.EVSETargetActivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.target_active_power_L3, out.EVSETargetActivePower_L3);
+
+    CPP2CB_CONVERT_IF_USED(in.target_reactive_power, out.EVSETargetReactivePower);
+    CPP2CB_CONVERT_IF_USED(in.target_reactive_power_L2, out.EVSETargetReactivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.target_reactive_power_L3, out.EVSETargetReactivePower_L3);
+
+    CPP2CB_CONVERT_IF_USED(in.present_active_power, out.EVSEPresentActivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L2, out.EVSEPresentActivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L3, out.EVSEPresentActivePower_L3);
+
+    convert(in.der_control_cl_res, out.DERControlCLRes);
+
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_charge_power, out.EVSEMaximumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_charge_power_L2, out.EVSEMaximumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_charge_power_L3, out.EVSEMaximumChargePower_L3);
+
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_discharge_power, out.EVSEMaximumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_discharge_power_L2, out.EVSEMaximumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_discharge_power_L3, out.EVSEMaximumDischargePower_L3);
+
+    if (in.required_der_operating_mode.has_value()) {
+        cb_convert_enum(in.required_der_operating_mode.value(), out.RequiredDEROperatingMode);
+        CB_SET_USED(out.RequiredDEROperatingMode);
+    }
+    if (in.grid_connection_mode.has_value()) {
+        cb_convert_enum(in.grid_connection_mode.value(), out.GridConnectionMode);
+        CB_SET_USED(out.GridConnectionMode);
+    }
+}
+
+template <>
+void convert(const struct iso20_ac_der_sae_DER_Dynamic_AC_CLResControlModeType& in,
+             dts::DER_Dynamic_AC_CLResControlMode& out) {
+    CB2CPP_ASSIGN_IF_USED(in.DepartureTime, out.departure_time);
+    CB2CPP_ASSIGN_IF_USED(in.MinimumSOC, out.minimum_soc);
+    CB2CPP_ASSIGN_IF_USED(in.TargetSOC, out.target_soc);
+    CB2CPP_ASSIGN_IF_USED(in.AckMaxDelay, out.ack_max_delay);
+
+    convert(in.EVSETargetActivePower, out.target_active_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetActivePower_L2, out.target_active_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetActivePower_L3, out.target_active_power_L3);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetReactivePower, out.target_reactive_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetReactivePower_L2, out.target_reactive_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSETargetReactivePower_L3, out.target_reactive_power_L3);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSEPresentActivePower, out.present_active_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSEPresentActivePower_L2, out.present_active_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSEPresentActivePower_L3, out.present_active_power_L3);
+
+    convert(in.DERControlCLRes, out.der_control_cl_res);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumChargePower, out.evse_maximum_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumChargePower_L2, out.evse_maximum_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumChargePower_L3, out.evse_maximum_charge_power_L3);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumDischargePower, out.evse_maximum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumDischargePower_L2, out.evse_maximum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSEMaximumDischargePower_L3, out.evse_maximum_discharge_power_L3);
+
+    if (in.RequiredDEROperatingMode_isUsed) {
+        cb_convert_enum(in.RequiredDEROperatingMode, out.required_der_operating_mode.emplace());
+    }
+    if (in.GridConnectionMode_isUsed) {
+        cb_convert_enum(in.GridConnectionMode, out.grid_connection_mode.emplace());
+    }
+}
+
+template <>
+void convert(const dts::DER_Dynamic_AC_CLResControlMode& in,
+             struct iso20_ac_der_sae_DER_Dynamic_AC_CLResControlModeType& out) {
+    init_iso20_ac_der_sae_DER_Dynamic_AC_CLResControlModeType(&out);
 
     CPP2CB_ASSIGN_IF_USED(in.departure_time, out.DepartureTime);
-    convert(in.target_energy_request, out.EVTargetEnergyRequest);
-    convert(in.max_energy_request, out.EVMaximumEnergyRequest);
-    convert(in.min_energy_request, out.EVMinimumEnergyRequest);
+    CPP2CB_ASSIGN_IF_USED(in.minimum_soc, out.MinimumSOC);
+    CPP2CB_ASSIGN_IF_USED(in.target_soc, out.TargetSOC);
+    CPP2CB_ASSIGN_IF_USED(in.ack_max_delay, out.AckMaxDelay);
 
-    convert(in.max_charge_power, out.EVMaximumChargePower);
-    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L2, out.EVMaximumChargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L3, out.EVMaximumChargePower_L3);
-    convert(in.min_charge_power, out.EVMinimumChargePower);
-    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L2, out.EVMinimumChargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L3, out.EVMinimumChargePower_L3);
-    convert(in.present_active_power, out.EVPresentActivePower);
-    CPP2CB_CONVERT_IF_USED(in.present_active_power_L2, out.EVPresentActivePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.present_active_power_L3, out.EVPresentActivePower_L3);
-    convert(in.present_reactive_power, out.EVPresentReactivePower);
-    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L2, out.EVPresentReactivePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L3, out.EVPresentReactivePower_L3);
+    convert(in.target_active_power, out.EVSETargetActivePower);
+    CPP2CB_CONVERT_IF_USED(in.target_active_power_L2, out.EVSETargetActivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.target_active_power_L3, out.EVSETargetActivePower_L3);
 
-    convert(in.maximum_discharge_power, out.EVMaximumDischargePower);
-    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L2, out.EVMaximumDischargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L3, out.EVMaximumDischargePower_L3);
-    convert(in.minimum_discharge_power, out.EVMinimumDischargePower);
-    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L2, out.EVMinimumDischargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L3, out.EVMinimumDischargePower_L3);
-    convert(in.present_voltage, out.EVPresentVoltage);
-    convert(in.present_frequency, out.EVPresentFrequency);
-    CPP2CB_CONVERT_IF_USED(in.session_total_discharge_energy_available, out.EVSessionTotalDischargeEnergyAvailable);
-    CPP2CB_CONVERT_IF_USED(in.apparent_power, out.EVApparentPower);
-    CPP2CB_CONVERT_IF_USED(in.reactive_power, out.EVReactivePower);
-    CPP2CB_CONVERT_IF_USED(in.excitation, out.EVExcitation);
-    CPP2CB_CONVERT_IF_USED(in.maximum_v2x_energy_request, out.EVMaximumV2XEnergyRequest);
-    CPP2CB_CONVERT_IF_USED(in.minimum_v2x_energy_request, out.EVMinimumV2XEnergyRequest);
+    CPP2CB_CONVERT_IF_USED(in.target_reactive_power, out.EVSETargetReactivePower);
+    CPP2CB_CONVERT_IF_USED(in.target_reactive_power_L2, out.EVSETargetReactivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.target_reactive_power_L3, out.EVSETargetReactivePower_L3);
 
-    cb_convert_enum(in.der_operational_state, out.DEROperationalState);
-    cb_convert_enum(in.der_connection_status, out.DERConnectionStatus);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power, out.EVSEPresentActivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L2, out.EVSEPresentActivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L3, out.EVSEPresentActivePower_L3);
 
-    out.EVUpdateTime = in.update_time;
-    out.EVMinimumChargingDuration = in.minimum_charging_duration;
-    out.EVDurationMaximumChargeRate = in.duration_maximum_charge_rate;
-    out.EVDurationMaximumDischargeRate = in.duration_maximum_discharge_rate;
-    out.DERAlarmStatus = in.der_alarm_status;
-    out.EnabledModes = in.enabled_modes;
+    convert(in.der_control_cl_res, out.DERControlCLRes);
+
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_charge_power, out.EVSEMaximumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_charge_power_L2, out.EVSEMaximumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_charge_power_L3, out.EVSEMaximumChargePower_L3);
+
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_discharge_power, out.EVSEMaximumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_discharge_power_L2, out.EVSEMaximumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.evse_maximum_discharge_power_L3, out.EVSEMaximumDischargePower_L3);
+
+    if (in.required_der_operating_mode.has_value()) {
+        cb_convert_enum(in.required_der_operating_mode.value(), out.RequiredDEROperatingMode);
+        CB_SET_USED(out.RequiredDEROperatingMode);
+    }
+    if (in.grid_connection_mode.has_value()) {
+        cb_convert_enum(in.grid_connection_mode.value(), out.GridConnectionMode);
+        CB_SET_USED(out.GridConnectionMode);
+    }
 }
 
-template <>
-void convert(const struct iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType& in,
-             datatypes::DER_Dynamic_AC_CLReqControlMode& out) {
-    CB2CPP_ASSIGN_IF_USED(in.DepartureTime, out.departure_time);
-    convert(in.EVTargetEnergyRequest, out.target_energy_request);
-    convert(in.EVMaximumEnergyRequest, out.max_energy_request);
-    convert(in.EVMinimumEnergyRequest, out.min_energy_request);
+namespace {
 
-    convert(in.EVMaximumChargePower, out.max_charge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L2, out.max_charge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L3, out.max_charge_power_L3);
-    convert(in.EVMinimumChargePower, out.min_charge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L2, out.min_charge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L3, out.min_charge_power_L3);
-    convert(in.EVPresentActivePower, out.present_active_power);
-    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L2, out.present_active_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L3, out.present_active_power_L3);
-    convert(in.EVPresentReactivePower, out.present_reactive_power);
-    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L2, out.present_reactive_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L3, out.present_reactive_power_L3);
+struct ControlModeVisitor {
+    using DER_ScheduledCM = dts::DER_Scheduled_AC_CLResControlMode;
+    using DER_DynamicCM = dts::DER_Dynamic_AC_CLResControlMode;
 
-    convert(in.EVMaximumDischargePower, out.maximum_discharge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L2, out.maximum_discharge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L3, out.maximum_discharge_power_L3);
-    convert(in.EVMinimumDischargePower, out.minimum_discharge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L2, out.minimum_discharge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L3, out.minimum_discharge_power_L3);
-    convert(in.EVPresentVoltage, out.present_voltage);
-    convert(in.EVPresentFrequency, out.present_frequency);
-    CB2CPP_CONVERT_IF_USED(in.EVSessionTotalDischargeEnergyAvailable, out.session_total_discharge_energy_available);
-    CB2CPP_CONVERT_IF_USED(in.EVApparentPower, out.apparent_power);
-    CB2CPP_CONVERT_IF_USED(in.EVReactivePower, out.reactive_power);
-    CB2CPP_CONVERT_IF_USED(in.EVExcitation, out.excitation);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumV2XEnergyRequest, out.maximum_v2x_energy_request);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumV2XEnergyRequest, out.minimum_v2x_energy_request);
-
-    cb_convert_enum(in.DEROperationalState, out.der_operational_state);
-    cb_convert_enum(in.DERConnectionStatus, out.der_connection_status);
-
-    out.update_time = in.EVUpdateTime;
-    out.minimum_charging_duration = in.EVMinimumChargingDuration;
-    out.duration_maximum_charge_rate = in.EVDurationMaximumChargeRate;
-    out.duration_maximum_discharge_rate = in.EVDurationMaximumDischargeRate;
-    out.der_alarm_status = in.DERAlarmStatus;
-    out.enabled_modes = in.EnabledModes;
-}
-
-template <>
-void convert(const datatypes::DER_Scheduled_AC_CLReqControlMode& in,
-             struct iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType& out) {
-    init_iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType(&out);
-
-    CPP2CB_CONVERT_IF_USED(in.target_energy_request, out.EVTargetEnergyRequest);
-    CPP2CB_CONVERT_IF_USED(in.max_energy_request, out.EVMaximumEnergyRequest);
-    CPP2CB_CONVERT_IF_USED(in.min_energy_request, out.EVMinimumEnergyRequest);
-
-    CPP2CB_CONVERT_IF_USED(in.max_charge_power, out.EVMaximumChargePower);
-    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L2, out.EVMaximumChargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L3, out.EVMaximumChargePower_L3);
-    CPP2CB_CONVERT_IF_USED(in.min_charge_power, out.EVMinimumChargePower);
-    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L2, out.EVMinimumChargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L3, out.EVMinimumChargePower_L3);
-    convert(in.present_active_power, out.EVPresentActivePower);
-    CPP2CB_CONVERT_IF_USED(in.present_active_power_L2, out.EVPresentActivePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.present_active_power_L3, out.EVPresentActivePower_L3);
-    CPP2CB_CONVERT_IF_USED(in.present_reactive_power, out.EVPresentReactivePower);
-    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L2, out.EVPresentReactivePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L3, out.EVPresentReactivePower_L3);
-
-    convert(in.present_voltage, out.EVPresentVoltage);
-    convert(in.present_frequency, out.EVPresentFrequency);
-
-    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power, out.EVMaximumDischargePower);
-    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L2, out.EVMaximumDischargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L3, out.EVMaximumDischargePower_L3);
-    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power, out.EVMinimumDischargePower);
-    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L2, out.EVMinimumDischargePower_L2);
-    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L3, out.EVMinimumDischargePower_L3);
-
-    cb_convert_enum(in.der_operational_state, out.DEROperationalState);
-    cb_convert_enum(in.der_connection_status, out.DERConnectionStatus);
-
-    CPP2CB_CONVERT_IF_USED(in.apparent_power, out.EVApparentPower);
-    CPP2CB_CONVERT_IF_USED(in.reactive_power, out.EVReactivePower);
-    CPP2CB_CONVERT_IF_USED(in.excitation, out.EVExcitation);
-
-    out.EVUpdateTime = in.update_time;
-    CPP2CB_ASSIGN_IF_USED(in.minimum_charging_duration, out.EVMinimumChargingDuration);
-    CPP2CB_ASSIGN_IF_USED(in.duration_maximum_charge_rate, out.EVDurationMaximumChargeRate);
-    CPP2CB_ASSIGN_IF_USED(in.duration_maximum_discharge_rate, out.EVDurationMaximumDischargeRate);
-    out.DERAlarmStatus = in.der_alarm_status;
-    out.EnabledModes = in.enabled_modes;
-}
-
-template <>
-void convert(const struct iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType& in,
-             datatypes::DER_Scheduled_AC_CLReqControlMode& out) {
-    CB2CPP_CONVERT_IF_USED(in.EVTargetEnergyRequest, out.target_energy_request);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumEnergyRequest, out.max_energy_request);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumEnergyRequest, out.min_energy_request);
-
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower, out.max_charge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L2, out.max_charge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L3, out.max_charge_power_L3);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower, out.min_charge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L2, out.min_charge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L3, out.min_charge_power_L3);
-    convert(in.EVPresentActivePower, out.present_active_power);
-    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L2, out.present_active_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L3, out.present_active_power_L3);
-    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower, out.present_reactive_power);
-    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L2, out.present_reactive_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L3, out.present_reactive_power_L3);
-
-    convert(in.EVPresentVoltage, out.present_voltage);
-    convert(in.EVPresentFrequency, out.present_frequency);
-
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower, out.maximum_discharge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L2, out.maximum_discharge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L3, out.maximum_discharge_power_L3);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower, out.minimum_discharge_power);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L2, out.minimum_discharge_power_L2);
-    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L3, out.minimum_discharge_power_L3);
-
-    cb_convert_enum(in.DEROperationalState, out.der_operational_state);
-    cb_convert_enum(in.DERConnectionStatus, out.der_connection_status);
-
-    CB2CPP_CONVERT_IF_USED(in.EVApparentPower, out.apparent_power);
-    CB2CPP_CONVERT_IF_USED(in.EVReactivePower, out.reactive_power);
-    CB2CPP_CONVERT_IF_USED(in.EVExcitation, out.excitation);
-
-    out.update_time = in.EVUpdateTime;
-    CB2CPP_ASSIGN_IF_USED(in.EVMinimumChargingDuration, out.minimum_charging_duration);
-    CB2CPP_ASSIGN_IF_USED(in.EVDurationMaximumChargeRate, out.duration_maximum_charge_rate);
-    CB2CPP_ASSIGN_IF_USED(in.EVDurationMaximumDischargeRate, out.duration_maximum_discharge_rate);
-    out.der_alarm_status = in.DERAlarmStatus;
-    out.enabled_modes = in.EnabledModes;
-}
-
-struct ReqControlModeVisitor {
-    using DER_ScheduledCM = datatypes::DER_Scheduled_AC_CLReqControlMode;
-    using DER_DynamicCM = datatypes::DER_Dynamic_AC_CLReqControlMode;
-
-    ReqControlModeVisitor(iso20_ac_der_sae_AC_ChargeLoopReqType& req_) : req(req_) {};
+    ControlModeVisitor(iso20_ac_der_sae_AC_ChargeLoopResType& res_) : res(res_){};
 
     void operator()(const DER_ScheduledCM& in) {
-        auto& out = req.DER_Scheduled_AC_CLReqControlMode;
-        init_iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType(&out);
-        convert(in, out);
-        CB_SET_USED(req.DER_Scheduled_AC_CLReqControlMode);
-    }
-
-    void operator()(const DER_DynamicCM& in) {
-        auto& out = req.DER_Dynamic_AC_CLReqControlMode;
-        init_iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType(&out);
-        convert(in, out);
-        CB_SET_USED(req.DER_Dynamic_AC_CLReqControlMode);
-    }
-
-private:
-    iso20_ac_der_sae_AC_ChargeLoopReqType& req;
-};
-
-template <> void convert(const DER_SAE_AC_ChargeLoopRequest& in, struct iso20_ac_der_sae_AC_ChargeLoopReqType& out) {
-    init_iso20_ac_der_sae_AC_ChargeLoopReqType(&out);
-
-    convert(in.header, out.Header);
-
-    CPP2CB_CONVERT_IF_USED(in.display_parameters, out.DisplayParameters);
-    out.MeterInfoRequested = static_cast<int>(in.meter_info_requested);
-
-    std::visit(ReqControlModeVisitor(out), in.control_mode);
-}
-
-template <> void convert(const struct iso20_ac_der_sae_AC_ChargeLoopReqType& in, DER_SAE_AC_ChargeLoopRequest& out) {
-    convert(in.Header, out.header);
-
-    CB2CPP_CONVERT_IF_USED(in.DisplayParameters, out.display_parameters);
-    out.meter_info_requested = static_cast<bool>(in.MeterInfoRequested);
-
-    if (in.DER_Scheduled_AC_CLReqControlMode_isUsed) {
-        convert(in.DER_Scheduled_AC_CLReqControlMode,
-                out.control_mode.emplace<datatypes::DER_Scheduled_AC_CLReqControlMode>());
-    } else if (in.DER_Dynamic_AC_CLReqControlMode_isUsed) {
-        convert(in.DER_Dynamic_AC_CLReqControlMode,
-                out.control_mode.emplace<datatypes::DER_Dynamic_AC_CLReqControlMode>());
-    } else {
-        // should not happen
-        assert(false);
-    }
-}
-
-template <> int serialize_to_exi(const DER_SAE_AC_ChargeLoopRequest& in, exi_bitstream_t& out) {
-    iso20_ac_der_sae_exiDocument doc{};
-    init_iso20_ac_der_sae_exiDocument(&doc);
-
-    CB_SET_USED(doc.AC_ChargeLoopReq);
-
-    convert(in, doc.AC_ChargeLoopReq);
-
-    return encode_iso20_ac_der_sae_exiDocument(&out, &doc);
-}
-
-template <> size_t serialize(const DER_SAE_AC_ChargeLoopRequest& in, const io::StreamOutputView& out) {
-    return serialize_helper(in, out);
-}
-
-template <> void insert_type(VariantAccess& va, const struct iso20_ac_der_sae_AC_ChargeLoopReqType& in) {
-    va.insert_type<DER_SAE_AC_ChargeLoopRequest>(in);
-}
-
-// Response message
-
-struct ResControlModeVisitor {
-    using DER_ScheduledCM = datatypes::DER_Scheduled_AC_CLResControlMode;
-    using DER_DynamicCM = datatypes::DER_Dynamic_AC_CLResControlMode;
-
-    ResControlModeVisitor(iso20_ac_der_sae_AC_ChargeLoopResType& req_) : req(req_) {};
-
-    void operator()(const DER_ScheduledCM& in) {
-        auto& out = req.DER_Scheduled_AC_CLResControlMode;
+        auto& out = res.DER_Scheduled_AC_CLResControlMode;
         init_iso20_ac_der_sae_DER_Scheduled_AC_CLResControlModeType(&out);
         convert(in, out);
-        CB_SET_USED(req.DER_Scheduled_AC_CLResControlMode);
+        CB_SET_USED(res.DER_Scheduled_AC_CLResControlMode);
     }
 
     void operator()(const DER_DynamicCM& in) {
-        auto& out = req.DER_Dynamic_AC_CLResControlMode;
+        auto& out = res.DER_Dynamic_AC_CLResControlMode;
         init_iso20_ac_der_sae_DER_Dynamic_AC_CLResControlModeType(&out);
         convert(in, out);
-        CB_SET_USED(req.DER_Dynamic_AC_CLResControlMode);
+        CB_SET_USED(res.DER_Dynamic_AC_CLResControlMode);
     }
 
 private:
-    iso20_ac_der_sae_AC_ChargeLoopResType& req;
+    iso20_ac_der_sae_AC_ChargeLoopResType& res;
 };
+
+} // namespace
 
 template <> void convert(const DER_SAE_AC_ChargeLoopResponse& in, struct iso20_ac_der_sae_AC_ChargeLoopResType& out) {
     init_iso20_ac_der_sae_AC_ChargeLoopResType(&out);
@@ -496,23 +366,22 @@ template <> void convert(const DER_SAE_AC_ChargeLoopResponse& in, struct iso20_a
 
     CPP2CB_CONVERT_IF_USED(in.target_frequency, out.EVSETargetFrequency);
 
-    std::visit(ResControlModeVisitor(out), in.control_mode);
+    std::visit(ControlModeVisitor(out), in.control_mode);
 }
 
 template <> void convert(const struct iso20_ac_der_sae_AC_ChargeLoopResType& in, DER_SAE_AC_ChargeLoopResponse& out) {
     convert(in.Header, out.header);
     cb_convert_enum(in.ResponseCode, out.response_code);
+    CB2CPP_CONVERT_IF_USED(in.EVSEStatus, out.status);
     CB2CPP_CONVERT_IF_USED(in.MeterInfo, out.meter_info);
     CB2CPP_CONVERT_IF_USED(in.Receipt, out.receipt);
-    CB2CPP_CONVERT_IF_USED(in.EVSEStatus, out.status);
     CB2CPP_CONVERT_IF_USED(in.EVSETargetFrequency, out.target_frequency);
 
     if (in.DER_Scheduled_AC_CLResControlMode_isUsed) {
         convert(in.DER_Scheduled_AC_CLResControlMode,
-                out.control_mode.emplace<datatypes::DER_Scheduled_AC_CLResControlMode>());
+                out.control_mode.emplace<dts::DER_Scheduled_AC_CLResControlMode>());
     } else if (in.DER_Dynamic_AC_CLResControlMode_isUsed) {
-        convert(in.DER_Dynamic_AC_CLResControlMode,
-                out.control_mode.emplace<datatypes::DER_Dynamic_AC_CLResControlMode>());
+        convert(in.DER_Dynamic_AC_CLResControlMode, out.control_mode.emplace<dts::DER_Dynamic_AC_CLResControlMode>());
     } else {
         // should not happen
         assert(false);

--- a/lib/everest/iso15118/src/iso15118/message/ac_der_sae_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/ac_der_sae_charge_loop.cpp
@@ -11,7 +11,7 @@ namespace iso15118::message_20 {
 
 namespace dts = datatypes::sae;
 
-// Response
+// Request
 
 template <> void convert(const struct iso20_ac_der_sae_DisplayParametersType& in, datatypes::DisplayParameters& out) {
     CB2CPP_ASSIGN_IF_USED(in.PresentSOC, out.present_soc);
@@ -44,6 +44,458 @@ template <> void convert(const datatypes::DisplayParameters& in, struct iso20_ac
     CPP2CB_CONVERT_IF_USED(in.battery_energy_capacity, out.BatteryEnergyCapacity);
     CPP2CB_ASSIGN_IF_USED(in.inlet_hot, out.InletHot);
 }
+
+template <> void convert(const struct iso20_ac_der_sae_EVApparentPowerType& in, dts::EVApparentPower& out) {
+    convert(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption,
+            out.maximum_apparent_power_during_charging_and_var_absorption);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L2,
+                           out.maximum_apparent_power_during_charging_and_var_absorption_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L3,
+                           out.maximum_apparent_power_during_charging_and_var_absorption_L3);
+    convert(in.EVMaximumApparentPowerDuringChargingAndVarInjection,
+            out.maximum_apparent_power_during_charging_and_var_injection);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarInjection_L2,
+                           out.maximum_apparent_power_during_charging_and_var_injection_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarInjection_L3,
+                           out.maximum_apparent_power_during_charging_and_var_injection_L3);
+    convert(in.EVMaximumApparentPowerDuringDischargingAndVarAbsorption,
+            out.maximum_apparent_power_during_discharging_and_var_absorption);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L2,
+                           out.maximum_apparent_power_during_discharging_and_var_absorption_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L3,
+                           out.maximum_apparent_power_during_discharging_and_var_absorption_L3);
+    convert(in.EVMaximumApparentPowerDuringDischargingAndVarInjection,
+            out.maximum_apparent_power_during_discharging_and_var_injection);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarInjection_L2,
+                           out.maximum_apparent_power_during_discharging_and_var_injection_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarInjection_L3,
+                           out.maximum_apparent_power_during_discharging_and_var_injection_L3);
+}
+
+template <> void convert(const dts::EVApparentPower& in, struct iso20_ac_der_sae_EVApparentPowerType& out) {
+    init_iso20_ac_der_sae_EVApparentPowerType(&out);
+    convert(in.maximum_apparent_power_during_charging_and_var_absorption,
+            out.EVMaximumApparentPowerDuringChargingAndVarAbsorption);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_absorption_L2,
+                           out.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_absorption_L3,
+                           out.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L3);
+    convert(in.maximum_apparent_power_during_charging_and_var_injection,
+            out.EVMaximumApparentPowerDuringChargingAndVarInjection);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_injection_L2,
+                           out.EVMaximumApparentPowerDuringChargingAndVarInjection_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_injection_L3,
+                           out.EVMaximumApparentPowerDuringChargingAndVarInjection_L3);
+    convert(in.maximum_apparent_power_during_discharging_and_var_absorption,
+            out.EVMaximumApparentPowerDuringDischargingAndVarAbsorption);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_absorption_L2,
+                           out.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_absorption_L3,
+                           out.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L3);
+    convert(in.maximum_apparent_power_during_discharging_and_var_injection,
+            out.EVMaximumApparentPowerDuringDischargingAndVarInjection);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_injection_L2,
+                           out.EVMaximumApparentPowerDuringDischargingAndVarInjection_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_injection_L3,
+                           out.EVMaximumApparentPowerDuringDischargingAndVarInjection_L3);
+}
+
+template <> void convert(const struct iso20_ac_der_sae_EVReactivePowerType& in, dts::EVReactivePower& out) {
+    convert(in.EVMaximumVarAbsorptionDuringCharging, out.maximum_var_absorption_during_charging);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringCharging_L2, out.maximum_var_absorption_during_charging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringCharging_L3, out.maximum_var_absorption_during_charging_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringCharging, out.minimum_var_absorption_during_charging);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringCharging_L2, out.minimum_var_absorption_during_charging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringCharging_L3, out.minimum_var_absorption_during_charging_L3);
+    convert(in.EVMaximumVarInjectionDuringCharging, out.maximum_var_injection_during_charging);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringCharging_L2, out.maximum_var_injection_during_charging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringCharging_L3, out.maximum_var_injection_during_charging_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringCharging, out.minimum_var_injection_during_charging);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringCharging_L2, out.minimum_var_injection_during_charging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringCharging_L3, out.minimum_var_injection_during_charging_L3);
+    convert(in.EVMaximumVarAbsorptionDuringDischarging, out.maximum_var_absorption_during_discharging);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringDischarging_L2,
+                           out.maximum_var_absorption_during_discharging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringDischarging_L3,
+                           out.maximum_var_absorption_during_discharging_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringDischarging, out.minimum_var_absorption_during_discharging);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringDischarging_L2,
+                           out.minimum_var_absorption_during_discharging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringDischarging_L3,
+                           out.minimum_var_absorption_during_discharging_L3);
+    convert(in.EVMaximumVarInjectionDuringDischarging, out.maximum_var_injection_during_discharging);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringDischarging_L2,
+                           out.maximum_var_injection_during_discharging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringDischarging_L3,
+                           out.maximum_var_injection_during_discharging_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringDischarging, out.minimum_var_injection_during_discharging);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringDischarging_L2,
+                           out.minimum_var_injection_during_discharging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringDischarging_L3,
+                           out.minimum_var_injection_during_discharging_L3);
+}
+
+template <> void convert(const dts::EVReactivePower& in, struct iso20_ac_der_sae_EVReactivePowerType& out) {
+    init_iso20_ac_der_sae_EVReactivePowerType(&out);
+    convert(in.maximum_var_absorption_during_charging, out.EVMaximumVarAbsorptionDuringCharging);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_charging_L2, out.EVMaximumVarAbsorptionDuringCharging_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_charging_L3, out.EVMaximumVarAbsorptionDuringCharging_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_charging, out.EVMinimumVarAbsorptionDuringCharging);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_charging_L2, out.EVMinimumVarAbsorptionDuringCharging_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_charging_L3, out.EVMinimumVarAbsorptionDuringCharging_L3);
+    convert(in.maximum_var_injection_during_charging, out.EVMaximumVarInjectionDuringCharging);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_charging_L2, out.EVMaximumVarInjectionDuringCharging_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_charging_L3, out.EVMaximumVarInjectionDuringCharging_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_charging, out.EVMinimumVarInjectionDuringCharging);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_charging_L2, out.EVMinimumVarInjectionDuringCharging_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_charging_L3, out.EVMinimumVarInjectionDuringCharging_L3);
+    convert(in.maximum_var_absorption_during_discharging, out.EVMaximumVarAbsorptionDuringDischarging);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_discharging_L2,
+                           out.EVMaximumVarAbsorptionDuringDischarging_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_discharging_L3,
+                           out.EVMaximumVarAbsorptionDuringDischarging_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_discharging, out.EVMinimumVarAbsorptionDuringDischarging);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_discharging_L2,
+                           out.EVMinimumVarAbsorptionDuringDischarging_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_discharging_L3,
+                           out.EVMinimumVarAbsorptionDuringDischarging_L3);
+    convert(in.maximum_var_injection_during_discharging, out.EVMaximumVarInjectionDuringDischarging);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_discharging_L2,
+                           out.EVMaximumVarInjectionDuringDischarging_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_discharging_L3,
+                           out.EVMaximumVarInjectionDuringDischarging_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_discharging, out.EVMinimumVarInjectionDuringDischarging);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_discharging_L2,
+                           out.EVMinimumVarInjectionDuringDischarging_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_discharging_L3,
+                           out.EVMinimumVarInjectionDuringDischarging_L3);
+}
+
+template <> void convert(const struct iso20_ac_der_sae_EVExcitationType& in, dts::EVExcitation& out) {
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor, out.specified_over_excited_power_factor);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor_L2, out.specified_over_excited_power_factor_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor_L3, out.specified_over_excited_power_factor_L3);
+    convert(in.EVSpecifiedOverExcitedDischargePower, out.specified_over_excited_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedDischargePower_L2, out.specified_over_excited_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedDischargePower_L3, out.specified_over_excited_discharge_power_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedPowerFactor, out.specified_under_excited_power_factor);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedPowerFactor_L2, out.specified_under_excited_power_factor_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedPowerFactor_L3, out.specified_under_excited_power_factor_L3);
+    convert(in.EVSpecifiedUnderExcitedDischargePower, out.specified_under_excited_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedDischargePower_L2, out.specified_under_excited_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedDischargePower_L3, out.specified_under_excited_discharge_power_L3);
+}
+
+template <> void convert(const dts::EVExcitation& in, struct iso20_ac_der_sae_EVExcitationType& out) {
+    init_iso20_ac_der_sae_EVExcitationType(&out);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor, out.EVSpecifiedOverExcitedPowerFactor);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor_L2, out.EVSpecifiedOverExcitedPowerFactor_L2);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor_L3, out.EVSpecifiedOverExcitedPowerFactor_L3);
+    convert(in.specified_over_excited_discharge_power, out.EVSpecifiedOverExcitedDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_discharge_power_L2, out.EVSpecifiedOverExcitedDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_discharge_power_L3, out.EVSpecifiedOverExcitedDischargePower_L3);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_power_factor, out.EVSpecifiedUnderExcitedPowerFactor);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_power_factor_L2, out.EVSpecifiedUnderExcitedPowerFactor_L2);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_power_factor_L3, out.EVSpecifiedUnderExcitedPowerFactor_L3);
+    convert(in.specified_under_excited_discharge_power, out.EVSpecifiedUnderExcitedDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_discharge_power_L2, out.EVSpecifiedUnderExcitedDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_discharge_power_L3, out.EVSpecifiedUnderExcitedDischargePower_L3);
+}
+
+template <>
+void convert(const dts::DER_Scheduled_AC_CLReqControlMode& in,
+             struct iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType& out) {
+    CPP2CB_CONVERT_IF_USED(in.target_energy_request, out.EVTargetEnergyRequest);
+    CPP2CB_CONVERT_IF_USED(in.max_energy_request, out.EVMaximumEnergyRequest);
+    CPP2CB_CONVERT_IF_USED(in.min_energy_request, out.EVMinimumEnergyRequest);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power, out.EVMaximumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L2, out.EVMaximumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L3, out.EVMaximumChargePower_L3);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power, out.EVMinimumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L2, out.EVMinimumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L3, out.EVMinimumChargePower_L3);
+    convert(in.present_active_power, out.EVPresentActivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L2, out.EVPresentActivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L3, out.EVPresentActivePower_L3);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power, out.EVPresentReactivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L2, out.EVPresentReactivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L3, out.EVPresentReactivePower_L3);
+
+    convert(in.present_voltage, out.EVPresentVoltage);
+    convert(in.present_frequency, out.EVPresentFrequency);
+
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power, out.EVMaximumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L2, out.EVMaximumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L3, out.EVMaximumDischargePower_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power, out.EVMinimumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L2, out.EVMinimumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L3, out.EVMinimumDischargePower_L3);
+
+    cb_convert_enum(in.der_operational_state, out.DEROperationalState);
+    cb_convert_enum(in.der_connection_status, out.DERConnectionStatus);
+
+    if (in.apparent_power.has_value()) {
+        convert(in.apparent_power.value(), out.EVApparentPower);
+        CB_SET_USED(out.EVApparentPower);
+    }
+    if (in.reactive_power.has_value()) {
+        convert(in.reactive_power.value(), out.EVReactivePower);
+        CB_SET_USED(out.EVReactivePower);
+    }
+    if (in.excitation.has_value()) {
+        convert(in.excitation.value(), out.EVExcitation);
+        CB_SET_USED(out.EVExcitation);
+    }
+
+    out.EVUpdateTime = in.update_time;
+    CPP2CB_ASSIGN_IF_USED(in.minimum_charging_duration, out.EVMinimumChargingDuration);
+    CPP2CB_ASSIGN_IF_USED(in.duration_maximum_charge_rate, out.EVDurationMaximumChargeRate);
+    CPP2CB_ASSIGN_IF_USED(in.duration_maximum_discharge_rate, out.EVDurationMaximumDischargeRate);
+    out.DERAlarmStatus = in.der_alarm_status;
+    out.EnabledModes = in.enabled_modes;
+}
+
+template <>
+void convert(const struct iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType& in,
+             dts::DER_Scheduled_AC_CLReqControlMode& out) {
+    CB2CPP_CONVERT_IF_USED(in.EVTargetEnergyRequest, out.target_energy_request);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumEnergyRequest, out.max_energy_request);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumEnergyRequest, out.min_energy_request);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower, out.max_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L2, out.max_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L3, out.max_charge_power_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower, out.min_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L2, out.min_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L3, out.min_charge_power_L3);
+    convert(in.EVPresentActivePower, out.present_active_power);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L2, out.present_active_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L3, out.present_active_power_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower, out.present_reactive_power);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L2, out.present_reactive_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L3, out.present_reactive_power_L3);
+
+    convert(in.EVPresentVoltage, out.present_voltage);
+    convert(in.EVPresentFrequency, out.present_frequency);
+
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower, out.maximum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L2, out.maximum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L3, out.maximum_discharge_power_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower, out.minimum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L2, out.minimum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L3, out.minimum_discharge_power_L3);
+
+    cb_convert_enum(in.DEROperationalState, out.der_operational_state);
+    cb_convert_enum(in.DERConnectionStatus, out.der_connection_status);
+
+    if (in.EVApparentPower_isUsed) {
+        convert(in.EVApparentPower, out.apparent_power.emplace());
+    }
+    if (in.EVReactivePower_isUsed) {
+        convert(in.EVReactivePower, out.reactive_power.emplace());
+    }
+    if (in.EVExcitation_isUsed) {
+        convert(in.EVExcitation, out.excitation.emplace());
+    }
+
+    out.update_time = in.EVUpdateTime;
+    CB2CPP_ASSIGN_IF_USED(in.EVMinimumChargingDuration, out.minimum_charging_duration);
+    CB2CPP_ASSIGN_IF_USED(in.EVDurationMaximumChargeRate, out.duration_maximum_charge_rate);
+    CB2CPP_ASSIGN_IF_USED(in.EVDurationMaximumDischargeRate, out.duration_maximum_discharge_rate);
+    out.der_alarm_status = in.DERAlarmStatus;
+    out.enabled_modes = in.EnabledModes;
+}
+
+template <>
+void convert(const dts::DER_Dynamic_AC_CLReqControlMode& in,
+             struct iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType& out) {
+    CPP2CB_ASSIGN_IF_USED(in.departure_time, out.DepartureTime);
+    convert(in.target_energy_request, out.EVTargetEnergyRequest);
+    convert(in.max_energy_request, out.EVMaximumEnergyRequest);
+    convert(in.min_energy_request, out.EVMinimumEnergyRequest);
+    convert(in.max_charge_power, out.EVMaximumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L2, out.EVMaximumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L3, out.EVMaximumChargePower_L3);
+    convert(in.min_charge_power, out.EVMinimumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L2, out.EVMinimumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L3, out.EVMinimumChargePower_L3);
+    convert(in.present_active_power, out.EVPresentActivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L2, out.EVPresentActivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L3, out.EVPresentActivePower_L3);
+    convert(in.present_reactive_power, out.EVPresentReactivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L2, out.EVPresentReactivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L3, out.EVPresentReactivePower_L3);
+
+    convert(in.maximum_discharge_power, out.EVMaximumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L2, out.EVMaximumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L3, out.EVMaximumDischargePower_L3);
+    convert(in.minimum_discharge_power, out.EVMinimumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L2, out.EVMinimumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L3, out.EVMinimumDischargePower_L3);
+
+    convert(in.present_voltage, out.EVPresentVoltage);
+    convert(in.present_frequency, out.EVPresentFrequency);
+
+    CPP2CB_CONVERT_IF_USED(in.session_total_discharge_energy_available, out.EVSessionTotalDischargeEnergyAvailable);
+
+    if (in.apparent_power.has_value()) {
+        convert(in.apparent_power.value(), out.EVApparentPower);
+        CB_SET_USED(out.EVApparentPower);
+    }
+    if (in.reactive_power.has_value()) {
+        convert(in.reactive_power.value(), out.EVReactivePower);
+        CB_SET_USED(out.EVReactivePower);
+    }
+    if (in.excitation.has_value()) {
+        convert(in.excitation.value(), out.EVExcitation);
+        CB_SET_USED(out.EVExcitation);
+    }
+
+    CPP2CB_CONVERT_IF_USED(in.maximum_v2x_energy_request, out.EVMaximumV2XEnergyRequest);
+    CPP2CB_CONVERT_IF_USED(in.minimum_v2x_energy_request, out.EVMinimumV2XEnergyRequest);
+
+    cb_convert_enum(in.der_operational_state, out.DEROperationalState);
+    cb_convert_enum(in.der_connection_status, out.DERConnectionStatus);
+
+    out.EVUpdateTime = in.update_time;
+    out.EVMinimumChargingDuration = in.minimum_charging_duration;
+    out.EVDurationMaximumChargeRate = in.duration_maximum_charge_rate;
+    out.EVDurationMaximumDischargeRate = in.duration_maximum_discharge_rate;
+    out.DERAlarmStatus = in.der_alarm_status;
+    out.EnabledModes = in.enabled_modes;
+}
+
+template <>
+void convert(const struct iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType& in,
+             dts::DER_Dynamic_AC_CLReqControlMode& out) {
+    CB2CPP_ASSIGN_IF_USED(in.DepartureTime, out.departure_time);
+    convert(in.EVTargetEnergyRequest, out.target_energy_request);
+    convert(in.EVMaximumEnergyRequest, out.max_energy_request);
+    convert(in.EVMinimumEnergyRequest, out.min_energy_request);
+    convert(in.EVMaximumChargePower, out.max_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L2, out.max_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L3, out.max_charge_power_L3);
+    convert(in.EVMinimumChargePower, out.min_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L2, out.min_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L3, out.min_charge_power_L3);
+    convert(in.EVPresentActivePower, out.present_active_power);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L2, out.present_active_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L3, out.present_active_power_L3);
+    convert(in.EVPresentReactivePower, out.present_reactive_power);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L2, out.present_reactive_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L3, out.present_reactive_power_L3);
+
+    convert(in.EVMaximumDischargePower, out.maximum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L2, out.maximum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L3, out.maximum_discharge_power_L3);
+    convert(in.EVMinimumDischargePower, out.minimum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L2, out.minimum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L3, out.minimum_discharge_power_L3);
+
+    convert(in.EVPresentVoltage, out.present_voltage);
+    convert(in.EVPresentFrequency, out.present_frequency);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSessionTotalDischargeEnergyAvailable, out.session_total_discharge_energy_available);
+
+    if (in.EVApparentPower_isUsed) {
+        convert(in.EVApparentPower, out.apparent_power.emplace());
+    }
+    if (in.EVReactivePower_isUsed) {
+        convert(in.EVReactivePower, out.reactive_power.emplace());
+    }
+    if (in.EVExcitation_isUsed) {
+        convert(in.EVExcitation, out.excitation.emplace());
+    }
+
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumV2XEnergyRequest, out.maximum_v2x_energy_request);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumV2XEnergyRequest, out.minimum_v2x_energy_request);
+
+    cb_convert_enum(in.DEROperationalState, out.der_operational_state);
+    cb_convert_enum(in.DERConnectionStatus, out.der_connection_status);
+
+    out.update_time = in.EVUpdateTime;
+    out.minimum_charging_duration = in.EVMinimumChargingDuration;
+    out.duration_maximum_charge_rate = in.EVDurationMaximumChargeRate;
+    out.duration_maximum_discharge_rate = in.EVDurationMaximumDischargeRate;
+    out.der_alarm_status = in.DERAlarmStatus;
+    out.enabled_modes = in.EnabledModes;
+}
+
+namespace {
+
+struct ReqControlModeVisitor {
+    using DER_ScheduledCM = dts::DER_Scheduled_AC_CLReqControlMode;
+    using DER_DynamicCM = dts::DER_Dynamic_AC_CLReqControlMode;
+
+    ReqControlModeVisitor(iso20_ac_der_sae_AC_ChargeLoopReqType& req_) : req(req_){};
+
+    void operator()(const DER_ScheduledCM& in) {
+        auto& out = req.DER_Scheduled_AC_CLReqControlMode;
+        init_iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType(&out);
+        convert(in, out);
+        CB_SET_USED(req.DER_Scheduled_AC_CLReqControlMode);
+    }
+
+    void operator()(const DER_DynamicCM& in) {
+        auto& out = req.DER_Dynamic_AC_CLReqControlMode;
+        init_iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType(&out);
+        convert(in, out);
+        CB_SET_USED(req.DER_Dynamic_AC_CLReqControlMode);
+    }
+
+private:
+    iso20_ac_der_sae_AC_ChargeLoopReqType& req;
+};
+
+} // namespace
+
+template <> void convert(const DER_SAE_AC_ChargeLoopRequest& in, struct iso20_ac_der_sae_AC_ChargeLoopReqType& out) {
+    init_iso20_ac_der_sae_AC_ChargeLoopReqType(&out);
+
+    convert(in.header, out.Header);
+
+    CPP2CB_CONVERT_IF_USED(in.display_parameters, out.DisplayParameters);
+    out.MeterInfoRequested = in.meter_info_requested;
+
+    std::visit(ReqControlModeVisitor(out), in.control_mode);
+}
+
+template <> void convert(const struct iso20_ac_der_sae_AC_ChargeLoopReqType& in, DER_SAE_AC_ChargeLoopRequest& out) {
+    convert(in.Header, out.header);
+
+    CB2CPP_CONVERT_IF_USED(in.DisplayParameters, out.display_parameters);
+    out.meter_info_requested = in.MeterInfoRequested;
+
+    if (in.DER_Scheduled_AC_CLReqControlMode_isUsed) {
+        convert(in.DER_Scheduled_AC_CLReqControlMode,
+                out.control_mode.emplace<dts::DER_Scheduled_AC_CLReqControlMode>());
+    } else if (in.DER_Dynamic_AC_CLReqControlMode_isUsed) {
+        convert(in.DER_Dynamic_AC_CLReqControlMode, out.control_mode.emplace<dts::DER_Dynamic_AC_CLReqControlMode>());
+    } else {
+        // should not happen
+        assert(false);
+    }
+}
+
+template <> int serialize_to_exi(const DER_SAE_AC_ChargeLoopRequest& in, exi_bitstream_t& out) {
+    iso20_ac_der_sae_exiDocument doc{};
+    init_iso20_ac_der_sae_exiDocument(&doc);
+
+    CB_SET_USED(doc.AC_ChargeLoopReq);
+
+    convert(in, doc.AC_ChargeLoopReq);
+
+    return encode_iso20_ac_der_sae_exiDocument(&out, &doc);
+}
+
+template <> size_t serialize(const DER_SAE_AC_ChargeLoopRequest& in, const io::StreamOutputView& out) {
+    return serialize_helper(in, out);
+}
+
+template <> void insert_type(VariantAccess& va, const struct iso20_ac_der_sae_AC_ChargeLoopReqType& in) {
+    va.insert_type<DER_SAE_AC_ChargeLoopRequest>(in);
+}
+
+// Response
 
 template <> void convert(const datatypes::DetailedCost& in, struct iso20_ac_der_sae_DetailedCostType& out) {
     init_iso20_ac_der_sae_DetailedCostType(&out);

--- a/lib/everest/iso15118/src/iso15118/message/variant.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/variant.cpp
@@ -182,10 +182,10 @@ static void handle_ac_sae_der(VariantAccess& va) {
         insert_type(va, doc.AC_ChargeParameterDiscoveryReq);
     } else if (doc.AC_ChargeParameterDiscoveryRes_isUsed) {
         insert_type(va, doc.AC_ChargeParameterDiscoveryRes);
-    } else if (doc.AC_ChargeLoopReq_isUsed) {
-        insert_type(va, doc.AC_ChargeLoopReq);
-    // } else if (doc.AC_ChargeLoopRes_isUsed) {
-    //     insert_type(va, doc.AC_ChargeLoopRes);
+        // } else if (doc.AC_ChargeLoopReq_isUsed) {
+        //     insert_type(va, doc.AC_ChargeLoopReq);
+    } else if (doc.AC_ChargeLoopRes_isUsed) {
+        insert_type(va, doc.AC_ChargeLoopRes);
     } else {
         va.error = "chosen message type unhandled";
     }

--- a/lib/everest/iso15118/src/iso15118/message/variant.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/variant.cpp
@@ -182,8 +182,8 @@ static void handle_ac_sae_der(VariantAccess& va) {
         insert_type(va, doc.AC_ChargeParameterDiscoveryReq);
     } else if (doc.AC_ChargeParameterDiscoveryRes_isUsed) {
         insert_type(va, doc.AC_ChargeParameterDiscoveryRes);
-        // } else if (doc.AC_ChargeLoopReq_isUsed) {
-        //     insert_type(va, doc.AC_ChargeLoopReq);
+    } else if (doc.AC_ChargeLoopReq_isUsed) {
+        insert_type(va, doc.AC_ChargeLoopReq);
     } else if (doc.AC_ChargeLoopRes_isUsed) {
         insert_type(va, doc.AC_ChargeLoopRes);
     } else {

--- a/lib/everest/iso15118/test/exi/cb/iso20/CMakeLists.txt
+++ b/lib/everest/iso15118/test/exi/cb/iso20/CMakeLists.txt
@@ -29,4 +29,5 @@ create_exi_test_target(ac_charge_loop)
 create_exi_test_target(ac_der_iec_charge_parameter_discovery)
 create_exi_test_target(ac_der_sae_charge_parameter_discovery)
 create_exi_test_target(ac_der_iec_charge_loop)
+create_exi_test_target(ac_der_sae_charge_loop)
 

--- a/lib/everest/iso15118/test/exi/cb/iso20/ac_der_iec_charge_loop.cpp
+++ b/lib/everest/iso15118/test/exi/cb/iso20/ac_der_iec_charge_loop.cpp
@@ -86,11 +86,13 @@ SCENARIO("Se/Deserialize ac der iec charge loop messages") {
 
             REQUIRE(dt::from_RationalNumber(control_mode.max_discharge_power) == 32);
             REQUIRE(dt::from_RationalNumber(control_mode.min_discharge_power) == 20);
-            REQUIRE(dt::from_RationalNumber(control_mode.max_charge_reactive_power.value_or({})) == 32);
-            REQUIRE(dt::from_RationalNumber(control_mode.max_discharge_reactive_power.value_or({})) == 32);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_charge_reactive_power.value_or(dt::RationalNumber{})) ==
+                    32);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_discharge_reactive_power.value_or(dt::RationalNumber{})) ==
+                    32);
             REQUIRE(control_mode.grid_event_condition == 0);
-            REQUIRE(dt::from_RationalNumber(control_mode.session_total_discharge_energy_available.value_or({})) ==
-                    20000);
+            REQUIRE(dt::from_RationalNumber(
+                        control_mode.session_total_discharge_energy_available.value_or(dt::RationalNumber{})) == 20000);
         }
     }
 
@@ -149,16 +151,19 @@ SCENARIO("Se/Deserialize ac der iec charge loop messages") {
 
             REQUIRE(std::holds_alternative<ScheduledMode>(msg.control_mode));
             const auto& control_mode = std::get<ScheduledMode>(msg.control_mode);
-            REQUIRE(dt::from_RationalNumber(control_mode.target_energy_request.value_or({})) == 25000);
-            REQUIRE(dt::from_RationalNumber(control_mode.max_energy_request.value_or({})) == 30000);
-            REQUIRE(dt::from_RationalNumber(control_mode.max_charge_power.value_or({})) == 32);
-            REQUIRE(dt::from_RationalNumber(control_mode.min_charge_power.value_or({})) == 20);
-            REQUIRE(dt::from_RationalNumber(control_mode.present_reactive_power.value_or({})) == 0);
+            REQUIRE(dt::from_RationalNumber(control_mode.target_energy_request.value_or(dt::RationalNumber{})) ==
+                    25000);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_energy_request.value_or(dt::RationalNumber{})) == 30000);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_charge_power.value_or(dt::RationalNumber{})) == 32);
+            REQUIRE(dt::from_RationalNumber(control_mode.min_charge_power.value_or(dt::RationalNumber{})) == 20);
+            REQUIRE(dt::from_RationalNumber(control_mode.present_reactive_power.value_or(dt::RationalNumber{})) == 0);
             REQUIRE(dt::from_RationalNumber(control_mode.present_active_power) == 15);
             REQUIRE(dt::from_RationalNumber(control_mode.max_discharge_power) == 32);
             REQUIRE(dt::from_RationalNumber(control_mode.min_discharge_power) == 20);
-            REQUIRE(dt::from_RationalNumber(control_mode.max_charge_reactive_power.value_or({})) == 32);
-            REQUIRE(dt::from_RationalNumber(control_mode.max_discharge_reactive_power.value_or({})) == 32);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_charge_reactive_power.value_or(dt::RationalNumber{})) ==
+                    32);
+            REQUIRE(dt::from_RationalNumber(control_mode.max_discharge_reactive_power.value_or(dt::RationalNumber{})) ==
+                    32);
             REQUIRE(control_mode.grid_event_condition == 0);
         }
     }
@@ -284,11 +289,12 @@ SCENARIO("Se/Deserialize ac der iec charge loop messages") {
             REQUIRE(control_mode.departure_time.value_or(0) == 1725470000);
             REQUIRE(control_mode.target_soc.value_or(0) == 80);
             REQUIRE(dt::from_RationalNumber(control_mode.target_active_power) == 32);
-            REQUIRE(dt::from_RationalNumber(control_mode.target_reactive_power.value_or({1, 0})) == 0);
-            REQUIRE(dt::from_RationalNumber(control_mode.present_active_power.value_or({})) == 15);
+            REQUIRE(dt::from_RationalNumber(control_mode.target_reactive_power.value_or(dt::RationalNumber{1, 0})) ==
+                    0);
+            REQUIRE(dt::from_RationalNumber(control_mode.present_active_power.value_or(dt::RationalNumber{})) == 15);
             REQUIRE(dt::from_RationalNumber(control_mode.max_charge_power) == 32);
             REQUIRE(dt::from_RationalNumber(control_mode.max_discharge_power) == 32);
-            REQUIRE(dt::from_RationalNumber(control_mode.dso_discharge_power.value_or({})) == 32);
+            REQUIRE(dt::from_RationalNumber(control_mode.dso_discharge_power.value_or(dt::RationalNumber{})) == 32);
 
             REQUIRE(control_mode.dso_q_setpoint.has_value());
             const auto& dsoq = control_mode.dso_q_setpoint.value();
@@ -347,12 +353,13 @@ SCENARIO("Se/Deserialize ac der iec charge loop messages") {
 
             REQUIRE(std::holds_alternative<ScheduledMode>(msg.control_mode));
             const auto& control_mode = std::get<ScheduledMode>(msg.control_mode);
-            REQUIRE(dt::from_RationalNumber(control_mode.target_active_power.value_or({})) == 32);
-            REQUIRE(dt::from_RationalNumber(control_mode.target_reactive_power.value_or({1, 0})) == 0);
-            REQUIRE(dt::from_RationalNumber(control_mode.present_active_power.value_or({})) == 15);
+            REQUIRE(dt::from_RationalNumber(control_mode.target_active_power.value_or(dt::RationalNumber{})) == 32);
+            REQUIRE(dt::from_RationalNumber(control_mode.target_reactive_power.value_or(dt::RationalNumber{1, 0})) ==
+                    0);
+            REQUIRE(dt::from_RationalNumber(control_mode.present_active_power.value_or(dt::RationalNumber{})) == 15);
             REQUIRE(dt::from_RationalNumber(control_mode.max_charge_power) == 32);
             REQUIRE(dt::from_RationalNumber(control_mode.max_discharge_power) == 32);
-            REQUIRE(dt::from_RationalNumber(control_mode.dso_discharge_power.value_or({})) == 20);
+            REQUIRE(dt::from_RationalNumber(control_mode.dso_discharge_power.value_or(dt::RationalNumber{})) == 20);
 
             REQUIRE(control_mode.dso_cos_phi_setpoint.has_value());
             const auto& dso_cos_phi = control_mode.dso_cos_phi_setpoint.value();

--- a/lib/everest/iso15118/test/exi/cb/iso20/ac_der_iec_charge_parameter_discovery.cpp
+++ b/lib/everest/iso15118/test/exi/cb/iso20/ac_der_iec_charge_parameter_discovery.cpp
@@ -34,14 +34,14 @@ SCENARIO("Se/Deserialize ac der iec charge parameter discovery messages") {
 
             REQUIRE(message_20::datatypes::from_RationalNumber(msg.transfer_mode.max_charge_power) == 32);
             REQUIRE(message_20::datatypes::from_RationalNumber(
-                        msg.transfer_mode.max_charge_power_L2.value_or({1, 0})) == 0.0f);
+                        msg.transfer_mode.max_charge_power_L2.value_or(dt::RationalNumber{1, 0})) == 0.0f);
             REQUIRE(message_20::datatypes::from_RationalNumber(
-                        msg.transfer_mode.max_charge_power_L3.value_or({1, 0})) == 0.0f);
+                        msg.transfer_mode.max_charge_power_L3.value_or(dt::RationalNumber{1, 0})) == 0.0f);
             REQUIRE(message_20::datatypes::from_RationalNumber(msg.transfer_mode.min_charge_power) == 20);
             REQUIRE(message_20::datatypes::from_RationalNumber(
-                        msg.transfer_mode.min_charge_power_L2.value_or({1, 0})) == 0.0f);
+                        msg.transfer_mode.min_charge_power_L2.value_or(dt::RationalNumber{1, 0})) == 0.0f);
             REQUIRE(message_20::datatypes::from_RationalNumber(
-                        msg.transfer_mode.min_charge_power_L3.value_or({1, 0})) == 0.0f);
+                        msg.transfer_mode.min_charge_power_L3.value_or(dt::RationalNumber{1, 0})) == 0.0f);
             REQUIRE(message_20::datatypes::from_RationalNumber(msg.transfer_mode.max_discharge_power) == 32);
             REQUIRE(message_20::datatypes::from_RationalNumber(msg.transfer_mode.min_discharge_power) == 20);
         }

--- a/lib/everest/iso15118/test/exi/cb/iso20/ac_der_sae_charge_loop.cpp
+++ b/lib/everest/iso15118/test/exi/cb/iso20/ac_der_sae_charge_loop.cpp
@@ -536,3 +536,436 @@ SCENARIO("Se/Deserialize ac der sae charge loop response messages") {
         }
     }
 }
+
+SCENARIO("Se/Deserialize ac der sae charge loop request messages") {
+
+    GIVEN("cl_req_scheduled_min") {
+
+        std::vector<uint8_t> bytes = {0x80, 0x08, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x3b,
+                                      0xfe, 0x1b, 0x60, 0x62, 0x89, 0x24, 0x18, 0x04, 0x94, 0x80, 0x0e, 0x60, 0x10,
+                                      0x40, 0x01, 0xe1, 0x81, 0x36, 0x1d, 0xff, 0x0d, 0xb0, 0x31, 0x80, 0x00, 0x18};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopReq);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopRequest>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456323);
+            REQUIRE(msg.meter_info_requested == false);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Scheduled_AC_CLReqControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Scheduled_AC_CLReqControlMode>(msg.control_mode);
+
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_voltage) == 230);
+            REQUIRE(dt::from_RationalNumber(mode.present_frequency) == 60);
+            REQUIRE(mode.der_operational_state == dtsae::DEROperationalState::On);
+            REQUIRE(mode.der_connection_status == dtsae::DERConnectionStatus::Connected);
+            REQUIRE(mode.update_time == 1725456323);
+            REQUIRE(mode.der_alarm_status == 0);
+            REQUIRE(mode.enabled_modes == 3);
+
+            // absent optionals
+            REQUIRE_FALSE(msg.display_parameters.has_value());
+            REQUIRE_FALSE(mode.target_energy_request.has_value());
+            REQUIRE_FALSE(mode.max_charge_power.has_value());
+            REQUIRE_FALSE(mode.present_active_power_L2.has_value());
+            REQUIRE_FALSE(mode.maximum_discharge_power.has_value());
+            REQUIRE_FALSE(mode.apparent_power.has_value());
+            REQUIRE_FALSE(mode.reactive_power.has_value());
+            REQUIRE_FALSE(mode.excitation.has_value());
+            REQUIRE_FALSE(mode.minimum_charging_duration.has_value());
+            REQUIRE_FALSE(mode.duration_maximum_charge_rate.has_value());
+            REQUIRE_FALSE(mode.duration_maximum_discharge_rate.has_value());
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopRequest req;
+            req.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
+            req.meter_info_requested = false;
+
+            dtsae::DER_Scheduled_AC_CLReqControlMode mode;
+            mode.present_active_power = {9, 3};
+            mode.present_voltage = {230, 0};
+            mode.present_frequency = {60, 0};
+            mode.der_operational_state = dtsae::DEROperationalState::On;
+            mode.der_connection_status = dtsae::DERConnectionStatus::Connected;
+            mode.update_time = 1725456323;
+            mode.der_alarm_status = 0;
+            mode.enabled_modes = 3;
+            req.control_mode = mode;
+
+            REQUIRE(serialize_helper(req) == bytes);
+        }
+    }
+
+    GIVEN("cl_req_dynamic_min") {
+
+        std::vector<uint8_t> bytes = {
+            0x80, 0x08, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x3b, 0xfe, 0x1b, 0x60, 0x62, 0x86,
+            0x90, 0x60, 0x50, 0x08, 0x30, 0x3c, 0x04, 0x18, 0x05, 0x02, 0x0c, 0x02, 0xc8, 0x80, 0x06, 0x42, 0x20, 0xc0,
+            0x24, 0x88, 0x00, 0x00, 0x22, 0x0c, 0x02, 0xc8, 0x80, 0x06, 0x42, 0x20, 0x03, 0x98, 0x04, 0x10, 0x00, 0x78,
+            0x60, 0x46, 0x1d, 0xff, 0x0d, 0xb0, 0x30, 0xd8, 0x04, 0x11, 0x01, 0xc2, 0x20, 0x38, 0x00, 0x00, 0x30};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopReq);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopRequest>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456323);
+            REQUIRE(msg.meter_info_requested == false);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Dynamic_AC_CLReqControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Dynamic_AC_CLReqControlMode>(msg.control_mode);
+
+            // Dynamic mode mandatory (1,1) fields
+            REQUIRE(dt::from_RationalNumber(mode.target_energy_request) == 40000);
+            REQUIRE(dt::from_RationalNumber(mode.max_energy_request) == 60000);
+            REQUIRE(dt::from_RationalNumber(mode.min_energy_request) == 10000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.min_charge_power) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_reactive_power) == 0);
+            REQUIRE(dt::from_RationalNumber(mode.maximum_discharge_power) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.minimum_discharge_power) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_voltage) == 230);
+            REQUIRE(dt::from_RationalNumber(mode.present_frequency) == 60);
+            REQUIRE(mode.der_operational_state == dtsae::DEROperationalState::On);
+            REQUIRE(mode.der_connection_status == dtsae::DERConnectionStatus::Connected);
+            REQUIRE(mode.update_time == 1725456323);
+            REQUIRE(mode.minimum_charging_duration == 600);
+            REQUIRE(mode.duration_maximum_charge_rate == 1800);
+            REQUIRE(mode.duration_maximum_discharge_rate == 1800);
+            REQUIRE(mode.der_alarm_status == 0);
+            REQUIRE(mode.enabled_modes == 3);
+
+            // absent optionals
+            REQUIRE_FALSE(msg.display_parameters.has_value());
+            REQUIRE_FALSE(mode.departure_time.has_value());
+            REQUIRE_FALSE(mode.max_charge_power_L2.has_value());
+            REQUIRE_FALSE(mode.session_total_discharge_energy_available.has_value());
+            REQUIRE_FALSE(mode.apparent_power.has_value());
+            REQUIRE_FALSE(mode.reactive_power.has_value());
+            REQUIRE_FALSE(mode.excitation.has_value());
+            REQUIRE_FALSE(mode.maximum_v2x_energy_request.has_value());
+            REQUIRE_FALSE(mode.minimum_v2x_energy_request.has_value());
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopRequest req;
+            req.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
+            req.meter_info_requested = false;
+
+            dtsae::DER_Dynamic_AC_CLReqControlMode mode;
+            mode.target_energy_request = {40, 3};
+            mode.max_energy_request = {60, 3};
+            mode.min_energy_request = {10, 3};
+            mode.max_charge_power = {11, 3};
+            mode.min_charge_power = {100, 0};
+            mode.present_active_power = {9, 3};
+            mode.present_reactive_power = {0, 0};
+            mode.maximum_discharge_power = {11, 3};
+            mode.minimum_discharge_power = {100, 0};
+            mode.present_voltage = {230, 0};
+            mode.present_frequency = {60, 0};
+            mode.der_operational_state = dtsae::DEROperationalState::On;
+            mode.der_connection_status = dtsae::DERConnectionStatus::Connected;
+            mode.update_time = 1725456323;
+            mode.minimum_charging_duration = 600;
+            mode.duration_maximum_charge_rate = 1800;
+            mode.duration_maximum_discharge_rate = 1800;
+            mode.der_alarm_status = 0;
+            mode.enabled_modes = 3;
+            req.control_mode = mode;
+
+            REQUIRE(serialize_helper(req) == bytes);
+        }
+    }
+
+    GIVEN("cl_req_scheduled_optionals") {
+
+        std::vector<uint8_t> bytes = {
+            0x80, 0x08, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x3b, 0xfe, 0x1b, 0x60,
+            0x62, 0x01, 0xb8, 0x07, 0x80, 0xa0, 0x41, 0x14, 0x02, 0x0c, 0x0a, 0x00, 0x20, 0xc0, 0xf0, 0x02,
+            0x0c, 0x02, 0x80, 0x41, 0x80, 0x58, 0x08, 0x30, 0x0b, 0x01, 0x06, 0x01, 0x60, 0x20, 0x01, 0x90,
+            0x88, 0x30, 0x09, 0x01, 0x06, 0x01, 0x20, 0x20, 0xc0, 0x24, 0x04, 0x00, 0x00, 0x11, 0x00, 0x1c,
+            0xc0, 0x20, 0x80, 0x03, 0xc0, 0x10, 0x60, 0x16, 0x22, 0x00, 0x19, 0x08, 0x10, 0x10, 0x60, 0x18,
+            0x44, 0x18, 0x06, 0x11, 0x06, 0x01, 0x84, 0x41, 0x80, 0x61, 0x02, 0x0c, 0x01, 0x4a, 0x41, 0x80,
+            0x29, 0x48, 0x30, 0x05, 0x29, 0x06, 0x00, 0xa5, 0x19, 0x06, 0x01, 0x05, 0x20, 0xc0, 0x20, 0x8c,
+            0x3b, 0xfe, 0x1b, 0x60, 0x60, 0x6c, 0x02, 0x04, 0x40, 0x70, 0x44, 0x07, 0x00, 0x00, 0x06, 0x00};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopReq);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopRequest>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456323);
+            REQUIRE(msg.meter_info_requested == true);
+
+            REQUIRE(msg.display_parameters.has_value());
+            REQUIRE(msg.display_parameters.value().present_soc.value() == 55);
+            REQUIRE(msg.display_parameters.value().min_soc.value() == 30);
+            REQUIRE(msg.display_parameters.value().target_soc.value() == 80);
+            REQUIRE(msg.display_parameters.value().charging_complete.value() == false);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Scheduled_AC_CLReqControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Scheduled_AC_CLReqControlMode>(msg.control_mode);
+
+            REQUIRE(dt::from_RationalNumber(mode.target_energy_request.value()) == 40000);
+            REQUIRE(dt::from_RationalNumber(mode.max_energy_request.value()) == 60000);
+            REQUIRE(dt::from_RationalNumber(mode.min_energy_request.value()) == 10000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power_L2.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power_L3.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.min_charge_power.value()) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power_L2.value()) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power_L3.value()) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_reactive_power.value()) == 0);
+            REQUIRE(dt::from_RationalNumber(mode.present_voltage) == 230);
+            REQUIRE(dt::from_RationalNumber(mode.present_frequency) == 60);
+            REQUIRE(dt::from_RationalNumber(mode.maximum_discharge_power.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.minimum_discharge_power.value()) == 100);
+            REQUIRE(mode.der_operational_state == dtsae::DEROperationalState::On);
+            REQUIRE(mode.der_connection_status == dtsae::DERConnectionStatus::Connected);
+
+            REQUIRE(mode.apparent_power.has_value());
+            const auto& ap = mode.apparent_power.value();
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_charging_and_var_absorption) == 12000);
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_charging_and_var_injection) == 12000);
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_discharging_and_var_absorption) == 12000);
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_discharging_and_var_injection) == 12000);
+            REQUIRE_FALSE(ap.maximum_apparent_power_during_charging_and_var_absorption_L2.has_value());
+
+            REQUIRE(mode.reactive_power.has_value());
+            const auto& rp = mode.reactive_power.value();
+            REQUIRE(dt::from_RationalNumber(rp.maximum_var_absorption_during_charging) == 5000);
+            REQUIRE(dt::from_RationalNumber(rp.maximum_var_injection_during_charging) == 5000);
+            REQUIRE(dt::from_RationalNumber(rp.maximum_var_absorption_during_discharging) == 5000);
+            REQUIRE(dt::from_RationalNumber(rp.maximum_var_injection_during_discharging) == 5000);
+            REQUIRE_FALSE(rp.minimum_var_absorption_during_charging.has_value());
+
+            REQUIRE(mode.excitation.has_value());
+            const auto& ex = mode.excitation.value();
+            REQUIRE(dt::from_RationalNumber(ex.specified_over_excited_discharge_power) == 8000);
+            REQUIRE(dt::from_RationalNumber(ex.specified_under_excited_discharge_power) == 8000);
+            REQUIRE_FALSE(ex.specified_over_excited_power_factor.has_value());
+
+            REQUIRE(mode.update_time == 1725456323);
+            REQUIRE(mode.minimum_charging_duration == 600);
+            REQUIRE(mode.duration_maximum_charge_rate == 1800);
+            REQUIRE(mode.duration_maximum_discharge_rate == 1800);
+            REQUIRE(mode.der_alarm_status == 0);
+            REQUIRE(mode.enabled_modes == 3);
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopRequest req;
+            req.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
+            req.meter_info_requested = true;
+
+            dt::DisplayParameters display_parameters;
+            display_parameters.present_soc = 55;
+            display_parameters.min_soc = 30;
+            display_parameters.target_soc = 80;
+            display_parameters.charging_complete = false;
+            req.display_parameters = display_parameters;
+
+            dtsae::DER_Scheduled_AC_CLReqControlMode mode;
+            mode.target_energy_request = dt::RationalNumber{40, 3};
+            mode.max_energy_request = dt::RationalNumber{60, 3};
+            mode.min_energy_request = dt::RationalNumber{10, 3};
+            mode.max_charge_power = dt::RationalNumber{11, 3};
+            mode.max_charge_power_L2 = dt::RationalNumber{11, 3};
+            mode.max_charge_power_L3 = dt::RationalNumber{11, 3};
+            mode.min_charge_power = dt::RationalNumber{100, 0};
+            mode.present_active_power = {9, 3};
+            mode.present_active_power_L2 = dt::RationalNumber{9, 3};
+            mode.present_active_power_L3 = dt::RationalNumber{9, 3};
+            mode.present_reactive_power = dt::RationalNumber{0, 0};
+            mode.present_voltage = {230, 0};
+            mode.present_frequency = {60, 0};
+            mode.maximum_discharge_power = dt::RationalNumber{11, 3};
+            mode.minimum_discharge_power = dt::RationalNumber{100, 0};
+            mode.der_operational_state = dtsae::DEROperationalState::On;
+            mode.der_connection_status = dtsae::DERConnectionStatus::Connected;
+
+            dtsae::EVApparentPower apparent_power;
+            apparent_power.maximum_apparent_power_during_charging_and_var_absorption = {12, 3};
+            apparent_power.maximum_apparent_power_during_charging_and_var_injection = {12, 3};
+            apparent_power.maximum_apparent_power_during_discharging_and_var_absorption = {12, 3};
+            apparent_power.maximum_apparent_power_during_discharging_and_var_injection = {12, 3};
+            mode.apparent_power = apparent_power;
+
+            dtsae::EVReactivePower reactive_power;
+            reactive_power.maximum_var_absorption_during_charging = {5, 3};
+            reactive_power.maximum_var_injection_during_charging = {5, 3};
+            reactive_power.maximum_var_absorption_during_discharging = {5, 3};
+            reactive_power.maximum_var_injection_during_discharging = {5, 3};
+            mode.reactive_power = reactive_power;
+
+            dtsae::EVExcitation excitation;
+            excitation.specified_over_excited_discharge_power = {8, 3};
+            excitation.specified_under_excited_discharge_power = {8, 3};
+            mode.excitation = excitation;
+
+            mode.update_time = 1725456323;
+            mode.minimum_charging_duration = 600;
+            mode.duration_maximum_charge_rate = 1800;
+            mode.duration_maximum_discharge_rate = 1800;
+            mode.der_alarm_status = 0;
+            mode.enabled_modes = 3;
+            req.control_mode = mode;
+
+            REQUIRE(serialize_helper(req) == bytes);
+        }
+    }
+
+    GIVEN("cl_req_dynamic_optionals") {
+
+        std::vector<uint8_t> bytes = {
+            0x80, 0x08, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x3b, 0xfe, 0x1b, 0x60, 0x62,
+            0x01, 0xb8, 0x54, 0x0e, 0x4c, 0x50, 0x1c, 0x04, 0x18, 0x14, 0x02, 0x0c, 0x0f, 0x01, 0x06, 0x01, 0x40,
+            0x83, 0x00, 0xb0, 0x20, 0xc0, 0x2c, 0x08, 0x30, 0x0b, 0x04, 0x00, 0x32, 0x11, 0x06, 0x01, 0x24, 0x40,
+            0x00, 0x01, 0x10, 0x60, 0x16, 0x44, 0x00, 0x32, 0x11, 0x00, 0x1c, 0xc0, 0x20, 0x80, 0x03, 0xc0, 0x10,
+            0x60, 0x3c, 0x01, 0x06, 0x01, 0x84, 0x41, 0x80, 0x61, 0x10, 0x60, 0x18, 0x44, 0x18, 0x06, 0x11, 0x64,
+            0x18, 0x04, 0x14, 0x83, 0x00, 0x82, 0x08, 0x30, 0x14, 0x02, 0x0c, 0x01, 0x40, 0x23, 0x0e, 0xff, 0x86,
+            0xd8, 0x18, 0x6c, 0x02, 0x08, 0x80, 0xe1, 0x10, 0x1c, 0x00, 0x00, 0x18};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopReq);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopRequest>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456323);
+            REQUIRE(msg.meter_info_requested == true);
+
+            REQUIRE(msg.display_parameters.has_value());
+            REQUIRE(msg.display_parameters.value().present_soc.value() == 55);
+            REQUIRE(msg.display_parameters.value().target_soc.value() == 80);
+            REQUIRE_FALSE(msg.display_parameters.value().min_soc.has_value());
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Dynamic_AC_CLReqControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Dynamic_AC_CLReqControlMode>(msg.control_mode);
+
+            REQUIRE(mode.departure_time.value() == 7200);
+            REQUIRE(dt::from_RationalNumber(mode.target_energy_request) == 40000);
+            REQUIRE(dt::from_RationalNumber(mode.max_energy_request) == 60000);
+            REQUIRE(dt::from_RationalNumber(mode.min_energy_request) == 10000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power_L2.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power_L3.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.min_charge_power) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_reactive_power) == 0);
+            REQUIRE(dt::from_RationalNumber(mode.maximum_discharge_power) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.minimum_discharge_power) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_voltage) == 230);
+            REQUIRE(dt::from_RationalNumber(mode.present_frequency) == 60);
+            REQUIRE(dt::from_RationalNumber(mode.session_total_discharge_energy_available.value()) == 30000);
+
+            REQUIRE(mode.apparent_power.has_value());
+            const auto& ap = mode.apparent_power.value();
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_charging_and_var_absorption) == 12000);
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_discharging_and_var_injection) == 12000);
+
+            REQUIRE_FALSE(mode.reactive_power.has_value());
+
+            REQUIRE(mode.excitation.has_value());
+            const auto& ex = mode.excitation.value();
+            REQUIRE(dt::from_RationalNumber(ex.specified_over_excited_discharge_power) == 8000);
+            REQUIRE(dt::from_RationalNumber(ex.specified_under_excited_discharge_power) == 8000);
+
+            REQUIRE(dt::from_RationalNumber(mode.maximum_v2x_energy_request.value()) == 20000);
+            REQUIRE(dt::from_RationalNumber(mode.minimum_v2x_energy_request.value()) == 5000);
+
+            REQUIRE(mode.der_operational_state == dtsae::DEROperationalState::On);
+            REQUIRE(mode.der_connection_status == dtsae::DERConnectionStatus::Connected);
+            REQUIRE(mode.update_time == 1725456323);
+            REQUIRE(mode.minimum_charging_duration == 600);
+            REQUIRE(mode.duration_maximum_charge_rate == 1800);
+            REQUIRE(mode.duration_maximum_discharge_rate == 1800);
+            REQUIRE(mode.der_alarm_status == 0);
+            REQUIRE(mode.enabled_modes == 3);
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopRequest req;
+            req.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
+            req.meter_info_requested = true;
+
+            dt::DisplayParameters display_parameters;
+            display_parameters.present_soc = 55;
+            display_parameters.target_soc = 80;
+            req.display_parameters = display_parameters;
+
+            dtsae::DER_Dynamic_AC_CLReqControlMode mode;
+            mode.departure_time = 7200;
+            mode.target_energy_request = {40, 3};
+            mode.max_energy_request = {60, 3};
+            mode.min_energy_request = {10, 3};
+            mode.max_charge_power = {11, 3};
+            mode.max_charge_power_L2 = dt::RationalNumber{11, 3};
+            mode.max_charge_power_L3 = dt::RationalNumber{11, 3};
+            mode.min_charge_power = {100, 0};
+            mode.present_active_power = {9, 3};
+            mode.present_reactive_power = {0, 0};
+            mode.maximum_discharge_power = {11, 3};
+            mode.minimum_discharge_power = {100, 0};
+            mode.present_voltage = {230, 0};
+            mode.present_frequency = {60, 0};
+            mode.session_total_discharge_energy_available = dt::RationalNumber{30, 3};
+
+            dtsae::EVApparentPower apparent_power;
+            apparent_power.maximum_apparent_power_during_charging_and_var_absorption = {12, 3};
+            apparent_power.maximum_apparent_power_during_charging_and_var_injection = {12, 3};
+            apparent_power.maximum_apparent_power_during_discharging_and_var_absorption = {12, 3};
+            apparent_power.maximum_apparent_power_during_discharging_and_var_injection = {12, 3};
+            mode.apparent_power = apparent_power;
+
+            dtsae::EVExcitation excitation;
+            excitation.specified_over_excited_discharge_power = {8, 3};
+            excitation.specified_under_excited_discharge_power = {8, 3};
+            mode.excitation = excitation;
+
+            mode.maximum_v2x_energy_request = dt::RationalNumber{20, 3};
+            mode.minimum_v2x_energy_request = dt::RationalNumber{5, 3};
+
+            mode.der_operational_state = dtsae::DEROperationalState::On;
+            mode.der_connection_status = dtsae::DERConnectionStatus::Connected;
+            mode.update_time = 1725456323;
+            mode.minimum_charging_duration = 600;
+            mode.duration_maximum_charge_rate = 1800;
+            mode.duration_maximum_discharge_rate = 1800;
+            mode.der_alarm_status = 0;
+            mode.enabled_modes = 3;
+            req.control_mode = mode;
+
+            REQUIRE(serialize_helper(req) == bytes);
+        }
+    }
+}

--- a/lib/everest/iso15118/test/exi/cb/iso20/ac_der_sae_charge_loop.cpp
+++ b/lib/everest/iso15118/test/exi/cb/iso20/ac_der_sae_charge_loop.cpp
@@ -1,0 +1,538 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <iso15118/message/ac_der_sae_charge_loop.hpp>
+#include <iso15118/message/variant.hpp>
+
+#include "helper.hpp"
+
+using namespace iso15118;
+
+namespace dt = message_20::datatypes;
+namespace dtsae = message_20::datatypes::sae;
+
+SCENARIO("Se/Deserialize ac der sae charge loop response messages") {
+
+    GIVEN("cl_res_scheduled_min") {
+
+        std::vector<uint8_t> bytes = {0x80, 0x0c, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d,
+                                      0x8c, 0x4b, 0xfe, 0x1b, 0x60, 0x62, 0x00, 0x89, 0x89, 0xe8, 0x00};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopRes);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopResponse>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456324);
+            REQUIRE(msg.response_code == dt::ResponseCode::OK);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Scheduled_AC_CLResControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Scheduled_AC_CLResControlMode>(msg.control_mode);
+
+            REQUIRE(mode.der_control_cl_res.enter_service_cl_res.permit_service == true);
+
+            // absent optionals
+            REQUIRE_FALSE(msg.status.has_value());
+            REQUIRE_FALSE(msg.meter_info.has_value());
+            REQUIRE_FALSE(msg.receipt.has_value());
+            REQUIRE_FALSE(msg.target_frequency.has_value());
+            REQUIRE_FALSE(mode.der_control_cl_res.voltage_trip.has_value());
+            REQUIRE_FALSE(mode.der_control_cl_res.frequency_trip.has_value());
+            REQUIRE_FALSE(mode.der_control_cl_res.reactive_power_support_cl_res.has_value());
+            REQUIRE_FALSE(mode.der_control_cl_res.active_power_support_cl_res.has_value());
+            REQUIRE_FALSE(mode.target_active_power.has_value());
+            REQUIRE_FALSE(mode.evse_maximum_charge_power.has_value());
+            REQUIRE_FALSE(mode.required_der_operating_mode.has_value());
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopResponse res;
+            res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456324};
+            res.response_code = dt::ResponseCode::OK;
+
+            dtsae::DER_Scheduled_AC_CLResControlMode mode;
+            mode.der_control_cl_res.enter_service_cl_res.permit_service = true;
+            res.control_mode = mode;
+
+            REQUIRE(serialize_helper(res) == bytes);
+        }
+    }
+
+    GIVEN("cl_res_dynamic_min") {
+
+        std::vector<uint8_t> bytes = {0x80, 0x0c, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x4b,
+                                      0xfe, 0x1b, 0x60, 0x62, 0x00, 0x78, 0x41, 0x80, 0x51, 0x11, 0x3d, 0x00};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopRes);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopResponse>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456324);
+            REQUIRE(msg.response_code == dt::ResponseCode::OK);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Dynamic_AC_CLResControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Dynamic_AC_CLResControlMode>(msg.control_mode);
+
+            // EVSETargetActivePower is mandatory (1,1) in Dynamic mode
+            REQUIRE(dt::from_RationalNumber(mode.target_active_power) == 10000);
+            REQUIRE(mode.der_control_cl_res.enter_service_cl_res.permit_service == true);
+
+            // absent optionals
+            REQUIRE_FALSE(msg.status.has_value());
+            REQUIRE_FALSE(msg.meter_info.has_value());
+            REQUIRE_FALSE(msg.receipt.has_value());
+            REQUIRE_FALSE(msg.target_frequency.has_value());
+            REQUIRE_FALSE(mode.departure_time.has_value());
+            REQUIRE_FALSE(mode.minimum_soc.has_value());
+            REQUIRE_FALSE(mode.target_soc.has_value());
+            REQUIRE_FALSE(mode.ack_max_delay.has_value());
+            REQUIRE_FALSE(mode.der_control_cl_res.voltage_trip.has_value());
+            REQUIRE_FALSE(mode.der_control_cl_res.frequency_trip.has_value());
+            REQUIRE_FALSE(mode.evse_maximum_charge_power.has_value());
+            REQUIRE_FALSE(mode.required_der_operating_mode.has_value());
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopResponse res;
+            res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456324};
+            res.response_code = dt::ResponseCode::OK;
+
+            dtsae::DER_Dynamic_AC_CLResControlMode mode;
+            mode.target_active_power = {10, 3};
+            mode.der_control_cl_res.enter_service_cl_res.permit_service = true;
+            res.control_mode = mode;
+
+            REQUIRE(serialize_helper(res) == bytes);
+        }
+    }
+
+    GIVEN("cl_res_scheduled_optionals") {
+
+        std::vector<uint8_t> bytes = {
+            0x80, 0x0c, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x4b, 0xfe, 0x1b, 0x60, 0x62, 0x00,
+            0x00, 0xf0, 0x00, 0x00, 0xf4, 0x55, 0x65, 0x34, 0x52, 0xd4, 0xd4, 0x55, 0x44, 0x55, 0x22, 0xd3, 0x03, 0x11,
+            0xc0, 0xba, 0xc0, 0x62, 0x5f, 0xf0, 0xdb, 0x03, 0x28, 0x10, 0x00, 0x78, 0x40, 0x20, 0xc0, 0x28, 0x22, 0x00,
+            0x00, 0x04, 0x41, 0x80, 0x49, 0x02, 0x40, 0x0c, 0x08, 0x00, 0x88, 0x02, 0x04, 0x00, 0x00, 0x80, 0x80, 0x0a,
+            0x00, 0x20, 0x3f, 0x80, 0x10, 0x61, 0x20, 0x06, 0x04, 0x00, 0x62, 0x00, 0x82, 0x00, 0x00, 0x80, 0x40, 0x05,
+            0x00, 0x08, 0x1f, 0xc0, 0x08, 0x34, 0x04, 0x84, 0x18, 0x10, 0x00, 0x7c, 0x08, 0x00, 0x01, 0x01, 0x00, 0x07,
+            0xe0, 0x7f, 0x00, 0x50, 0xc2, 0x42, 0x0c, 0x08, 0x00, 0x3a, 0x04, 0x00, 0x00, 0x80, 0x80, 0x03, 0x90, 0x3f,
+            0x80, 0x28, 0x68, 0x40, 0x40, 0x07, 0xe8, 0x08, 0x08, 0x00, 0xcf, 0x01, 0x01, 0x00, 0x07, 0xa0, 0x20, 0x00,
+            0xec, 0x04, 0x00, 0x56, 0x01, 0x01, 0x00, 0x07, 0x80, 0x40, 0x03, 0xc0, 0x01, 0x00, 0x10, 0x7e, 0x05, 0xf2,
+            0x13, 0x01, 0x00, 0x10, 0x0f, 0xa0, 0x48, 0x07, 0xe0, 0x05, 0x21, 0x10, 0x00, 0x0a, 0x14, 0x49, 0x40, 0xc0,
+            0x20, 0xc0, 0x58, 0x22, 0x0c, 0x03, 0xc4, 0x00, 0x00};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopRes);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopResponse>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456324);
+            REQUIRE(msg.response_code == dt::ResponseCode::OK);
+
+            // populated optionals
+            REQUIRE(msg.status.has_value());
+            REQUIRE(msg.status.value().notification == dt::EvseNotification::Pause);
+            REQUIRE(msg.status.value().notification_max_delay == 60);
+            REQUIRE(msg.meter_info.has_value());
+            REQUIRE(msg.meter_info.value().meter_id == "EVSE-METER-01");
+            REQUIRE(msg.meter_info.value().charged_energy_reading_wh == 12000);
+            REQUIRE(msg.receipt.has_value());
+            REQUIRE(msg.receipt.value().time_anchor == 1725456324);
+            REQUIRE(msg.target_frequency.has_value());
+            REQUIRE(dt::from_RationalNumber(msg.target_frequency.value()) == 60);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Scheduled_AC_CLResControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Scheduled_AC_CLResControlMode>(msg.control_mode);
+
+            REQUIRE(dt::from_RationalNumber(mode.target_active_power.value()) == 10000);
+            REQUIRE(dt::from_RationalNumber(mode.target_reactive_power.value()) == 0);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power.value()) == 9000);
+
+            const auto& der_control = mode.der_control_cl_res;
+            REQUIRE(der_control.enter_service_cl_res.permit_service == true);
+            REQUIRE(dt::from_RationalNumber(der_control.enter_service_cl_res.enter_service_voltage_high.value()) ==
+                    253);
+            REQUIRE(dt::from_RationalNumber(der_control.enter_service_cl_res.enter_service_voltage_low.value()) == 207);
+            REQUIRE(dt::from_RationalNumber(der_control.enter_service_cl_res.enter_service_delay.value()) == 300);
+            REQUIRE(dt::from_RationalNumber(der_control.enter_service_cl_res.enter_service_ramp_time.value()) == 120);
+
+            // VoltageTrip curve coverage
+            REQUIRE(der_control.voltage_trip.has_value());
+            const auto& ov = der_control.voltage_trip.value().over_voltage_must_trip_curve;
+            REQUIRE(ov.enable == true);
+            REQUIRE(ov.x_unit == dtsae::DERUnit::V);
+            REQUIRE(ov.y_unit == dtsae::DERUnit::s);
+            REQUIRE(ov.curve_data_points.size() == 2);
+            REQUIRE(dt::from_RationalNumber(ov.curve_data_points[0].x_value) == 264);
+            REQUIRE(dt::from_RationalNumber(ov.curve_data_points[0].y_value) == 1);
+            REQUIRE(dt::from_RationalNumber(ov.curve_data_points[1].x_value) == 288);
+            REQUIRE_THAT(dt::from_RationalNumber(ov.curve_data_points[1].y_value),
+                         Catch::Matchers::WithinRel(0.2, 0.001));
+            const auto& uv = der_control.voltage_trip.value().under_voltage_must_trip_curve;
+            REQUIRE(uv.curve_data_points.size() == 2);
+            REQUIRE(dt::from_RationalNumber(uv.curve_data_points[0].x_value) == 196);
+
+            // FrequencyTrip curve coverage
+            REQUIRE(der_control.frequency_trip.has_value());
+            const auto& of = der_control.frequency_trip.value().over_frequency_must_trip_curve;
+            REQUIRE(of.enable == true);
+            REQUIRE(of.x_unit == dtsae::DERUnit::Hz);
+            REQUIRE(of.curve_data_points.size() == 2);
+            REQUIRE(dt::from_RationalNumber(of.curve_data_points[0].x_value) == 62);
+
+            // ReactivePowerSupport: ConstantPowerFactor
+            REQUIRE(der_control.reactive_power_support_cl_res.has_value());
+            const auto& rps = der_control.reactive_power_support_cl_res.value();
+            REQUIRE(rps.constant_power_factor.has_value());
+            REQUIRE(rps.constant_power_factor.value().enable == true);
+            REQUIRE(rps.constant_power_factor.value().priority.value() == 1);
+            REQUIRE(rps.constant_power_factor.value().power_factor_excitation ==
+                    dtsae::PowerFactorExcitation::OverExcited);
+            REQUIRE_FALSE(rps.volt_var.has_value());
+
+            // ActivePowerSupport: FrequencyDroop + LimitMaxDischargePower
+            REQUIRE(der_control.active_power_support_cl_res.has_value());
+            const auto& aps = der_control.active_power_support_cl_res.value();
+            REQUIRE(aps.frequency_droop.has_value());
+            REQUIRE(aps.frequency_droop.value().enable == true);
+            REQUIRE(aps.frequency_droop.value().priority.value() == 2);
+            REQUIRE(aps.frequency_droop.value().over_frequency_droop.has_value());
+            REQUIRE(aps.frequency_droop.value().over_frequency_droop.value().power_reference ==
+                    dtsae::PowerReference::MaximumActivePower);
+            REQUIRE(aps.limit_max_discharge_power.has_value());
+            REQUIRE(aps.limit_max_discharge_power.value().percentage_value == 80);
+
+            REQUIRE(dt::from_RationalNumber(mode.evse_maximum_charge_power.value()) == 22000);
+            REQUIRE(dt::from_RationalNumber(mode.evse_maximum_discharge_power.value()) == 15000);
+            REQUIRE(mode.required_der_operating_mode.value() == dtsae::RequiredDEROperatingMode::GridFollowing);
+            REQUIRE(mode.grid_connection_mode.value() == dtsae::GridConnectionMode::GridConnected);
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopResponse res;
+            res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456324};
+            res.response_code = dt::ResponseCode::OK;
+
+            res.status = dt::EvseStatus{60, dt::EvseNotification::Pause};
+
+            dt::MeterInfo meter_info;
+            meter_info.meter_id = "EVSE-METER-01";
+            meter_info.charged_energy_reading_wh = 12000;
+            res.meter_info = meter_info;
+
+            dt::Receipt receipt;
+            receipt.time_anchor = 1725456324;
+            res.receipt = receipt;
+
+            res.target_frequency = dt::RationalNumber{60, 0};
+
+            dtsae::DER_Scheduled_AC_CLResControlMode mode;
+            mode.target_active_power = {10, 3};
+            mode.target_reactive_power = {0, 0};
+            mode.present_active_power = {9, 3};
+
+            auto& der_control = mode.der_control_cl_res;
+
+            dtsae::VoltageTrip voltage_trip;
+            auto& ov_must = voltage_trip.over_voltage_must_trip_curve;
+            ov_must.enable = true;
+            ov_must.x_unit = dtsae::DERUnit::V;
+            ov_must.y_unit = dtsae::DERUnit::s;
+            ov_must.curve_data_points.push_back(dtsae::DataTuple{{264, 0}, {1, 0}});
+            ov_must.curve_data_points.push_back(dtsae::DataTuple{{288, 0}, {2, -1}});
+            auto& uv_must = voltage_trip.under_voltage_must_trip_curve;
+            uv_must.enable = true;
+            uv_must.x_unit = dtsae::DERUnit::V;
+            uv_must.y_unit = dtsae::DERUnit::s;
+            uv_must.curve_data_points.push_back(dtsae::DataTuple{{196, 0}, {2, 0}});
+            uv_must.curve_data_points.push_back(dtsae::DataTuple{{160, 0}, {2, -1}});
+            der_control.voltage_trip = voltage_trip;
+
+            dtsae::FrequencyTrip frequency_trip;
+            auto& of_must = frequency_trip.over_frequency_must_trip_curve;
+            of_must.enable = true;
+            of_must.x_unit = dtsae::DERUnit::Hz;
+            of_must.y_unit = dtsae::DERUnit::s;
+            of_must.curve_data_points.push_back(dtsae::DataTuple{{62, 0}, {1, 0}});
+            of_must.curve_data_points.push_back(dtsae::DataTuple{{63, 0}, {5, -1}});
+            auto& uf_must = frequency_trip.under_frequency_must_trip_curve;
+            uf_must.enable = true;
+            uf_must.x_unit = dtsae::DERUnit::Hz;
+            uf_must.y_unit = dtsae::DERUnit::s;
+            uf_must.curve_data_points.push_back(dtsae::DataTuple{{58, 0}, {1, 0}});
+            uf_must.curve_data_points.push_back(dtsae::DataTuple{{57, 0}, {5, -1}});
+            der_control.frequency_trip = frequency_trip;
+
+            auto& enter_service = der_control.enter_service_cl_res;
+            enter_service.permit_service = true;
+            enter_service.enter_service_voltage_high = {253, 0};
+            enter_service.enter_service_voltage_low = {207, 0};
+            enter_service.enter_service_frequency_high = {61, 0};
+            enter_service.enter_service_frequency_low = {59, 0};
+            enter_service.enter_service_delay = {300, 0};
+            enter_service.enter_service_randomized_delay = {60, 0};
+            enter_service.enter_service_ramp_time = {120, 0};
+
+            dtsae::ReactivePowerSupportCLRes reactive_support;
+            dtsae::ConstantPowerFactor cpf;
+            cpf.enable = true;
+            cpf.priority = 1;
+            cpf.power_factor_value = {95, -2};
+            cpf.power_factor_excitation = dtsae::PowerFactorExcitation::OverExcited;
+            reactive_support.constant_power_factor = cpf;
+            der_control.reactive_power_support_cl_res = reactive_support;
+
+            dtsae::ActivePowerSupportCLRes active_support;
+            dtsae::FrequencyDroop frequency_droop;
+            frequency_droop.enable = true;
+            frequency_droop.priority = 2;
+            dtsae::FrequencyDroopSettings over_droop;
+            over_droop.db = {36, -3};
+            over_droop.droop_factor = {5, -2};
+            over_droop.power_reference = dtsae::PowerReference::MaximumActivePower;
+            over_droop.open_loop_response_time = {5, 0};
+            frequency_droop.over_frequency_droop = over_droop;
+            active_support.frequency_droop = frequency_droop;
+            dtsae::LimitMaxDischargePower limit_max;
+            limit_max.enable = true;
+            limit_max.percentage_value = 80;
+            active_support.limit_max_discharge_power = limit_max;
+            der_control.active_power_support_cl_res = active_support;
+
+            mode.evse_maximum_charge_power = {22, 3};
+            mode.evse_maximum_discharge_power = {15, 3};
+            mode.required_der_operating_mode = dtsae::RequiredDEROperatingMode::GridFollowing;
+            mode.grid_connection_mode = dtsae::GridConnectionMode::GridConnected;
+
+            res.control_mode = mode;
+
+            REQUIRE(serialize_helper(res) == bytes);
+        }
+    }
+
+    GIVEN("cl_res_dynamic_optionals") {
+
+        std::vector<uint8_t> bytes = {
+            0x80, 0x0c, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x4b, 0xfe, 0x1b, 0x60, 0x62,
+            0x00, 0x00, 0xf0, 0x00, 0x00, 0xf4, 0x55, 0x65, 0x34, 0x52, 0xd4, 0xd4, 0x55, 0x44, 0x55, 0x22, 0xd3,
+            0x03, 0x11, 0xc0, 0xba, 0xc0, 0x62, 0x5f, 0xf0, 0xdb, 0x03, 0x28, 0x10, 0x00, 0x78, 0x30, 0xa0, 0x38,
+            0x01, 0xe0, 0xa0, 0x01, 0x41, 0x06, 0x01, 0x41, 0x10, 0x00, 0x00, 0x22, 0x0c, 0x02, 0x48, 0x12, 0x00,
+            0x60, 0x40, 0x04, 0x40, 0x10, 0x20, 0x00, 0x04, 0x04, 0x00, 0x50, 0x01, 0x01, 0xfc, 0x00, 0x83, 0x09,
+            0x00, 0x30, 0x20, 0x03, 0x10, 0x04, 0x10, 0x00, 0x04, 0x02, 0x00, 0x28, 0x00, 0x40, 0xfe, 0x00, 0x41,
+            0xa0, 0x24, 0x20, 0xc0, 0x80, 0x03, 0xe0, 0x40, 0x00, 0x08, 0x08, 0x00, 0x3f, 0x03, 0xf8, 0x02, 0x86,
+            0x12, 0x10, 0x60, 0x40, 0x01, 0xd0, 0x20, 0x00, 0x04, 0x04, 0x00, 0x1c, 0x81, 0xfc, 0x01, 0x43, 0x42,
+            0x02, 0x00, 0x3f, 0x40, 0x40, 0x40, 0x06, 0x78, 0x08, 0x08, 0x00, 0x3d, 0x01, 0x00, 0x07, 0x63, 0x09,
+            0x00, 0x10, 0x01, 0x00, 0x80, 0x0c, 0xf0, 0x10, 0x41, 0x80, 0x18, 0x08, 0x00, 0xfd, 0x01, 0x04, 0x18,
+            0x81, 0x06, 0x20, 0x00, 0x14, 0x48, 0x00, 0xe6, 0x01, 0x00, 0xac, 0x02, 0x21, 0x10, 0x03, 0x08, 0x30,
+            0x05, 0x21, 0x08, 0x08, 0x30, 0x16, 0x08, 0x83, 0x00, 0xf1, 0x21, 0x00};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopRes);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopResponse>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456324);
+            REQUIRE(msg.response_code == dt::ResponseCode::OK);
+
+            REQUIRE(msg.status.has_value());
+            REQUIRE(msg.status.value().notification == dt::EvseNotification::Pause);
+            REQUIRE(msg.meter_info.has_value());
+            REQUIRE(msg.meter_info.value().meter_id == "EVSE-METER-01");
+            REQUIRE(msg.receipt.has_value());
+            REQUIRE(msg.receipt.value().time_anchor == 1725456324);
+            REQUIRE(msg.target_frequency.has_value());
+            REQUIRE(dt::from_RationalNumber(msg.target_frequency.value()) == 60);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Dynamic_AC_CLResControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Dynamic_AC_CLResControlMode>(msg.control_mode);
+
+            REQUIRE(mode.departure_time.value() == 7200);
+            REQUIRE(mode.minimum_soc.value() == 30);
+            REQUIRE(mode.target_soc.value() == 80);
+            REQUIRE(mode.ack_max_delay.value() == 10);
+            REQUIRE(dt::from_RationalNumber(mode.target_active_power) == 10000);
+            REQUIRE(dt::from_RationalNumber(mode.target_reactive_power.value()) == 0);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power.value()) == 9000);
+
+            const auto& der_control = mode.der_control_cl_res;
+            REQUIRE(der_control.enter_service_cl_res.permit_service == true);
+            REQUIRE(dt::from_RationalNumber(der_control.enter_service_cl_res.enter_service_voltage_high.value()) ==
+                    253);
+            REQUIRE(dt::from_RationalNumber(der_control.enter_service_cl_res.enter_service_frequency_low.value()) ==
+                    59);
+            // not present in the dynamic case
+            REQUIRE_FALSE(der_control.enter_service_cl_res.enter_service_delay.has_value());
+            REQUIRE_FALSE(der_control.enter_service_cl_res.enter_service_ramp_time.has_value());
+
+            // VoltageTrip curve coverage
+            REQUIRE(der_control.voltage_trip.has_value());
+            const auto& ov = der_control.voltage_trip.value().over_voltage_must_trip_curve;
+            REQUIRE(ov.enable == true);
+            REQUIRE(ov.curve_data_points.size() == 2);
+            REQUIRE(dt::from_RationalNumber(ov.curve_data_points[0].x_value) == 264);
+            REQUIRE(dt::from_RationalNumber(ov.curve_data_points[1].x_value) == 288);
+
+            // FrequencyTrip curve coverage
+            REQUIRE(der_control.frequency_trip.has_value());
+            REQUIRE(der_control.frequency_trip.value().over_frequency_must_trip_curve.curve_data_points.size() == 2);
+
+            // ReactivePowerSupport: VoltVar
+            REQUIRE(der_control.reactive_power_support_cl_res.has_value());
+            const auto& rps = der_control.reactive_power_support_cl_res.value();
+            REQUIRE(rps.volt_var.has_value());
+            const auto& vv = rps.volt_var.value();
+            REQUIRE(vv.enable == true);
+            REQUIRE(vv.priority.value() == 1);
+            REQUIRE(vv.x_unit == dtsae::DERUnit::V);
+            REQUIRE(vv.y_unit == dtsae::DERUnit::var);
+            REQUIRE(vv.curve_data_points.size() == 2);
+            REQUIRE(dt::from_RationalNumber(vv.curve_data_points[0].x_value) == 207);
+            REQUIRE(dt::from_RationalNumber(vv.curve_data_points[0].y_value) == 3000);
+            REQUIRE(dt::from_RationalNumber(vv.curve_data_points[1].y_value) == -3000);
+            REQUIRE(dt::from_RationalNumber(vv.reference_voltage) == 230);
+            REQUIRE(vv.autonomous_reference_voltage_adjustment_enable == false);
+            REQUIRE(vv.reference_voltage_adjustment_time_constant == 300);
+            REQUIRE_FALSE(rps.constant_power_factor.has_value());
+
+            // ActivePowerSupport: ConstantWatt
+            REQUIRE(der_control.active_power_support_cl_res.has_value());
+            const auto& aps = der_control.active_power_support_cl_res.value();
+            REQUIRE(aps.constant_watt.has_value());
+            REQUIRE(aps.constant_watt.value().enable == true);
+            REQUIRE(aps.constant_watt.value().priority.value() == 3);
+            REQUIRE(dt::from_RationalNumber(aps.constant_watt.value().watt_setpoint) == 5000);
+            REQUIRE(aps.constant_watt.value().unit == dtsae::DERUnit::W);
+            REQUIRE_FALSE(aps.frequency_droop.has_value());
+
+            REQUIRE(dt::from_RationalNumber(mode.evse_maximum_charge_power.value()) == 22000);
+            REQUIRE(dt::from_RationalNumber(mode.evse_maximum_discharge_power.value()) == 15000);
+            REQUIRE(mode.required_der_operating_mode.value() == dtsae::RequiredDEROperatingMode::GridForming);
+            REQUIRE(mode.grid_connection_mode.value() == dtsae::GridConnectionMode::GridIslanded);
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopResponse res;
+            res.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456324};
+            res.response_code = dt::ResponseCode::OK;
+
+            res.status = dt::EvseStatus{60, dt::EvseNotification::Pause};
+
+            dt::MeterInfo meter_info;
+            meter_info.meter_id = "EVSE-METER-01";
+            meter_info.charged_energy_reading_wh = 12000;
+            res.meter_info = meter_info;
+
+            dt::Receipt receipt;
+            receipt.time_anchor = 1725456324;
+            res.receipt = receipt;
+
+            res.target_frequency = dt::RationalNumber{60, 0};
+
+            dtsae::DER_Dynamic_AC_CLResControlMode mode;
+            mode.departure_time = 7200;
+            mode.minimum_soc = 30;
+            mode.target_soc = 80;
+            mode.ack_max_delay = 10;
+            mode.target_active_power = {10, 3};
+            mode.target_reactive_power = {0, 0};
+            mode.present_active_power = {9, 3};
+
+            auto& der_control = mode.der_control_cl_res;
+
+            dtsae::VoltageTrip voltage_trip;
+            auto& ov_must = voltage_trip.over_voltage_must_trip_curve;
+            ov_must.enable = true;
+            ov_must.x_unit = dtsae::DERUnit::V;
+            ov_must.y_unit = dtsae::DERUnit::s;
+            ov_must.curve_data_points.push_back(dtsae::DataTuple{{264, 0}, {1, 0}});
+            ov_must.curve_data_points.push_back(dtsae::DataTuple{{288, 0}, {2, -1}});
+            auto& uv_must = voltage_trip.under_voltage_must_trip_curve;
+            uv_must.enable = true;
+            uv_must.x_unit = dtsae::DERUnit::V;
+            uv_must.y_unit = dtsae::DERUnit::s;
+            uv_must.curve_data_points.push_back(dtsae::DataTuple{{196, 0}, {2, 0}});
+            uv_must.curve_data_points.push_back(dtsae::DataTuple{{160, 0}, {2, -1}});
+            der_control.voltage_trip = voltage_trip;
+
+            dtsae::FrequencyTrip frequency_trip;
+            auto& of_must = frequency_trip.over_frequency_must_trip_curve;
+            of_must.enable = true;
+            of_must.x_unit = dtsae::DERUnit::Hz;
+            of_must.y_unit = dtsae::DERUnit::s;
+            of_must.curve_data_points.push_back(dtsae::DataTuple{{62, 0}, {1, 0}});
+            of_must.curve_data_points.push_back(dtsae::DataTuple{{63, 0}, {5, -1}});
+            auto& uf_must = frequency_trip.under_frequency_must_trip_curve;
+            uf_must.enable = true;
+            uf_must.x_unit = dtsae::DERUnit::Hz;
+            uf_must.y_unit = dtsae::DERUnit::s;
+            uf_must.curve_data_points.push_back(dtsae::DataTuple{{58, 0}, {1, 0}});
+            uf_must.curve_data_points.push_back(dtsae::DataTuple{{57, 0}, {5, -1}});
+            der_control.frequency_trip = frequency_trip;
+
+            auto& enter_service = der_control.enter_service_cl_res;
+            enter_service.permit_service = true;
+            enter_service.enter_service_voltage_high = {253, 0};
+            enter_service.enter_service_voltage_low = {207, 0};
+            enter_service.enter_service_frequency_high = {61, 0};
+            enter_service.enter_service_frequency_low = {59, 0};
+
+            dtsae::ReactivePowerSupportCLRes reactive_support;
+            dtsae::VoltVar volt_var;
+            volt_var.enable = true;
+            volt_var.priority = 1;
+            volt_var.x_unit = dtsae::DERUnit::V;
+            volt_var.y_unit = dtsae::DERUnit::var;
+            volt_var.curve_data_points.push_back(dtsae::DataTuple{{207, 0}, {3, 3}});
+            volt_var.curve_data_points.push_back(dtsae::DataTuple{{253, 0}, {-3, 3}});
+            volt_var.open_loop_response_time = {5, 0};
+            volt_var.reference_voltage = {230, 0};
+            volt_var.autonomous_reference_voltage_adjustment_enable = false;
+            volt_var.reference_voltage_adjustment_time_constant = 300;
+            reactive_support.volt_var = volt_var;
+            der_control.reactive_power_support_cl_res = reactive_support;
+
+            dtsae::ActivePowerSupportCLRes active_support;
+            dtsae::ConstantWatt constant_watt;
+            constant_watt.enable = true;
+            constant_watt.priority = 3;
+            constant_watt.watt_setpoint = {5, 3};
+            constant_watt.unit = dtsae::DERUnit::W;
+            active_support.constant_watt = constant_watt;
+            der_control.active_power_support_cl_res = active_support;
+
+            mode.evse_maximum_charge_power = {22, 3};
+            mode.evse_maximum_discharge_power = {15, 3};
+            mode.required_der_operating_mode = dtsae::RequiredDEROperatingMode::GridForming;
+            mode.grid_connection_mode = dtsae::GridConnectionMode::GridIslanded;
+
+            res.control_mode = mode;
+
+            REQUIRE(serialize_helper(res) == bytes);
+        }
+    }
+}


### PR DESCRIPTION
Scheduled and Dynamic AC-DER-SAE ChargeLoop Response convert functions with EXI round-trip tests covering the curve-bearing DERControl optionals.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

