### PR TITLE
feat(ocpp21): V2X operationMode profile validation

### DIFF
--- a/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/functional_blocks/smart_charging.hpp
@@ -79,6 +79,8 @@ enum class ProfileValidationResultEnum {
     ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported,
     ChargingSchedulePeriodPriorityChargingNotChargingOnly,
     ChargingSchedulePeriodUnsupportedOperationMode,
+    ChargingSchedulePeriodOperationModeNotInSupportedList,
+    ChargingSchedulePeriodLocalLoadBalancingNotSupported,
     ChargingSchedulePeriodUnsupportedLimitSetpoint,
     ChargingSchedulePeriodNoPhaseForDC,
     ChargingSchedulePeriodNoFreqWattCurve,
@@ -265,6 +267,15 @@ protected:
     /// we set it to the default value (3).
     ProfileValidationResultEnum validate_profile_schedules(ChargingProfile& profile,
                                                            std::optional<EvseInterface*> evse_opt = std::nullopt) const;
+
+    ///
+    /// \brief Q09.FR.01: whether \p operation_mode is listed in V2XChargingCtrlr.SupportedOperationModes for
+    ///        the given EVSE. The variable is per-EVSE (component evse = *, there is no Charging-Station-level
+    ///        instance), so callers check the profile's EVSE, or every EVSE for a station-wide profile.
+    /// \return true for ChargingOnly or when \p operation_mode is listed; false when the variable is absent
+    ///         (no V2X advertised) or the mode is not listed.
+    ///
+    bool is_operation_mode_supported_by_evse(OperationModeEnum operation_mode, std::int32_t evse_id) const;
 
     ///
     /// \brief V2X.05: Ensure every charging schedule period has setpoint within [dischargeLimit, limit].

--- a/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -197,6 +197,10 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingSchedulePeriodPriorityChargingNotChargingOnly";
     case ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedOperationMode:
         return "ChargingSchedulePeriodUnsupportedOperationMode";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodOperationModeNotInSupportedList:
+        return "ChargingSchedulePeriodOperationModeNotInSupportedList";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodLocalLoadBalancingNotSupported:
+        return "ChargingSchedulePeriodLocalLoadBalancingNotSupported";
     case ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedLimitSetpoint:
         return "ChargingSchedulePeriodUnsupportedLimitSetpoint";
     case ProfileValidationResultEnum::ChargingSchedulePeriodNoPhaseForDC:
@@ -279,6 +283,10 @@ std::string profile_validation_result_to_reason_code(ProfileValidationResultEnum
     case ProfileValidationResultEnum::ChargingSchedulePeriodNonFiniteValue:
     case ProfileValidationResultEnum::ChargingSchedulePeriodSetpointOutOfRange:
         return "InvalidSchedule";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodLocalLoadBalancingNotSupported:
+        return "UnsupportedParam";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodOperationModeNotInSupportedList:
+        return "InvalidOperationMode";
     case ProfileValidationResultEnum::ChargingSchedulePeriodPhaseConflict:
         return "PhaseConflict";
     case ProfileValidationResultEnum::ChargingSchedulePeriodNoPhaseForDC:
@@ -927,6 +935,20 @@ ProfileValidationResultEnum SmartCharging::validate_priority_charging_profile(co
  * - K01.FR.90
  */
 
+bool SmartCharging::is_operation_mode_supported_by_evse(const OperationModeEnum operation_mode,
+                                                        const std::int32_t evse_id) const {
+    if (operation_mode == OperationModeEnum::ChargingOnly) {
+        return true;
+    }
+    const auto supported_operation_modes = this->context.device_model.get_optional_value<std::string>(
+        V2xComponentVariables::get_component_variable(evse_id, V2xComponentVariables::SupportedOperationModes));
+    if (!supported_operation_modes.has_value()) {
+        return false;
+    }
+    return supported_operation_modes.value().find(conversions::operation_mode_enum_to_string(operation_mode)) !=
+           std::string::npos;
+}
+
 ProfileValidationResultEnum SmartCharging::validate_profile_schedules(ChargingProfile& profile,
                                                                       std::optional<EvseInterface*> evse_opt) const {
     if (profile.chargingSchedule.empty()) {
@@ -1106,17 +1128,38 @@ ProfileValidationResultEnum SmartCharging::validate_profile_schedules(ChargingPr
                     return ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedOperationMode;
                 }
 
+                // Q09.FR.01: operationMode must be in V2XChargingCtrlr.SupportedOperationModes (per-EVSE;
+                // evseId 0 must be supported by every EVSE).
+                bool operation_mode_supported = true;
+                if (evse_opt.has_value()) {
+                    operation_mode_supported =
+                        this->is_operation_mode_supported_by_evse(operation_mode, evse_opt.value()->get_id());
+                } else {
+                    for (std::int32_t id = 1;
+                         id <= static_cast<std::int32_t>(this->context.evse_manager.get_number_of_evses()); ++id) {
+                        if (this->context.evse_manager.does_evse_exist(id) &&
+                            !this->is_operation_mode_supported_by_evse(operation_mode, id)) {
+                            operation_mode_supported = false;
+                            break;
+                        }
+                    }
+                }
+                if (!operation_mode_supported) {
+                    // Q09.FR.01 carves out LocalLoadBalancing with reasonCode UnsupportedParam; every other
+                    // operationMode not listed in V2XSupportedOperationModes uses InvalidOperationMode (K01.FR.115).
+                    return operation_mode == OperationModeEnum::LocalLoadBalancing
+                               ? ProfileValidationResultEnum::ChargingSchedulePeriodLocalLoadBalancingNotSupported
+                               : ProfileValidationResultEnum::ChargingSchedulePeriodOperationModeNotInSupportedList;
+                }
+
                 // Q08.FR.05: LocalFrequency should have chargingRateUnit `W`.
                 if (operation_mode == OperationModeEnum::LocalFrequency &&
                     schedule.chargingRateUnit == ChargingRateUnitEnum::A) {
                     return ProfileValidationResultEnum::ChargingScheduleChargingRateUnitUnsupported;
                 }
 
-                // K01.FR.126: EvseSleep is not supported.
-                if (charging_schedule_period.evseSleep.value_or(false) &&
-                    !this->context.device_model
-                         .get_optional_value<bool>(ControllerComponentVariables::SupportsEvseSleep)
-                         .value_or(false)) {
+                // K01.FR.126: evseSleep is only valid with operationMode Idle.
+                if (charging_schedule_period.evseSleep.value_or(false) && operation_mode != OperationModeEnum::Idle) {
                     return ProfileValidationResultEnum::ChargingScheduleUnsupportedEvseSleep;
                 }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.cpp
@@ -212,7 +212,29 @@ bool DeviceModelTestHelper::set_variable_attribute_value_null(const std::string&
 
 void DeviceModelTestHelper::create_device_model_db() {
     InitDeviceModelDb db(this->database_path, this->migration_files_path);
-    const auto component_configs = get_all_component_configs(this->config_path);
+    auto component_configs = get_all_component_configs(this->config_path);
+
+    DeviceModelVariable supported_operation_modes;
+    supported_operation_modes.name = "SupportedOperationModes";
+    VariableCharacteristics characteristics;
+    characteristics.dataType = DataEnum::MemberList;
+    characteristics.supportsMonitoring = false;
+    supported_operation_modes.characteristics = characteristics;
+    DbVariableAttribute supported_operation_modes_attribute;
+    supported_operation_modes_attribute.variable_attribute.mutability = MutabilityEnum::ReadWrite;
+    supported_operation_modes_attribute.variable_attribute.value =
+        "ChargingOnly,CentralSetpoint,ExternalSetpoint,ExternalLimits,CentralFrequency,LocalFrequency,"
+        "LocalLoadBalancing,Idle";
+    supported_operation_modes_attribute.variable_attribute.type = AttributeEnum::Actual;
+    supported_operation_modes.attributes = std::vector<DbVariableAttribute>{supported_operation_modes_attribute};
+    const std::vector<DeviceModelVariable> v2x_variables{supported_operation_modes};
+    for (const std::int32_t evse_id : {1, 2}) {
+        ComponentKey v2x_ctrl;
+        v2x_ctrl.name = "V2XChargingCtrlr";
+        v2x_ctrl.evse_id = evse_id;
+        component_configs.insert(std::make_pair(v2x_ctrl, v2x_variables));
+    }
+
     db.initialize_database(component_configs, true);
 }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_smart_charging.cpp
@@ -348,7 +348,7 @@ TEST_F(SmartChargingTestV21, K01FR125_LimitAtSoCNotSupported) {
 }
 
 TEST_F(SmartChargingTestV21, K01FR126_EvseSleepNotSupported) {
-    // EvseSleep is default not supported, so we don't set the value in the device model here.
+    // K01.FR.126: evseSleep is only valid with operationMode Idle; default operationMode is ChargingOnly.
     auto periods = create_charging_schedule_periods(0, 1, 1, 0.5f);
     ASSERT_GE(periods.size(), 1);
     periods.at(0).evseSleep = true;
@@ -363,6 +363,45 @@ TEST_F(SmartChargingTestV21, K01FR126_EvseSleepNotSupported) {
     EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Rejected));
     EXPECT_EQ(response.statusInfo.value().reasonCode, "InvalidSchedule");
     EXPECT_EQ(response.statusInfo.value().additionalInfo, "ChargingScheduleUnsupportedEvseSleep");
+}
+
+TEST_F(SmartChargingTestV21, Q10FR05_IdleEvseSleepUnsupported_NotRejected) {
+    // Q10 error handling / Q10.FR.05: when EvseSleep is unsupported, the flag must be ignored (accept, not reject).
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_id).WillByDefault(testing::Return(1));
+
+    auto periods = create_charging_schedule_periods({0});
+    ASSERT_GE(periods.size(), 1);
+    periods.at(0).operationMode = OperationModeEnum::Idle;
+    periods.at(0).evseSleep = true;
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_NE(sut, ProfileValidationResultEnum::ChargingScheduleUnsupportedEvseSleep);
+}
+
+TEST_F(SmartChargingTestV21, K01FR126_EvseSleepNonIdle_RejectedEvenWhenSupported) {
+    // K01.FR.126: non-Idle + evseSleep=true must reject even when SupportsEvseSleep=true.
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_id).WillByDefault(testing::Return(1));
+
+    const auto& cv = ControllerComponentVariables::SupportsEvseSleep;
+    device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "true", "test", true);
+
+    auto periods = create_charging_schedule_periods(0, 1, 1, 0.5f);
+    ASSERT_GE(periods.size(), 1);
+    periods.at(0).operationMode = OperationModeEnum::ChargingOnly;
+    periods.at(0).evseSleep = true;
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingScheduleUnsupportedEvseSleep);
 }
 
 // Test for Table 95. operationMode for various ChargingProfilePurposes
@@ -550,6 +589,66 @@ TEST_P(LimitsAndSetpointsForOperationModeV21_Param_Test, Q08FR04_LimitsAndSetpoi
     } else {
         EXPECT_EQ(sut, ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedLimitSetpoint);
     }
+}
+
+TEST_F(SmartChargingTestV21, Q09FR01_LocalLoadBalancingNotInSupportedOperationModes_RejectedUnsupportedParam) {
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_id).WillByDefault(testing::Return(1));
+    const auto cv = V2xComponentVariables::get_component_variable(1, V2xComponentVariables::SupportedOperationModes);
+    device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "ChargingOnly,Idle", "test",
+                            true);
+
+    auto periods = create_charging_schedule_periods(0, 1, 1);
+    ASSERT_GE(periods.size(), 1);
+    periods.at(0).operationMode = OperationModeEnum::LocalLoadBalancing;
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodLocalLoadBalancingNotSupported));
+    EXPECT_EQ(conversions::profile_validation_result_to_reason_code(sut), "UnsupportedParam");
+}
+
+TEST_F(SmartChargingTestV21, K01FR115_OperationModeNotInSupportedOperationModes_RejectedInvalidOperationMode) {
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_id).WillByDefault(testing::Return(1));
+    const auto cv = V2xComponentVariables::get_component_variable(1, V2xComponentVariables::SupportedOperationModes);
+    device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "ChargingOnly,Idle", "test",
+                            true);
+
+    auto periods = create_charging_schedule_periods(0, 1, 1);
+    ASSERT_GE(periods.size(), 1);
+    periods.at(0).operationMode = OperationModeEnum::CentralSetpoint;
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodOperationModeNotInSupportedList));
+    EXPECT_EQ(conversions::profile_validation_result_to_reason_code(sut), "InvalidOperationMode");
+}
+
+TEST_F(SmartChargingTestV21, K01FR115_OperationModeInSupportedOperationModes_NotRejected) {
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_id).WillByDefault(testing::Return(1));
+    const auto cv = V2xComponentVariables::get_component_variable(1, V2xComponentVariables::SupportedOperationModes);
+    device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "ChargingOnly,Idle", "test",
+                            true);
+
+    auto periods = create_charging_schedule_periods(0, 1, 1);
+    ASSERT_GE(periods.size(), 1);
+    periods.at(0).operationMode = OperationModeEnum::Idle;
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::W, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    auto sut = smart_charging.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_NE(sut, ProfileValidationResultEnum::ChargingSchedulePeriodLocalLoadBalancingNotSupported);
+    EXPECT_NE(sut, ProfileValidationResultEnum::ChargingSchedulePeriodOperationModeNotInSupportedList);
 }
 
 TEST_F(SmartChargingTestV21, Q08FR02_LocalFrequency_ChargingRateUnitW_NoFreqWattCurve) {

--- a/modules/EVSE/OCPP201/device_model/everest_device_model_storage.cpp
+++ b/modules/EVSE/OCPP201/device_model/everest_device_model_storage.cpp
@@ -371,8 +371,8 @@ EverestDeviceModelStorage::EverestDeviceModelStorage(
                          }) != supported_energy_transfer_modes.cend();
         component_configs[v2x_component_key] = build_v2x_variables(
             supports_v2x, supported_energy_transfer_modes_vector_to_string(supported_energy_transfer_modes),
-            supported_operation_modes_vector_to_string(
-                std::vector<ocpp::v2::OperationModeEnum>{ocpp::v2::OperationModeEnum::ChargingOnly}));
+            supported_operation_modes_vector_to_string(std::vector<ocpp::v2::OperationModeEnum>{
+                ocpp::v2::OperationModeEnum::ChargingOnly, ocpp::v2::OperationModeEnum::Idle}));
 
         const auto connected_ev_component_key = get_connected_ev_component_key(evse_info.id);
         component_configs[connected_ev_component_key] = build_connected_ev_variables();


### PR DESCRIPTION
Reject operationMode absent from V2XChargingCtrlr. SupportedOperationModes (Q09.FR.01, K01.FR.115). Fix K01.FR.126: reject evseSleep only when operationMode is not Idle (Q10.FR.05: unsupported EvseSleep is accepted).

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

