### PR TITLE
feat(iso15118): SAE ChargeLoop Req convert + tests

### DIFF
--- a/lib/everest/iso15118/src/iso15118/message/ac_der_sae_charge_loop.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/ac_der_sae_charge_loop.cpp
@@ -11,7 +11,7 @@ namespace iso15118::message_20 {
 
 namespace dts = datatypes::sae;
 
-// Response
+// Request
 
 template <> void convert(const struct iso20_ac_der_sae_DisplayParametersType& in, datatypes::DisplayParameters& out) {
     CB2CPP_ASSIGN_IF_USED(in.PresentSOC, out.present_soc);
@@ -44,6 +44,458 @@ template <> void convert(const datatypes::DisplayParameters& in, struct iso20_ac
     CPP2CB_CONVERT_IF_USED(in.battery_energy_capacity, out.BatteryEnergyCapacity);
     CPP2CB_ASSIGN_IF_USED(in.inlet_hot, out.InletHot);
 }
+
+template <> void convert(const struct iso20_ac_der_sae_EVApparentPowerType& in, dts::EVApparentPower& out) {
+    convert(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption,
+            out.maximum_apparent_power_during_charging_and_var_absorption);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L2,
+                           out.maximum_apparent_power_during_charging_and_var_absorption_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L3,
+                           out.maximum_apparent_power_during_charging_and_var_absorption_L3);
+    convert(in.EVMaximumApparentPowerDuringChargingAndVarInjection,
+            out.maximum_apparent_power_during_charging_and_var_injection);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarInjection_L2,
+                           out.maximum_apparent_power_during_charging_and_var_injection_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringChargingAndVarInjection_L3,
+                           out.maximum_apparent_power_during_charging_and_var_injection_L3);
+    convert(in.EVMaximumApparentPowerDuringDischargingAndVarAbsorption,
+            out.maximum_apparent_power_during_discharging_and_var_absorption);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L2,
+                           out.maximum_apparent_power_during_discharging_and_var_absorption_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L3,
+                           out.maximum_apparent_power_during_discharging_and_var_absorption_L3);
+    convert(in.EVMaximumApparentPowerDuringDischargingAndVarInjection,
+            out.maximum_apparent_power_during_discharging_and_var_injection);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarInjection_L2,
+                           out.maximum_apparent_power_during_discharging_and_var_injection_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumApparentPowerDuringDischargingAndVarInjection_L3,
+                           out.maximum_apparent_power_during_discharging_and_var_injection_L3);
+}
+
+template <> void convert(const dts::EVApparentPower& in, struct iso20_ac_der_sae_EVApparentPowerType& out) {
+    init_iso20_ac_der_sae_EVApparentPowerType(&out);
+    convert(in.maximum_apparent_power_during_charging_and_var_absorption,
+            out.EVMaximumApparentPowerDuringChargingAndVarAbsorption);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_absorption_L2,
+                           out.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_absorption_L3,
+                           out.EVMaximumApparentPowerDuringChargingAndVarAbsorption_L3);
+    convert(in.maximum_apparent_power_during_charging_and_var_injection,
+            out.EVMaximumApparentPowerDuringChargingAndVarInjection);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_injection_L2,
+                           out.EVMaximumApparentPowerDuringChargingAndVarInjection_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_charging_and_var_injection_L3,
+                           out.EVMaximumApparentPowerDuringChargingAndVarInjection_L3);
+    convert(in.maximum_apparent_power_during_discharging_and_var_absorption,
+            out.EVMaximumApparentPowerDuringDischargingAndVarAbsorption);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_absorption_L2,
+                           out.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_absorption_L3,
+                           out.EVMaximumApparentPowerDuringDischargingAndVarAbsorption_L3);
+    convert(in.maximum_apparent_power_during_discharging_and_var_injection,
+            out.EVMaximumApparentPowerDuringDischargingAndVarInjection);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_injection_L2,
+                           out.EVMaximumApparentPowerDuringDischargingAndVarInjection_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_apparent_power_during_discharging_and_var_injection_L3,
+                           out.EVMaximumApparentPowerDuringDischargingAndVarInjection_L3);
+}
+
+template <> void convert(const struct iso20_ac_der_sae_EVReactivePowerType& in, dts::EVReactivePower& out) {
+    convert(in.EVMaximumVarAbsorptionDuringCharging, out.maximum_var_absorption_during_charging);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringCharging_L2, out.maximum_var_absorption_during_charging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringCharging_L3, out.maximum_var_absorption_during_charging_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringCharging, out.minimum_var_absorption_during_charging);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringCharging_L2, out.minimum_var_absorption_during_charging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringCharging_L3, out.minimum_var_absorption_during_charging_L3);
+    convert(in.EVMaximumVarInjectionDuringCharging, out.maximum_var_injection_during_charging);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringCharging_L2, out.maximum_var_injection_during_charging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringCharging_L3, out.maximum_var_injection_during_charging_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringCharging, out.minimum_var_injection_during_charging);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringCharging_L2, out.minimum_var_injection_during_charging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringCharging_L3, out.minimum_var_injection_during_charging_L3);
+    convert(in.EVMaximumVarAbsorptionDuringDischarging, out.maximum_var_absorption_during_discharging);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringDischarging_L2,
+                           out.maximum_var_absorption_during_discharging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarAbsorptionDuringDischarging_L3,
+                           out.maximum_var_absorption_during_discharging_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringDischarging, out.minimum_var_absorption_during_discharging);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringDischarging_L2,
+                           out.minimum_var_absorption_during_discharging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarAbsorptionDuringDischarging_L3,
+                           out.minimum_var_absorption_during_discharging_L3);
+    convert(in.EVMaximumVarInjectionDuringDischarging, out.maximum_var_injection_during_discharging);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringDischarging_L2,
+                           out.maximum_var_injection_during_discharging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumVarInjectionDuringDischarging_L3,
+                           out.maximum_var_injection_during_discharging_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringDischarging, out.minimum_var_injection_during_discharging);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringDischarging_L2,
+                           out.minimum_var_injection_during_discharging_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumVarInjectionDuringDischarging_L3,
+                           out.minimum_var_injection_during_discharging_L3);
+}
+
+template <> void convert(const dts::EVReactivePower& in, struct iso20_ac_der_sae_EVReactivePowerType& out) {
+    init_iso20_ac_der_sae_EVReactivePowerType(&out);
+    convert(in.maximum_var_absorption_during_charging, out.EVMaximumVarAbsorptionDuringCharging);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_charging_L2, out.EVMaximumVarAbsorptionDuringCharging_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_charging_L3, out.EVMaximumVarAbsorptionDuringCharging_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_charging, out.EVMinimumVarAbsorptionDuringCharging);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_charging_L2, out.EVMinimumVarAbsorptionDuringCharging_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_charging_L3, out.EVMinimumVarAbsorptionDuringCharging_L3);
+    convert(in.maximum_var_injection_during_charging, out.EVMaximumVarInjectionDuringCharging);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_charging_L2, out.EVMaximumVarInjectionDuringCharging_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_charging_L3, out.EVMaximumVarInjectionDuringCharging_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_charging, out.EVMinimumVarInjectionDuringCharging);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_charging_L2, out.EVMinimumVarInjectionDuringCharging_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_charging_L3, out.EVMinimumVarInjectionDuringCharging_L3);
+    convert(in.maximum_var_absorption_during_discharging, out.EVMaximumVarAbsorptionDuringDischarging);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_discharging_L2,
+                           out.EVMaximumVarAbsorptionDuringDischarging_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_absorption_during_discharging_L3,
+                           out.EVMaximumVarAbsorptionDuringDischarging_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_discharging, out.EVMinimumVarAbsorptionDuringDischarging);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_discharging_L2,
+                           out.EVMinimumVarAbsorptionDuringDischarging_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_absorption_during_discharging_L3,
+                           out.EVMinimumVarAbsorptionDuringDischarging_L3);
+    convert(in.maximum_var_injection_during_discharging, out.EVMaximumVarInjectionDuringDischarging);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_discharging_L2,
+                           out.EVMaximumVarInjectionDuringDischarging_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_var_injection_during_discharging_L3,
+                           out.EVMaximumVarInjectionDuringDischarging_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_discharging, out.EVMinimumVarInjectionDuringDischarging);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_discharging_L2,
+                           out.EVMinimumVarInjectionDuringDischarging_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_var_injection_during_discharging_L3,
+                           out.EVMinimumVarInjectionDuringDischarging_L3);
+}
+
+template <> void convert(const struct iso20_ac_der_sae_EVExcitationType& in, dts::EVExcitation& out) {
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor, out.specified_over_excited_power_factor);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor_L2, out.specified_over_excited_power_factor_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedPowerFactor_L3, out.specified_over_excited_power_factor_L3);
+    convert(in.EVSpecifiedOverExcitedDischargePower, out.specified_over_excited_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedDischargePower_L2, out.specified_over_excited_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedOverExcitedDischargePower_L3, out.specified_over_excited_discharge_power_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedPowerFactor, out.specified_under_excited_power_factor);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedPowerFactor_L2, out.specified_under_excited_power_factor_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedPowerFactor_L3, out.specified_under_excited_power_factor_L3);
+    convert(in.EVSpecifiedUnderExcitedDischargePower, out.specified_under_excited_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedDischargePower_L2, out.specified_under_excited_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVSpecifiedUnderExcitedDischargePower_L3, out.specified_under_excited_discharge_power_L3);
+}
+
+template <> void convert(const dts::EVExcitation& in, struct iso20_ac_der_sae_EVExcitationType& out) {
+    init_iso20_ac_der_sae_EVExcitationType(&out);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor, out.EVSpecifiedOverExcitedPowerFactor);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor_L2, out.EVSpecifiedOverExcitedPowerFactor_L2);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_power_factor_L3, out.EVSpecifiedOverExcitedPowerFactor_L3);
+    convert(in.specified_over_excited_discharge_power, out.EVSpecifiedOverExcitedDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_discharge_power_L2, out.EVSpecifiedOverExcitedDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.specified_over_excited_discharge_power_L3, out.EVSpecifiedOverExcitedDischargePower_L3);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_power_factor, out.EVSpecifiedUnderExcitedPowerFactor);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_power_factor_L2, out.EVSpecifiedUnderExcitedPowerFactor_L2);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_power_factor_L3, out.EVSpecifiedUnderExcitedPowerFactor_L3);
+    convert(in.specified_under_excited_discharge_power, out.EVSpecifiedUnderExcitedDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_discharge_power_L2, out.EVSpecifiedUnderExcitedDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.specified_under_excited_discharge_power_L3, out.EVSpecifiedUnderExcitedDischargePower_L3);
+}
+
+template <>
+void convert(const dts::DER_Scheduled_AC_CLReqControlMode& in,
+             struct iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType& out) {
+    CPP2CB_CONVERT_IF_USED(in.target_energy_request, out.EVTargetEnergyRequest);
+    CPP2CB_CONVERT_IF_USED(in.max_energy_request, out.EVMaximumEnergyRequest);
+    CPP2CB_CONVERT_IF_USED(in.min_energy_request, out.EVMinimumEnergyRequest);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power, out.EVMaximumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L2, out.EVMaximumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L3, out.EVMaximumChargePower_L3);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power, out.EVMinimumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L2, out.EVMinimumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L3, out.EVMinimumChargePower_L3);
+    convert(in.present_active_power, out.EVPresentActivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L2, out.EVPresentActivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L3, out.EVPresentActivePower_L3);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power, out.EVPresentReactivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L2, out.EVPresentReactivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L3, out.EVPresentReactivePower_L3);
+
+    convert(in.present_voltage, out.EVPresentVoltage);
+    convert(in.present_frequency, out.EVPresentFrequency);
+
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power, out.EVMaximumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L2, out.EVMaximumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L3, out.EVMaximumDischargePower_L3);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power, out.EVMinimumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L2, out.EVMinimumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L3, out.EVMinimumDischargePower_L3);
+
+    cb_convert_enum(in.der_operational_state, out.DEROperationalState);
+    cb_convert_enum(in.der_connection_status, out.DERConnectionStatus);
+
+    if (in.apparent_power.has_value()) {
+        convert(in.apparent_power.value(), out.EVApparentPower);
+        CB_SET_USED(out.EVApparentPower);
+    }
+    if (in.reactive_power.has_value()) {
+        convert(in.reactive_power.value(), out.EVReactivePower);
+        CB_SET_USED(out.EVReactivePower);
+    }
+    if (in.excitation.has_value()) {
+        convert(in.excitation.value(), out.EVExcitation);
+        CB_SET_USED(out.EVExcitation);
+    }
+
+    out.EVUpdateTime = in.update_time;
+    CPP2CB_ASSIGN_IF_USED(in.minimum_charging_duration, out.EVMinimumChargingDuration);
+    CPP2CB_ASSIGN_IF_USED(in.duration_maximum_charge_rate, out.EVDurationMaximumChargeRate);
+    CPP2CB_ASSIGN_IF_USED(in.duration_maximum_discharge_rate, out.EVDurationMaximumDischargeRate);
+    out.DERAlarmStatus = in.der_alarm_status;
+    out.EnabledModes = in.enabled_modes;
+}
+
+template <>
+void convert(const struct iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType& in,
+             dts::DER_Scheduled_AC_CLReqControlMode& out) {
+    CB2CPP_CONVERT_IF_USED(in.EVTargetEnergyRequest, out.target_energy_request);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumEnergyRequest, out.max_energy_request);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumEnergyRequest, out.min_energy_request);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower, out.max_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L2, out.max_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L3, out.max_charge_power_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower, out.min_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L2, out.min_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L3, out.min_charge_power_L3);
+    convert(in.EVPresentActivePower, out.present_active_power);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L2, out.present_active_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L3, out.present_active_power_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower, out.present_reactive_power);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L2, out.present_reactive_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L3, out.present_reactive_power_L3);
+
+    convert(in.EVPresentVoltage, out.present_voltage);
+    convert(in.EVPresentFrequency, out.present_frequency);
+
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower, out.maximum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L2, out.maximum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L3, out.maximum_discharge_power_L3);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower, out.minimum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L2, out.minimum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L3, out.minimum_discharge_power_L3);
+
+    cb_convert_enum(in.DEROperationalState, out.der_operational_state);
+    cb_convert_enum(in.DERConnectionStatus, out.der_connection_status);
+
+    if (in.EVApparentPower_isUsed) {
+        convert(in.EVApparentPower, out.apparent_power.emplace());
+    }
+    if (in.EVReactivePower_isUsed) {
+        convert(in.EVReactivePower, out.reactive_power.emplace());
+    }
+    if (in.EVExcitation_isUsed) {
+        convert(in.EVExcitation, out.excitation.emplace());
+    }
+
+    out.update_time = in.EVUpdateTime;
+    CB2CPP_ASSIGN_IF_USED(in.EVMinimumChargingDuration, out.minimum_charging_duration);
+    CB2CPP_ASSIGN_IF_USED(in.EVDurationMaximumChargeRate, out.duration_maximum_charge_rate);
+    CB2CPP_ASSIGN_IF_USED(in.EVDurationMaximumDischargeRate, out.duration_maximum_discharge_rate);
+    out.der_alarm_status = in.DERAlarmStatus;
+    out.enabled_modes = in.EnabledModes;
+}
+
+template <>
+void convert(const dts::DER_Dynamic_AC_CLReqControlMode& in,
+             struct iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType& out) {
+    CPP2CB_ASSIGN_IF_USED(in.departure_time, out.DepartureTime);
+    convert(in.target_energy_request, out.EVTargetEnergyRequest);
+    convert(in.max_energy_request, out.EVMaximumEnergyRequest);
+    convert(in.min_energy_request, out.EVMinimumEnergyRequest);
+    convert(in.max_charge_power, out.EVMaximumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L2, out.EVMaximumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.max_charge_power_L3, out.EVMaximumChargePower_L3);
+    convert(in.min_charge_power, out.EVMinimumChargePower);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L2, out.EVMinimumChargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.min_charge_power_L3, out.EVMinimumChargePower_L3);
+    convert(in.present_active_power, out.EVPresentActivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L2, out.EVPresentActivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_active_power_L3, out.EVPresentActivePower_L3);
+    convert(in.present_reactive_power, out.EVPresentReactivePower);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L2, out.EVPresentReactivePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.present_reactive_power_L3, out.EVPresentReactivePower_L3);
+
+    convert(in.maximum_discharge_power, out.EVMaximumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L2, out.EVMaximumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.maximum_discharge_power_L3, out.EVMaximumDischargePower_L3);
+    convert(in.minimum_discharge_power, out.EVMinimumDischargePower);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L2, out.EVMinimumDischargePower_L2);
+    CPP2CB_CONVERT_IF_USED(in.minimum_discharge_power_L3, out.EVMinimumDischargePower_L3);
+
+    convert(in.present_voltage, out.EVPresentVoltage);
+    convert(in.present_frequency, out.EVPresentFrequency);
+
+    CPP2CB_CONVERT_IF_USED(in.session_total_discharge_energy_available, out.EVSessionTotalDischargeEnergyAvailable);
+
+    if (in.apparent_power.has_value()) {
+        convert(in.apparent_power.value(), out.EVApparentPower);
+        CB_SET_USED(out.EVApparentPower);
+    }
+    if (in.reactive_power.has_value()) {
+        convert(in.reactive_power.value(), out.EVReactivePower);
+        CB_SET_USED(out.EVReactivePower);
+    }
+    if (in.excitation.has_value()) {
+        convert(in.excitation.value(), out.EVExcitation);
+        CB_SET_USED(out.EVExcitation);
+    }
+
+    CPP2CB_CONVERT_IF_USED(in.maximum_v2x_energy_request, out.EVMaximumV2XEnergyRequest);
+    CPP2CB_CONVERT_IF_USED(in.minimum_v2x_energy_request, out.EVMinimumV2XEnergyRequest);
+
+    cb_convert_enum(in.der_operational_state, out.DEROperationalState);
+    cb_convert_enum(in.der_connection_status, out.DERConnectionStatus);
+
+    out.EVUpdateTime = in.update_time;
+    out.EVMinimumChargingDuration = in.minimum_charging_duration;
+    out.EVDurationMaximumChargeRate = in.duration_maximum_charge_rate;
+    out.EVDurationMaximumDischargeRate = in.duration_maximum_discharge_rate;
+    out.DERAlarmStatus = in.der_alarm_status;
+    out.EnabledModes = in.enabled_modes;
+}
+
+template <>
+void convert(const struct iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType& in,
+             dts::DER_Dynamic_AC_CLReqControlMode& out) {
+    CB2CPP_ASSIGN_IF_USED(in.DepartureTime, out.departure_time);
+    convert(in.EVTargetEnergyRequest, out.target_energy_request);
+    convert(in.EVMaximumEnergyRequest, out.max_energy_request);
+    convert(in.EVMinimumEnergyRequest, out.min_energy_request);
+    convert(in.EVMaximumChargePower, out.max_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L2, out.max_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumChargePower_L3, out.max_charge_power_L3);
+    convert(in.EVMinimumChargePower, out.min_charge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L2, out.min_charge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumChargePower_L3, out.min_charge_power_L3);
+    convert(in.EVPresentActivePower, out.present_active_power);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L2, out.present_active_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentActivePower_L3, out.present_active_power_L3);
+    convert(in.EVPresentReactivePower, out.present_reactive_power);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L2, out.present_reactive_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVPresentReactivePower_L3, out.present_reactive_power_L3);
+
+    convert(in.EVMaximumDischargePower, out.maximum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L2, out.maximum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumDischargePower_L3, out.maximum_discharge_power_L3);
+    convert(in.EVMinimumDischargePower, out.minimum_discharge_power);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L2, out.minimum_discharge_power_L2);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumDischargePower_L3, out.minimum_discharge_power_L3);
+
+    convert(in.EVPresentVoltage, out.present_voltage);
+    convert(in.EVPresentFrequency, out.present_frequency);
+
+    CB2CPP_CONVERT_IF_USED(in.EVSessionTotalDischargeEnergyAvailable, out.session_total_discharge_energy_available);
+
+    if (in.EVApparentPower_isUsed) {
+        convert(in.EVApparentPower, out.apparent_power.emplace());
+    }
+    if (in.EVReactivePower_isUsed) {
+        convert(in.EVReactivePower, out.reactive_power.emplace());
+    }
+    if (in.EVExcitation_isUsed) {
+        convert(in.EVExcitation, out.excitation.emplace());
+    }
+
+    CB2CPP_CONVERT_IF_USED(in.EVMaximumV2XEnergyRequest, out.maximum_v2x_energy_request);
+    CB2CPP_CONVERT_IF_USED(in.EVMinimumV2XEnergyRequest, out.minimum_v2x_energy_request);
+
+    cb_convert_enum(in.DEROperationalState, out.der_operational_state);
+    cb_convert_enum(in.DERConnectionStatus, out.der_connection_status);
+
+    out.update_time = in.EVUpdateTime;
+    out.minimum_charging_duration = in.EVMinimumChargingDuration;
+    out.duration_maximum_charge_rate = in.EVDurationMaximumChargeRate;
+    out.duration_maximum_discharge_rate = in.EVDurationMaximumDischargeRate;
+    out.der_alarm_status = in.DERAlarmStatus;
+    out.enabled_modes = in.EnabledModes;
+}
+
+namespace {
+
+struct ReqControlModeVisitor {
+    using DER_ScheduledCM = dts::DER_Scheduled_AC_CLReqControlMode;
+    using DER_DynamicCM = dts::DER_Dynamic_AC_CLReqControlMode;
+
+    ReqControlModeVisitor(iso20_ac_der_sae_AC_ChargeLoopReqType& req_) : req(req_){};
+
+    void operator()(const DER_ScheduledCM& in) {
+        auto& out = req.DER_Scheduled_AC_CLReqControlMode;
+        init_iso20_ac_der_sae_DER_Scheduled_AC_CLReqControlModeType(&out);
+        convert(in, out);
+        CB_SET_USED(req.DER_Scheduled_AC_CLReqControlMode);
+    }
+
+    void operator()(const DER_DynamicCM& in) {
+        auto& out = req.DER_Dynamic_AC_CLReqControlMode;
+        init_iso20_ac_der_sae_DER_Dynamic_AC_CLReqControlModeType(&out);
+        convert(in, out);
+        CB_SET_USED(req.DER_Dynamic_AC_CLReqControlMode);
+    }
+
+private:
+    iso20_ac_der_sae_AC_ChargeLoopReqType& req;
+};
+
+} // namespace
+
+template <> void convert(const DER_SAE_AC_ChargeLoopRequest& in, struct iso20_ac_der_sae_AC_ChargeLoopReqType& out) {
+    init_iso20_ac_der_sae_AC_ChargeLoopReqType(&out);
+
+    convert(in.header, out.Header);
+
+    CPP2CB_CONVERT_IF_USED(in.display_parameters, out.DisplayParameters);
+    out.MeterInfoRequested = in.meter_info_requested;
+
+    std::visit(ReqControlModeVisitor(out), in.control_mode);
+}
+
+template <> void convert(const struct iso20_ac_der_sae_AC_ChargeLoopReqType& in, DER_SAE_AC_ChargeLoopRequest& out) {
+    convert(in.Header, out.header);
+
+    CB2CPP_CONVERT_IF_USED(in.DisplayParameters, out.display_parameters);
+    out.meter_info_requested = in.MeterInfoRequested;
+
+    if (in.DER_Scheduled_AC_CLReqControlMode_isUsed) {
+        convert(in.DER_Scheduled_AC_CLReqControlMode,
+                out.control_mode.emplace<dts::DER_Scheduled_AC_CLReqControlMode>());
+    } else if (in.DER_Dynamic_AC_CLReqControlMode_isUsed) {
+        convert(in.DER_Dynamic_AC_CLReqControlMode, out.control_mode.emplace<dts::DER_Dynamic_AC_CLReqControlMode>());
+    } else {
+        // should not happen
+        assert(false);
+    }
+}
+
+template <> int serialize_to_exi(const DER_SAE_AC_ChargeLoopRequest& in, exi_bitstream_t& out) {
+    iso20_ac_der_sae_exiDocument doc{};
+    init_iso20_ac_der_sae_exiDocument(&doc);
+
+    CB_SET_USED(doc.AC_ChargeLoopReq);
+
+    convert(in, doc.AC_ChargeLoopReq);
+
+    return encode_iso20_ac_der_sae_exiDocument(&out, &doc);
+}
+
+template <> size_t serialize(const DER_SAE_AC_ChargeLoopRequest& in, const io::StreamOutputView& out) {
+    return serialize_helper(in, out);
+}
+
+template <> void insert_type(VariantAccess& va, const struct iso20_ac_der_sae_AC_ChargeLoopReqType& in) {
+    va.insert_type<DER_SAE_AC_ChargeLoopRequest>(in);
+}
+
+// Response
 
 template <> void convert(const datatypes::DetailedCost& in, struct iso20_ac_der_sae_DetailedCostType& out) {
     init_iso20_ac_der_sae_DetailedCostType(&out);

--- a/lib/everest/iso15118/src/iso15118/message/variant.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/variant.cpp
@@ -182,8 +182,8 @@ static void handle_ac_sae_der(VariantAccess& va) {
         insert_type(va, doc.AC_ChargeParameterDiscoveryReq);
     } else if (doc.AC_ChargeParameterDiscoveryRes_isUsed) {
         insert_type(va, doc.AC_ChargeParameterDiscoveryRes);
-        // } else if (doc.AC_ChargeLoopReq_isUsed) {
-        //     insert_type(va, doc.AC_ChargeLoopReq);
+    } else if (doc.AC_ChargeLoopReq_isUsed) {
+        insert_type(va, doc.AC_ChargeLoopReq);
     } else if (doc.AC_ChargeLoopRes_isUsed) {
         insert_type(va, doc.AC_ChargeLoopRes);
     } else {

--- a/lib/everest/iso15118/test/exi/cb/iso20/ac_der_sae_charge_loop.cpp
+++ b/lib/everest/iso15118/test/exi/cb/iso20/ac_der_sae_charge_loop.cpp
@@ -536,3 +536,436 @@ SCENARIO("Se/Deserialize ac der sae charge loop response messages") {
         }
     }
 }
