### PR TITLE
Auth: Fix the ordering of the PluginEvent algorithm

### DIFF
--- a/modules/EVSE/Auth/BUILD.bazel
+++ b/modules/EVSE/Auth/BUILD.bazel
@@ -1,21 +1,12 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("//modules:module.bzl", "cc_everest_module")
+load("//third-party/bazel/toolchains:defs.bzl", "CROSS_TEST_INCOMPATIBLE")
 
 cc_library(
     name = "auth_handler",
     srcs = glob(["lib/*.cpp"]),
     hdrs = glob(["include/*.hpp"]),
-    strip_include_prefix = "include",
-    deps = [
-        "//lib/everest/timer:libtimer",
-        "@boost.asio",
-        "//lib/everest/framework:framework",
-        "@com_github_HowardHinnant_date//:date",
-        "//types:types_lib",
-        "//interfaces:interfaces_lib",
-        "//lib/everest/helpers",
-        "//lib/everest/util",
-    ],
+    copts = ["-std=c++17"],
     # See https://github.com/HowardHinnant/date/issues/324
     local_defines = [
         "BUILD_TZ_LIB=ON",
@@ -24,7 +15,17 @@ cc_library(
         "USE_AUTOLOAD=0",
         "HAS_REMOTE_API=0",
     ],
-    copts = ["-std=c++17"],
+    strip_include_prefix = "include",
+    deps = [
+        "//interfaces:interfaces_lib",
+        "//lib/everest/framework",
+        "//lib/everest/helpers",
+        "//lib/everest/timer:libtimer",
+        "//lib/everest/util",
+        "//types:types_lib",
+        "@boost.asio",
+        "@com_github_HowardHinnant_date//:date",
+    ],
 )
 
 IMPLS = [
@@ -34,9 +35,37 @@ IMPLS = [
 
 cc_everest_module(
     name = "Auth",
-    deps = [
-        "//lib/everest/timer:libtimer",
-        ":auth_handler",
-    ],
     impls = IMPLS,
+    deps = [
+        ":auth_handler",
+        "//lib/everest/timer:libtimer",
+    ],
+)
+
+cc_test(
+    name = "auth_tests",
+    srcs = [
+        "tests/auth_tests.cpp",
+        "tests/FakeAuthReceiver.hpp",
+    ],
+    copts = [
+        "-std=c++17",
+    ],
+    includes = [
+        "tests",
+    ],
+    local_defines = [
+        "BUILD_TZ_LIB=ON",
+        "USE_SYSTEM_TZ_DB=ON",
+        "USE_OS_TZDB=1",
+        "USE_AUTOLOAD=0",
+        "HAS_REMOTE_API=0",
+    ],
+    target_compatible_with = CROSS_TEST_INCOMPATIBLE,
+    deps = [
+        ":auth_handler",
+        "//lib/everest/framework",
+        "//lib/everest/helpers",
+        "@googletest//:gtest_main",
+    ],
 )

--- a/modules/EVSE/Auth/lib/AuthHandler.cpp
+++ b/modules/EVSE/Auth/lib/AuthHandler.cpp
@@ -524,9 +524,10 @@ bool AuthHandler::equals_master_pass_group_id(const std::optional<types::authori
 }
 
 int AuthHandler::get_latest_plugin(const std::vector<int>& evse_ids) {
-    for (const auto evse_id : this->plug_in_queue) {
-        if (std::find(evse_ids.begin(), evse_ids.end(), evse_id) != evse_ids.end()) {
-            return evse_id;
+    // plug ins are appended to the back of the queue, so we iterate from the back to find the most recent plug in
+    for (auto it = this->plug_in_queue.rbegin(); it != this->plug_in_queue.rend(); ++it) {
+        if (std::find(evse_ids.begin(), evse_ids.end(), *it) != evse_ids.end()) {
+            return *it;
         }
     }
     return -1;

--- a/modules/EVSE/Auth/tests/auth_tests.cpp
+++ b/modules/EVSE/Auth/tests/auth_tests.cpp
@@ -557,10 +557,37 @@ TEST_F(AuthTest, test_two_plugins) {
     ASSERT_TRUE(this->auth_receiver->get_authorization(1));
 }
 
+/// \brief Test that when two EVSEs are plugged in at different times and a single token references both, the most
+/// recently plugged in EVSE receives the authorization (PlugEvents selection algorithm).
+TEST_F(AuthTest, test_latest_plugin_is_selected) {
+
+    SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
+
+    // evse#2 is plugged in first, evse#1 afterwards. evse#1 is therefore the latest plug in and must be selected.
+    // Plug in sequentially so the order is deterministic.
+    this->auth_handler->handle_session_event(2, session_event);
+    this->auth_handler->handle_session_event(1, session_event);
+
+    std::vector<int32_t> connectors{1, 2};
+    ProvidedIdToken provided_token = get_provided_token(VALID_TOKEN_1, connectors);
+
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Processing));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Accepted));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::UsedToStart));
+
+    const auto result = this->auth_handler->on_token(provided_token);
+    ASSERT_TRUE(result == TokenHandlingResult::USED_TO_START_TRANSACTION);
+    // evse#1 (evse_index 0) is the latest plug in and must receive the authorization, not evse#2 (evse_index 1)
+    ASSERT_TRUE(this->auth_receiver->get_authorization(0));
+    ASSERT_FALSE(this->auth_receiver->get_authorization(1));
+}
+
 /// \brief Test if a connector receives authorization after subsequent plug-in and plug-out events
 TEST_F(AuthTest, test_authorization_after_plug_in_and_plug_out) {
     TokenHandlingResult result1;
-    TokenHandlingResult result2;
     std::vector<int32_t> connectors{1, 2};
     ProvidedIdToken provided_token_1 = get_provided_token(VALID_TOKEN_1, connectors);
 
@@ -601,8 +628,10 @@ TEST_F(AuthTest, test_two_plugins_with_invalid_rfid) {
 
     SessionEvent session_event = get_session_started_event(types::evse_manager::StartSessionReason::EVConnected);
 
-    std::thread t1([this, session_event]() { this->auth_handler->handle_session_event(1, session_event); });
-    std::thread t2([this, session_event]() { this->auth_handler->handle_session_event(2, session_event); });
+    // Plug in evse#1 first, then evse#2. evse#2 is therefore the latest plug in and must be selected for the valid
+    // token (PlugEvents selection algorithm). Plug in sequentially so the order is deterministic.
+    this->auth_handler->handle_session_event(1, session_event);
+    this->auth_handler->handle_session_event(2, session_event);
 
     std::vector<int32_t> connectors{1, 2};
     ProvidedIdToken provided_token_1 = get_provided_token(VALID_TOKEN_1, connectors);
@@ -619,19 +648,17 @@ TEST_F(AuthTest, test_two_plugins_with_invalid_rfid) {
                 Call(Field(&ProvidedIdToken::id_token, provided_token_1.id_token), TokenValidationStatus::UsedToStart));
     EXPECT_CALL(mock_publish_token_validation_status_callback,
                 Call(Field(&ProvidedIdToken::id_token, provided_token_2.id_token), TokenValidationStatus::Rejected));
-    t1.join();
-    t2.join();
     std::thread t3([this, provided_token_1, &result1]() { result1 = this->auth_handler->on_token(provided_token_1); });
     t3.join();
 
     ASSERT_TRUE(result1 == TokenHandlingResult::USED_TO_START_TRANSACTION);
-    ASSERT_TRUE(this->auth_receiver->get_authorization(0));
+    ASSERT_TRUE(this->auth_receiver->get_authorization(1));
 
     std::thread t4([this, provided_token_2, &result2]() { result2 = this->auth_handler->on_token(provided_token_2); });
     t4.join();
 
     ASSERT_TRUE(result2 == TokenHandlingResult::REJECTED);
-    ASSERT_FALSE(this->auth_receiver->get_authorization(1));
+    ASSERT_FALSE(this->auth_receiver->get_authorization(0));
 }
 
 /// \brief Test if state permanent fault leads to not provide authorization


### PR DESCRIPTION
## Describe your changes

I'm actually not certain from the behavior since it's not clearly documented but the name `get_latest_plugin` implies that we want to get the most recent plugin and not the oldest. This seems also to be nicer with the customers since if we have 2 customers connecting it seems to make sense to assume that the most recent one is the one authorizing 
