### PR TITLE
BuildKit: Use corepack to provide a newer version of npm in the CI containers

### DIFF
--- a/.ci/build-kit/docker/Dockerfile
+++ b/.ci/build-kit/docker/Dockerfile
@@ -14,6 +14,7 @@ FROM ghcr.io/everest/everest-ci/build-kit-base:${BASE_IMAGE_TAG}
 # FIXME(kai): Install libsystemd-dev as a dependency of sdbus-c++
 RUN apt-get update && apt-get -y install libsystemd-dev
 
+# FIXME: move this snippet to everest-ci Dockerfiles
 # Make sure we use a recent enough npm
 RUN npm install -g corepack@0.33.0 \
     && apt-get -y remove npm \

--- a/.ci/build-kit/docker/Dockerfile
+++ b/.ci/build-kit/docker/Dockerfile
@@ -13,3 +13,9 @@ FROM ghcr.io/everest/everest-ci/build-kit-base:${BASE_IMAGE_TAG}
 
 # FIXME(kai): Install libsystemd-dev as a dependency of sdbus-c++
 RUN apt-get update && apt-get -y install libsystemd-dev
+
+# Make sure we use a recent enough npm
+RUN npm install -g corepack@0.33.0 \
+    && apt-get -y remove npm \
+    && corepack enable npm --install-directory /usr/bin \
+    && corepack prepare npm@10.9.8 --activate


### PR DESCRIPTION
## Describe your changes

Extends the buildkit dockerfile with a step that replaces the ubuntu-provided npm with one from corepack so that we can manually specify the version. If npm is used with package.json files that contain a package-manager field it should now always use the pinned version for those as well.
Fixes the CI failure when building the AsyncAPI documentation.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

