### PR TITLE
feat(EvseManager): Waiting for early on imd result delayed

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -2084,34 +2084,36 @@ void EvseManager::cable_check() {
             r_imd[0]->call_start_self_test(config.cable_check_relays_open_voltage_V);
             EVLOG_info << "CableCheck: Early IMD self test started.";
 
-            // Wait for the result of the self test
-            bool result{false};
-            bool result_received{false};
+            if (not config.cable_check_enable_imd_self_test) {
+                // Wait for the result of the self test
+                bool result{false};
+                bool result_received{false};
 
-            for (int wait_seconds = 0; wait_seconds < CABLECHECK_SELFTEST_TIMEOUT; wait_seconds++) {
-                if (cable_check_should_exit()) {
-                    fail_cable_check("Cancel cable check");
+                for (int wait_seconds = 0; wait_seconds < CABLECHECK_SELFTEST_TIMEOUT; wait_seconds++) {
+                    if (cable_check_should_exit()) {
+                        fail_cable_check("Cancel cable check");
+                        return;
+                    }
+                    if (selftest_result.wait_for(result, 1s)) {
+                        result_received = true;
+                        break;
+                    }
+                }
+
+                if (not result_received) {
+                    fail_cable_check("CableCheck: Did not get a early self test result from IMD within timeout");
                     return;
                 }
-                if (selftest_result.wait_for(result, 1s)) {
-                    result_received = true;
-                    break;
+
+                if (not result) {
+                    EVLOG_error << "CableCheck: Early IMD Self test failed";
+                    fail_cable_check("Early IMD self test failed during cable check");
+                    return;
                 }
-            }
 
-            if (not result_received) {
-                fail_cable_check("CableCheck: Did not get a early self test result from IMD within timeout");
-                return;
+                powersupply_DC_off();
+                charger->get_stopwatch().mark("Early IMD self test");
             }
-
-            if (not result) {
-                EVLOG_error << "CableCheck: Early IMD Self test failed";
-                fail_cable_check("Early IMD self test failed during cable check");
-                return;
-            }
-
-            powersupply_DC_off();
-            charger->get_stopwatch().mark("Early IMD self test");
         }
 
         // normally contactors should be closed before entering cable check routine.
@@ -2195,9 +2197,11 @@ void EvseManager::cable_check() {
 
         // CC 4.1.3: Now relais are closed, voltage is up. We need to perform a self test of the IMD device
         if (config.cable_check_enable_imd_self_test) {
-            selftest_result.clear();
-            r_imd[0]->call_start_self_test(cable_check_voltage);
-            EVLOG_info << "CableCheck: IMD self test started.";
+            if (not config.cable_check_enable_imd_self_test_relays_open) {
+                selftest_result.clear();
+                r_imd[0]->call_start_self_test(cable_check_voltage);
+                EVLOG_info << "CableCheck: IMD self test started.";
+            }
 
             // Wait for the result of the self test
             bool result{false};

--- a/modules/EVSE/EvseManager/manifest.yaml
+++ b/modules/EVSE/EvseManager/manifest.yaml
@@ -120,10 +120,13 @@ config:
   cable_check_enable_imd_self_test_relays_open:
     description: >-
       Enable self testing of IMD at the beginning of cable check where the relays may still be open.
-      The voltage is set by the cable_check_relays_open_voltage_V config option and may differ from the 
+      The voltage is set by the cable_check_relays_open_voltage_V config option and may differ from the
       voltage that is later used to perform the isolation resistance sample.
       cable_check_wait_number_of_imd_measurements needs to be >=1 in this case as no isolation resistance checking
       can be performed at this stage.
+      If both this option and cable_check_enable_imd_self_test are enabled, the selftest is started with
+      relays open, but the result is captured later on, as it would be with the regular selftest sequence.
+      In this case the powersupply will remain active and transition to the regular cable check voltage.
       A self test is required for IEC 61851-23 (2023) compliance.
     type: boolean
     default: false


### PR DESCRIPTION
## Describe your changes
In certain situations it is necessary to start an early IMD self-test. Waiting for the result though can be safely delayed, which speeds up the cable check sequence

The combination of setting both:

-   cable_check_enable_imd_self_test_relays_open: true 
-   cable_check_enable_imd_self_test: true

result in the early IMD self-test  with delayed result capture

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

