### PR TITLE
Fix california pricing testcase for recent Python

### DIFF
--- a/tests/ocpp_tests/test_sets/ocpp201/california_pricing.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/california_pricing.py
@@ -239,7 +239,7 @@ class TestOcpp201CostAndPrice:
         received_data['cost_chunks'][0] = {
             'cost': {'value': 5510000}, 'metervalue_to': 0, 'timestamp_to': ANY}
         received_data['status'] = 'Finished'
-        probe_module_mock_fn.call_count = 0
+        probe_module_mock_fn.reset_mock()
 
         assert await wait_for_and_validate(test_utility, chargepoint_with_pm, "TransactionEvent",
                                            {"eventType": "Ended"})
@@ -336,7 +336,7 @@ class TestOcpp201CostAndPrice:
         # Clear cache
         r: call_result201.ClearCache = await chargepoint_with_pm.clear_cache_req()
         assert r.status == ClearCacheStatusEnumType.accepted
-        session_cost_mock.call_count = 0
+        session_cost_mock.reset_mock()
 
         await chargepoint_with_pm.cost_update_req(total_cost=1.345, transaction_id=transaction_id,
                                                   custom_data=self.cost_updated_custom_data)
@@ -348,7 +348,7 @@ class TestOcpp201CostAndPrice:
         # Clear cache
         r: call_result201.ClearCache = await chargepoint_with_pm.clear_cache_req()
         assert r.status == ClearCacheStatusEnumType.accepted
-        session_cost_mock.call_count = 0
+        session_cost_mock.reset_mock()
 
         # Set transaction id to a not existing transaction id.
         await chargepoint_with_pm.cost_update_req(total_cost=1.345, transaction_id="12345",


### PR DESCRIPTION
## Describe your changes

Fixes the california pricing OCPP 2.0.1 test for Python >= 3.13
mock.call_count = 0 no longer actually resets the counter. Instead reset_mock() needs to be used now

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