+
+SCENARIO("Se/Deserialize ac der sae charge loop request messages") {
+
+    GIVEN("cl_req_scheduled_min") {
+
+        std::vector<uint8_t> bytes = {0x80, 0x08, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x3b,
+                                      0xfe, 0x1b, 0x60, 0x62, 0x89, 0x24, 0x18, 0x04, 0x94, 0x80, 0x0e, 0x60, 0x10,
+                                      0x40, 0x01, 0xe1, 0x81, 0x36, 0x1d, 0xff, 0x0d, 0xb0, 0x31, 0x80, 0x00, 0x18};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopReq);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopRequest>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456323);
+            REQUIRE(msg.meter_info_requested == false);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Scheduled_AC_CLReqControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Scheduled_AC_CLReqControlMode>(msg.control_mode);
+
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_voltage) == 230);
+            REQUIRE(dt::from_RationalNumber(mode.present_frequency) == 60);
+            REQUIRE(mode.der_operational_state == dtsae::DEROperationalState::On);
+            REQUIRE(mode.der_connection_status == dtsae::DERConnectionStatus::Connected);
+            REQUIRE(mode.update_time == 1725456323);
+            REQUIRE(mode.der_alarm_status == 0);
+            REQUIRE(mode.enabled_modes == 3);
+
+            // absent optionals
+            REQUIRE_FALSE(msg.display_parameters.has_value());
+            REQUIRE_FALSE(mode.target_energy_request.has_value());
+            REQUIRE_FALSE(mode.max_charge_power.has_value());
+            REQUIRE_FALSE(mode.present_active_power_L2.has_value());
+            REQUIRE_FALSE(mode.maximum_discharge_power.has_value());
+            REQUIRE_FALSE(mode.apparent_power.has_value());
+            REQUIRE_FALSE(mode.reactive_power.has_value());
+            REQUIRE_FALSE(mode.excitation.has_value());
+            REQUIRE_FALSE(mode.minimum_charging_duration.has_value());
+            REQUIRE_FALSE(mode.duration_maximum_charge_rate.has_value());
+            REQUIRE_FALSE(mode.duration_maximum_discharge_rate.has_value());
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopRequest req;
+            req.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
+            req.meter_info_requested = false;
+
+            dtsae::DER_Scheduled_AC_CLReqControlMode mode;
+            mode.present_active_power = {9, 3};
+            mode.present_voltage = {230, 0};
+            mode.present_frequency = {60, 0};
+            mode.der_operational_state = dtsae::DEROperationalState::On;
+            mode.der_connection_status = dtsae::DERConnectionStatus::Connected;
+            mode.update_time = 1725456323;
+            mode.der_alarm_status = 0;
+            mode.enabled_modes = 3;
+            req.control_mode = mode;
+
+            REQUIRE(serialize_helper(req) == bytes);
+        }
+    }
+
+    GIVEN("cl_req_dynamic_min") {
+
+        std::vector<uint8_t> bytes = {
+            0x80, 0x08, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x3b, 0xfe, 0x1b, 0x60, 0x62, 0x86,
+            0x90, 0x60, 0x50, 0x08, 0x30, 0x3c, 0x04, 0x18, 0x05, 0x02, 0x0c, 0x02, 0xc8, 0x80, 0x06, 0x42, 0x20, 0xc0,
+            0x24, 0x88, 0x00, 0x00, 0x22, 0x0c, 0x02, 0xc8, 0x80, 0x06, 0x42, 0x20, 0x03, 0x98, 0x04, 0x10, 0x00, 0x78,
+            0x60, 0x46, 0x1d, 0xff, 0x0d, 0xb0, 0x30, 0xd8, 0x04, 0x11, 0x01, 0xc2, 0x20, 0x38, 0x00, 0x00, 0x30};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopReq);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopRequest>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456323);
+            REQUIRE(msg.meter_info_requested == false);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Dynamic_AC_CLReqControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Dynamic_AC_CLReqControlMode>(msg.control_mode);
+
+            // Dynamic mode mandatory (1,1) fields
+            REQUIRE(dt::from_RationalNumber(mode.target_energy_request) == 40000);
+            REQUIRE(dt::from_RationalNumber(mode.max_energy_request) == 60000);
+            REQUIRE(dt::from_RationalNumber(mode.min_energy_request) == 10000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.min_charge_power) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_reactive_power) == 0);
+            REQUIRE(dt::from_RationalNumber(mode.maximum_discharge_power) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.minimum_discharge_power) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_voltage) == 230);
+            REQUIRE(dt::from_RationalNumber(mode.present_frequency) == 60);
+            REQUIRE(mode.der_operational_state == dtsae::DEROperationalState::On);
+            REQUIRE(mode.der_connection_status == dtsae::DERConnectionStatus::Connected);
+            REQUIRE(mode.update_time == 1725456323);
+            REQUIRE(mode.minimum_charging_duration == 600);
+            REQUIRE(mode.duration_maximum_charge_rate == 1800);
+            REQUIRE(mode.duration_maximum_discharge_rate == 1800);
+            REQUIRE(mode.der_alarm_status == 0);
+            REQUIRE(mode.enabled_modes == 3);
+
+            // absent optionals
+            REQUIRE_FALSE(msg.display_parameters.has_value());
+            REQUIRE_FALSE(mode.departure_time.has_value());
+            REQUIRE_FALSE(mode.max_charge_power_L2.has_value());
+            REQUIRE_FALSE(mode.session_total_discharge_energy_available.has_value());
+            REQUIRE_FALSE(mode.apparent_power.has_value());
+            REQUIRE_FALSE(mode.reactive_power.has_value());
+            REQUIRE_FALSE(mode.excitation.has_value());
+            REQUIRE_FALSE(mode.maximum_v2x_energy_request.has_value());
+            REQUIRE_FALSE(mode.minimum_v2x_energy_request.has_value());
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopRequest req;
+            req.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
+            req.meter_info_requested = false;
+
+            dtsae::DER_Dynamic_AC_CLReqControlMode mode;
+            mode.target_energy_request = {40, 3};
+            mode.max_energy_request = {60, 3};
+            mode.min_energy_request = {10, 3};
+            mode.max_charge_power = {11, 3};
+            mode.min_charge_power = {100, 0};
+            mode.present_active_power = {9, 3};
+            mode.present_reactive_power = {0, 0};
+            mode.maximum_discharge_power = {11, 3};
+            mode.minimum_discharge_power = {100, 0};
+            mode.present_voltage = {230, 0};
+            mode.present_frequency = {60, 0};
+            mode.der_operational_state = dtsae::DEROperationalState::On;
+            mode.der_connection_status = dtsae::DERConnectionStatus::Connected;
+            mode.update_time = 1725456323;
+            mode.minimum_charging_duration = 600;
+            mode.duration_maximum_charge_rate = 1800;
+            mode.duration_maximum_discharge_rate = 1800;
+            mode.der_alarm_status = 0;
+            mode.enabled_modes = 3;
+            req.control_mode = mode;
+
+            REQUIRE(serialize_helper(req) == bytes);
+        }
+    }
+
+    GIVEN("cl_req_scheduled_optionals") {
+
+        std::vector<uint8_t> bytes = {
+            0x80, 0x08, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x3b, 0xfe, 0x1b, 0x60,
+            0x62, 0x01, 0xb8, 0x07, 0x80, 0xa0, 0x41, 0x14, 0x02, 0x0c, 0x0a, 0x00, 0x20, 0xc0, 0xf0, 0x02,
+            0x0c, 0x02, 0x80, 0x41, 0x80, 0x58, 0x08, 0x30, 0x0b, 0x01, 0x06, 0x01, 0x60, 0x20, 0x01, 0x90,
+            0x88, 0x30, 0x09, 0x01, 0x06, 0x01, 0x20, 0x20, 0xc0, 0x24, 0x04, 0x00, 0x00, 0x11, 0x00, 0x1c,
+            0xc0, 0x20, 0x80, 0x03, 0xc0, 0x10, 0x60, 0x16, 0x22, 0x00, 0x19, 0x08, 0x10, 0x10, 0x60, 0x18,
+            0x44, 0x18, 0x06, 0x11, 0x06, 0x01, 0x84, 0x41, 0x80, 0x61, 0x02, 0x0c, 0x01, 0x4a, 0x41, 0x80,
+            0x29, 0x48, 0x30, 0x05, 0x29, 0x06, 0x00, 0xa5, 0x19, 0x06, 0x01, 0x05, 0x20, 0xc0, 0x20, 0x8c,
+            0x3b, 0xfe, 0x1b, 0x60, 0x60, 0x6c, 0x02, 0x04, 0x40, 0x70, 0x44, 0x07, 0x00, 0x00, 0x06, 0x00};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopReq);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopRequest>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456323);
+            REQUIRE(msg.meter_info_requested == true);
+
+            REQUIRE(msg.display_parameters.has_value());
+            REQUIRE(msg.display_parameters.value().present_soc.value() == 55);
+            REQUIRE(msg.display_parameters.value().min_soc.value() == 30);
+            REQUIRE(msg.display_parameters.value().target_soc.value() == 80);
+            REQUIRE(msg.display_parameters.value().charging_complete.value() == false);
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Scheduled_AC_CLReqControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Scheduled_AC_CLReqControlMode>(msg.control_mode);
+
+            REQUIRE(dt::from_RationalNumber(mode.target_energy_request.value()) == 40000);
+            REQUIRE(dt::from_RationalNumber(mode.max_energy_request.value()) == 60000);
+            REQUIRE(dt::from_RationalNumber(mode.min_energy_request.value()) == 10000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power_L2.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power_L3.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.min_charge_power.value()) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power_L2.value()) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power_L3.value()) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_reactive_power.value()) == 0);
+            REQUIRE(dt::from_RationalNumber(mode.present_voltage) == 230);
+            REQUIRE(dt::from_RationalNumber(mode.present_frequency) == 60);
+            REQUIRE(dt::from_RationalNumber(mode.maximum_discharge_power.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.minimum_discharge_power.value()) == 100);
+            REQUIRE(mode.der_operational_state == dtsae::DEROperationalState::On);
+            REQUIRE(mode.der_connection_status == dtsae::DERConnectionStatus::Connected);
+
+            REQUIRE(mode.apparent_power.has_value());
+            const auto& ap = mode.apparent_power.value();
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_charging_and_var_absorption) == 12000);
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_charging_and_var_injection) == 12000);
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_discharging_and_var_absorption) == 12000);
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_discharging_and_var_injection) == 12000);
+            REQUIRE_FALSE(ap.maximum_apparent_power_during_charging_and_var_absorption_L2.has_value());
+
+            REQUIRE(mode.reactive_power.has_value());
+            const auto& rp = mode.reactive_power.value();
+            REQUIRE(dt::from_RationalNumber(rp.maximum_var_absorption_during_charging) == 5000);
+            REQUIRE(dt::from_RationalNumber(rp.maximum_var_injection_during_charging) == 5000);
+            REQUIRE(dt::from_RationalNumber(rp.maximum_var_absorption_during_discharging) == 5000);
+            REQUIRE(dt::from_RationalNumber(rp.maximum_var_injection_during_discharging) == 5000);
+            REQUIRE_FALSE(rp.minimum_var_absorption_during_charging.has_value());
+
+            REQUIRE(mode.excitation.has_value());
+            const auto& ex = mode.excitation.value();
+            REQUIRE(dt::from_RationalNumber(ex.specified_over_excited_discharge_power) == 8000);
+            REQUIRE(dt::from_RationalNumber(ex.specified_under_excited_discharge_power) == 8000);
+            REQUIRE_FALSE(ex.specified_over_excited_power_factor.has_value());
+
+            REQUIRE(mode.update_time == 1725456323);
+            REQUIRE(mode.minimum_charging_duration == 600);
+            REQUIRE(mode.duration_maximum_charge_rate == 1800);
+            REQUIRE(mode.duration_maximum_discharge_rate == 1800);
+            REQUIRE(mode.der_alarm_status == 0);
+            REQUIRE(mode.enabled_modes == 3);
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopRequest req;
+            req.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
+            req.meter_info_requested = true;
+
+            dt::DisplayParameters display_parameters;
+            display_parameters.present_soc = 55;
+            display_parameters.min_soc = 30;
+            display_parameters.target_soc = 80;
+            display_parameters.charging_complete = false;
+            req.display_parameters = display_parameters;
+
+            dtsae::DER_Scheduled_AC_CLReqControlMode mode;
+            mode.target_energy_request = dt::RationalNumber{40, 3};
+            mode.max_energy_request = dt::RationalNumber{60, 3};
+            mode.min_energy_request = dt::RationalNumber{10, 3};
+            mode.max_charge_power = dt::RationalNumber{11, 3};
+            mode.max_charge_power_L2 = dt::RationalNumber{11, 3};
+            mode.max_charge_power_L3 = dt::RationalNumber{11, 3};
+            mode.min_charge_power = dt::RationalNumber{100, 0};
+            mode.present_active_power = {9, 3};
+            mode.present_active_power_L2 = dt::RationalNumber{9, 3};
+            mode.present_active_power_L3 = dt::RationalNumber{9, 3};
+            mode.present_reactive_power = dt::RationalNumber{0, 0};
+            mode.present_voltage = {230, 0};
+            mode.present_frequency = {60, 0};
+            mode.maximum_discharge_power = dt::RationalNumber{11, 3};
+            mode.minimum_discharge_power = dt::RationalNumber{100, 0};
+            mode.der_operational_state = dtsae::DEROperationalState::On;
+            mode.der_connection_status = dtsae::DERConnectionStatus::Connected;
+
+            dtsae::EVApparentPower apparent_power;
+            apparent_power.maximum_apparent_power_during_charging_and_var_absorption = {12, 3};
+            apparent_power.maximum_apparent_power_during_charging_and_var_injection = {12, 3};
+            apparent_power.maximum_apparent_power_during_discharging_and_var_absorption = {12, 3};
+            apparent_power.maximum_apparent_power_during_discharging_and_var_injection = {12, 3};
+            mode.apparent_power = apparent_power;
+
+            dtsae::EVReactivePower reactive_power;
+            reactive_power.maximum_var_absorption_during_charging = {5, 3};
+            reactive_power.maximum_var_injection_during_charging = {5, 3};
+            reactive_power.maximum_var_absorption_during_discharging = {5, 3};
+            reactive_power.maximum_var_injection_during_discharging = {5, 3};
+            mode.reactive_power = reactive_power;
+
+            dtsae::EVExcitation excitation;
+            excitation.specified_over_excited_discharge_power = {8, 3};
+            excitation.specified_under_excited_discharge_power = {8, 3};
+            mode.excitation = excitation;
+
+            mode.update_time = 1725456323;
+            mode.minimum_charging_duration = 600;
+            mode.duration_maximum_charge_rate = 1800;
+            mode.duration_maximum_discharge_rate = 1800;
+            mode.der_alarm_status = 0;
+            mode.enabled_modes = 3;
+            req.control_mode = mode;
+
+            REQUIRE(serialize_helper(req) == bytes);
+        }
+    }
+
+    GIVEN("cl_req_dynamic_optionals") {
+
+        std::vector<uint8_t> bytes = {
+            0x80, 0x08, 0x04, 0x1e, 0xa6, 0x5f, 0xc9, 0x9b, 0xa7, 0x6c, 0x4d, 0x8c, 0x3b, 0xfe, 0x1b, 0x60, 0x62,
+            0x01, 0xb8, 0x54, 0x0e, 0x4c, 0x50, 0x1c, 0x04, 0x18, 0x14, 0x02, 0x0c, 0x0f, 0x01, 0x06, 0x01, 0x40,
+            0x83, 0x00, 0xb0, 0x20, 0xc0, 0x2c, 0x08, 0x30, 0x0b, 0x04, 0x00, 0x32, 0x11, 0x06, 0x01, 0x24, 0x40,
+            0x00, 0x01, 0x10, 0x60, 0x16, 0x44, 0x00, 0x32, 0x11, 0x00, 0x1c, 0xc0, 0x20, 0x80, 0x03, 0xc0, 0x10,
+            0x60, 0x3c, 0x01, 0x06, 0x01, 0x84, 0x41, 0x80, 0x61, 0x10, 0x60, 0x18, 0x44, 0x18, 0x06, 0x11, 0x64,
+            0x18, 0x04, 0x14, 0x83, 0x00, 0x82, 0x08, 0x30, 0x14, 0x02, 0x0c, 0x01, 0x40, 0x23, 0x0e, 0xff, 0x86,
+            0xd8, 0x18, 0x6c, 0x02, 0x08, 0x80, 0xe1, 0x10, 0x1c, 0x00, 0x00, 0x18};
+
+        const io::StreamInputView stream_view{bytes.data(), bytes.size()};
+
+        message_20::Variant variant(io::v2gtp::PayloadType::Part20DerSae, stream_view);
+
+        THEN("It should be deserialized successfully") {
+            REQUIRE(variant.get_type() == message_20::Type::DER_SAE_AC_ChargeLoopReq);
+
+            const auto& msg = variant.get<message_20::DER_SAE_AC_ChargeLoopRequest>();
+            const auto& header = msg.header;
+
+            REQUIRE(header.session_id == std::array<uint8_t, 8>{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B});
+            REQUIRE(header.timestamp == 1725456323);
+            REQUIRE(msg.meter_info_requested == true);
+
+            REQUIRE(msg.display_parameters.has_value());
+            REQUIRE(msg.display_parameters.value().present_soc.value() == 55);
+            REQUIRE(msg.display_parameters.value().target_soc.value() == 80);
+            REQUIRE_FALSE(msg.display_parameters.value().min_soc.has_value());
+
+            REQUIRE(std::holds_alternative<dtsae::DER_Dynamic_AC_CLReqControlMode>(msg.control_mode));
+            const auto& mode = std::get<dtsae::DER_Dynamic_AC_CLReqControlMode>(msg.control_mode);
+
+            REQUIRE(mode.departure_time.value() == 7200);
+            REQUIRE(dt::from_RationalNumber(mode.target_energy_request) == 40000);
+            REQUIRE(dt::from_RationalNumber(mode.max_energy_request) == 60000);
+            REQUIRE(dt::from_RationalNumber(mode.min_energy_request) == 10000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power_L2.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.max_charge_power_L3.value()) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.min_charge_power) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_active_power) == 9000);
+            REQUIRE(dt::from_RationalNumber(mode.present_reactive_power) == 0);
+            REQUIRE(dt::from_RationalNumber(mode.maximum_discharge_power) == 11000);
+            REQUIRE(dt::from_RationalNumber(mode.minimum_discharge_power) == 100);
+            REQUIRE(dt::from_RationalNumber(mode.present_voltage) == 230);
+            REQUIRE(dt::from_RationalNumber(mode.present_frequency) == 60);
+            REQUIRE(dt::from_RationalNumber(mode.session_total_discharge_energy_available.value()) == 30000);
+
+            REQUIRE(mode.apparent_power.has_value());
+            const auto& ap = mode.apparent_power.value();
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_charging_and_var_absorption) == 12000);
+            REQUIRE(dt::from_RationalNumber(ap.maximum_apparent_power_during_discharging_and_var_injection) == 12000);
+
+            REQUIRE_FALSE(mode.reactive_power.has_value());
+
+            REQUIRE(mode.excitation.has_value());
+            const auto& ex = mode.excitation.value();
+            REQUIRE(dt::from_RationalNumber(ex.specified_over_excited_discharge_power) == 8000);
+            REQUIRE(dt::from_RationalNumber(ex.specified_under_excited_discharge_power) == 8000);
+
+            REQUIRE(dt::from_RationalNumber(mode.maximum_v2x_energy_request.value()) == 20000);
+            REQUIRE(dt::from_RationalNumber(mode.minimum_v2x_energy_request.value()) == 5000);
+
+            REQUIRE(mode.der_operational_state == dtsae::DEROperationalState::On);
+            REQUIRE(mode.der_connection_status == dtsae::DERConnectionStatus::Connected);
+            REQUIRE(mode.update_time == 1725456323);
+            REQUIRE(mode.minimum_charging_duration == 600);
+            REQUIRE(mode.duration_maximum_charge_rate == 1800);
+            REQUIRE(mode.duration_maximum_discharge_rate == 1800);
+            REQUIRE(mode.der_alarm_status == 0);
+            REQUIRE(mode.enabled_modes == 3);
+        }
+
+        THEN("It should serialize back to the same bytes") {
+            message_20::DER_SAE_AC_ChargeLoopRequest req;
+            req.header = message_20::Header{{0x3D, 0x4C, 0xBF, 0x93, 0x37, 0x4E, 0xD8, 0x9B}, 1725456323};
+            req.meter_info_requested = true;
+
+            dt::DisplayParameters display_parameters;
+            display_parameters.present_soc = 55;
+            display_parameters.target_soc = 80;
+            req.display_parameters = display_parameters;
+
+            dtsae::DER_Dynamic_AC_CLReqControlMode mode;
+            mode.departure_time = 7200;
+            mode.target_energy_request = {40, 3};
+            mode.max_energy_request = {60, 3};
+            mode.min_energy_request = {10, 3};
+            mode.max_charge_power = {11, 3};
+            mode.max_charge_power_L2 = dt::RationalNumber{11, 3};
+            mode.max_charge_power_L3 = dt::RationalNumber{11, 3};
+            mode.min_charge_power = {100, 0};
+            mode.present_active_power = {9, 3};
+            mode.present_reactive_power = {0, 0};
+            mode.maximum_discharge_power = {11, 3};
+            mode.minimum_discharge_power = {100, 0};
+            mode.present_voltage = {230, 0};
+            mode.present_frequency = {60, 0};
+            mode.session_total_discharge_energy_available = dt::RationalNumber{30, 3};
+
+            dtsae::EVApparentPower apparent_power;
+            apparent_power.maximum_apparent_power_during_charging_and_var_absorption = {12, 3};
+            apparent_power.maximum_apparent_power_during_charging_and_var_injection = {12, 3};
+            apparent_power.maximum_apparent_power_during_discharging_and_var_absorption = {12, 3};
+            apparent_power.maximum_apparent_power_during_discharging_and_var_injection = {12, 3};
+            mode.apparent_power = apparent_power;
+
+            dtsae::EVExcitation excitation;
+            excitation.specified_over_excited_discharge_power = {8, 3};
+            excitation.specified_under_excited_discharge_power = {8, 3};
+            mode.excitation = excitation;
+
+            mode.maximum_v2x_energy_request = dt::RationalNumber{20, 3};
+            mode.minimum_v2x_energy_request = dt::RationalNumber{5, 3};
+
+            mode.der_operational_state = dtsae::DEROperationalState::On;
+            mode.der_connection_status = dtsae::DERConnectionStatus::Connected;
+            mode.update_time = 1725456323;
+            mode.minimum_charging_duration = 600;
+            mode.duration_maximum_charge_rate = 1800;
+            mode.duration_maximum_discharge_rate = 1800;
+            mode.der_alarm_status = 0;
+            mode.enabled_modes = 3;
+            req.control_mode = mode;
+
+            REQUIRE(serialize_helper(req) == bytes);
+        }
+    }
+}


### PR DESCRIPTION
Scheduled and Dynamic AC-DER-SAE ChargeLoop Request convert functions with EXI round-trip tests, and enable the Request decode branch in the SAE DER variant handler.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

