### PR TITLE
feat(ocpp): dynamic DER grid_support for OCPP 2.1

### DIFF
--- a/interfaces/grid_support.yaml
+++ b/interfaces/grid_support.yaml
@@ -33,9 +33,6 @@ vars:
     description: >-
       Grid event alarm raised by the device. alarm_ended=false marks the
       condition turning on, alarm_ended=true marks it clearing/turning off.
-      Forwarded upstream by the protocol backend. Alarms published before the
-      backend has accepted a capability for any EVSE are buffered and delivered
-      once the first capability is accepted; if no capability is ever accepted,
-      buffered alarms are never delivered.
+      Forwarded upstream by the protocol backend.
     type: object
     $ref: /grid_support#/GridAlarm

--- a/interfaces/grid_support.yaml
+++ b/interfaces/grid_support.yaml
@@ -33,6 +33,9 @@ vars:
     description: >-
       Grid event alarm raised by the device. alarm_ended=false marks the
       condition turning on, alarm_ended=true marks it clearing/turning off.
-      Forwarded upstream by the protocol backend.
+      Forwarded upstream by the protocol backend. Alarms published before the
+      backend has accepted a capability for any EVSE are buffered and delivered
+      once the first capability is accepted; if no capability is ever accepted,
+      buffered alarms are never delivered.
     type: object
     $ref: /grid_support#/GridAlarm

--- a/lib/everest/ocpp/doc/v2/ocpp_201_device_model_initialization.md
+++ b/lib/everest/ocpp/doc/v2/ocpp_201_device_model_initialization.md
@@ -55,3 +55,13 @@ one of the required Variables is not there.
 
 This also implies, that if you write code that needs a required `Variable`, when trying to get that variable with 
 `DeviceModel::get_value(...)`, you should first check if the Component that Variable belongs to is `Available`.
+
+## DER control: construct-on-enable
+
+The DER functional block (`ocpp::v21::DERControl`) follows a stricter variant of the `Available`-gated pattern above. It is
+**not** constructed eagerly during `ChargePoint` initialization. Instead, `ChargePoint` registers a device-model variable
+listener on the `DCDERCtrlr` / `ACDERCtrlr` `Available` variable and builds the DER block lazily the first time either flips
+to `true`, whether at startup (if a component is already `Available`) or later at runtime via `SetVariables`. Integrators who
+need DER control active from the start must ensure at least one of `DCDERCtrlr.Available` / `ACDERCtrlr.Available` is `true` in
+the device model; otherwise the DER block stays unbuilt and DER messages are answered with `NotImplemented` until a component
+is enabled.

--- a/lib/everest/ocpp/doc/v2/ocpp_201_device_model_initialization.md
+++ b/lib/everest/ocpp/doc/v2/ocpp_201_device_model_initialization.md
@@ -58,10 +58,15 @@ This also implies, that if you write code that needs a required `Variable`, when
 
 ## DER control: construct-on-enable
 
-The DER functional block (`ocpp::v21::DERControl`) follows a stricter variant of the `Available`-gated pattern above. It is
-**not** constructed eagerly during `ChargePoint` initialization. Instead, `ChargePoint` registers a device-model variable
-listener on the `DCDERCtrlr` / `ACDERCtrlr` `Available` variable and builds the DER block lazily the first time either flips
-to `true`, whether at startup (if a component is already `Available`) or later at runtime via `SetVariables`. Integrators who
-need DER control active from the start must ensure at least one of `DCDERCtrlr.Available` / `ACDERCtrlr.Available` is `true` in
-the device model; otherwise the DER block stays unbuilt and DER messages are answered with `NotImplemented` until a component
-is enabled.
+The DER functional block (`ocpp::v21::DERControl`) follows a stricter variant of the `Available`-gated pattern above.
+Admission and block construction are strictly opt-in. It is **not** constructed eagerly during `ChargePoint`
+initialization. A component counts as active only when `Available == true` **and** `Enabled == true`, evaluated per EVSE.
+Both variables are read with `value_or(false)`, so a missing `Available` or `Enabled` variable means disabled. Static
+device-model configs must therefore define `Enabled` (typically `"true"`) alongside `Available` for the DER block to build
+at boot; a config that defines only `Available` leaves the block unbuilt. DC directive admission likewise requires
+`Available == true` (in addition to `Enabled` and `ModesSupported`). The lazy construction path still exists for
+components enabled later at runtime: `ChargePoint` registers a device-model variable listener on the `DCDERCtrlr` /
+`ACDERCtrlr` `Available` and `Enabled` variables and builds the DER block the first time a component of either type
+becomes active via `SetVariables`. Integrators who need DER control active from the start must ensure at least one EVSE
+has an active `DCDERCtrlr` / `ACDERCtrlr` component; otherwise the DER block stays unbuilt and DER messages are answered
+with `NotImplemented` until a component is enabled.

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point.hpp
@@ -7,6 +7,8 @@
 #include <memory>
 #include <set>
 
+#include <everest/util/async/monitor.hpp>
+
 #include <ocpp/common/message_dispatcher.hpp>
 
 #include <ocpp/common/charging_station_base.hpp>
@@ -25,6 +27,8 @@
 #include <ocpp/v2/messages/Get15118EVCertificate.hpp>
 #include <ocpp/v2/messages/GetCompositeSchedule.hpp>
 #include <ocpp/v2/messages/NotifyEVChargingNeeds.hpp>
+
+#include <ocpp/v21/messages/NotifyDERAlarm.hpp>
 
 #include "component_state_manager.hpp"
 
@@ -136,6 +140,14 @@ public:
     virtual void on_firmware_update_status_notification(std::int32_t request_id,
                                                         const FirmwareStatusEnum& firmware_update_status,
                                                         const bool disable_connectors_during_install = true) = 0;
+
+    /// \brief Sends a NotifyDERAlarm to the CSMS for a DER grid event. No-op if no EVSE declares DER support.
+    virtual void on_der_alarm(const ocpp::v21::NotifyDERAlarmRequest& request) = 0;
+
+    /// \brief Re-emit the current active DER directive set through the der_active_directives_callback. Lets a
+    /// provider learn the standing set when a newly-enabled EVSE joins an already-built DER block (whose
+    /// construction-time emit already fired). No-op if the DER functional block is not available.
+    virtual void on_der_republish_active_directives() = 0;
 
     /// \brief Event handler that should be called when a session has started
     /// \param evse_id
@@ -412,7 +424,7 @@ private:
     std::unique_ptr<ProvisioningInterface> provisioning;
     std::unique_ptr<RemoteTransactionControlInterface> remote_transaction_control;
     std::unique_ptr<BidirectionalInterface> bidirectional;
-    std::unique_ptr<v21::DERControlInterface> der_control;
+    everest::lib::util::monitor<std::unique_ptr<v21::DERControlInterface>> der_control;
 
     // utility
     std::shared_ptr<MessageQueue<v2::MessageType>> message_queue;
@@ -461,6 +473,10 @@ private:
     OcspUpdater make_ocsp_updater();
     void update_dm_availability_state(const std::int32_t evse_id, const std::int32_t connector_id,
                                       const ConnectorStatusEnum status);
+
+    /// \brief Builds the DER functional block if not yet built and any DER component reports Available==true.
+    /// Idempotent. Invoked at construction and from the variable listener when Available flips false->true.
+    void build_der_control_if_enabled();
 
     void message_callback(const std::string& message);
 
@@ -598,6 +614,10 @@ public:
     void on_firmware_update_status_notification(std::int32_t request_id,
                                                 const FirmwareStatusEnum& firmware_update_status,
                                                 bool disable_connectors_during_install = true) override;
+
+    void on_der_alarm(const ocpp::v21::NotifyDERAlarmRequest& request) override;
+
+    void on_der_republish_active_directives() override;
 
     void on_session_started(const std::int32_t evse_id, const std::int32_t connector_id) override;
 

--- a/lib/everest/ocpp/include/ocpp/v2/charge_point_callbacks.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/charge_point_callbacks.hpp
@@ -18,6 +18,9 @@
 #include <ocpp/v2/messages/UnlockConnector.hpp>
 #include <ocpp/v2/messages/UpdateFirmware.hpp>
 
+#include <ocpp/v21/functional_blocks/der_control.hpp>
+#include <ocpp/v21/messages/SetDERControl.hpp>
+
 namespace ocpp::v2 {
 struct Callbacks {
     /// @addtogroup ocpp201_callbacks OCPP 2.0.1 callbacks
@@ -188,6 +191,11 @@ struct Callbacks {
     std::optional<std::function<bool(const std::vector<ocpp::v2::EnergyTransferModeEnum> allowed_energy_transfer_modes,
                                      const CiString<36> transaction_id)>>
         update_allowed_energy_transfer_modes_callback;
+
+    /// \brief Carries the full set of currently-active DER controls, emitted after every accepted transition.
+    /// The provider replaces its applied set wholesale from this argument rather than tracking transitions.
+    std::optional<std::function<void(const std::vector<ocpp::v21::SetDERControlRequest>& active_controls)>>
+        der_active_directives_callback;
 
     /// @} // End group
 };

--- a/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
+++ b/lib/everest/ocpp/include/ocpp/v2/ctrlr_component_variables.hpp
@@ -451,6 +451,7 @@ void clear_slot_in_device_model(DeviceModelInterface& dm, int32_t slot);
 
 namespace DERComponentVariables {
 extern const Variable Available;
+extern const Variable Enabled;
 extern const Variable ModesSupported;
 ComponentVariable get_dc_component_variable(const std::int32_t evse_id, const Variable& variable);
 ComponentVariable get_ac_component_variable(const std::int32_t evse_id, const Variable& variable);

--- a/lib/everest/ocpp/include/ocpp/v21/functional_blocks/der_control.hpp
+++ b/lib/everest/ocpp/include/ocpp/v21/functional_blocks/der_control.hpp
@@ -12,15 +12,31 @@
 
 #include <ocpp/v21/messages/ClearDERControl.hpp>
 #include <ocpp/v21/messages/GetDERControl.hpp>
+#include <ocpp/v21/messages/NotifyDERAlarm.hpp>
 #include <ocpp/v21/messages/NotifyDERStartStop.hpp>
 #include <ocpp/v21/messages/ReportDERControl.hpp>
 #include <ocpp/v21/messages/SetDERControl.hpp>
 
+#include <functional>
+#include <optional>
+#include <vector>
+
 namespace ocpp::v21 {
+
+/// \brief Callback carrying the full set of currently-active DER controls, emitted after every accepted
+/// transition. The provider replaces its applied set wholesale from this argument.
+using DERActiveDirectivesCallback = std::function<void(const std::vector<SetDERControlRequest>&)>;
 
 class DERControlInterface : public v2::MessageHandlerInterface {
 public:
     ~DERControlInterface() override = default;
+
+    /// \brief Send a NotifyDERAlarm to the CSMS for a DER grid event.
+    virtual void notify_der_alarm(const NotifyDERAlarmRequest& request) = 0;
+
+    /// \brief Re-emit the current active-directive set on demand (no transition occurred). Lets a provider
+    /// learn the standing set when, e.g., a newly-enabled EVSE joins an already-built block.
+    virtual void republish_active_directives() const = 0;
 };
 
 /// Functional block R (DER control) for OCPP 2.1. libocpp stores and serves the DER controls (grid
@@ -29,7 +45,8 @@ public:
 /// All DER controls are persisted in the database, no in-memory cache.
 class DERControl : public DERControlInterface {
 public:
-    explicit DERControl(const v2::FunctionalBlockContext& context);
+    explicit DERControl(const v2::FunctionalBlockContext& context,
+                        std::optional<DERActiveDirectivesCallback> active_directives_callback = std::nullopt);
     ~DERControl() override;
 
     void handle_message(const ocpp::EnhancedMessage<v2::MessageType>& message) override;
@@ -37,8 +54,13 @@ public:
     /// Periodic check for expired scheduled controls. Call this to trigger a manual check.
     void check_scheduled_controls();
 
+    void notify_der_alarm(const NotifyDERAlarmRequest& request) override;
+
+    void republish_active_directives() const override;
+
 private:
     const v2::FunctionalBlockContext& context;
+    std::optional<DERActiveDirectivesCallback> active_directives_callback;
     // Destructor must block until any in-flight timer callback finishes;
     // the callback holds a handle on `stopping` so the destructor's
     // re-acquisition forces a wait. Required because the callback touches the
@@ -62,6 +84,14 @@ private:
 
     /// Validate that the correct control field is populated for the given controlType (R04.FR.16-17)
     bool validate_control_fields(const SetDERControlRequest& req) const;
+
+    /// Compute the currently-effective DER controls from the database: not-superseded rows that are a
+    /// default, or a scheduled control whose startTime has arrived and whose duration has not elapsed.
+    std::vector<SetDERControlRequest> compute_active_directives() const;
+
+    /// Emit the active-directives callback (if registered). The provider is third-party code run on the
+    /// timer thread, so an escaping exception (→ std::terminate()) must never propagate out of here.
+    void emit_active_directives() const;
 };
 
 } // namespace ocpp::v21

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -596,8 +596,8 @@ void ChargePoint::initialize(const std::map<std::int32_t, std::int32_t>& evse_co
                const Variable& variable, const VariableCharacteristics& /*characteristics*/,
                const VariableAttribute& /*attribute*/, const std::string& /*value_previous*/,
                const std::string& value_current) {
-            if ((component.name == "DCDERCtrlr" || component.name == "ACDERCtrlr") && variable.name == "Available" &&
-                value_current == "true") {
+            if ((component.name == "DCDERCtrlr" || component.name == "ACDERCtrlr") &&
+                (variable.name == "Enabled" || variable.name == "Available") && value_current == "true") {
                 this->build_der_control_if_enabled();
             }
         });
@@ -718,17 +718,30 @@ void ChargePoint::build_der_control_if_enabled() {
         return;
     }
 
+    // A DER component is active if Available==true and Enabled==true. A missing variable means disabled:
+    // static configs must define Enabled (typically "true") for the block to build.
     const auto number_of_evses = static_cast<std::int32_t>(this->evse_manager->get_number_of_evses());
     bool der_available = false;
     for (std::int32_t evse = 1; evse <= number_of_evses; evse++) {
-        if (this->device_model
+        const bool dc_active =
+            this->device_model
                 ->get_optional_value<bool>(
                     DERComponentVariables::get_dc_component_variable(evse, DERComponentVariables::Available))
-                .value_or(false) ||
+                .value_or(false) &&
+            this->device_model
+                ->get_optional_value<bool>(
+                    DERComponentVariables::get_dc_component_variable(evse, DERComponentVariables::Enabled))
+                .value_or(false);
+        const bool ac_active =
             this->device_model
                 ->get_optional_value<bool>(
                     DERComponentVariables::get_ac_component_variable(evse, DERComponentVariables::Available))
-                .value_or(false)) {
+                .value_or(false) &&
+            this->device_model
+                ->get_optional_value<bool>(
+                    DERComponentVariables::get_ac_component_variable(evse, DERComponentVariables::Enabled))
+                .value_or(false);
+        if (dc_active || ac_active) {
             der_available = true;
             break;
         }

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point.cpp
@@ -183,6 +183,25 @@ void ChargePoint::on_firmware_update_status_notification(std::int32_t request_id
                                                                   disable_connectors_during_install);
 }
 
+void ChargePoint::on_der_alarm(const ocpp::v21::NotifyDERAlarmRequest& request) {
+    auto handle = this->der_control.handle();
+    if (*handle != nullptr) {
+        (*handle)->notify_der_alarm(request);
+    } else {
+        EVLOG_warning << "on_der_alarm called but DER functional block is not available; ignoring";
+    }
+}
+
+void ChargePoint::on_der_republish_active_directives() {
+    auto handle = this->der_control.handle();
+    if (*handle != nullptr) {
+        (*handle)->republish_active_directives();
+    } else {
+        EVLOG_warning
+            << "on_der_republish_active_directives called but DER functional block is not available; ignoring";
+    }
+}
+
 void ChargePoint::connect_websocket(std::optional<std::int32_t> network_profile_slot) {
     this->connectivity_manager->connect(network_profile_slot);
 }
@@ -572,6 +591,17 @@ void ChargePoint::initialize(const std::map<std::int32_t, std::int32_t>& evse_co
         *this->message_dispatcher, *this->device_model, *this->connectivity_manager, *this->evse_manager,
         *this->database_handler, *this->evse_security, *this->component_state_manager, this->ocpp_version);
 
+    this->device_model->register_variable_listener(
+        [this](const std::unordered_map<std::int64_t, VariableMonitoringMeta>& /*monitors*/, const Component& component,
+               const Variable& variable, const VariableCharacteristics& /*characteristics*/,
+               const VariableAttribute& /*attribute*/, const std::string& /*value_previous*/,
+               const std::string& value_current) {
+            if ((component.name == "DCDERCtrlr" || component.name == "ACDERCtrlr") && variable.name == "Available" &&
+                value_current == "true") {
+                this->build_der_control_if_enabled();
+            }
+        });
+
     this->data_transfer = std::make_unique<DataTransfer>(
         *this->functional_block_context, this->callbacks.data_transfer_callback, DEFAULT_WAIT_FOR_FUTURE_TIMEOUT);
     this->security = std::make_unique<Security>(*this->functional_block_context, *this->logging, this->ocsp_updater,
@@ -673,29 +703,41 @@ void ChargePoint::initialize(const std::map<std::int32_t, std::int32_t>& evse_co
             *this->functional_block_context, this->callbacks.update_allowed_energy_transfer_modes_callback);
     }
 
-    // Check if any EVSE supports DER control (DC or AC DERCtrlr)
-    const bool der_available =
-        std::any_of(evse_connector_structure.begin(), evse_connector_structure.end(), [this](const auto& entry) {
-            const auto& [evse, connectors] = entry;
-            return this->device_model
-                       ->get_optional_value<bool>(
-                           DERComponentVariables::get_dc_component_variable(evse, DERComponentVariables::Available))
-                       .value_or(false) ||
-                   this->device_model
-                       ->get_optional_value<bool>(
-                           DERComponentVariables::get_ac_component_variable(evse, DERComponentVariables::Available))
-                       .value_or(false);
-        });
-
-    if (der_available) {
-        this->der_control = std::make_unique<v21::DERControl>(*this->functional_block_context);
-    }
+    this->build_der_control_if_enabled();
 
     Variable field_length = {"FieldLength"};
     field_length.instance = "Get15118EVCertificateResponse.exiResponse";
     this->device_model->set_value(ControllerComponents::OCPPCommCtrlr, field_length, AttributeEnum::Actual,
                                   std::to_string(ISO15118_GET_EV_CERTIFICATE_EXI_RESPONSE_SIZE),
                                   VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL, true);
+}
+
+void ChargePoint::build_der_control_if_enabled() {
+    auto handle = this->der_control.handle();
+    if (*handle != nullptr) {
+        return;
+    }
+
+    const auto number_of_evses = static_cast<std::int32_t>(this->evse_manager->get_number_of_evses());
+    bool der_available = false;
+    for (std::int32_t evse = 1; evse <= number_of_evses; evse++) {
+        if (this->device_model
+                ->get_optional_value<bool>(
+                    DERComponentVariables::get_dc_component_variable(evse, DERComponentVariables::Available))
+                .value_or(false) ||
+            this->device_model
+                ->get_optional_value<bool>(
+                    DERComponentVariables::get_ac_component_variable(evse, DERComponentVariables::Available))
+                .value_or(false)) {
+            der_available = true;
+            break;
+        }
+    }
+
+    if (der_available) {
+        *handle = std::make_unique<v21::DERControl>(*this->functional_block_context,
+                                                    this->callbacks.der_active_directives_callback);
+    }
 }
 
 OcspUpdater ChargePoint::make_ocsp_updater() {
@@ -812,13 +854,15 @@ void ChargePoint::handle_message(const EnhancedMessage<v2::MessageType>& message
             break;
         case MessageType::SetDERControl:
         case MessageType::GetDERControl:
-        case MessageType::ClearDERControl:
-            if (this->der_control != nullptr) {
-                this->der_control->handle_message(message);
+        case MessageType::ClearDERControl: {
+            auto handle = this->der_control.handle();
+            if (*handle != nullptr) {
+                (*handle)->handle_message(message);
             } else {
                 send_not_implemented_error(message.uniqueId, message.messageTypeId);
             }
             break;
+        }
         case MessageType::Authorize:
         case MessageType::AuthorizeResponse:
         case MessageType::BootNotification:

--- a/lib/everest/ocpp/lib/ocpp/v2/charge_point_callbacks.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/charge_point_callbacks.cpp
@@ -107,6 +107,29 @@ bool Callbacks::all_callbacks_valid(std::shared_ptr<DeviceModelAbstract> device_
                 valid = false;
             }
         }
+
+        // Gate on presence (.has_value()), not availability: the block may be built lazily later.
+        const bool der_present = std::any_of(
+            evse_connector_structure.begin(), evse_connector_structure.end(), [device_model](const auto& entry) {
+                const auto& [evse, connectors] = entry;
+                return device_model
+                           ->get_optional_value<bool>(
+                               DERComponentVariables::get_dc_component_variable(evse, DERComponentVariables::Available))
+                           .has_value() or
+                       device_model
+                           ->get_optional_value<bool>(
+                               DERComponentVariables::get_ac_component_variable(evse, DERComponentVariables::Available))
+                           .has_value();
+            });
+
+        if (der_present) {
+            if (!this->der_active_directives_callback.has_value() or
+                this->der_active_directives_callback.value() == nullptr) {
+                EVLOG_error << "A DER component is present in the device model, but "
+                               "der_active_directives_callback is not implemented";
+                valid = false;
+            }
+        }
     }
 
     return valid;

--- a/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -1529,6 +1529,7 @@ ComponentVariable get_component_variable(const std::int32_t evse_id, const Varia
 namespace DERComponentVariables {
 
 const Variable Available = {"Available"};
+const Variable Enabled = {"Enabled"};
 const Variable ModesSupported = {"ModesSupported"};
 
 ComponentVariable get_dc_component_variable(const std::int32_t evse_id, const Variable& variable) {

--- a/lib/everest/ocpp/lib/ocpp/v21/functional_blocks/der_control.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v21/functional_blocks/der_control.cpp
@@ -312,18 +312,27 @@ bool DERControl::is_control_type_supported(v2::DERControlEnum control_type) cons
     const auto& evse_manager = this->context.evse_manager;
 
     for (int32_t evse_id = 1; evse_id <= static_cast<int32_t>(evse_manager.get_number_of_evses()); evse_id++) {
-        auto ac_mode = DERComponentVariables::get_ac_component_variable(evse_id, DERComponentVariables::Available);
-        auto is_ac_der = this->context.device_model.get_optional_value<bool>(ac_mode);
+        // A missing Available or Enabled variable means disabled: DER admission is strictly opt-in.
+        auto ac_available_cv =
+            DERComponentVariables::get_ac_component_variable(evse_id, DERComponentVariables::Available);
+        auto ac_enabled_cv = DERComponentVariables::get_ac_component_variable(evse_id, DERComponentVariables::Enabled);
         // Exception is made for AC as we do not know what control types the EV supports, so we accept all
-        if (is_ac_der.has_value() && is_ac_der.value()) {
+        if (this->context.device_model.get_optional_value<bool>(ac_available_cv).value_or(false) &&
+            this->context.device_model.get_optional_value<bool>(ac_enabled_cv).value_or(false)) {
             return true;
         }
 
-        auto dc_modes_cv =
-            DERComponentVariables::get_dc_component_variable(evse_id, DERComponentVariables::ModesSupported);
-        auto dc_modes = this->context.device_model.get_optional_value<std::string>(dc_modes_cv);
-        if (dc_modes.has_value() && mode_list_contains(dc_modes.value(), control_type_str)) {
-            return true;
+        auto dc_available_cv =
+            DERComponentVariables::get_dc_component_variable(evse_id, DERComponentVariables::Available);
+        auto dc_enabled_cv = DERComponentVariables::get_dc_component_variable(evse_id, DERComponentVariables::Enabled);
+        if (this->context.device_model.get_optional_value<bool>(dc_available_cv).value_or(false) &&
+            this->context.device_model.get_optional_value<bool>(dc_enabled_cv).value_or(false)) {
+            auto dc_modes_cv =
+                DERComponentVariables::get_dc_component_variable(evse_id, DERComponentVariables::ModesSupported);
+            auto dc_modes = this->context.device_model.get_optional_value<std::string>(dc_modes_cv);
+            if (dc_modes.has_value() && mode_list_contains(dc_modes.value(), control_type_str)) {
+                return true;
+            }
         }
     }
     return false;

--- a/lib/everest/ocpp/lib/ocpp/v21/functional_blocks/der_control.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v21/functional_blocks/der_control.cpp
@@ -264,7 +264,9 @@ bool validate_yunit(DERControlEnum control_type, const DERCurve& curve) {
 
 } // anonymous namespace
 
-DERControl::DERControl(const v2::FunctionalBlockContext& context) : context(context) {
+DERControl::DERControl(const v2::FunctionalBlockContext& context,
+                       std::optional<DERActiveDirectivesCallback> active_directives_callback) :
+    context(context), active_directives_callback(std::move(active_directives_callback)) {
     // Lambda holds a stopping handle for callback duration so destructor can wait for in-flight runs.
     this->scheduled_control_timer.interval(
         [this]() {
@@ -275,6 +277,8 @@ DERControl::DERControl(const v2::FunctionalBlockContext& context) : context(cont
             this->check_scheduled_controls();
         },
         SCHEDULED_CONTROL_CHECK_INTERVAL);
+
+    this->emit_active_directives();
 }
 
 DERControl::~DERControl() {
@@ -637,6 +641,8 @@ void DERControl::handle_set_der_control(ocpp::Call<SetDERControlRequest> call) {
             }
             this->send_notify_start_stop(request.controlId, true, ocpp::DateTime(), superseded_opt);
         }
+
+        this->emit_active_directives();
     } catch (const everest::db::QueryExecutionException& e) {
         EVLOG_error << "DER control database error in SetDERControl: " << e.what();
         response.status = DERControlStatusEnum::Rejected;
@@ -722,6 +728,9 @@ void DERControl::handle_clear_der_control(ocpp::Call<ClearDERControlRequest> cal
             response.status = deleted ? DERControlStatusEnum::Accepted : DERControlStatusEnum::NotFound;
             ocpp::CallResult<ClearDERControlResponse> call_result(response, call.uniqueId);
             this->context.message_dispatcher.dispatch_call_result(call_result);
+            if (deleted) {
+                this->emit_active_directives();
+            }
             return;
         }
 
@@ -754,6 +763,10 @@ void DERControl::handle_clear_der_control(ocpp::Call<ClearDERControlRequest> cal
 
         ocpp::CallResult<ClearDERControlResponse> call_result(response, call.uniqueId);
         this->context.message_dispatcher.dispatch_call_result(call_result);
+
+        if (deleted_count > 0) {
+            this->emit_active_directives();
+        }
     } catch (const everest::db::QueryExecutionException& e) {
         EVLOG_error << "DER control database error in ClearDERControl: " << e.what();
         response.status = DERControlStatusEnum::Rejected;
@@ -776,11 +789,97 @@ void DERControl::send_notify_start_stop(const CiString<36>& control_id, bool sta
     this->context.message_dispatcher.dispatch_call(call, false);
 }
 
+std::vector<SetDERControlRequest> DERControl::compute_active_directives() const {
+    // No in-memory cache; recover the active set from the persisted CONTROL_JSON rows.
+    auto controls =
+        this->context.database_handler.get_der_controls_matching_criteria(std::nullopt, std::nullopt, std::nullopt);
+
+    auto now = ocpp::DateTime();
+    std::vector<SetDERControlRequest> active;
+    active.reserve(controls.size());
+    for (const auto& control_json_str : controls) {
+        try {
+            auto control = json::parse(control_json_str);
+            if (control.at("isSuperseded").get<bool>()) {
+                continue;
+            }
+
+            // A scheduled control is effective only between startTime and startTime+duration; a default
+            // control (no startTime) is always effective.
+            if (control.contains("startTime")) {
+                auto start_time = ocpp::DateTime(control.at("startTime").get<std::string>());
+                if (start_time > now) {
+                    continue;
+                }
+                if (control.contains("duration")) {
+                    auto duration_seconds = control.at("duration").get<float>();
+                    if (std::isfinite(duration_seconds) && duration_seconds >= 0.0F) {
+                        auto expiry_tp = start_time.to_time_point() +
+                                         std::chrono::duration_cast<std::chrono::seconds>(
+                                             std::chrono::duration<double>(static_cast<double>(duration_seconds)));
+                        if (ocpp::DateTime(expiry_tp) <= now) {
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            active.push_back(control.at("request").get<SetDERControlRequest>());
+        } catch (const std::exception& e) {
+            // Dropping a row under wholesale-replace means the provider stops enforcing a directive the
+            // DB still holds active — possible DER state desync, so log at error. controlId is best-effort.
+            std::string control_id = "<unknown>";
+            try {
+                control_id = json::parse(control_json_str).at("request").at("controlId").get<std::string>();
+            } catch (const std::exception&) {
+            }
+            EVLOG_error << "Dropping malformed DER control row (controlId=" << control_id
+                        << ") from the active directive set: " << e.what()
+                        << " — enforcement of this directive stops, possible DER state desync";
+        }
+    }
+    return active;
+}
+
+void DERControl::emit_active_directives() const {
+    if (!this->active_directives_callback.has_value()) {
+        return;
+    }
+
+    std::vector<SetDERControlRequest> active;
+    try {
+        active = this->compute_active_directives();
+    } catch (const everest::db::QueryExecutionException& e) {
+        EVLOG_error << "DER active-directives DB read failed: " << e.what()
+                    << " — active directive set could not be recomputed and is now stale";
+        return;
+    }
+
+    try {
+        this->active_directives_callback.value()(active);
+    } catch (const std::exception& e) {
+        EVLOG_error << "DER active-directives callback threw: " << e.what();
+    } catch (...) {
+        EVLOG_error << "DER active-directives callback threw a non-std exception";
+    }
+}
+
+void DERControl::republish_active_directives() const {
+    this->emit_active_directives();
+}
+
+void DERControl::notify_der_alarm(const NotifyDERAlarmRequest& request) {
+    ocpp::Call<NotifyDERAlarmRequest> call(request);
+    this->context.message_dispatcher.dispatch_call(call, false);
+}
+
 void DERControl::check_scheduled_controls() {
     // DB writes inside the transaction; notifications queued and dispatched post-commit
     // so rollback discards them and CSMS never sees a notify for rolled-back state.
     // Reboot replay: FR.20/22 use timestamp = dispatch-time, so first post-boot run fires elapsed schedules.
     std::vector<NotifyDERStartStopRequest> pending_notifications;
+
+    bool active_set_changed = false;
 
     try {
         auto transaction = this->context.database_handler.begin_transaction();
@@ -804,6 +903,7 @@ void DERControl::check_scheduled_controls() {
             start_req.supersededIds = std::optional<std::vector<CiString<36>>>{
                 std::vector<CiString<36>>{CiString<36>(activation.existing_id)}};
             pending_notifications.push_back(std::move(start_req));
+            active_set_changed = true;
         }
 
         // R04.FR.20/21: first-observation start-notify for non-default scheduled controls.
@@ -815,6 +915,7 @@ void DERControl::check_scheduled_controls() {
             start_req.started = true;
             start_req.timestamp = now;
             pending_notifications.push_back(std::move(start_req));
+            active_set_changed = true;
         }
 
         auto controls = this->context.database_handler.get_der_controls_matching_criteria(std::optional<bool>(false),
@@ -870,6 +971,7 @@ void DERControl::check_scheduled_controls() {
                     pending_notifications.push_back(std::move(stop_req));
 
                     this->context.database_handler.delete_der_control(control_id);
+                    active_set_changed = true;
                     // DEBUG: routine, contains CSMS string
                     EVLOG_debug << "DER control " << control_id << " expired, deleted from database";
                 }
@@ -893,6 +995,10 @@ void DERControl::check_scheduled_controls() {
         } catch (const std::exception& e) {
             EVLOG_error << "DER scheduled-control notify dispatch failed: " << e.what();
         }
+    }
+
+    if (active_set_changed) {
+        this->emit_active_directives();
     }
 }
 

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.cpp
@@ -12,10 +12,11 @@ using namespace everest::db::sqlite;
 
 namespace ocpp::v2 {
 DeviceModelTestHelper::DeviceModelTestHelper(const std::string& database_path, const std::string& migration_files_path,
-                                             const std::string& config_path) :
+                                             const std::string& config_path, bool seed_der_ctrlr_enabled) :
     database_path(database_path),
     migration_files_path(migration_files_path),
     config_path(config_path),
+    seed_der_ctrlr_enabled(seed_der_ctrlr_enabled),
     database_connection(std::make_unique<everest::db::sqlite::Connection>(database_path)) {
     this->database_connection->open_connection();
     this->device_model = create_device_model();
@@ -233,6 +234,26 @@ void DeviceModelTestHelper::create_device_model_db() {
         v2x_ctrl.name = "V2XChargingCtrlr";
         v2x_ctrl.evse_id = evse_id;
         component_configs.insert(std::make_pair(v2x_ctrl, v2x_variables));
+    }
+
+    if (this->seed_der_ctrlr_enabled) {
+        DeviceModelVariable der_enabled;
+        der_enabled.name = "Enabled";
+        VariableCharacteristics der_enabled_characteristics;
+        der_enabled_characteristics.dataType = DataEnum::boolean;
+        der_enabled_characteristics.supportsMonitoring = false;
+        der_enabled.characteristics = der_enabled_characteristics;
+        DbVariableAttribute der_enabled_attribute;
+        der_enabled_attribute.variable_attribute.mutability = MutabilityEnum::ReadWrite;
+        der_enabled_attribute.variable_attribute.value = "true";
+        der_enabled_attribute.variable_attribute.type = AttributeEnum::Actual;
+        der_enabled.attributes = std::vector<DbVariableAttribute>{der_enabled_attribute};
+        for (auto& [component_key, variables] : component_configs) {
+            if ((component_key.name == "DCDERCtrlr" || component_key.name == "ACDERCtrlr") &&
+                component_key.evse_id == 1) {
+                variables.push_back(der_enabled);
+            }
+        }
     }
 
     db.initialize_database(component_configs, true);

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/device_model_test_helper.hpp
@@ -32,9 +32,13 @@ namespace v2 {
 
 class DeviceModelTestHelper {
 public:
+    /// \param seed_der_ctrlr_enabled  When true, seed a DCDERCtrlr EVSE 1 `Enabled` variable (ReadWrite boolean,
+    ///                                initial "true"). The shipped DER config carries no `Enabled` variable, so tests
+    ///                                that need to flip it must opt in here; leaving it false keeps the absent-variable
+    ///                                path intact for existing tests.
     explicit DeviceModelTestHelper(const std::string& database_path = DEVICE_MODEL_DB_IN_MEMORY_PATH,
                                    const std::string& migration_files_path = MIGRATION_FILES_PATH,
-                                   const std::string& config_path = CONFIG_PATH);
+                                   const std::string& config_path = CONFIG_PATH, bool seed_der_ctrlr_enabled = false);
     DeviceModel* get_device_model();
 
     ///
@@ -102,6 +106,7 @@ private:
     const std::string& database_path;
     const std::string& migration_files_path;
     const std::string& config_path;
+    bool seed_der_ctrlr_enabled;
 
     // Connection as member so the database keeps open and is not destroyed (because this is an in memory
     // database).

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
@@ -84,6 +84,8 @@ public:
         v2x_ctrl.evse_id = 2;
         component_configs.insert(std::make_pair(v2x_ctrl, variables));
 
+        // ACDERCtrlr on an in-range EVSE: Available is a ReadOnly capability flag fixed true, Enabled is the
+        // ReadWrite runtime gate defaulting false. The DER block must stay unbuilt until Enabled flips true.
         std::vector<DeviceModelVariable> ac_der_variables;
         DeviceModelVariable ac_der_available;
         ac_der_available.name = "Available";
@@ -92,14 +94,26 @@ public:
         ac_der_available_characteristics.supportsMonitoring = false;
         ac_der_available.characteristics = ac_der_available_characteristics;
         DbVariableAttribute ac_der_available_attribute;
-        ac_der_available_attribute.variable_attribute.mutability = MutabilityEnum::ReadWrite;
-        ac_der_available_attribute.variable_attribute.value = "false";
+        ac_der_available_attribute.variable_attribute.mutability = MutabilityEnum::ReadOnly;
+        ac_der_available_attribute.variable_attribute.value = "true";
         ac_der_available_attribute.variable_attribute.type = AttributeEnum::Actual;
         ac_der_available.attributes = std::vector<DbVariableAttribute>{ac_der_available_attribute};
         ac_der_variables.push_back(ac_der_available);
+        DeviceModelVariable ac_der_enabled;
+        ac_der_enabled.name = "Enabled";
+        VariableCharacteristics ac_der_enabled_characteristics;
+        ac_der_enabled_characteristics.dataType = DataEnum::boolean;
+        ac_der_enabled_characteristics.supportsMonitoring = false;
+        ac_der_enabled.characteristics = ac_der_enabled_characteristics;
+        DbVariableAttribute ac_der_enabled_attribute;
+        ac_der_enabled_attribute.variable_attribute.mutability = MutabilityEnum::ReadWrite;
+        ac_der_enabled_attribute.variable_attribute.value = "false";
+        ac_der_enabled_attribute.variable_attribute.type = AttributeEnum::Actual;
+        ac_der_enabled.attributes = std::vector<DbVariableAttribute>{ac_der_enabled_attribute};
+        ac_der_variables.push_back(ac_der_enabled);
         ComponentKey ac_der_ctrl;
         ac_der_ctrl.name = "ACDERCtrlr";
-        ac_der_ctrl.evse_id = 3;
+        ac_der_ctrl.evse_id = 2;
         component_configs.insert(std::make_pair(ac_der_ctrl, ac_der_variables));
 
         db.initialize_database(component_configs, true);
@@ -543,21 +557,24 @@ TEST_F(ChargePointCommonTestFixtureV2, DERComponentPresentRequiresActiveDirectiv
     configure_callbacks_with_mocks();
 
     // EVSE 1 (DC DER present): unset callback invalid, set callback valid.
+    std::map<std::int32_t, std::int32_t> evse_connector_structure_dc_der;
+    evse_connector_structure_dc_der.insert_or_assign(1, 1);
     callbacks.der_active_directives_callback = std::nullopt;
-    EXPECT_FALSE(callbacks.all_callbacks_valid(device_model, evse_connector_structure));
+    EXPECT_FALSE(callbacks.all_callbacks_valid(device_model, evse_connector_structure_dc_der));
 
     callbacks.der_active_directives_callback = [](const std::vector<ocpp::v21::SetDERControlRequest>&) {};
-    EXPECT_TRUE(callbacks.all_callbacks_valid(device_model, evse_connector_structure));
+    EXPECT_TRUE(callbacks.all_callbacks_valid(device_model, evse_connector_structure_dc_der));
 
-    // EVSE 2 (no DER): absent callback is valid.
+    // EVSE 4 (no DER component): absent callback is valid.
     std::map<std::int32_t, std::int32_t> evse_connector_structure_no_der;
-    evse_connector_structure_no_der.insert_or_assign(2, 1);
+    evse_connector_structure_no_der.insert_or_assign(4, 1);
     callbacks.der_active_directives_callback = std::nullopt;
     EXPECT_TRUE(callbacks.all_callbacks_valid(device_model, evse_connector_structure_no_der));
 
-    // EVSE 3 (AC DER only): same presence requirement via the AC term of der_present.
+    // EVSE 2 (AC DER only): same presence requirement via the AC term of der_present. Presence gates on the
+    // Available variable existing, so Enabled==false does not hide it.
     std::map<std::int32_t, std::int32_t> evse_connector_structure_ac_der;
-    evse_connector_structure_ac_der.insert_or_assign(3, 1);
+    evse_connector_structure_ac_der.insert_or_assign(2, 1);
     callbacks.der_active_directives_callback = std::nullopt;
     EXPECT_FALSE(callbacks.all_callbacks_valid(device_model, evse_connector_structure_ac_der));
 
@@ -874,14 +891,16 @@ TEST_F(ChargePointFunctionalityTestFixtureV2, OnDerAlarm_WhenDerControlAbsent_No
     EXPECT_NO_FATAL_FAILURE(charge_point->on_der_alarm(req));
 }
 
-// The DER block is built only once a component reports Available==true. EVSE 1's DC DER component defaults
-// to false, so SetDERControl gets NotImplemented at first and a CALLRESULT after Available flips true.
-TEST_F(ChargePointFunctionalityTestFixtureV2, SetDERControl_BuildsBlockWhenAvailableFlipsTrue) {
+// The DER block is built only once a component reports Enabled==true. EVSE 2's AC DER component is
+// Available==true but Enabled==false at construction, so SetDERControl gets NotImplemented at first and a
+// CALLRESULT after Enabled flips true.
+TEST_F(ChargePointFunctionalityTestFixtureV2, SetDERControl_BuildsBlockWhenEnabledFlipsTrue) {
     ocpp::v21::SetDERControlRequest req;
     req.isDefault = false;
     req.controlId = "ctrl-lifecycle";
-    // HFMustTrip is not in DCDERCtrlr_1.json's ModesSupported, so once the block exists it answers with a
-    // CALLRESULT (NotSupported) without touching the DER database tables.
+    // Once the block exists the request is accepted: EVSE 2's AC DER component is enabled by then and AC
+    // admission accepts all control types. The persisted control is deleted at the end of the test because
+    // the handler database is file-backed and shared across tests.
     req.controlType = DERControlEnum::HFMustTrip;
     DERCurve curve;
     curve.priority = 0;
@@ -896,7 +915,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV2, SetDERControl_BuildsBlockWhenAvail
         return request_to_enhanced_message<ocpp::v21::SetDERControlRequest, MessageType::SetDERControl>(req);
     };
 
-    // Available==false at construction: block absent, response is a NotImplemented CALLERROR.
+    // Enabled==false at construction: block absent, response is a NotImplemented CALLERROR.
     this->sent_messages.clear();
     charge_point->handle_message(build_message());
     ASSERT_FALSE(this->sent_messages.empty());
@@ -904,9 +923,9 @@ TEST_F(ChargePointFunctionalityTestFixtureV2, SetDERControl_BuildsBlockWhenAvail
     EXPECT_EQ(error_response.at(MESSAGE_TYPE_ID).get<MessageTypeId>(), MessageTypeId::CALLERROR);
     EXPECT_EQ(error_response.at(CALLERROR_ERROR_CODE).get<std::string>(), "NotImplemented");
 
-    // Flip Available true: the registered variable listener builds the block.
-    const auto der_available_cv = DERComponentVariables::get_dc_component_variable(1, DERComponentVariables::Available);
-    this->device_model->set_value(der_available_cv.component, der_available_cv.variable.value(), AttributeEnum::Actual,
+    // Flip Enabled true: the registered variable listener builds the block.
+    const auto der_enabled_cv = DERComponentVariables::get_ac_component_variable(2, DERComponentVariables::Enabled);
+    this->device_model->set_value(der_enabled_cv.component, der_enabled_cv.variable.value(), AttributeEnum::Actual,
                                   "true", "internal", true);
 
     // Same SetDERControl now reaches the block and is answered with a CALLRESULT (not NotImplemented).
@@ -915,22 +934,73 @@ TEST_F(ChargePointFunctionalityTestFixtureV2, SetDERControl_BuildsBlockWhenAvail
     ASSERT_FALSE(this->sent_messages.empty());
     const auto& result_response = this->sent_messages.back();
     EXPECT_EQ(result_response.at(MESSAGE_TYPE_ID).get<MessageTypeId>(), MessageTypeId::CALLRESULT);
+
+    auto cleanup_handler = create_database_handler();
+    cleanup_handler->open_connection();
+    cleanup_handler->delete_der_control("ctrl-lifecycle");
 }
 
-// When the DER block is built (here lazily, once a DER component reports Available==true), it self-emits
+// When the DER block is built (here lazily, once a DER component reports Enabled==true), it self-emits
 // the current active set so the provider learns the standing state. The DER_CONTROLS table is empty at
 // startup, so the initial emit carries an empty set.
 TEST_F(ChargePointFunctionalityTestFixtureV2, DerBlockBuild_EmitsInitialActiveSet) {
-    // EVSE 1's DC DER component defaults to Available==false, so no block (and no emit) yet at construction.
+    // EVSE 2's AC DER component is Available==true but Enabled==false, so no block (and no emit) yet at
+    // construction.
     ASSERT_EQ(this->der_active_directives_emit_count, 0);
 
-    // Flip Available true: the registered variable listener builds the block, which self-emits its
+    // Flip Enabled true: the registered variable listener builds the block, which self-emits its
     // initial (empty) active set.
-    const auto der_available_cv = DERComponentVariables::get_dc_component_variable(1, DERComponentVariables::Available);
-    this->device_model->set_value(der_available_cv.component, der_available_cv.variable.value(), AttributeEnum::Actual,
+    const auto der_enabled_cv = DERComponentVariables::get_ac_component_variable(2, DERComponentVariables::Enabled);
+    this->device_model->set_value(der_enabled_cv.component, der_enabled_cv.variable.value(), AttributeEnum::Actual,
                                   "true", "internal", true);
 
     EXPECT_EQ(this->der_active_directives_emit_count, 1);
     EXPECT_TRUE(this->last_der_active_directives.empty());
+}
+
+// Available==true alone must not build the DER block at boot: the Enabled gate (false here) keeps it unbuilt.
+TEST_F(ChargePointFunctionalityTestFixtureV2, DerBlock_NotBuiltAtBoot_WhenAvailableTrueButEnabledFalse) {
+    // EVSE 2's AC DER component is Available==true, Enabled==false at construction. No block, no emit.
+    EXPECT_EQ(this->der_active_directives_emit_count, 0);
+
+    ocpp::v21::SetDERControlRequest req;
+    req.isDefault = false;
+    req.controlId = "ctrl-boot-gate";
+    req.controlType = DERControlEnum::HFMustTrip;
+    DERCurve curve;
+    curve.priority = 0;
+    curve.yUnit = DERUnitEnum::Not_Applicable;
+    DERCurvePoints p1;
+    p1.x = 0.0f;
+    p1.y = 0.0f;
+    curve.curveData = {p1};
+    req.curve = curve;
+
+    this->sent_messages.clear();
+    charge_point->handle_message(
+        request_to_enhanced_message<ocpp::v21::SetDERControlRequest, MessageType::SetDERControl>(req));
+    ASSERT_FALSE(this->sent_messages.empty());
+    const auto& error_response = this->sent_messages.back();
+    EXPECT_EQ(error_response.at(MESSAGE_TYPE_ID).get<MessageTypeId>(), MessageTypeId::CALLERROR);
+    EXPECT_EQ(error_response.at(CALLERROR_ERROR_CODE).get<std::string>(), "NotImplemented");
+}
+
+// Strict opt-in: a DER component with Available==true but no Enabled variable stays disabled, so the
+// block is not built at boot (Enabled.value_or(false)).
+TEST_F(ChargePointConstructorTestFixtureV2, DerBlock_NotBuiltAtBoot_WhenNoEnabledVariable) {
+    configure_callbacks_with_mocks();
+
+    // EVSE 1's DC DER component (from DCDERCtrlr_1.json) has no Enabled variable. Flip its Available true
+    // before construction; the missing Enabled must keep the block unbuilt.
+    const auto dc_available_cv = DERComponentVariables::get_dc_component_variable(1, DERComponentVariables::Available);
+    this->device_model->set_value(dc_available_cv.component, dc_available_cv.variable.value(), AttributeEnum::Actual,
+                                  "true", "internal", true);
+
+    ASSERT_EQ(this->der_active_directives_emit_count, 0);
+
+    ocpp::v2::ChargePoint charge_point(evse_connector_structure, device_model, database_handler,
+                                       create_message_queue(database_handler), "/tmp", evse_security, callbacks);
+
+    EXPECT_EQ(this->der_active_directives_emit_count, 0);
 }
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v2/test_charge_point.cpp
@@ -15,6 +15,8 @@
 #include "ocpp/v2/init_device_model_db.hpp"
 #include "ocpp/v2/ocpp_enums.hpp"
 #include "ocpp/v2/types.hpp"
+#include "ocpp/v21/messages/NotifyDERAlarm.hpp"
+#include "ocpp/v21/messages/SetDERControl.hpp"
 #include "smart_charging_test_utils.hpp"
 
 #include "gmock/gmock.h"
@@ -81,6 +83,25 @@ public:
         component_configs.insert(std::make_pair(v2x_ctrl, variables));
         v2x_ctrl.evse_id = 2;
         component_configs.insert(std::make_pair(v2x_ctrl, variables));
+
+        std::vector<DeviceModelVariable> ac_der_variables;
+        DeviceModelVariable ac_der_available;
+        ac_der_available.name = "Available";
+        VariableCharacteristics ac_der_available_characteristics;
+        ac_der_available_characteristics.dataType = DataEnum::boolean;
+        ac_der_available_characteristics.supportsMonitoring = false;
+        ac_der_available.characteristics = ac_der_available_characteristics;
+        DbVariableAttribute ac_der_available_attribute;
+        ac_der_available_attribute.variable_attribute.mutability = MutabilityEnum::ReadWrite;
+        ac_der_available_attribute.variable_attribute.value = "false";
+        ac_der_available_attribute.variable_attribute.type = AttributeEnum::Actual;
+        ac_der_available.attributes = std::vector<DbVariableAttribute>{ac_der_available_attribute};
+        ac_der_variables.push_back(ac_der_available);
+        ComponentKey ac_der_ctrl;
+        ac_der_ctrl.name = "ACDERCtrlr";
+        ac_der_ctrl.evse_id = 3;
+        component_configs.insert(std::make_pair(ac_der_ctrl, ac_der_variables));
+
         db.initialize_database(component_configs, true);
     }
 
@@ -123,7 +144,10 @@ public:
     create_message_queue(std::shared_ptr<DatabaseHandler>& database_handler) {
         const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 2E5;
         return std::make_shared<ocpp::MessageQueue<v2::MessageType>>(
-            [this](json message) -> bool { return false; },
+            [this](json message) -> bool {
+                this->sent_messages.push_back(message);
+                return false;
+            },
             MessageQueueConfig<v2::MessageType>{
                 this->device_model->get_value<int>(ControllerComponentVariables::MessageAttempts),
                 this->device_model->get_value<int>(ControllerComponentVariables::MessageAttemptInterval),
@@ -154,10 +178,16 @@ public:
         callbacks.cancel_reservation_callback = cancel_reservation_callback_mock.AsStdFunction();
         callbacks.update_allowed_energy_transfer_modes_callback =
             update_allowed_energy_transfer_modes_callback.AsStdFunction();
+        callbacks.der_active_directives_callback = [this](const std::vector<ocpp::v21::SetDERControlRequest>& active) {
+            this->der_active_directives_emit_count++;
+            this->last_der_active_directives = active;
+        };
     }
 
     std::shared_ptr<DeviceModel> device_model;
     std::map<std::int32_t, std::int32_t> evse_connector_structure;
+
+    std::vector<json> sent_messages;
 
     testing::MockFunction<bool(const std::optional<const std::int32_t> evse_id, const ResetEnum& reset_type)>
         is_reset_allowed_callback_mock;
@@ -191,6 +221,9 @@ public:
         update_allowed_energy_transfer_modes_callback;
 
     ocpp::v2::Callbacks callbacks;
+
+    int der_active_directives_emit_count = 0;
+    std::vector<ocpp::v21::SetDERControlRequest> last_der_active_directives;
 };
 
 /*
@@ -487,6 +520,49 @@ TEST_F(ChargePointCommonTestFixtureV2,
         transaction_event_response_callback_mock;
     callbacks.transaction_event_response_callback = transaction_event_response_callback_mock.AsStdFunction();
     EXPECT_TRUE(callbacks.all_callbacks_valid(device_model, evse_connector_structure));
+}
+
+// A set-but-empty der_active_directives_callback is invalid (a registered-yet-null
+// optional callback must fail validation); unset or non-null is valid.
+TEST_F(ChargePointCommonTestFixtureV2,
+       K01FR02_CallbacksValidityChecksIfOptionalDERActiveDirectivesCallbackIsNotSetOrNotNull) {
+    configure_callbacks_with_mocks();
+
+    callbacks.der_active_directives_callback = nullptr;
+    EXPECT_FALSE(callbacks.all_callbacks_valid(device_model, evse_connector_structure));
+
+    testing::MockFunction<void(const std::vector<ocpp::v21::SetDERControlRequest>& active_controls)>
+        der_active_directives_callback_mock;
+    callbacks.der_active_directives_callback = der_active_directives_callback_mock.AsStdFunction();
+    EXPECT_TRUE(callbacks.all_callbacks_valid(device_model, evse_connector_structure));
+}
+
+// der_active_directives_callback is required on component presence, not availability. EVSE 1 has a DC DER
+// component, EVSE 2 has none, EVSE 3 has only an AC DER component (covers the AC term of der_present).
+TEST_F(ChargePointCommonTestFixtureV2, DERComponentPresentRequiresActiveDirectivesCallback) {
+    configure_callbacks_with_mocks();
+
+    // EVSE 1 (DC DER present): unset callback invalid, set callback valid.
+    callbacks.der_active_directives_callback = std::nullopt;
+    EXPECT_FALSE(callbacks.all_callbacks_valid(device_model, evse_connector_structure));
+
+    callbacks.der_active_directives_callback = [](const std::vector<ocpp::v21::SetDERControlRequest>&) {};
+    EXPECT_TRUE(callbacks.all_callbacks_valid(device_model, evse_connector_structure));
+
+    // EVSE 2 (no DER): absent callback is valid.
+    std::map<std::int32_t, std::int32_t> evse_connector_structure_no_der;
+    evse_connector_structure_no_der.insert_or_assign(2, 1);
+    callbacks.der_active_directives_callback = std::nullopt;
+    EXPECT_TRUE(callbacks.all_callbacks_valid(device_model, evse_connector_structure_no_der));
+
+    // EVSE 3 (AC DER only): same presence requirement via the AC term of der_present.
+    std::map<std::int32_t, std::int32_t> evse_connector_structure_ac_der;
+    evse_connector_structure_ac_der.insert_or_assign(3, 1);
+    callbacks.der_active_directives_callback = std::nullopt;
+    EXPECT_FALSE(callbacks.all_callbacks_valid(device_model, evse_connector_structure_ac_der));
+
+    callbacks.der_active_directives_callback = [](const std::vector<ocpp::v21::SetDERControlRequest>&) {};
+    EXPECT_TRUE(callbacks.all_callbacks_valid(device_model, evse_connector_structure_ac_der));
 }
 
 TEST_F(ChargePointCommonTestFixtureV2, ReservationAvailableReserveNowCallbackNotSet) {
@@ -786,5 +862,75 @@ TEST_F(ChargePointFunctionalityTestFixtureV2, K02FR05_TransactionEnds_WillDelete
     EXPECT_CALL(*smart_charging, delete_transaction_tx_profiles(transaction->get_transaction().transactionId.get()));
     charge_point->on_transaction_finished(DEFAULT_EVSE_ID, timestamp, MeterValue(), ReasonEnum::StoppedByEV,
                                           TriggerReasonEnum::StopAuthorized, {}, {}, ChargingStateEnum::EVConnected);
+}
+
+// on_der_alarm must no-op (not dereference null) when no DER component exists and der_control is unbuilt.
+TEST_F(ChargePointFunctionalityTestFixtureV2, OnDerAlarm_WhenDerControlAbsent_NoOpsWithoutCrash) {
+    ocpp::v21::NotifyDERAlarmRequest req;
+    req.controlType = ocpp::v2::DERControlEnum::FreqDroop;
+    req.timestamp = ocpp::DateTime("2020-01-01T00:00:00Z");
+    req.gridEventFault = ocpp::v2::GridEventFaultEnum::OverFrequency;
+
+    EXPECT_NO_FATAL_FAILURE(charge_point->on_der_alarm(req));
+}
+
+// The DER block is built only once a component reports Available==true. EVSE 1's DC DER component defaults
+// to false, so SetDERControl gets NotImplemented at first and a CALLRESULT after Available flips true.
+TEST_F(ChargePointFunctionalityTestFixtureV2, SetDERControl_BuildsBlockWhenAvailableFlipsTrue) {
+    ocpp::v21::SetDERControlRequest req;
+    req.isDefault = false;
+    req.controlId = "ctrl-lifecycle";
+    // HFMustTrip is not in DCDERCtrlr_1.json's ModesSupported, so once the block exists it answers with a
+    // CALLRESULT (NotSupported) without touching the DER database tables.
+    req.controlType = DERControlEnum::HFMustTrip;
+    DERCurve curve;
+    curve.priority = 0;
+    curve.yUnit = DERUnitEnum::Not_Applicable;
+    DERCurvePoints p1;
+    p1.x = 0.0f;
+    p1.y = 0.0f;
+    curve.curveData = {p1};
+    req.curve = curve;
+
+    auto build_message = [&]() {
+        return request_to_enhanced_message<ocpp::v21::SetDERControlRequest, MessageType::SetDERControl>(req);
+    };
+
+    // Available==false at construction: block absent, response is a NotImplemented CALLERROR.
+    this->sent_messages.clear();
+    charge_point->handle_message(build_message());
+    ASSERT_FALSE(this->sent_messages.empty());
+    const auto& error_response = this->sent_messages.back();
+    EXPECT_EQ(error_response.at(MESSAGE_TYPE_ID).get<MessageTypeId>(), MessageTypeId::CALLERROR);
+    EXPECT_EQ(error_response.at(CALLERROR_ERROR_CODE).get<std::string>(), "NotImplemented");
+
+    // Flip Available true: the registered variable listener builds the block.
+    const auto der_available_cv = DERComponentVariables::get_dc_component_variable(1, DERComponentVariables::Available);
+    this->device_model->set_value(der_available_cv.component, der_available_cv.variable.value(), AttributeEnum::Actual,
+                                  "true", "internal", true);
+
+    // Same SetDERControl now reaches the block and is answered with a CALLRESULT (not NotImplemented).
+    this->sent_messages.clear();
+    charge_point->handle_message(build_message());
+    ASSERT_FALSE(this->sent_messages.empty());
+    const auto& result_response = this->sent_messages.back();
+    EXPECT_EQ(result_response.at(MESSAGE_TYPE_ID).get<MessageTypeId>(), MessageTypeId::CALLRESULT);
+}
+
+// When the DER block is built (here lazily, once a DER component reports Available==true), it self-emits
+// the current active set so the provider learns the standing state. The DER_CONTROLS table is empty at
+// startup, so the initial emit carries an empty set.
+TEST_F(ChargePointFunctionalityTestFixtureV2, DerBlockBuild_EmitsInitialActiveSet) {
+    // EVSE 1's DC DER component defaults to Available==false, so no block (and no emit) yet at construction.
+    ASSERT_EQ(this->der_active_directives_emit_count, 0);
+
+    // Flip Available true: the registered variable listener builds the block, which self-emits its
+    // initial (empty) active set.
+    const auto der_available_cv = DERComponentVariables::get_dc_component_variable(1, DERComponentVariables::Available);
+    this->device_model->set_value(der_available_cv.component, der_available_cv.variable.value(), AttributeEnum::Actual,
+                                  "true", "internal", true);
+
+    EXPECT_EQ(this->der_active_directives_emit_count, 1);
+    EXPECT_TRUE(this->last_der_active_directives.empty());
 }
 } // namespace ocpp::v2

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_der_control.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_der_control.cpp
@@ -54,8 +54,11 @@ protected:
     std::atomic<ocpp::OcppProtocolVersion> ocpp_version;
     FunctionalBlockContext functional_block_context;
 
-    DERControlTest() :
-        device_model_test_helper(),
+    DERControlTest() : DERControlTest(true) {
+    }
+
+    explicit DERControlTest(bool seed_der_enabled) :
+        device_model_test_helper(DEVICE_MODEL_DB_IN_MEMORY_PATH, MIGRATION_FILES_PATH, CONFIG_PATH, seed_der_enabled),
         mock_dispatcher(),
         device_model(device_model_test_helper.get_device_model()),
         connectivity_manager(),
@@ -74,6 +77,12 @@ protected:
         ON_CALL(database_handler_mock, begin_transaction()).WillByDefault(Invoke([] {
             return std::make_unique<::testing::NiceMock<TransactionMock>>();
         }));
+
+        // DC admission gates on Available; the test config ships it false.
+        const auto dc_available_cv =
+            DERComponentVariables::get_dc_component_variable(1, DERComponentVariables::Available);
+        device_model->set_value(dc_available_cv.component, dc_available_cv.variable.value(), AttributeEnum::Actual,
+                                "true", "TEST", true);
     }
 
     // DCDERCtrlr values for EVSE 1 come from the test-only DER config at
@@ -150,6 +159,22 @@ protected:
         ASSERT_EQ(this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "true",
                                                 "TEST", true),
                   SetVariableStatusEnum::Accepted);
+    }
+
+    SetDERControlRequest make_hf_must_trip_request(const std::string& control_id) {
+        SetDERControlRequest req;
+        req.isDefault = true;
+        req.controlId = control_id;
+        req.controlType = DERControlEnum::HFMustTrip; // Not in the DC ModesSupported
+        DERCurve curve;
+        curve.priority = 0;
+        curve.yUnit = DERUnitEnum::Not_Applicable;
+        DERCurvePoints p1;
+        p1.x = 62.0f;
+        p1.y = 1.0f;
+        curve.curveData = {p1};
+        req.curve = curve;
+        return req;
     }
 };
 
@@ -247,6 +272,156 @@ TEST_F(DERControlTest, SetDERControl_NewDefault_Accepted) {
     EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
         auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<SetDERControlResponse>();
         EXPECT_EQ(response.status, DERControlStatusEnum::Accepted);
+    }));
+
+    der_control.handle_message(msg);
+}
+
+// --- R04.FR.01: Admission skips DER EVSEs whose Enabled variable is "false" ---
+
+// Fixture alias for tests that flip the seeded Enabled variable on the DCDERCtrlr and ACDERCtrlr EVSE 1
+// components. The base fixture seeds Enabled "true" by default; a missing Enabled variable means disabled.
+class DERControlEnabledTest : public DERControlTest {
+protected:
+    void set_dc_der_enabled(int32_t evse_id, const std::string& value) {
+        const auto cv = DERComponentVariables::get_dc_component_variable(evse_id, DERComponentVariables::Enabled);
+        device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, value, "test", true);
+    }
+
+    void set_ac_der_enabled(int32_t evse_id, const std::string& value) {
+        const auto cv = DERComponentVariables::get_ac_component_variable(evse_id, DERComponentVariables::Enabled);
+        device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, value, "test", true);
+    }
+};
+
+// Fixture without the seeded Enabled variable: strict opt-in, absent Enabled admits nothing.
+class DERControlAbsentEnabledTest : public DERControlTest {
+protected:
+    DERControlAbsentEnabledTest() : DERControlTest(false) {
+    }
+};
+
+TEST_F(DERControlEnabledTest, SetDERControl_EvseDisabled_ReturnsNotSupported) {
+    set_dc_der_enabled(1, "false");
+
+    DERControl der_control(functional_block_context);
+    auto req = make_freq_droop_request("ctrl-disabled", true, 0);
+    auto msg = make_set_der_control_msg(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<SetDERControlResponse>();
+        EXPECT_EQ(response.status, DERControlStatusEnum::NotSupported);
+    }));
+
+    der_control.handle_message(msg);
+}
+
+TEST_F(DERControlEnabledTest, SetDERControl_EvseReEnabled_Accepted) {
+    set_dc_der_enabled(1, "true");
+
+    DERControl der_control(functional_block_context);
+    auto req = make_freq_droop_request("ctrl-reenabled", true, 0);
+    auto msg = make_set_der_control_msg(req);
+
+    EXPECT_CALL(database_handler_mock,
+                get_der_controls_matching_criteria(std::optional<bool>(true), std::optional<std::string>("FreqDroop"),
+                                                   std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{}));
+    EXPECT_CALL(database_handler_mock,
+                insert_or_update_der_control("ctrl-reenabled", true, "FreqDroop", false, 0, _, _, _))
+        .Times(1);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<SetDERControlResponse>();
+        EXPECT_EQ(response.status, DERControlStatusEnum::Accepted);
+    }));
+
+    der_control.handle_message(msg);
+}
+
+// The AC accept-all admission is gated per EVSE on Enabled: an available but disabled ACDERCtrlr must not
+// accept a control type no enabled component supports.
+TEST_F(DERControlEnabledTest, SetDERControl_AcAvailableButDisabled_ReturnsNotSupported) {
+    enable_ac_der();
+    set_ac_der_enabled(1, "false");
+
+    DERControl der_control(functional_block_context);
+    auto msg = make_set_der_control_msg(make_hf_must_trip_request("ctrl-ac-disabled"));
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<SetDERControlResponse>();
+        EXPECT_EQ(response.status, DERControlStatusEnum::NotSupported);
+    }));
+
+    der_control.handle_message(msg);
+}
+
+// With the ACDERCtrlr available and explicitly enabled, the accept-all admission fires for a control type
+// absent from the DC ModesSupported.
+TEST_F(DERControlEnabledTest, SetDERControl_AcAvailableAndEnabled_AcceptsUnlistedType) {
+    enable_ac_der();
+    set_ac_der_enabled(1, "true");
+
+    DERControl der_control(functional_block_context);
+    auto msg = make_set_der_control_msg(make_hf_must_trip_request("ctrl-ac-enabled"));
+
+    EXPECT_CALL(database_handler_mock,
+                get_der_controls_matching_criteria(std::optional<bool>(true), std::optional<std::string>("HFMustTrip"),
+                                                   std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{}));
+    EXPECT_CALL(database_handler_mock,
+                insert_or_update_der_control("ctrl-ac-enabled", true, "HFMustTrip", false, 0, _, _, _))
+        .Times(1);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<SetDERControlResponse>();
+        EXPECT_EQ(response.status, DERControlStatusEnum::Accepted);
+    }));
+
+    der_control.handle_message(msg);
+}
+
+// DC admission requires Available: ModesSupported and Enabled alone do not admit.
+TEST_F(DERControlEnabledTest, SetDERControl_DcUnavailable_ReturnsNotSupported) {
+    const auto cv = DERComponentVariables::get_dc_component_variable(1, DERComponentVariables::Available);
+    ASSERT_EQ(device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "false", "TEST", true),
+              SetVariableStatusEnum::Accepted);
+
+    DERControl der_control(functional_block_context);
+    auto req = make_freq_droop_request("ctrl-dc-unavailable", true, 0);
+    auto msg = make_set_der_control_msg(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<SetDERControlResponse>();
+        EXPECT_EQ(response.status, DERControlStatusEnum::NotSupported);
+    }));
+
+    der_control.handle_message(msg);
+}
+
+TEST_F(DERControlAbsentEnabledTest, SetDERControl_DcNoEnabledVariable_ReturnsNotSupported) {
+    DERControl der_control(functional_block_context);
+    auto req = make_freq_droop_request("ctrl-dc-no-enabled", true, 0);
+    auto msg = make_set_der_control_msg(req);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<SetDERControlResponse>();
+        EXPECT_EQ(response.status, DERControlStatusEnum::NotSupported);
+    }));
+
+    der_control.handle_message(msg);
+}
+
+// The AC accept-all path also requires an explicit Enabled "true".
+TEST_F(DERControlAbsentEnabledTest, SetDERControl_AcNoEnabledVariable_ReturnsNotSupported) {
+    enable_ac_der();
+
+    DERControl der_control(functional_block_context);
+    auto msg = make_set_der_control_msg(make_hf_must_trip_request("ctrl-ac-no-enabled"));
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<SetDERControlResponse>();
+        EXPECT_EQ(response.status, DERControlStatusEnum::NotSupported);
     }));
 
     der_control.handle_message(msg);

--- a/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_der_control.cpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v21/functional_blocks/test_der_control.cpp
@@ -6,6 +6,8 @@
 
 #include <ocpp/v21/functional_blocks/der_control.hpp>
 
+#include <ocpp/v21/messages/NotifyDERAlarm.hpp>
+
 #include <ocpp/common/call_types.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/device_model.hpp>
@@ -2329,4 +2331,439 @@ TEST_F(DERControlTest, CheckScheduledControls_FR07_AppendsDisplacedIdOnActivatio
     EXPECT_CALL(mock_dispatcher, dispatch_call(_, _));
 
     der_control.check_scheduled_controls();
+}
+
+// =============================================================================
+// DER active-directives callback + notify_der_alarm hooks (provider notifications)
+// =============================================================================
+
+// Building the block emits the current active set once. With an empty DER_CONTROLS table the initial
+// emit carries an empty set, so the provider learns the standing state immediately at startup.
+TEST_F(DERControlTest, BuildingBlock_EmptyTable_EmitsEmptyActiveSetOnce) {
+    int emit_count = 0;
+    std::vector<SetDERControlRequest> captured;
+
+    // The construction-time emit recomputes from the whole table (no filters) and finds it empty.
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{}));
+
+    DERControl der_control(functional_block_context, [&](const std::vector<SetDERControlRequest>& active) {
+        emit_count++;
+        captured = active;
+    });
+
+    EXPECT_EQ(emit_count, 1);
+    EXPECT_TRUE(captured.empty());
+}
+
+// Building the block over a DER_CONTROLS table that already holds a standing (persisted-across-boot)
+// default control emits that control in the initial active set.
+TEST_F(DERControlTest, BuildingBlock_StandingControl_EmitsItInInitialActiveSet) {
+    std::vector<SetDERControlRequest> captured;
+
+    std::string standing_row =
+        R"({"isSuperseded":false,"priority":0,"request":{"controlId":"ctrl-standing","controlType":"FreqDroop","isDefault":true}})";
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{standing_row}));
+
+    DERControl der_control(functional_block_context,
+                           [&captured](const std::vector<SetDERControlRequest>& active) { captured = active; });
+
+    ASSERT_EQ(captured.size(), 1u);
+    EXPECT_EQ(captured[0].controlId.get(), "ctrl-standing");
+    EXPECT_EQ(captured[0].controlType, DERControlEnum::FreqDroop);
+}
+
+// republish_active_directives re-runs the existing emit path on demand: it recomputes the current
+// active set from the table and invokes the callback again, without any transition having occurred. The
+// provider uses this to learn the standing set when a newly-enabled EVSE joins an already-built block.
+TEST_F(DERControlTest, RepublishActiveDirectives_ReEmitsCurrentActiveSet) {
+    int emit_count = 0;
+    std::vector<SetDERControlRequest> captured;
+
+    // Construction-time emit over an empty table.
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{}));
+
+    DERControl der_control(functional_block_context, [&](const std::vector<SetDERControlRequest>& active) {
+        emit_count++;
+        captured = active;
+    });
+    ASSERT_EQ(emit_count, 1);
+
+    // On-demand re-emit: the table now holds a standing default; the callback fires again carrying it.
+    std::string standing_row =
+        R"({"isSuperseded":false,"priority":0,"request":{"controlId":"ctrl-standing","controlType":"FreqDroop","isDefault":true}})";
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{standing_row}));
+
+    der_control.republish_active_directives();
+
+    EXPECT_EQ(emit_count, 2);
+    ASSERT_EQ(captured.size(), 1u);
+    EXPECT_EQ(captured[0].controlId.get(), "ctrl-standing");
+}
+
+// Default Set, then a higher-priority same-type Set, then a Clear: the active-directives callback fires
+// each time carrying the effective set — first the default, then only the winner, then empty.
+TEST_F(DERControlTest, ActiveDirectivesEmittedOnTransitions) {
+    std::vector<SetDERControlRequest> captured;
+    DERControl der_control(functional_block_context,
+                           [&captured](const std::vector<SetDERControlRequest>& active) { captured = active; });
+
+    // CONTROL_JSON for a default FreqDroop control as it would be persisted.
+    auto default_row = [](const std::string& id, int32_t priority) {
+        json stored;
+        stored["isSuperseded"] = false;
+        stored["priority"] = priority;
+        json request;
+        request["isDefault"] = true;
+        request["controlId"] = id;
+        request["controlType"] = "FreqDroop";
+        json fd;
+        fd["priority"] = priority;
+        fd["overFreq"] = 61.0;
+        fd["underFreq"] = 59.0;
+        fd["overDroop"] = 5.0;
+        fd["underDroop"] = 5.0;
+        fd["responseTime"] = 3.0;
+        request["freqDroop"] = fd;
+        stored["request"] = request;
+        return stored.dump();
+    };
+
+    // --- Transition 1: accept a new default FreqDroop control (priority 5). ---
+    {
+        auto req = make_freq_droop_request("ctrl-default", true, 5);
+        auto msg = make_set_der_control_msg(req);
+
+        // Supersede analysis (same type / isDefault) — no existing controls.
+        EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(true),
+                                                                              std::optional<std::string>("FreqDroop"),
+                                                                              std::optional<std::string>(std::nullopt)))
+            .WillOnce(Return(std::vector<std::string>{}));
+        EXPECT_CALL(database_handler_mock,
+                    insert_or_update_der_control("ctrl-default", true, "FreqDroop", false, 5, _, _, _));
+        // emit_active_directives queries the whole table (no filters) post-commit.
+        EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                              std::optional<std::string>(std::nullopt),
+                                                                              std::optional<std::string>(std::nullopt)))
+            .WillOnce(Return(std::vector<std::string>{default_row("ctrl-default", 5)}));
+        EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+
+        der_control.handle_message(msg);
+
+        ASSERT_EQ(captured.size(), 1u);
+        EXPECT_EQ(captured[0].controlId.get(), "ctrl-default");
+        EXPECT_EQ(captured[0].controlType, DERControlEnum::FreqDroop);
+
+        ::testing::Mock::VerifyAndClearExpectations(&database_handler_mock);
+        ::testing::Mock::VerifyAndClearExpectations(&mock_dispatcher);
+    }
+
+    // --- Transition 2: a higher-priority (lower value) default supersedes it. ---
+    {
+        auto req = make_freq_droop_request("ctrl-winner", true, 0);
+        auto msg = make_set_der_control_msg(req);
+
+        // Supersede analysis returns the existing lower-priority default.
+        EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(true),
+                                                                              std::optional<std::string>("FreqDroop"),
+                                                                              std::optional<std::string>(std::nullopt)))
+            .WillOnce(Return(std::vector<std::string>{default_row("ctrl-default", 5)}));
+        EXPECT_CALL(database_handler_mock, update_der_control_superseded("ctrl-default", true));
+        EXPECT_CALL(database_handler_mock,
+                    insert_or_update_der_control("ctrl-winner", true, "FreqDroop", false, 0, _, _, _));
+        // Post-commit the table holds the winner active and the old one superseded;
+        // emit must surface only the winner.
+        std::string superseded_old =
+            R"({"isSuperseded":true,"priority":5,"request":{"controlId":"ctrl-default","controlType":"FreqDroop","isDefault":true}})";
+        EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                              std::optional<std::string>(std::nullopt),
+                                                                              std::optional<std::string>(std::nullopt)))
+            .WillOnce(Return(std::vector<std::string>{default_row("ctrl-winner", 0), superseded_old}));
+        EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+
+        der_control.handle_message(msg);
+
+        ASSERT_EQ(captured.size(), 1u);
+        EXPECT_EQ(captured[0].controlId.get(), "ctrl-winner");
+
+        ::testing::Mock::VerifyAndClearExpectations(&database_handler_mock);
+        ::testing::Mock::VerifyAndClearExpectations(&mock_dispatcher);
+    }
+
+    // --- Transition 3: clear the winner; active set becomes empty. ---
+    {
+        ClearDERControlRequest req;
+        req.isDefault = true;
+        req.controlId = "ctrl-winner";
+        auto msg = make_clear_der_control_msg(req);
+
+        EXPECT_CALL(database_handler_mock, delete_der_control_by_id_and_default("ctrl-winner", true))
+            .WillOnce(Return(true));
+        // Post-clear the table is empty.
+        EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                              std::optional<std::string>(std::nullopt),
+                                                                              std::optional<std::string>(std::nullopt)))
+            .WillOnce(Return(std::vector<std::string>{}));
+        EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+
+        der_control.handle_message(msg);
+
+        EXPECT_TRUE(captured.empty());
+    }
+}
+
+// Timer path: when check_scheduled_controls deletes an expired control, the post-commit emit recomputes
+// from the now-empty table and the captured set is empty.
+TEST_F(DERControlTest, ActiveDirectives_ScheduledExpiry_EmitsEmptyActiveSet) {
+    bool emitted = false;
+    std::vector<SetDERControlRequest> captured;
+    DERControl der_control(functional_block_context, [&](const std::vector<SetDERControlRequest>& active) {
+        emitted = true;
+        captured = active;
+    });
+
+    EXPECT_CALL(database_handler_mock, get_der_control_pending_supersede_activations(_))
+        .WillOnce(Return(std::vector<DatabaseHandlerInterface::PendingSupersedeActivation>{}));
+    EXPECT_CALL(database_handler_mock, get_der_controls_needing_start_notify(_))
+        .WillOnce(Return(std::vector<std::string>{}));
+    // Scheduled scan returns one expired control; the post-emit recompute (no
+    // filters) sees the now-empty table.
+    EXPECT_CALL(database_handler_mock,
+                get_der_controls_matching_criteria(std::optional<bool>(false), std::optional<std::string>(std::nullopt),
+                                                   std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{make_expired_scheduled_control_json("ctrl-expired")}));
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{}));
+    EXPECT_CALL(database_handler_mock, delete_der_control("ctrl-expired"));
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)); // NotifyDERStartStop(started=false)
+
+    der_control.check_scheduled_controls();
+
+    EXPECT_TRUE(emitted);
+    EXPECT_TRUE(captured.empty());
+}
+
+// Timer path: when a pending supersede's startTime arrives, check_scheduled_controls flips the displaced
+// control and the post-commit emit surfaces only the winner.
+TEST_F(DERControlTest, ActiveDirectives_DeferredSupersedeActivation_EmitsWinner) {
+    std::vector<SetDERControlRequest> captured;
+    DERControl der_control(functional_block_context,
+                           [&captured](const std::vector<SetDERControlRequest>& active) { captured = active; });
+
+    DatabaseHandlerInterface::PendingSupersedeActivation activation;
+    activation.new_id = "ctrl-winner";
+    activation.existing_id = "ctrl-displaced";
+    EXPECT_CALL(database_handler_mock, get_der_control_pending_supersede_activations(_))
+        .WillOnce(Return(std::vector<DatabaseHandlerInterface::PendingSupersedeActivation>{activation}));
+    EXPECT_CALL(database_handler_mock, get_der_controls_needing_start_notify(_))
+        .WillOnce(Return(std::vector<std::string>{}));
+
+    // CONTROL_JSON for the just-activated winner: a default FreqDroop so it is
+    // unconditionally effective in compute_active_directives.
+    std::string winner_row =
+        R"({"isSuperseded":false,"priority":0,"request":{"controlId":"ctrl-winner","controlType":"FreqDroop","isDefault":true}})";
+    std::string displaced_row =
+        R"({"isSuperseded":true,"priority":5,"request":{"controlId":"ctrl-displaced","controlType":"FreqDroop","isDefault":true}})";
+
+    // Scheduled scan (isDefault=false) finds nothing to expire; the post-emit
+    // recompute (no filters) sees the winner active and the displaced one
+    // superseded.
+    EXPECT_CALL(database_handler_mock,
+                get_der_controls_matching_criteria(std::optional<bool>(false), std::optional<std::string>(std::nullopt),
+                                                   std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{}));
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{winner_row, displaced_row}));
+
+    EXPECT_CALL(database_handler_mock, update_der_control_superseded("ctrl-displaced", true));
+    EXPECT_CALL(database_handler_mock, clear_der_control_pending_supersede("ctrl-winner"));
+    EXPECT_CALL(database_handler_mock, append_der_control_displaced_id("ctrl-winner", "ctrl-displaced"));
+    EXPECT_CALL(database_handler_mock, mark_der_control_started_notified("ctrl-winner"));
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)); // NotifyDERStartStop(started=true)
+
+    der_control.check_scheduled_controls();
+
+    ASSERT_EQ(captured.size(), 1u);
+    EXPECT_EQ(captured[0].controlId.get(), "ctrl-winner");
+}
+
+// compute_active_directives predicate (exercised via a synchronous Clear's post-commit emit): of four
+// rows — future-start, expired, superseded, current default — only the current default stays effective.
+TEST_F(DERControlTest, ComputeActiveDirectives_FiltersByEffectiveness) {
+    std::vector<SetDERControlRequest> captured;
+    DERControl der_control(functional_block_context,
+                           [&captured](const std::vector<SetDERControlRequest>& active) { captured = active; });
+
+    // Future-start: startTime far ahead → not yet effective.
+    json future;
+    future["isSuperseded"] = false;
+    future["priority"] = 1;
+    future["startTime"] = "2999-01-01T00:00:00Z";
+    future["duration"] = 3600.0F;
+    future["request"] = {{"controlId", "ctrl-future"}, {"controlType", "FreqDroop"}, {"isDefault", false}};
+
+    // Expired: startTime well in the past + short duration → already elapsed.
+    json expired;
+    expired["isSuperseded"] = false;
+    expired["priority"] = 2;
+    expired["startTime"] = "2020-01-01T00:00:00Z";
+    expired["duration"] = 60.0F;
+    expired["request"] = {{"controlId", "ctrl-expired"}, {"controlType", "FreqDroop"}, {"isDefault", false}};
+
+    // Superseded: flagged out of play.
+    json superseded;
+    superseded["isSuperseded"] = true;
+    superseded["priority"] = 3;
+    superseded["request"] = {{"controlId", "ctrl-superseded"}, {"controlType", "FreqDroop"}, {"isDefault", true}};
+
+    // Current default: no startTime → unconditionally effective.
+    json current;
+    current["isSuperseded"] = false;
+    current["priority"] = 0;
+    current["request"] = {{"controlId", "ctrl-current"}, {"controlType", "FreqDroop"}, {"isDefault", true}};
+
+    ClearDERControlRequest req;
+    req.isDefault = false;
+    req.controlId = "ctrl-expired";
+    auto msg = make_clear_der_control_msg(req);
+
+    EXPECT_CALL(database_handler_mock, delete_der_control_by_id_and_default("ctrl-expired", false))
+        .WillOnce(Return(true));
+    // Post-commit recompute observes all four rows.
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{future.dump(), expired.dump(), superseded.dump(), current.dump()}));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+
+    der_control.handle_message(msg);
+
+    ASSERT_EQ(captured.size(), 1u);
+    EXPECT_EQ(captured[0].controlId.get(), "ctrl-current");
+}
+
+// A DB read failure on the emit path is a database fault, not a callback fault: it must neither invoke
+// the provider callback nor propagate out of the timer-callback path (else io_context.run() → terminate).
+TEST_F(DERControlTest, ActiveDirectives_DbReadThrowsOnEmit_DoesNotInvokeCallback) {
+    bool callback_invoked = false;
+    DERControl der_control(functional_block_context,
+                           [&callback_invoked](const std::vector<SetDERControlRequest>&) { callback_invoked = true; });
+
+    // Disregard the construction-time initial emit; this test is about the timer-path emit.
+    callback_invoked = false;
+
+    EXPECT_CALL(database_handler_mock, get_der_control_pending_supersede_activations(_))
+        .WillOnce(Return(std::vector<DatabaseHandlerInterface::PendingSupersedeActivation>{}));
+    EXPECT_CALL(database_handler_mock, get_der_controls_needing_start_notify(_))
+        .WillOnce(Return(std::vector<std::string>{}));
+    // Scheduled scan finds one expired control → a transition occurs → emit runs.
+    EXPECT_CALL(database_handler_mock,
+                get_der_controls_matching_criteria(std::optional<bool>(false), std::optional<std::string>(std::nullopt),
+                                                   std::optional<std::string>(std::nullopt)))
+        .WillOnce(Return(std::vector<std::string>{make_expired_scheduled_control_json("ctrl-expired")}));
+    // The post-commit recompute read throws a DB fault.
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(std::optional<bool>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt),
+                                                                          std::optional<std::string>(std::nullopt)))
+        .WillOnce(::testing::Throw(everest::db::QueryExecutionException("simulated DB read failure")));
+    EXPECT_CALL(database_handler_mock, delete_der_control("ctrl-expired"));
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)); // NotifyDERStartStop(started=false)
+
+    EXPECT_NO_THROW(der_control.check_scheduled_controls());
+
+    EXPECT_FALSE(callback_invoked) << "DB read failure must not be surfaced to the provider callback";
+}
+
+// notify_der_alarm dispatches a Call<NotifyDERAlarmRequest> via the message dispatcher.
+TEST_F(DERControlTest, NotifyDerAlarm_DispatchesNotifyDERAlarmRequest) {
+    DERControl der_control(functional_block_context);
+
+    NotifyDERAlarmRequest req;
+    req.controlType = DERControlEnum::FreqDroop;
+    req.timestamp = ocpp::DateTime("2020-01-01T00:00:00Z");
+    req.gridEventFault = GridEventFaultEnum::OverFrequency;
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, false)).WillOnce(Invoke([](const json& call, bool /*t*/) {
+        auto action = call[ocpp::CALL_ACTION].get<std::string>();
+        EXPECT_EQ(action, "NotifyDERAlarm");
+        auto payload = call[ocpp::CALL_PAYLOAD];
+        EXPECT_EQ(payload["controlType"], "FreqDroop");
+        EXPECT_EQ(payload["gridEventFault"], "OverFrequency");
+    }));
+
+    der_control.notify_der_alarm(req);
+}
+
+// =============================================================================
+// Provider-callback fault isolation: a throwing provider callback on the timer
+// thread must not escape to io_context.run() → std::terminate().
+// =============================================================================
+
+// A throwing active-directives callback must not propagate out of check_scheduled_controls.
+TEST_F(DERControlTest, ActiveDirectives_ThrowingOnTimerPath_DoesNotTerminate) {
+    DERControl der_control(functional_block_context, [](const std::vector<SetDERControlRequest>& /*active*/) {
+        throw std::runtime_error("provider blew up");
+    });
+
+    EXPECT_CALL(database_handler_mock, get_der_control_pending_supersede_activations(_))
+        .WillOnce(Return(std::vector<DatabaseHandlerInterface::PendingSupersedeActivation>{}));
+    EXPECT_CALL(database_handler_mock, get_der_controls_needing_start_notify(_))
+        .WillOnce(Return(std::vector<std::string>{}));
+    // One expired control drives a transition, so emit_active_directives runs.
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(_, _, _))
+        .WillRepeatedly(Return(std::vector<std::string>{make_expired_scheduled_control_json("ctrl-expired")}));
+    EXPECT_CALL(database_handler_mock, delete_der_control("ctrl-expired"));
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)); // NotifyDERStartStop(started=false)
+
+    EXPECT_NO_THROW(der_control.check_scheduled_controls());
+}
+
+// No callback registered: ClearDERControl by id does zero extra reads (no get_der_control, no recompute).
+TEST_F(DERControlTest, NoCallback_ClearById_DoesNotReadForReconstruction) {
+    DERControl der_control(functional_block_context); // no callback
+
+    ClearDERControlRequest req;
+    req.isDefault = false;
+    req.controlId = "ctrl-x";
+    auto msg = make_clear_der_control_msg(req);
+
+    EXPECT_CALL(database_handler_mock, get_der_control(_)).Times(0);
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(_, _, _)).Times(0);
+    EXPECT_CALL(database_handler_mock, delete_der_control_by_id_and_default("ctrl-x", false)).WillOnce(Return(true));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+
+    der_control.handle_message(msg);
+}
+
+// No callback registered: ClearDERControl by criteria does not recompute the active set.
+TEST_F(DERControlTest, NoCallback_ClearByCriteria_DoesNotPreReadForReconstruction) {
+    DERControl der_control(functional_block_context); // no callback
+
+    ClearDERControlRequest req;
+    req.isDefault = false;
+    req.controlType = DERControlEnum::FreqDroop;
+    auto msg = make_clear_der_control_msg(req);
+
+    EXPECT_CALL(database_handler_mock, get_der_controls_matching_criteria(_, _, _)).Times(0);
+    EXPECT_CALL(database_handler_mock,
+                delete_der_controls_matching_criteria(false, std::optional<std::string>("FreqDroop")))
+        .WillOnce(Return(1));
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_));
+
+    der_control.handle_message(msg);
 }

--- a/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/conversions.hpp
+++ b/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/conversions.hpp
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#include <functional>
+#include <string>
+#include <vector>
+
 #include "ocpp/v2/messages/ChangeAvailability.hpp"
 #include "ocpp/v2/ocpp_enums.hpp"
 #include "ocpp/v2/types.hpp"
@@ -26,6 +30,11 @@
 #include <ocpp/v2/messages/SetDisplayMessage.hpp>
 #include <ocpp/v2/messages/TransactionEvent.hpp>
 #include <ocpp/v2/messages/UpdateFirmware.hpp>
+
+namespace ocpp::v21 {
+struct NotifyDERAlarmRequest;
+struct SetDERControlRequest;
+} // namespace ocpp::v21
 
 namespace ocpp_module_common {
 namespace conversions {
@@ -304,6 +313,31 @@ ocpp::v2::ChangeAvailabilityRequest
 to_ocpp_change_availability_request(const types::ocpp::ChangeAvailabilityRequest& request);
 types::ocpp::ChangeAvailabilityResponse
 to_everest_change_availability_response(const ocpp::v2::ChangeAvailabilityResponse& response);
+
+/// \brief Converts a given ocpp::v2::DERControlEnum \p control_type to a types::grid_support::DirectiveType.
+/// \details Total over the 22 OCPP DERControlEnum values; the 6 ISO-only DirectiveType values have no OCPP producer.
+types::grid_support::DirectiveType to_grid_support_directive_type(const ocpp::v2::DERControlEnum control_type);
+
+/// \brief Converts a given types::grid_support::GridEventFault \p fault to an ocpp::v2::GridEventFaultEnum.
+ocpp::v2::GridEventFaultEnum to_ocpp_grid_event_fault(const types::grid_support::GridEventFault fault);
+
+/// \brief Converts a given ocpp::v21::SetDERControlRequest \p request to a types::grid_support::Directive.
+/// \param source Origin of the directive (e.g. the producing protocol).
+/// \param received_at Time the directive was received (date-time string).
+types::grid_support::Directive to_grid_support_directive(const ocpp::v21::SetDERControlRequest& request,
+                                                         const std::string& source, const std::string& received_at);
+
+/// \brief Translates each control in \p controls via \p translate, skipping (and logging) any whose
+/// translation throws std::out_of_range (an unmapped DERControlEnum), so one bad control never discards
+/// the rest of the batch. Surviving controls are returned in order.
+std::vector<types::grid_support::Directive> translate_active_controls(
+    const std::vector<ocpp::v21::SetDERControlRequest>& controls,
+    const std::function<types::grid_support::Directive(const ocpp::v21::SetDERControlRequest&)>& translate);
+
+/// \brief Converts a given types::grid_support::GridAlarm \p alarm to an ocpp::v21::NotifyDERAlarmRequest.
+/// \warning Throws std::invalid_argument when alarm.directive_type is unset (OCPP mandates controlType) or carries an
+///          ISO-only value, and when alarm.timestamp cannot be parsed as an RFC3339 date-time.
+ocpp::v21::NotifyDERAlarmRequest to_ocpp_notify_der_alarm(const types::grid_support::GridAlarm& alarm);
 
 } // namespace conversions
 } // namespace ocpp_module_common

--- a/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/definitions.hpp
+++ b/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/definitions.hpp
@@ -47,6 +47,7 @@ extern const VariableCharacteristics SupportedOperationModes;
 namespace DERDefinitions {
 namespace Characteristics {
 extern const VariableCharacteristics Available;
+extern const VariableCharacteristics Enabled;
 extern const VariableCharacteristics ModesSupported;
 extern const VariableCharacteristics Decimal;
 extern const VariableCharacteristics InverterString;

--- a/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/definitions.hpp
+++ b/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/definitions.hpp
@@ -5,6 +5,9 @@
 
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 
+#include <string>
+#include <vector>
+
 using ocpp::v2::EVSE;
 using ocpp::v2::VariableCharacteristics;
 
@@ -40,6 +43,19 @@ extern const VariableCharacteristics SupportedEnergyTransferModes;
 extern const VariableCharacteristics SupportedOperationModes;
 } // namespace Characteristics
 } // namespace V2XDefinitions
+
+namespace DERDefinitions {
+namespace Characteristics {
+extern const VariableCharacteristics Available;
+extern const VariableCharacteristics ModesSupported;
+extern const VariableCharacteristics Decimal;
+extern const VariableCharacteristics InverterString;
+} // namespace Characteristics
+
+// DER controller variable names, shared by the device-model builder and to_der_ctrlr_config_set_variables.
+extern const std::vector<std::string> DecimalVariableNames;
+extern const std::vector<std::string> InverterStringVariableNames;
+} // namespace DERDefinitions
 
 namespace ISO15118Definitions {
 namespace Characteristics {

--- a/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/everest_device_model_storage.hpp
+++ b/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/everest_device_model_storage.hpp
@@ -47,6 +47,12 @@ to_der_ctrlr_config_set_variables(int32_t evse_id, const types::grid_support::DE
 ocpp::v2::SetVariableData to_der_ctrlr_available_set_variable(int32_t evse_id,
                                                               const types::grid_support::DERCapability& capability);
 
+/// \brief Forces the DER controller (DCDERCtrlr and ACDERCtrlr) of \p evse_id to Available "false" in \p storage.
+/// \details Writes "false" to the Available Actual attribute only when its current value is "true"; absent
+///          components/variables and values already not "true" are skipped silently. Used at startup to clear a
+///          persisted Available "true" on an EVSE that no longer has a wired grid_support connection.
+void disable_der_ctrlr(ocpp::v2::DeviceModelStorageInterface& storage, int32_t evse_id);
+
 class EverestDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
 public:
     EverestDeviceModelStorage(
@@ -89,6 +95,9 @@ public:
 
     /// \bried Updates the VehicleId variable for the ConnectedEV component
     void update_connected_ev_vehicle_id(const int32_t evse_id, const std::string& vehicle_id);
+
+    /// \brief Forces the DER controller (DC or AC) of \p evse_id to Available "false", if present.
+    void disable_der(const int32_t evse_id);
 
 private:
     const std::vector<std::unique_ptr<evse_managerIntf>>& r_evse_manager;

--- a/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/everest_device_model_storage.hpp
+++ b/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/everest_device_model_storage.hpp
@@ -8,13 +8,45 @@
 #include <generated/interfaces/evse_manager/Interface.hpp>
 #include <generated/interfaces/iso15118_extensions/Interface.hpp>
 #include <generated/types/evse_board_support.hpp>
+#include <generated/types/grid_support.hpp>
+#include <generated/types/iso15118.hpp>
 #include <generated/types/powermeter.hpp>
 
 #include <ocpp/v2/device_model_storage_interface.hpp>
 #include <ocpp/v2/device_model_storage_sqlite.hpp>
+#include <ocpp/v2/init_device_model_db.hpp>
 #include <utils/config_service.hpp>
 
 namespace ocpp_module_common::device_model {
+
+/// \brief Builds the DER controller component config for a single EVSE from its supported energy transfer modes.
+///
+/// DER-capable iff it advertises a DER/bidirectional mode: AC_DER_IEC/AC_DER_SAE/AC_BPT_DER for AC, DC_BPT/DC_ACDP_BPT
+/// for DC. AC vs DC is chosen from the presence of any DC_* mode. The component is provisioned disabled
+/// (Available "false", ReadWrite) with empty ModesSupported, for the consumer to enable at runtime.
+///
+/// \returns The (ComponentKey, variables) pair for a DCDERCtrlr/ACDERCtrlr component, or std::nullopt if
+///          the EVSE is not DER-capable.
+std::optional<std::pair<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>>>
+build_der_ctrlr_component_config(
+    int32_t evse_id, const std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes);
+
+/// \brief Builds the device-model SetVariableData vector that configures (but does not enable) the DER
+///        controller for a given DER \p capability on EVSE \p evse_id.
+/// \details Emits ModesSupported and, on the DC path (capability.dc set), best-effort nameplate scalars and
+///          inverter strings. The nameplate scalars exist only on the DC component; no ACDERCtrlr nameplate
+///          variables exist. The enabling Available write is deliberately kept separate (see
+///          to_der_ctrlr_available_set_variable) so the consumer can apply config first and enable only if
+///          everything was accepted.
+std::vector<ocpp::v2::SetVariableData>
+to_der_ctrlr_config_set_variables(int32_t evse_id, const types::grid_support::DERCapability& capability);
+
+/// \brief Builds the single Available="true" write that enables the DER controller for a given DER
+///        \p capability on EVSE \p evse_id.
+/// \details Targets the DCDERCtrlr component when capability.dc is set, ACDERCtrlr otherwise.
+ocpp::v2::SetVariableData to_der_ctrlr_available_set_variable(int32_t evse_id,
+                                                              const types::grid_support::DERCapability& capability);
+
 class EverestDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
 public:
     EverestDeviceModelStorage(

--- a/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/everest_device_model_storage.hpp
+++ b/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/everest_device_model_storage.hpp
@@ -21,9 +21,10 @@ namespace ocpp_module_common::device_model {
 
 /// \brief Builds the DER controller component config for a single EVSE from its supported energy transfer modes.
 ///
-/// DER-capable iff it advertises a DER/bidirectional mode: AC_DER_IEC/AC_DER_SAE/AC_BPT_DER for AC, DC_BPT/DC_ACDP_BPT
-/// for DC. AC vs DC is chosen from the presence of any DC_* mode. The component is provisioned disabled
-/// (Available "false", ReadWrite) with empty ModesSupported, for the consumer to enable at runtime.
+/// DER-capable if it advertises a DER/bidirectional mode: AC_DER_IEC/AC_DER_SAE/AC_BPT_DER for AC, DC_BPT/DC_ACDP_BPT
+/// for DC. AC vs DC is chosen from the presence of any DC_* mode. The component is provisioned with Available "true"
+/// (ReadOnly, marking static presence) and Enabled "true" (ReadWrite, the CSMS runtime control) with empty
+/// ModesSupported.
 ///
 /// \returns The (ComponentKey, variables) pair for a DCDERCtrlr/ACDERCtrlr component, or std::nullopt if
 ///          the EVSE is not DER-capable.
@@ -35,22 +36,16 @@ build_der_ctrlr_component_config(
 ///        controller for a given DER \p capability on EVSE \p evse_id.
 /// \details Emits ModesSupported and, on the DC path (capability.dc set), best-effort nameplate scalars and
 ///          inverter strings. The nameplate scalars exist only on the DC component; no ACDERCtrlr nameplate
-///          variables exist. The enabling Available write is deliberately kept separate (see
-///          to_der_ctrlr_available_set_variable) so the consumer can apply config first and enable only if
-///          everything was accepted.
+///          variables exist. This writes config variables only and never enables the component.
 std::vector<ocpp::v2::SetVariableData>
 to_der_ctrlr_config_set_variables(int32_t evse_id, const types::grid_support::DERCapability& capability);
 
-/// \brief Builds the single Available="true" write that enables the DER controller for a given DER
-///        \p capability on EVSE \p evse_id.
-/// \details Targets the DCDERCtrlr component when capability.dc is set, ACDERCtrlr otherwise.
-ocpp::v2::SetVariableData to_der_ctrlr_available_set_variable(int32_t evse_id,
-                                                              const types::grid_support::DERCapability& capability);
-
-/// \brief Forces the DER controller (DCDERCtrlr and ACDERCtrlr) of \p evse_id to Available "false" in \p storage.
-/// \details Writes "false" to the Available Actual attribute only when its current value is "true"; absent
-///          components/variables and values already not "true" are skipped silently. Used at startup to clear a
-///          persisted Available "true" on an EVSE that no longer has a wired grid_support connection.
+/// \brief Forces the DER controller (DCDERCtrlr and ACDERCtrlr) of \p evse_id to Available "false" and
+///        Enabled "false" in \p storage.
+/// \details Writes "false" to the Available and Enabled Actual attributes only when the current value is
+///          "true"; absent components/variables and values already not "true" are skipped silently. The
+///          only-clear-"true" guard preserves a CSMS-written Enabled "false" and its source across an
+///          unwire/rewire cycle. Used at startup on an EVSE that no longer has a wired grid_support connection.
 void disable_der_ctrlr(ocpp::v2::DeviceModelStorageInterface& storage, int32_t evse_id);
 
 class EverestDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
@@ -96,7 +91,7 @@ public:
     /// \bried Updates the VehicleId variable for the ConnectedEV component
     void update_connected_ev_vehicle_id(const int32_t evse_id, const std::string& vehicle_id);
 
-    /// \brief Forces the DER controller (DC or AC) of \p evse_id to Available "false", if present.
+    /// \brief Forces the DER controller (DC or AC) of \p evse_id to Available "false" and Enabled "false", if present.
     void disable_der(const int32_t evse_id);
 
 private:

--- a/lib/everest/ocpp_module_common/src/conversions.cpp
+++ b/lib/everest/ocpp_module_common/src/conversions.cpp
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include <everest/conversions/ocpp/ocpp_conversions.hpp>
 #include <everest/logging.hpp>
 #include <everest/ocpp_module_common/conversions.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v21/messages/NotifyDERAlarm.hpp>
+#include <ocpp/v21/messages/SetDERControl.hpp>
 
 namespace ocpp_module_common {
 namespace conversions {
@@ -1955,6 +1962,318 @@ to_everest_change_availability_response(const ocpp::v2::ChangeAvailabilityRespon
         result.status_info = to_everest_status_info(response.statusInfo.value());
     }
     return result;
+}
+
+types::grid_support::DirectiveType to_grid_support_directive_type(const ocpp::v2::DERControlEnum control_type) {
+    switch (control_type) {
+    case ocpp::v2::DERControlEnum::EnterService:
+        return types::grid_support::DirectiveType::EnterService;
+    case ocpp::v2::DERControlEnum::FreqDroop:
+        return types::grid_support::DirectiveType::FreqDroop;
+    case ocpp::v2::DERControlEnum::FreqWatt:
+        return types::grid_support::DirectiveType::FreqWatt;
+    case ocpp::v2::DERControlEnum::FixedPFAbsorb:
+        return types::grid_support::DirectiveType::FixedPFAbsorb;
+    case ocpp::v2::DERControlEnum::FixedPFInject:
+        return types::grid_support::DirectiveType::FixedPFInject;
+    case ocpp::v2::DERControlEnum::FixedVar:
+        return types::grid_support::DirectiveType::FixedVar;
+    case ocpp::v2::DERControlEnum::Gradients:
+        return types::grid_support::DirectiveType::Gradients;
+    case ocpp::v2::DERControlEnum::HFMustTrip:
+        return types::grid_support::DirectiveType::HFMustTrip;
+    case ocpp::v2::DERControlEnum::HFMayTrip:
+        return types::grid_support::DirectiveType::HFMayTrip;
+    case ocpp::v2::DERControlEnum::HVMustTrip:
+        return types::grid_support::DirectiveType::HVMustTrip;
+    case ocpp::v2::DERControlEnum::HVMomCess:
+        return types::grid_support::DirectiveType::HVMomCess;
+    case ocpp::v2::DERControlEnum::HVMayTrip:
+        return types::grid_support::DirectiveType::HVMayTrip;
+    case ocpp::v2::DERControlEnum::LimitMaxDischarge:
+        return types::grid_support::DirectiveType::LimitMaxDischarge;
+    case ocpp::v2::DERControlEnum::LFMustTrip:
+        return types::grid_support::DirectiveType::LFMustTrip;
+    case ocpp::v2::DERControlEnum::LVMustTrip:
+        return types::grid_support::DirectiveType::LVMustTrip;
+    case ocpp::v2::DERControlEnum::LVMomCess:
+        return types::grid_support::DirectiveType::LVMomCess;
+    case ocpp::v2::DERControlEnum::LVMayTrip:
+        return types::grid_support::DirectiveType::LVMayTrip;
+    case ocpp::v2::DERControlEnum::PowerMonitoringMustTrip:
+        return types::grid_support::DirectiveType::PowerMonitoringMustTrip;
+    case ocpp::v2::DERControlEnum::VoltVar:
+        return types::grid_support::DirectiveType::VoltVar;
+    case ocpp::v2::DERControlEnum::VoltWatt:
+        return types::grid_support::DirectiveType::VoltWatt;
+    case ocpp::v2::DERControlEnum::WattPF:
+        return types::grid_support::DirectiveType::WattPF;
+    case ocpp::v2::DERControlEnum::WattVar:
+        return types::grid_support::DirectiveType::WattVar;
+    }
+    throw std::out_of_range("Could not convert DERControlEnum to DirectiveType");
+}
+
+ocpp::v2::GridEventFaultEnum to_ocpp_grid_event_fault(const types::grid_support::GridEventFault fault) {
+    switch (fault) {
+    case types::grid_support::GridEventFault::CurrentImbalance:
+        return ocpp::v2::GridEventFaultEnum::CurrentImbalance;
+    case types::grid_support::GridEventFault::LocalEmergency:
+        return ocpp::v2::GridEventFaultEnum::LocalEmergency;
+    case types::grid_support::GridEventFault::LowInputPower:
+        return ocpp::v2::GridEventFaultEnum::LowInputPower;
+    case types::grid_support::GridEventFault::OverCurrent:
+        return ocpp::v2::GridEventFaultEnum::OverCurrent;
+    case types::grid_support::GridEventFault::OverFrequency:
+        return ocpp::v2::GridEventFaultEnum::OverFrequency;
+    case types::grid_support::GridEventFault::OverVoltage:
+        return ocpp::v2::GridEventFaultEnum::OverVoltage;
+    case types::grid_support::GridEventFault::PhaseRotation:
+        return ocpp::v2::GridEventFaultEnum::PhaseRotation;
+    case types::grid_support::GridEventFault::RemoteEmergency:
+        return ocpp::v2::GridEventFaultEnum::RemoteEmergency;
+    case types::grid_support::GridEventFault::UnderFrequency:
+        return ocpp::v2::GridEventFaultEnum::UnderFrequency;
+    case types::grid_support::GridEventFault::UnderVoltage:
+        return ocpp::v2::GridEventFaultEnum::UnderVoltage;
+    case types::grid_support::GridEventFault::VoltageImbalance:
+        return ocpp::v2::GridEventFaultEnum::VoltageImbalance;
+    }
+    throw std::out_of_range("Could not convert GridEventFault");
+}
+
+namespace {
+
+types::grid_support::DERUnit to_grid_support_der_unit(const ocpp::v2::DERUnitEnum unit) {
+    switch (unit) {
+    case ocpp::v2::DERUnitEnum::Not_Applicable:
+        return types::grid_support::DERUnit::Not_Applicable;
+    case ocpp::v2::DERUnitEnum::PctMaxW:
+        return types::grid_support::DERUnit::PctMaxW;
+    case ocpp::v2::DERUnitEnum::PctMaxVar:
+        return types::grid_support::DERUnit::PctMaxVar;
+    case ocpp::v2::DERUnitEnum::PctWAvail:
+        return types::grid_support::DERUnit::PctWAvail;
+    case ocpp::v2::DERUnitEnum::PctVarAvail:
+        return types::grid_support::DERUnit::PctVarAvail;
+    case ocpp::v2::DERUnitEnum::PctEffectiveV:
+        return types::grid_support::DERUnit::PctEffectiveV;
+    }
+    throw std::out_of_range("Could not convert DERUnitEnum");
+}
+
+types::grid_support::PowerDuringCessation
+to_grid_support_power_during_cessation(const ocpp::v2::PowerDuringCessationEnum value) {
+    switch (value) {
+    case ocpp::v2::PowerDuringCessationEnum::Active:
+        return types::grid_support::PowerDuringCessation::Active;
+    case ocpp::v2::PowerDuringCessationEnum::Reactive:
+        return types::grid_support::PowerDuringCessation::Reactive;
+    }
+    throw std::out_of_range("Could not convert PowerDuringCessationEnum");
+}
+
+types::grid_support::DERCurve to_grid_support_curve(const ocpp::v2::DERCurve& curve) {
+    types::grid_support::DERCurve result;
+    result.y_unit = to_grid_support_der_unit(curve.yUnit);
+    result.curve_data.reserve(curve.curveData.size());
+    for (const auto& point : curve.curveData) {
+        result.curve_data.push_back(types::grid_support::DERCurvePoint{point.x, point.y});
+    }
+    if (curve.hysteresis) {
+        types::grid_support::Hysteresis hysteresis;
+        hysteresis.hysteresis_high = curve.hysteresis->hysteresisHigh;
+        hysteresis.hysteresis_low = curve.hysteresis->hysteresisLow;
+        hysteresis.hysteresis_delay = curve.hysteresis->hysteresisDelay;
+        hysteresis.hysteresis_gradient = curve.hysteresis->hysteresisGradient;
+        result.hysteresis = hysteresis;
+    }
+    if (curve.reactivePowerParams) {
+        types::grid_support::ReactivePowerParams params;
+        params.v_ref = curve.reactivePowerParams->vRef;
+        params.autonomous_v_ref_enable = curve.reactivePowerParams->autonomousVRefEnable;
+        params.autonomous_v_ref_time_constant = curve.reactivePowerParams->autonomousVRefTimeConstant;
+        result.reactive_power_params = params;
+    }
+    if (curve.voltageParams) {
+        types::grid_support::VoltageParams params;
+        params.hv_10min_mean_value = curve.voltageParams->hv10MinMeanValue;
+        params.hv_10min_mean_trip_delay = curve.voltageParams->hv10MinMeanTripDelay;
+        if (curve.voltageParams->powerDuringCessation) {
+            params.power_during_cessation =
+                to_grid_support_power_during_cessation(curve.voltageParams->powerDuringCessation.value());
+        }
+        result.voltage_params = params;
+    }
+    result.response_time = curve.responseTime;
+    return result;
+}
+
+types::grid_support::EnterServiceParams to_grid_support_enter_service(const ocpp::v2::EnterService& enter_service) {
+    types::grid_support::EnterServiceParams result;
+    result.high_voltage = enter_service.highVoltage;
+    result.low_voltage = enter_service.lowVoltage;
+    result.high_freq = enter_service.highFreq;
+    result.low_freq = enter_service.lowFreq;
+    result.delay = enter_service.delay;
+    result.random_delay = enter_service.randomDelay;
+    result.ramp_rate = enter_service.rampRate;
+    return result;
+}
+
+types::grid_support::FreqDroopParams to_grid_support_freq_droop(const ocpp::v2::FreqDroop& freq_droop) {
+    types::grid_support::FreqDroopParams result;
+    result.over_freq = freq_droop.overFreq;
+    result.under_freq = freq_droop.underFreq;
+    result.over_droop = freq_droop.overDroop;
+    result.under_droop = freq_droop.underDroop;
+    result.response_time = freq_droop.responseTime;
+    return result;
+}
+
+types::grid_support::FixedPFParams to_grid_support_fixed_pf(const ocpp::v2::FixedPF& fixed_pf) {
+    types::grid_support::FixedPFParams result;
+    result.displacement = fixed_pf.displacement;
+    result.excitation = fixed_pf.excitation;
+    return result;
+}
+
+types::grid_support::FixedVarParams to_grid_support_fixed_var(const ocpp::v2::FixedVar& fixed_var) {
+    types::grid_support::FixedVarParams result;
+    result.setpoint = fixed_var.setpoint;
+    result.unit = to_grid_support_der_unit(fixed_var.unit);
+    return result;
+}
+
+types::grid_support::GradientParams to_grid_support_gradient(const ocpp::v2::Gradient& gradient) {
+    types::grid_support::GradientParams result;
+    result.gradient = gradient.gradient;
+    result.soft_gradient = gradient.softGradient;
+    return result;
+}
+
+types::grid_support::LimitMaxDischargeParams
+to_grid_support_limit_max_discharge(const ocpp::v2::LimitMaxDischarge& limit) {
+    types::grid_support::LimitMaxDischargeParams result;
+    result.pct_max_discharge_power = limit.pctMaxDischargePower;
+    if (limit.powerMonitoringMustTrip) {
+        result.power_monitoring_must_trip = to_grid_support_curve(limit.powerMonitoringMustTrip.value());
+    }
+    return result;
+}
+
+} // namespace
+
+types::grid_support::Directive to_grid_support_directive(const ocpp::v21::SetDERControlRequest& request,
+                                                         const std::string& source, const std::string& received_at) {
+    types::grid_support::Directive directive;
+    directive.id = request.controlId.get();
+    directive.directive_type = to_grid_support_directive_type(request.controlType);
+    directive.is_default = request.isDefault;
+    directive.source = source;
+    directive.received_at = received_at;
+
+    const auto apply_schedule = [&directive, &request](std::int32_t priority,
+                                                       const std::optional<ocpp::DateTime>& start_time,
+                                                       const std::optional<float>& duration) {
+        directive.priority = priority;
+        if (start_time) {
+            directive.start_time = start_time->to_rfc3339();
+        }
+        if (duration) {
+            const float v = duration.value();
+            if (not std::isfinite(v) or v < 0.0F) {
+                EVLOG_warning << "SetDERControlRequest controlId=" << request.controlId.get()
+                              << " has non-finite/negative duration " << v
+                              << "; treating as unbounded (duration_s unset)";
+            } else {
+                directive.duration_s =
+                    static_cast<int>(std::clamp<long long>(std::llround(v), 0, std::numeric_limits<int>::max()));
+            }
+        }
+    };
+
+    // Populate from whichever OCPP optional is set; fixedPFAbsorb/fixedPFInject both map to fixed_pf.
+    if (request.curve) {
+        apply_schedule(request.curve->priority, request.curve->startTime, request.curve->duration);
+        directive.curve = to_grid_support_curve(request.curve.value());
+    } else if (request.enterService) {
+        directive.priority = request.enterService->priority;
+        directive.enter_service = to_grid_support_enter_service(request.enterService.value());
+    } else if (request.freqDroop) {
+        apply_schedule(request.freqDroop->priority, request.freqDroop->startTime, request.freqDroop->duration);
+        directive.freq_droop = to_grid_support_freq_droop(request.freqDroop.value());
+    } else if (request.fixedPFAbsorb) {
+        apply_schedule(request.fixedPFAbsorb->priority, request.fixedPFAbsorb->startTime,
+                       request.fixedPFAbsorb->duration);
+        directive.fixed_pf = to_grid_support_fixed_pf(request.fixedPFAbsorb.value());
+    } else if (request.fixedPFInject) {
+        apply_schedule(request.fixedPFInject->priority, request.fixedPFInject->startTime,
+                       request.fixedPFInject->duration);
+        directive.fixed_pf = to_grid_support_fixed_pf(request.fixedPFInject.value());
+    } else if (request.fixedVar) {
+        apply_schedule(request.fixedVar->priority, request.fixedVar->startTime, request.fixedVar->duration);
+        directive.fixed_var = to_grid_support_fixed_var(request.fixedVar.value());
+    } else if (request.gradient) {
+        directive.priority = request.gradient->priority;
+        directive.gradient = to_grid_support_gradient(request.gradient.value());
+    } else if (request.limitMaxDischarge) {
+        apply_schedule(request.limitMaxDischarge->priority, request.limitMaxDischarge->startTime,
+                       request.limitMaxDischarge->duration);
+        directive.limit_max_discharge = to_grid_support_limit_max_discharge(request.limitMaxDischarge.value());
+    } else {
+        // No payload: the 6 ISO-only trip/fault types are parameter-free; anything else lost its payload.
+        directive.priority = 0;
+        EVLOG_warning << "SetDERControlRequest controlId=" << request.controlId.get()
+                      << " controlType=" << static_cast<int>(request.controlType)
+                      << " carried no recognized payload; emitting payload-less Directive (priority=0)";
+    }
+
+    return directive;
+}
+
+std::vector<types::grid_support::Directive> translate_active_controls(
+    const std::vector<ocpp::v21::SetDERControlRequest>& controls,
+    const std::function<types::grid_support::Directive(const ocpp::v21::SetDERControlRequest&)>& translate) {
+    std::vector<types::grid_support::Directive> directives;
+    directives.reserve(controls.size());
+    for (const auto& control : controls) {
+        try {
+            directives.push_back(translate(control));
+        } catch (const std::out_of_range& e) {
+            EVLOG_error << "Skipping DER control controlId=" << control.controlId.get()
+                        << " controlType=" << static_cast<int>(control.controlType) << ": no DirectiveType mapping ("
+                        << e.what() << ")";
+            continue;
+        }
+    }
+    return directives;
+}
+
+ocpp::v21::NotifyDERAlarmRequest to_ocpp_notify_der_alarm(const types::grid_support::GridAlarm& alarm) {
+    if (not alarm.directive_type.has_value()) {
+        throw std::invalid_argument("GridAlarm.directive_type is required to build a NotifyDERAlarmRequest "
+                                    "(OCPP mandates controlType)");
+    }
+
+    ocpp::v21::NotifyDERAlarmRequest request;
+    const auto control_type = to_ocpp_der_control(alarm.directive_type.value());
+    if (not control_type.has_value()) {
+        throw std::invalid_argument("GridAlarm.directive_type has no OCPP controlType mapping (ISO-only value)");
+    }
+    request.controlType = control_type.value();
+    request.gridEventFault = to_ocpp_grid_event_fault(alarm.fault);
+    request.alarmEnded = alarm.alarm_ended;
+    try {
+        request.timestamp = ocpp::DateTime(alarm.timestamp);
+    } catch (const std::exception& e) {
+        throw std::invalid_argument("GridAlarm.timestamp could not be parsed as an RFC3339 date-time: \"" +
+                                    alarm.timestamp + "\" (" + e.what() + ")");
+    }
+    if (alarm.extra_info) {
+        request.extraInfo = alarm.extra_info.value();
+    }
+    return request;
 }
 
 } // namespace conversions

--- a/lib/everest/ocpp_module_common/src/device_model/definitions.cpp
+++ b/lib/everest/ocpp_module_common/src/device_model/definitions.cpp
@@ -156,6 +156,13 @@ const VariableCharacteristics Available = [] {
     return var;
 }();
 
+const VariableCharacteristics Enabled = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::boolean;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
 const VariableCharacteristics ModesSupported = [] {
     VariableCharacteristics var;
     var.dataType = DataEnum::MemberList;

--- a/lib/everest/ocpp_module_common/src/device_model/definitions.cpp
+++ b/lib/everest/ocpp_module_common/src/device_model/definitions.cpp
@@ -147,6 +147,49 @@ const VariableCharacteristics SupportedOperationModes = [] {
 } // namespace Characteristics
 } // namespace V2XDefinitions
 
+namespace DERDefinitions {
+namespace Characteristics {
+const VariableCharacteristics Available = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::boolean;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
+const VariableCharacteristics ModesSupported = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::MemberList;
+    var.supportsMonitoring = false;
+    var.valuesList = "EnterService,FreqDroop,FreqWatt,FixedPFAbsorb,FixedPFInject,FixedVar,Gradients,"
+                     "HFMustTrip,HFMayTrip,HVMustTrip,HVMomCess,HVMayTrip,LimitMaxDischarge,LFMustTrip,"
+                     "LVMustTrip,LVMomCess,LVMayTrip,PowerMonitoringMustTrip,VoltVar,VoltWatt,WattPF,WattVar";
+    return var;
+}();
+
+const VariableCharacteristics Decimal = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::decimal;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
+const VariableCharacteristics InverterString = [] {
+    VariableCharacteristics var;
+    var.dataType = DataEnum::string;
+    var.supportsMonitoring = false;
+    return var;
+}();
+
+} // namespace Characteristics
+
+const std::vector<std::string> DecimalVariableNames = {
+    "MaxW",          "MaxVA",          "MaxVar",       "MaxVarNeg",     "MaxChargeRateW",
+    "OverExcitedPF", "UnderExcitedPF", "OverExcitedW", "UnderExcitedW", "ReactiveSusceptance"};
+
+const std::vector<std::string> InverterStringVariableNames = {"InverterManufacturer", "InverterModel",
+                                                              "InverterSwVersion", "InverterHwVersion"};
+} // namespace DERDefinitions
+
 namespace ISO15118Definitions {
 namespace Characteristics {
 const VariableCharacteristics Enabled = [] {

--- a/lib/everest/ocpp_module_common/src/device_model/everest_device_model_storage.cpp
+++ b/lib/everest/ocpp_module_common/src/device_model/everest_device_model_storage.cpp
@@ -273,13 +273,17 @@ std::vector<DeviceModelVariable> build_connected_ev_variables() {
     return connected_ev_variables;
 }
 
-// DC DER controller variables, provisioned disabled (Available=false). Every variable
-// the config/available builders may write on the DC path must be defined here, else the write targets an
-// unknown variable and is rejected.
+// DC DER controller variables: Available marks static presence (provisioned "true", ReadOnly) and Enabled
+// is the CSMS runtime control (provisioned "true", ReadWrite). Every variable the config/enable builders may
+// write
+// on the DC path must be defined here, else the write targets an unknown variable and is rejected.
 std::vector<DeviceModelVariable> build_dc_der_ctrlr_variables() {
     std::vector<DeviceModelVariable> variables;
     variables.push_back(make_variable(ocpp::v2::DERComponentVariables::Available.name,
-                                      DERDefinitions::Characteristics::Available, "false",
+                                      DERDefinitions::Characteristics::Available, "true",
+                                      ocpp::v2::MutabilityEnum::ReadOnly));
+    variables.push_back(make_variable(ocpp::v2::DERComponentVariables::Enabled.name,
+                                      DERDefinitions::Characteristics::Enabled, "true",
                                       ocpp::v2::MutabilityEnum::ReadWrite));
     variables.push_back(make_variable(ocpp::v2::DERComponentVariables::ModesSupported.name,
                                       DERDefinitions::Characteristics::ModesSupported, ""));
@@ -292,11 +296,14 @@ std::vector<DeviceModelVariable> build_dc_der_ctrlr_variables() {
     return variables;
 }
 
-// AC DER controller variables: only Available and ModesSupported. The nameplate scalars live exclusively
-// on the DC component (matching to_der_ctrlr_config_set_variables).
+// AC DER controller variables: Available (static presence, ReadOnly), Enabled (CSMS runtime control, provisioned
+// "true", ReadWrite) and ModesSupported. The nameplate scalars live exclusively on the DC component
+// (matching to_der_ctrlr_config_set_variables).
 std::vector<DeviceModelVariable> build_ac_der_ctrlr_variables() {
     return {make_variable(ocpp::v2::DERComponentVariables::Available.name, DERDefinitions::Characteristics::Available,
-                          "false", ocpp::v2::MutabilityEnum::ReadWrite),
+                          "true", ocpp::v2::MutabilityEnum::ReadOnly),
+            make_variable(ocpp::v2::DERComponentVariables::Enabled.name, DERDefinitions::Characteristics::Enabled,
+                          "true", ocpp::v2::MutabilityEnum::ReadWrite),
             make_variable(ocpp::v2::DERComponentVariables::ModesSupported.name,
                           DERDefinitions::Characteristics::ModesSupported, "")};
 }
@@ -415,14 +422,6 @@ std::optional<std::pair<ocpp::v2::ComponentKey, std::vector<DeviceModelVariable>
     return std::nullopt;
 }
 
-ocpp::v2::SetVariableData to_der_ctrlr_available_set_variable(const int32_t evse_id,
-                                                              const types::grid_support::DERCapability& capability) {
-    const auto get_component_variable = capability.dc.has_value()
-                                            ? &ocpp::v2::DERComponentVariables::get_dc_component_variable
-                                            : &ocpp::v2::DERComponentVariables::get_ac_component_variable;
-    return make_set_variable_data(get_component_variable(evse_id, ocpp::v2::DERComponentVariables::Available), "true");
-}
-
 std::vector<ocpp::v2::SetVariableData>
 to_der_ctrlr_config_set_variables(const int32_t evse_id, const types::grid_support::DERCapability& capability) {
     std::vector<ocpp::v2::SetVariableData> result;
@@ -509,7 +508,7 @@ to_der_ctrlr_config_set_variables(const int32_t evse_id, const types::grid_suppo
 }
 
 void disable_der_ctrlr(ocpp::v2::DeviceModelStorageInterface& storage, const int32_t evse_id) {
-    const auto force_unavailable = [&](const ocpp::v2::ComponentVariable& component_variable) {
+    const auto force_false = [&](const ocpp::v2::ComponentVariable& component_variable) {
         if (not component_variable.variable.has_value()) {
             return;
         }
@@ -522,17 +521,22 @@ void disable_der_ctrlr(ocpp::v2::DeviceModelStorageInterface& storage, const int
         if (not attribute.value().value.has_value()) {
             return;
         }
-        // Only clear a persisted Available="true"; leave any other value untouched.
+        // Only clear a persisted Available/Enabled="true"; leave any other value untouched (preserves the
+        // source marker of a CSMS-written Enabled="false" across an unwire/rewire cycle).
         if (attribute.value().value.value().get() != "true") {
             return;
         }
         storage.set_variable_attribute_value(component_variable.component, variable, ocpp::v2::AttributeEnum::Actual,
                                              "false", VARIABLE_SOURCE_EVEREST);
     };
-    force_unavailable(ocpp::v2::DERComponentVariables::get_dc_component_variable(
-        evse_id, ocpp::v2::DERComponentVariables::Available));
-    force_unavailable(ocpp::v2::DERComponentVariables::get_ac_component_variable(
-        evse_id, ocpp::v2::DERComponentVariables::Available));
+    force_false(ocpp::v2::DERComponentVariables::get_dc_component_variable(evse_id,
+                                                                           ocpp::v2::DERComponentVariables::Available));
+    force_false(ocpp::v2::DERComponentVariables::get_ac_component_variable(evse_id,
+                                                                           ocpp::v2::DERComponentVariables::Available));
+    force_false(
+        ocpp::v2::DERComponentVariables::get_dc_component_variable(evse_id, ocpp::v2::DERComponentVariables::Enabled));
+    force_false(
+        ocpp::v2::DERComponentVariables::get_ac_component_variable(evse_id, ocpp::v2::DERComponentVariables::Enabled));
 }
 
 EverestDeviceModelStorage::EverestDeviceModelStorage(

--- a/lib/everest/ocpp_module_common/src/device_model/everest_device_model_storage.cpp
+++ b/lib/everest/ocpp_module_common/src/device_model/everest_device_model_storage.cpp
@@ -6,6 +6,7 @@
 
 #include <everest/ocpp_module_common/device_model/definitions.hpp>
 #include <everest/ocpp_module_common/device_model/everest_device_model_storage.hpp>
+#include <ocpp/v2/ctrlr_component_variables.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 
@@ -123,6 +124,20 @@ ComponentKey get_iso15118_component_key(const int32_t evse_id) {
 ComponentKey get_connected_ev_component_key(const int32_t evse_id) {
     ComponentKey component;
     component.name = "ConnectedEV";
+    component.evse_id = evse_id;
+    return component;
+}
+
+ComponentKey get_dc_der_ctrlr_component_key(const int32_t evse_id) {
+    ComponentKey component;
+    component.name = "DCDERCtrlr";
+    component.evse_id = evse_id;
+    return component;
+}
+
+ComponentKey get_ac_der_ctrlr_component_key(const int32_t evse_id) {
+    ComponentKey component;
+    component.name = "ACDERCtrlr";
     component.evse_id = evse_id;
     return component;
 }
@@ -258,6 +273,34 @@ std::vector<DeviceModelVariable> build_connected_ev_variables() {
     return connected_ev_variables;
 }
 
+// DC DER controller variables, provisioned disabled (Available=false). Every variable
+// the config/available builders may write on the DC path must be defined here, else the write targets an
+// unknown variable and is rejected.
+std::vector<DeviceModelVariable> build_dc_der_ctrlr_variables() {
+    std::vector<DeviceModelVariable> variables;
+    variables.push_back(make_variable(ocpp::v2::DERComponentVariables::Available.name,
+                                      DERDefinitions::Characteristics::Available, "false",
+                                      ocpp::v2::MutabilityEnum::ReadWrite));
+    variables.push_back(make_variable(ocpp::v2::DERComponentVariables::ModesSupported.name,
+                                      DERDefinitions::Characteristics::ModesSupported, ""));
+    for (const auto& name : DERDefinitions::DecimalVariableNames) {
+        variables.push_back(make_variable(name, DERDefinitions::Characteristics::Decimal));
+    }
+    for (const auto& name : DERDefinitions::InverterStringVariableNames) {
+        variables.push_back(make_variable(name, DERDefinitions::Characteristics::InverterString));
+    }
+    return variables;
+}
+
+// AC DER controller variables: only Available and ModesSupported. The nameplate scalars live exclusively
+// on the DC component (matching to_der_ctrlr_config_set_variables).
+std::vector<DeviceModelVariable> build_ac_der_ctrlr_variables() {
+    return {make_variable(ocpp::v2::DERComponentVariables::Available.name, DERDefinitions::Characteristics::Available,
+                          "false", ocpp::v2::MutabilityEnum::ReadWrite),
+            make_variable(ocpp::v2::DERComponentVariables::ModesSupported.name,
+                          DERDefinitions::Characteristics::ModesSupported, "")};
+}
+
 std::string get_everest_config_value(const everest::config::ModuleConfigurationParameters& module_config,
                                      const std::string& impl, const std::string& config_key) {
     const auto& config = module_config.at(impl);
@@ -328,7 +371,142 @@ std::string build_supported_protocol_string(const std::string& uri, const int32_
     return uri + ',' + std::to_string(major) + ',' + std::to_string(minor);
 }
 
+ocpp::v2::SetVariableData make_set_variable_data(const ocpp::v2::ComponentVariable& component_variable,
+                                                 const std::string& value) {
+    ocpp::v2::SetVariableData data;
+    data.component = component_variable.component;
+    if (component_variable.variable) {
+        data.variable = component_variable.variable.value();
+    }
+    data.attributeValue = value;
+    return data;
+}
+
 } // anonymous namespace
+
+std::optional<std::pair<ocpp::v2::ComponentKey, std::vector<DeviceModelVariable>>> build_der_ctrlr_component_config(
+    int32_t evse_id, const std::vector<types::iso15118::EnergyTransferMode>& supported_energy_transfer_modes) {
+    const auto supports_mode = [&](const types::iso15118::EnergyTransferMode mode) {
+        return std::find(supported_energy_transfer_modes.cbegin(), supported_energy_transfer_modes.cend(), mode) !=
+               supported_energy_transfer_modes.cend();
+    };
+    const bool is_dc_evse =
+        std::any_of(supported_energy_transfer_modes.cbegin(), supported_energy_transfer_modes.cend(),
+                    [](const types::iso15118::EnergyTransferMode& mode) {
+                        return mode == types::iso15118::EnergyTransferMode::DC_core or
+                               mode == types::iso15118::EnergyTransferMode::DC_extended or
+                               mode == types::iso15118::EnergyTransferMode::DC_combo_core or
+                               mode == types::iso15118::EnergyTransferMode::DC_unique or
+                               mode == types::iso15118::EnergyTransferMode::DC or
+                               mode == types::iso15118::EnergyTransferMode::DC_BPT or
+                               mode == types::iso15118::EnergyTransferMode::DC_ACDP or
+                               mode == types::iso15118::EnergyTransferMode::DC_ACDP_BPT;
+                    });
+    const bool dc_der_capable = supports_mode(types::iso15118::EnergyTransferMode::DC_BPT) or
+                                supports_mode(types::iso15118::EnergyTransferMode::DC_ACDP_BPT);
+    const bool ac_der_capable = supports_mode(types::iso15118::EnergyTransferMode::AC_DER_IEC) or
+                                supports_mode(types::iso15118::EnergyTransferMode::AC_DER_SAE) or
+                                supports_mode(types::iso15118::EnergyTransferMode::AC_BPT_DER);
+    if (is_dc_evse and dc_der_capable) {
+        return std::make_pair(get_dc_der_ctrlr_component_key(evse_id), build_dc_der_ctrlr_variables());
+    } else if (ac_der_capable) {
+        return std::make_pair(get_ac_der_ctrlr_component_key(evse_id), build_ac_der_ctrlr_variables());
+    }
+    return std::nullopt;
+}
+
+ocpp::v2::SetVariableData to_der_ctrlr_available_set_variable(const int32_t evse_id,
+                                                              const types::grid_support::DERCapability& capability) {
+    const auto get_component_variable = capability.dc.has_value()
+                                            ? &ocpp::v2::DERComponentVariables::get_dc_component_variable
+                                            : &ocpp::v2::DERComponentVariables::get_ac_component_variable;
+    return make_set_variable_data(get_component_variable(evse_id, ocpp::v2::DERComponentVariables::Available), "true");
+}
+
+std::vector<ocpp::v2::SetVariableData>
+to_der_ctrlr_config_set_variables(const int32_t evse_id, const types::grid_support::DERCapability& capability) {
+    std::vector<ocpp::v2::SetVariableData> result;
+
+    using ComponentVariableGetter = ocpp::v2::ComponentVariable (*)(const std::int32_t, const ocpp::v2::Variable&);
+    const ComponentVariableGetter get_component_variable =
+        capability.dc.has_value() ? &ocpp::v2::DERComponentVariables::get_dc_component_variable
+                                  : &ocpp::v2::DERComponentVariables::get_ac_component_variable;
+
+    const auto named_variable = [&](const std::string& name) {
+        ocpp::v2::Variable variable;
+        variable.name = name;
+        return get_component_variable(evse_id, variable);
+    };
+
+    std::string modes_csv;
+    for (const auto& directive_type : capability.supported_types) {
+        if (not modes_csv.empty()) {
+            modes_csv += ",";
+        }
+        modes_csv += types::grid_support::directive_type_to_string(directive_type);
+    }
+    result.push_back(make_set_variable_data(
+        get_component_variable(evse_id, ocpp::v2::DERComponentVariables::ModesSupported), modes_csv));
+
+    // Nameplate scalars below exist only on the DC component (DCDERCtrlr_1.json); emit on DC path only.
+    if (not capability.dc) {
+        return result;
+    }
+
+    const auto& nameplate = capability.nameplate;
+    const auto emit_float = [&](const std::string& name, const float value) {
+        result.push_back(make_set_variable_data(named_variable(name), std::to_string(value)));
+    };
+    const auto emit_string = [&](const std::string& name, const std::string& value) {
+        result.push_back(make_set_variable_data(named_variable(name), value));
+    };
+
+    emit_float("MaxW", nameplate.max_w_W);
+    emit_float("MaxVA", nameplate.max_va_VA);
+    if (nameplate.max_var_over_excited_var) {
+        emit_float("MaxVar", nameplate.max_var_over_excited_var.value());
+    }
+    if (nameplate.max_var_under_excited_var) {
+        emit_float("MaxVarNeg", nameplate.max_var_under_excited_var.value());
+    }
+    if (nameplate.max_charge_w_W) {
+        emit_float("MaxChargeRateW", nameplate.max_charge_w_W.value());
+    }
+
+    const auto& dc = capability.dc.value();
+    if (dc.device_info) {
+        const auto& info = dc.device_info.value();
+        if (info.manufacturer) {
+            emit_string("InverterManufacturer", info.manufacturer.value());
+        }
+        if (info.model) {
+            emit_string("InverterModel", info.model.value());
+        }
+        if (info.sw_version) {
+            emit_string("InverterSwVersion", info.sw_version.value());
+        }
+        if (info.hw_version) {
+            emit_string("InverterHwVersion", info.hw_version.value());
+        }
+    }
+    if (dc.over_excited_pf) {
+        emit_float("OverExcitedPF", dc.over_excited_pf.value());
+    }
+    if (dc.under_excited_pf) {
+        emit_float("UnderExcitedPF", dc.under_excited_pf.value());
+    }
+    if (dc.over_excited_w) {
+        emit_float("OverExcitedW", dc.over_excited_w.value());
+    }
+    if (dc.under_excited_w) {
+        emit_float("UnderExcitedW", dc.under_excited_w.value());
+    }
+    if (dc.reactive_susceptance) {
+        emit_float("ReactiveSusceptance", dc.reactive_susceptance.value());
+    }
+
+    return result;
+}
 
 EverestDeviceModelStorage::EverestDeviceModelStorage(
     const std::vector<std::unique_ptr<evse_managerIntf>>& r_evse_manager,
@@ -376,6 +554,11 @@ EverestDeviceModelStorage::EverestDeviceModelStorage(
 
         const auto connected_ev_component_key = get_connected_ev_component_key(evse_info.id);
         component_configs[connected_ev_component_key] = build_connected_ev_variables();
+
+        auto der_ctrlr_config = build_der_ctrlr_component_config(evse_info.id, supported_energy_transfer_modes);
+        if (der_ctrlr_config.has_value()) {
+            component_configs[der_ctrlr_config->first] = std::move(der_ctrlr_config->second);
+        }
     }
     for (const auto& extension : r_extensions_15118) {
         auto mapping = extension->get_mapping();

--- a/lib/everest/ocpp_module_common/src/device_model/everest_device_model_storage.cpp
+++ b/lib/everest/ocpp_module_common/src/device_model/everest_device_model_storage.cpp
@@ -508,6 +508,33 @@ to_der_ctrlr_config_set_variables(const int32_t evse_id, const types::grid_suppo
     return result;
 }
 
+void disable_der_ctrlr(ocpp::v2::DeviceModelStorageInterface& storage, const int32_t evse_id) {
+    const auto force_unavailable = [&](const ocpp::v2::ComponentVariable& component_variable) {
+        if (not component_variable.variable.has_value()) {
+            return;
+        }
+        const auto& variable = component_variable.variable.value();
+        const auto attribute =
+            storage.get_variable_attribute(component_variable.component, variable, ocpp::v2::AttributeEnum::Actual);
+        if (not attribute.has_value()) {
+            return;
+        }
+        if (not attribute.value().value.has_value()) {
+            return;
+        }
+        // Only clear a persisted Available="true"; leave any other value untouched.
+        if (attribute.value().value.value().get() != "true") {
+            return;
+        }
+        storage.set_variable_attribute_value(component_variable.component, variable, ocpp::v2::AttributeEnum::Actual,
+                                             "false", VARIABLE_SOURCE_EVEREST);
+    };
+    force_unavailable(ocpp::v2::DERComponentVariables::get_dc_component_variable(
+        evse_id, ocpp::v2::DERComponentVariables::Available));
+    force_unavailable(ocpp::v2::DERComponentVariables::get_ac_component_variable(
+        evse_id, ocpp::v2::DERComponentVariables::Available));
+}
+
 EverestDeviceModelStorage::EverestDeviceModelStorage(
     const std::vector<std::unique_ptr<evse_managerIntf>>& r_evse_manager,
     const std::vector<std::unique_ptr<iso15118_extensionsIntf>>& r_extensions_15118,
@@ -831,6 +858,11 @@ void EverestDeviceModelStorage::update_connected_ev_vehicle_id(const int32_t evs
     this->device_model_storage->set_variable_attribute_value(
         connected_ev_component, ocpp::v2::ConnectedEvComponentVariables::VehicleId, ocpp::v2::AttributeEnum::Actual,
         vehicle_id, VARIABLE_SOURCE_EVEREST);
+}
+
+void EverestDeviceModelStorage::disable_der(const int32_t evse_id) {
+    std::lock_guard<std::mutex> lock(device_model_mutex);
+    disable_der_ctrlr(*this->device_model_storage, evse_id);
 }
 
 void EverestDeviceModelStorage::update_power(const int32_t evse_id, const float total_power_active_import) {

--- a/lib/everest/ocpp_module_common/tests/CMakeLists.txt
+++ b/lib/everest/ocpp_module_common/tests/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(${TEST_TARGET_NAME})
 target_sources(${TEST_TARGET_NAME}
     PRIVATE
     error_handling_tests.cpp
+    everest_device_model_storage_test.cpp
+    grid_support_conversions_test.cpp
     transaction_handler_tests.cpp
 )
 

--- a/lib/everest/ocpp_module_common/tests/CMakeLists.txt
+++ b/lib/everest/ocpp_module_common/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(${TEST_TARGET_NAME}
 target_compile_definitions(${TEST_TARGET_NAME}
     PRIVATE
     TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data"
+    DEVICE_MODEL_MIGRATIONS_DIR="${PROJECT_SOURCE_DIR}/lib/everest/ocpp/config/common/device_model_migrations"
 )
 
 target_link_libraries(${TEST_TARGET_NAME}

--- a/lib/everest/ocpp_module_common/tests/everest_device_model_storage_test.cpp
+++ b/lib/everest/ocpp_module_common/tests/everest_device_model_storage_test.cpp
@@ -3,6 +3,8 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
+#include <map>
 #include <optional>
 #include <vector>
 
@@ -12,6 +14,7 @@
 #include <generated/types/iso15118.hpp>
 
 #include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/device_model_storage_sqlite.hpp>
 #include <ocpp/v2/init_device_model_db.hpp>
 #include <ocpp/v2/ocpp_types.hpp>
 
@@ -234,6 +237,95 @@ TEST(EverestDeviceModelStorageDerTest, AcCapabilityUsesAcComponent) {
     EXPECT_EQ(available.variable.name.get(), "Available");
     EXPECT_EQ(available.component.name.get(), "ACDERCtrlr");
     EXPECT_EQ(available.attributeValue.get(), "true");
+}
+
+namespace dm = ocpp_module_common::device_model;
+
+std::filesystem::path make_temp_db_path(const std::string& tag) {
+    auto path = std::filesystem::temp_directory_path() / ("ocpp_module_common_der_disable_" + tag + ".db");
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+    return path;
+}
+
+// Builds a device model DB at db_path holding a single DER controller for evse_id, derived from modes.
+void init_db_with_der_ctrlr(const std::filesystem::path& db_path, const int32_t evse_id,
+                            const std::vector<etm::EnergyTransferMode>& modes) {
+    const auto der = dm::build_der_ctrlr_component_config(evse_id, modes);
+    ASSERT_TRUE(der.has_value());
+    std::map<ocpp::v2::ComponentKey, std::vector<ocpp::v2::DeviceModelVariable>> component_configs;
+    component_configs[der->first] = der->second;
+    ocpp::v2::InitDeviceModelDb init_db(db_path, DEVICE_MODEL_MIGRATIONS_DIR);
+    init_db.initialize_database(component_configs, true);
+    init_db.close_connection();
+}
+
+std::optional<std::string> read_der_available(ocpp::v2::DeviceModelStorageInterface& storage,
+                                              const ocpp::v2::ComponentVariable& cv) {
+    const auto attr =
+        storage.get_variable_attribute(cv.component, cv.variable.value(), ocpp::v2::AttributeEnum::Actual);
+    if (not attr.has_value() or not attr->value.has_value()) {
+        return std::nullopt;
+    }
+    return attr->value.value().get();
+}
+
+// disable_der_ctrlr forces a persisted DCDERCtrlr Available "true" back to "false".
+TEST(EverestDeviceModelStorageDisableDerTest, DcDerCtrlrForcedToUnavailable) {
+    const auto db_path = make_temp_db_path("dc");
+    init_db_with_der_ctrlr(db_path, 1, {etm::EnergyTransferMode::DC_extended, etm::EnergyTransferMode::DC_BPT});
+
+    ocpp::v2::DeviceModelStorageSqlite storage(db_path);
+    const auto cv =
+        ocpp::v2::DERComponentVariables::get_dc_component_variable(1, ocpp::v2::DERComponentVariables::Available);
+    ASSERT_TRUE(cv.variable.has_value());
+
+    ASSERT_EQ(storage.set_variable_attribute_value(cv.component, cv.variable.value(), ocpp::v2::AttributeEnum::Actual,
+                                                   "true", "EVEREST"),
+              ocpp::v2::SetVariableStatusEnum::Accepted);
+    ASSERT_EQ(read_der_available(storage, cv), "true");
+
+    dm::disable_der_ctrlr(storage, 1);
+
+    EXPECT_EQ(read_der_available(storage, cv), "false");
+}
+
+// disable_der_ctrlr forces a persisted ACDERCtrlr Available "true" back to "false".
+TEST(EverestDeviceModelStorageDisableDerTest, AcDerCtrlrForcedToUnavailable) {
+    const auto db_path = make_temp_db_path("ac");
+    init_db_with_der_ctrlr(db_path, 1,
+                           {etm::EnergyTransferMode::AC_single_phase_core, etm::EnergyTransferMode::AC_BPT_DER});
+
+    ocpp::v2::DeviceModelStorageSqlite storage(db_path);
+    const auto cv =
+        ocpp::v2::DERComponentVariables::get_ac_component_variable(1, ocpp::v2::DERComponentVariables::Available);
+    ASSERT_TRUE(cv.variable.has_value());
+
+    ASSERT_EQ(storage.set_variable_attribute_value(cv.component, cv.variable.value(), ocpp::v2::AttributeEnum::Actual,
+                                                   "true", "EVEREST"),
+              ocpp::v2::SetVariableStatusEnum::Accepted);
+    ASSERT_EQ(read_der_available(storage, cv), "true");
+
+    dm::disable_der_ctrlr(storage, 1);
+
+    EXPECT_EQ(read_der_available(storage, cv), "false");
+}
+
+// An EVSE with no DER component is a silent no-op: no throw, nothing created.
+TEST(EverestDeviceModelStorageDisableDerTest, NoDerCtrlrIsSilentNoOp) {
+    const auto db_path = make_temp_db_path("noder");
+    // The DB only holds a DER controller for evse 1; evse 2 has none.
+    init_db_with_der_ctrlr(db_path, 1, {etm::EnergyTransferMode::DC_extended, etm::EnergyTransferMode::DC_BPT});
+
+    ocpp::v2::DeviceModelStorageSqlite storage(db_path);
+    EXPECT_NO_THROW(dm::disable_der_ctrlr(storage, 2));
+
+    const auto dc_cv =
+        ocpp::v2::DERComponentVariables::get_dc_component_variable(2, ocpp::v2::DERComponentVariables::Available);
+    EXPECT_FALSE(read_der_available(storage, dc_cv).has_value());
+    const auto ac_cv =
+        ocpp::v2::DERComponentVariables::get_ac_component_variable(2, ocpp::v2::DERComponentVariables::Available);
+    EXPECT_FALSE(read_der_available(storage, ac_cv).has_value());
 }
 
 } // namespace

--- a/lib/everest/ocpp_module_common/tests/everest_device_model_storage_test.cpp
+++ b/lib/everest/ocpp_module_common/tests/everest_device_model_storage_test.cpp
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <vector>
+
+#include <everest/ocpp_module_common/device_model/everest_device_model_storage.hpp>
+
+#include <generated/types/grid_support.hpp>
+#include <generated/types/iso15118.hpp>
+
+#include <ocpp/v2/ctrlr_component_variables.hpp>
+#include <ocpp/v2/init_device_model_db.hpp>
+#include <ocpp/v2/ocpp_types.hpp>
+
+namespace {
+
+namespace etm = types::iso15118;
+namespace gs = types::grid_support;
+
+const ocpp::v2::DeviceModelVariable* find_variable(const std::vector<ocpp::v2::DeviceModelVariable>& variables,
+                                                   const std::string& name) {
+    for (const auto& variable : variables) {
+        if (variable.name == name) {
+            return &variable;
+        }
+    }
+    return nullptr;
+}
+
+// AC_BPT_DER generates an ACDERCtrlr, provisioned disabled (Available "false"/ReadWrite, empty ModesSupported).
+TEST(EverestDeviceModelStorageDerTest, AcDerCapableEvseGeneratesAcDerCtrlr) {
+    constexpr int32_t evse_id = 1;
+    const std::vector<etm::EnergyTransferMode> modes{etm::EnergyTransferMode::AC_single_phase_core,
+                                                     etm::EnergyTransferMode::AC_BPT_DER};
+
+    const auto config = ocpp_module_common::device_model::build_der_ctrlr_component_config(evse_id, modes);
+
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->first.name, "ACDERCtrlr");
+    EXPECT_EQ(config->first.evse_id, evse_id);
+
+    const auto* available = find_variable(config->second, ocpp::v2::DERComponentVariables::Available.name);
+    ASSERT_NE(available, nullptr);
+    ASSERT_EQ(available->attributes.size(), 1u);
+    const auto& available_attr = available->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(available_attr.value.has_value());
+    EXPECT_EQ(available_attr.value.value().get(), "false");
+    ASSERT_TRUE(available_attr.mutability.has_value());
+    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
+
+    const auto* modes_supported = find_variable(config->second, ocpp::v2::DERComponentVariables::ModesSupported.name);
+    ASSERT_NE(modes_supported, nullptr);
+    ASSERT_EQ(modes_supported->attributes.size(), 1u);
+    const auto& modes_attr = modes_supported->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(modes_attr.value.has_value());
+    EXPECT_EQ(modes_attr.value.value().get(), "");
+}
+
+// DC_BPT generates a DCDERCtrlr, not an ACDERCtrlr.
+TEST(EverestDeviceModelStorageDerTest, DcDerCapableEvseGeneratesDcDerCtrlr) {
+    constexpr int32_t evse_id = 1;
+    const std::vector<etm::EnergyTransferMode> modes{etm::EnergyTransferMode::DC_extended,
+                                                     etm::EnergyTransferMode::DC_BPT};
+
+    const auto config = ocpp_module_common::device_model::build_der_ctrlr_component_config(evse_id, modes);
+
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->first.name, "DCDERCtrlr");
+    EXPECT_EQ(config->first.evse_id, evse_id);
+
+    const auto* available = find_variable(config->second, ocpp::v2::DERComponentVariables::Available.name);
+    ASSERT_NE(available, nullptr);
+    ASSERT_EQ(available->attributes.size(), 1u);
+    const auto& available_attr = available->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(available_attr.value.has_value());
+    EXPECT_EQ(available_attr.value.value().get(), "false");
+    ASSERT_TRUE(available_attr.mutability.has_value());
+    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
+
+    const auto* modes_supported = find_variable(config->second, ocpp::v2::DERComponentVariables::ModesSupported.name);
+    ASSERT_NE(modes_supported, nullptr);
+    ASSERT_EQ(modes_supported->attributes.size(), 1u);
+    const auto& modes_attr = modes_supported->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(modes_attr.value.has_value());
+    EXPECT_EQ(modes_attr.value.value().get(), "");
+}
+
+// With both a DC-DER (DC_BPT) and an AC-DER (AC_BPT_DER) mode, the DC branch takes precedence.
+TEST(EverestDeviceModelStorageDerTest, DcDerWinsOverAcDerWhenBothPresent) {
+    constexpr int32_t evse_id = 1;
+    const std::vector<etm::EnergyTransferMode> modes{etm::EnergyTransferMode::DC_BPT,
+                                                     etm::EnergyTransferMode::AC_BPT_DER};
+
+    const auto config = ocpp_module_common::device_model::build_der_ctrlr_component_config(evse_id, modes);
+
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->first.name, "DCDERCtrlr");
+    EXPECT_EQ(config->first.evse_id, evse_id);
+
+    const auto* available = find_variable(config->second, ocpp::v2::DERComponentVariables::Available.name);
+    ASSERT_NE(available, nullptr);
+    ASSERT_EQ(available->attributes.size(), 1u);
+    const auto& available_attr = available->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(available_attr.value.has_value());
+    EXPECT_EQ(available_attr.value.value().get(), "false");
+    ASSERT_TRUE(available_attr.mutability.has_value());
+    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
+
+    const auto* modes_supported = find_variable(config->second, ocpp::v2::DERComponentVariables::ModesSupported.name);
+    ASSERT_NE(modes_supported, nullptr);
+    ASSERT_EQ(modes_supported->attributes.size(), 1u);
+    const auto& modes_attr = modes_supported->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(modes_attr.value.has_value());
+    EXPECT_EQ(modes_attr.value.value().get(), "");
+}
+
+// Non-DER DC mode (DC_core) plus bare AC_DER_IEC falls through to the AC branch. Also covers the bare
+// AC_DER_IEC disjunct (the AC test above uses AC_BPT_DER).
+TEST(EverestDeviceModelStorageDerTest, NonDcDerWithBareAcDerGeneratesAcDerCtrlr) {
+    constexpr int32_t evse_id = 1;
+    const std::vector<etm::EnergyTransferMode> modes{etm::EnergyTransferMode::DC_core,
+                                                     etm::EnergyTransferMode::AC_DER_IEC};
+
+    const auto config = ocpp_module_common::device_model::build_der_ctrlr_component_config(evse_id, modes);
+
+    ASSERT_TRUE(config.has_value());
+    EXPECT_EQ(config->first.name, "ACDERCtrlr");
+    EXPECT_EQ(config->first.evse_id, evse_id);
+
+    const auto* available = find_variable(config->second, ocpp::v2::DERComponentVariables::Available.name);
+    ASSERT_NE(available, nullptr);
+    ASSERT_EQ(available->attributes.size(), 1u);
+    const auto& available_attr = available->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(available_attr.value.has_value());
+    EXPECT_EQ(available_attr.value.value().get(), "false");
+    ASSERT_TRUE(available_attr.mutability.has_value());
+    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
+
+    const auto* modes_supported = find_variable(config->second, ocpp::v2::DERComponentVariables::ModesSupported.name);
+    ASSERT_NE(modes_supported, nullptr);
+    ASSERT_EQ(modes_supported->attributes.size(), 1u);
+    const auto& modes_attr = modes_supported->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(modes_attr.value.has_value());
+    EXPECT_EQ(modes_attr.value.value().get(), "");
+}
+
+// Plain AC/DC charging modes (none of AC_DER_IEC/AC_DER_SAE/AC_BPT_DER/DC_BPT/DC_ACDP_BPT) generate no DER controller.
+TEST(EverestDeviceModelStorageDerTest, NonDerEvseGeneratesNoDerCtrlr) {
+    constexpr int32_t evse_id = 2;
+    const std::vector<etm::EnergyTransferMode> modes{etm::EnergyTransferMode::AC_single_phase_core,
+                                                     etm::EnergyTransferMode::AC_three_phase_core,
+                                                     etm::EnergyTransferMode::DC_extended};
+
+    const auto config = ocpp_module_common::device_model::build_der_ctrlr_component_config(evse_id, modes);
+
+    EXPECT_FALSE(config.has_value());
+}
+
+const ocpp::v2::SetVariableData* find_set_variable(const std::vector<ocpp::v2::SetVariableData>& vars,
+                                                   const std::string& name) {
+    for (const auto& v : vars) {
+        if (v.variable.name.get() == name) {
+            return &v;
+        }
+    }
+    return nullptr;
+}
+
+// DC config emits ModesSupported and nameplate scalars but never the enabling Available write; the
+// Available write is a separate single SetVariableData targeting the DCDERCtrlr component.
+TEST(EverestDeviceModelStorageDerTest, DcCapabilityEmitsConfigAndSeparateAvailable) {
+    gs::DERCapability capability;
+    capability.supported_types = {gs::DirectiveType::VoltVar, gs::DirectiveType::FreqDroop};
+    capability.nameplate.max_w_W = 11000.0f;
+    capability.nameplate.max_va_VA = 12000.0f;
+    capability.nameplate.v_nom_V = 230.0f;
+    gs::DCCapability dc;
+    gs::DeviceInfo info;
+    info.manufacturer = "Acme";
+    dc.device_info = info;
+    capability.dc = dc;
+
+    const auto config = ocpp_module_common::device_model::to_der_ctrlr_config_set_variables(1, capability);
+
+    // Config carries no enabling Available write.
+    EXPECT_EQ(find_set_variable(config, "Available"), nullptr);
+
+    const auto* modes = find_set_variable(config, "ModesSupported");
+    ASSERT_NE(modes, nullptr);
+    EXPECT_EQ(modes->component.name.get(), "DCDERCtrlr");
+    EXPECT_EQ(modes->attributeValue.get(), "VoltVar,FreqDroop");
+
+    const auto* manufacturer = find_set_variable(config, "InverterManufacturer");
+    ASSERT_NE(manufacturer, nullptr);
+    EXPECT_EQ(manufacturer->attributeValue.get(), "Acme");
+
+    const auto available = ocpp_module_common::device_model::to_der_ctrlr_available_set_variable(1, capability);
+    EXPECT_EQ(available.variable.name.get(), "Available");
+    EXPECT_EQ(available.component.name.get(), "DCDERCtrlr");
+    EXPECT_EQ(available.attributeValue.get(), "true");
+}
+
+// AC config emits only ModesSupported (no enabling Available, no nameplate scalars); the Available write
+// targets the ACDERCtrlr component.
+TEST(EverestDeviceModelStorageDerTest, AcCapabilityUsesAcComponent) {
+    gs::DERCapability capability;
+    capability.supported_types = {gs::DirectiveType::VoltVar};
+    capability.nameplate.max_w_W = 7400.0f;
+    capability.nameplate.max_va_VA = 7400.0f;
+    capability.nameplate.v_nom_V = 230.0f;
+    gs::ACCapability ac;
+    ac.phase_count = 3;
+    capability.ac = ac;
+
+    const auto config = ocpp_module_common::device_model::to_der_ctrlr_config_set_variables(2, capability);
+
+    // Config carries no enabling Available write.
+    EXPECT_EQ(find_set_variable(config, "Available"), nullptr);
+
+    const auto* modes = find_set_variable(config, "ModesSupported");
+    ASSERT_NE(modes, nullptr);
+    EXPECT_EQ(modes->component.name.get(), "ACDERCtrlr");
+    EXPECT_EQ(modes->attributeValue.get(), "VoltVar");
+
+    // Nameplate scalars have no ACDERCtrlr variable and must not be emitted.
+    EXPECT_EQ(find_set_variable(config, "MaxW"), nullptr);
+    EXPECT_EQ(find_set_variable(config, "MaxVA"), nullptr);
+    EXPECT_EQ(find_set_variable(config, "InverterManufacturer"), nullptr);
+
+    const auto available = ocpp_module_common::device_model::to_der_ctrlr_available_set_variable(2, capability);
+    EXPECT_EQ(available.variable.name.get(), "Available");
+    EXPECT_EQ(available.component.name.get(), "ACDERCtrlr");
+    EXPECT_EQ(available.attributeValue.get(), "true");
+}
+
+} // namespace

--- a/lib/everest/ocpp_module_common/tests/everest_device_model_storage_test.cpp
+++ b/lib/everest/ocpp_module_common/tests/everest_device_model_storage_test.cpp
@@ -33,7 +33,8 @@ const ocpp::v2::DeviceModelVariable* find_variable(const std::vector<ocpp::v2::D
     return nullptr;
 }
 
-// AC_BPT_DER generates an ACDERCtrlr, provisioned disabled (Available "false"/ReadWrite, empty ModesSupported).
+// AC_BPT_DER generates an ACDERCtrlr with static presence (Available "true"/ReadOnly) and a runtime
+// Enabled control (provisioned "true"/ReadWrite), empty ModesSupported.
 TEST(EverestDeviceModelStorageDerTest, AcDerCapableEvseGeneratesAcDerCtrlr) {
     constexpr int32_t evse_id = 1;
     const std::vector<etm::EnergyTransferMode> modes{etm::EnergyTransferMode::AC_single_phase_core,
@@ -50,9 +51,18 @@ TEST(EverestDeviceModelStorageDerTest, AcDerCapableEvseGeneratesAcDerCtrlr) {
     ASSERT_EQ(available->attributes.size(), 1u);
     const auto& available_attr = available->attributes.at(0).variable_attribute;
     ASSERT_TRUE(available_attr.value.has_value());
-    EXPECT_EQ(available_attr.value.value().get(), "false");
+    EXPECT_EQ(available_attr.value.value().get(), "true");
     ASSERT_TRUE(available_attr.mutability.has_value());
-    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
+    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadOnly);
+
+    const auto* enabled = find_variable(config->second, ocpp::v2::DERComponentVariables::Enabled.name);
+    ASSERT_NE(enabled, nullptr);
+    ASSERT_EQ(enabled->attributes.size(), 1u);
+    const auto& enabled_attr = enabled->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(enabled_attr.value.has_value());
+    EXPECT_EQ(enabled_attr.value.value().get(), "true");
+    ASSERT_TRUE(enabled_attr.mutability.has_value());
+    EXPECT_EQ(enabled_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
 
     const auto* modes_supported = find_variable(config->second, ocpp::v2::DERComponentVariables::ModesSupported.name);
     ASSERT_NE(modes_supported, nullptr);
@@ -79,9 +89,18 @@ TEST(EverestDeviceModelStorageDerTest, DcDerCapableEvseGeneratesDcDerCtrlr) {
     ASSERT_EQ(available->attributes.size(), 1u);
     const auto& available_attr = available->attributes.at(0).variable_attribute;
     ASSERT_TRUE(available_attr.value.has_value());
-    EXPECT_EQ(available_attr.value.value().get(), "false");
+    EXPECT_EQ(available_attr.value.value().get(), "true");
     ASSERT_TRUE(available_attr.mutability.has_value());
-    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
+    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadOnly);
+
+    const auto* enabled = find_variable(config->second, ocpp::v2::DERComponentVariables::Enabled.name);
+    ASSERT_NE(enabled, nullptr);
+    ASSERT_EQ(enabled->attributes.size(), 1u);
+    const auto& enabled_attr = enabled->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(enabled_attr.value.has_value());
+    EXPECT_EQ(enabled_attr.value.value().get(), "true");
+    ASSERT_TRUE(enabled_attr.mutability.has_value());
+    EXPECT_EQ(enabled_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
 
     const auto* modes_supported = find_variable(config->second, ocpp::v2::DERComponentVariables::ModesSupported.name);
     ASSERT_NE(modes_supported, nullptr);
@@ -108,9 +127,18 @@ TEST(EverestDeviceModelStorageDerTest, DcDerWinsOverAcDerWhenBothPresent) {
     ASSERT_EQ(available->attributes.size(), 1u);
     const auto& available_attr = available->attributes.at(0).variable_attribute;
     ASSERT_TRUE(available_attr.value.has_value());
-    EXPECT_EQ(available_attr.value.value().get(), "false");
+    EXPECT_EQ(available_attr.value.value().get(), "true");
     ASSERT_TRUE(available_attr.mutability.has_value());
-    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
+    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadOnly);
+
+    const auto* enabled = find_variable(config->second, ocpp::v2::DERComponentVariables::Enabled.name);
+    ASSERT_NE(enabled, nullptr);
+    ASSERT_EQ(enabled->attributes.size(), 1u);
+    const auto& enabled_attr = enabled->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(enabled_attr.value.has_value());
+    EXPECT_EQ(enabled_attr.value.value().get(), "true");
+    ASSERT_TRUE(enabled_attr.mutability.has_value());
+    EXPECT_EQ(enabled_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
 
     const auto* modes_supported = find_variable(config->second, ocpp::v2::DERComponentVariables::ModesSupported.name);
     ASSERT_NE(modes_supported, nullptr);
@@ -138,9 +166,18 @@ TEST(EverestDeviceModelStorageDerTest, NonDcDerWithBareAcDerGeneratesAcDerCtrlr)
     ASSERT_EQ(available->attributes.size(), 1u);
     const auto& available_attr = available->attributes.at(0).variable_attribute;
     ASSERT_TRUE(available_attr.value.has_value());
-    EXPECT_EQ(available_attr.value.value().get(), "false");
+    EXPECT_EQ(available_attr.value.value().get(), "true");
     ASSERT_TRUE(available_attr.mutability.has_value());
-    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
+    EXPECT_EQ(available_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadOnly);
+
+    const auto* enabled = find_variable(config->second, ocpp::v2::DERComponentVariables::Enabled.name);
+    ASSERT_NE(enabled, nullptr);
+    ASSERT_EQ(enabled->attributes.size(), 1u);
+    const auto& enabled_attr = enabled->attributes.at(0).variable_attribute;
+    ASSERT_TRUE(enabled_attr.value.has_value());
+    EXPECT_EQ(enabled_attr.value.value().get(), "true");
+    ASSERT_TRUE(enabled_attr.mutability.has_value());
+    EXPECT_EQ(enabled_attr.mutability.value(), ocpp::v2::MutabilityEnum::ReadWrite);
 
     const auto* modes_supported = find_variable(config->second, ocpp::v2::DERComponentVariables::ModesSupported.name);
     ASSERT_NE(modes_supported, nullptr);
@@ -172,9 +209,9 @@ const ocpp::v2::SetVariableData* find_set_variable(const std::vector<ocpp::v2::S
     return nullptr;
 }
 
-// DC config emits ModesSupported and nameplate scalars but never the enabling Available write; the
-// Available write is a separate single SetVariableData targeting the DCDERCtrlr component.
-TEST(EverestDeviceModelStorageDerTest, DcCapabilityEmitsConfigAndSeparateAvailable) {
+// DC config emits ModesSupported and nameplate scalars but never the enabling Enabled write; the
+// Enabled write is a separate single SetVariableData targeting the DCDERCtrlr component.
+TEST(EverestDeviceModelStorageDerTest, DcCapabilityEmitsConfigAndSeparateEnabled) {
     gs::DERCapability capability;
     capability.supported_types = {gs::DirectiveType::VoltVar, gs::DirectiveType::FreqDroop};
     capability.nameplate.max_w_W = 11000.0f;
@@ -188,8 +225,8 @@ TEST(EverestDeviceModelStorageDerTest, DcCapabilityEmitsConfigAndSeparateAvailab
 
     const auto config = ocpp_module_common::device_model::to_der_ctrlr_config_set_variables(1, capability);
 
-    // Config carries no enabling Available write.
-    EXPECT_EQ(find_set_variable(config, "Available"), nullptr);
+    // Config carries no enabling Enabled write.
+    EXPECT_EQ(find_set_variable(config, "Enabled"), nullptr);
 
     const auto* modes = find_set_variable(config, "ModesSupported");
     ASSERT_NE(modes, nullptr);
@@ -199,14 +236,9 @@ TEST(EverestDeviceModelStorageDerTest, DcCapabilityEmitsConfigAndSeparateAvailab
     const auto* manufacturer = find_set_variable(config, "InverterManufacturer");
     ASSERT_NE(manufacturer, nullptr);
     EXPECT_EQ(manufacturer->attributeValue.get(), "Acme");
-
-    const auto available = ocpp_module_common::device_model::to_der_ctrlr_available_set_variable(1, capability);
-    EXPECT_EQ(available.variable.name.get(), "Available");
-    EXPECT_EQ(available.component.name.get(), "DCDERCtrlr");
-    EXPECT_EQ(available.attributeValue.get(), "true");
 }
 
-// AC config emits only ModesSupported (no enabling Available, no nameplate scalars); the Available write
+// AC config emits only ModesSupported (no enabling Enabled, no nameplate scalars); the Enabled write
 // targets the ACDERCtrlr component.
 TEST(EverestDeviceModelStorageDerTest, AcCapabilityUsesAcComponent) {
     gs::DERCapability capability;
@@ -220,8 +252,8 @@ TEST(EverestDeviceModelStorageDerTest, AcCapabilityUsesAcComponent) {
 
     const auto config = ocpp_module_common::device_model::to_der_ctrlr_config_set_variables(2, capability);
 
-    // Config carries no enabling Available write.
-    EXPECT_EQ(find_set_variable(config, "Available"), nullptr);
+    // Config carries no enabling Enabled write.
+    EXPECT_EQ(find_set_variable(config, "Enabled"), nullptr);
 
     const auto* modes = find_set_variable(config, "ModesSupported");
     ASSERT_NE(modes, nullptr);
@@ -232,11 +264,6 @@ TEST(EverestDeviceModelStorageDerTest, AcCapabilityUsesAcComponent) {
     EXPECT_EQ(find_set_variable(config, "MaxW"), nullptr);
     EXPECT_EQ(find_set_variable(config, "MaxVA"), nullptr);
     EXPECT_EQ(find_set_variable(config, "InverterManufacturer"), nullptr);
-
-    const auto available = ocpp_module_common::device_model::to_der_ctrlr_available_set_variable(2, capability);
-    EXPECT_EQ(available.variable.name.get(), "Available");
-    EXPECT_EQ(available.component.name.get(), "ACDERCtrlr");
-    EXPECT_EQ(available.attributeValue.get(), "true");
 }
 
 namespace dm = ocpp_module_common::device_model;
@@ -270,45 +297,82 @@ std::optional<std::string> read_der_available(ocpp::v2::DeviceModelStorageInterf
     return attr->value.value().get();
 }
 
-// disable_der_ctrlr forces a persisted DCDERCtrlr Available "true" back to "false".
+// disable_der_ctrlr forces both a persisted DCDERCtrlr Available "true" and Enabled "true" back to "false".
 TEST(EverestDeviceModelStorageDisableDerTest, DcDerCtrlrForcedToUnavailable) {
     const auto db_path = make_temp_db_path("dc");
     init_db_with_der_ctrlr(db_path, 1, {etm::EnergyTransferMode::DC_extended, etm::EnergyTransferMode::DC_BPT});
 
     ocpp::v2::DeviceModelStorageSqlite storage(db_path);
-    const auto cv =
+    const auto available_cv =
         ocpp::v2::DERComponentVariables::get_dc_component_variable(1, ocpp::v2::DERComponentVariables::Available);
-    ASSERT_TRUE(cv.variable.has_value());
+    const auto enabled_cv =
+        ocpp::v2::DERComponentVariables::get_dc_component_variable(1, ocpp::v2::DERComponentVariables::Enabled);
+    ASSERT_TRUE(available_cv.variable.has_value());
+    ASSERT_TRUE(enabled_cv.variable.has_value());
 
-    ASSERT_EQ(storage.set_variable_attribute_value(cv.component, cv.variable.value(), ocpp::v2::AttributeEnum::Actual,
-                                                   "true", "EVEREST"),
+    ASSERT_EQ(storage.set_variable_attribute_value(available_cv.component, available_cv.variable.value(),
+                                                   ocpp::v2::AttributeEnum::Actual, "true", "EVEREST"),
               ocpp::v2::SetVariableStatusEnum::Accepted);
-    ASSERT_EQ(read_der_available(storage, cv), "true");
+    ASSERT_EQ(storage.set_variable_attribute_value(enabled_cv.component, enabled_cv.variable.value(),
+                                                   ocpp::v2::AttributeEnum::Actual, "true", "EVEREST"),
+              ocpp::v2::SetVariableStatusEnum::Accepted);
+    ASSERT_EQ(read_der_available(storage, available_cv), "true");
+    ASSERT_EQ(read_der_available(storage, enabled_cv), "true");
 
     dm::disable_der_ctrlr(storage, 1);
 
-    EXPECT_EQ(read_der_available(storage, cv), "false");
+    EXPECT_EQ(read_der_available(storage, available_cv), "false");
+    EXPECT_EQ(read_der_available(storage, enabled_cv), "false");
 }
 
-// disable_der_ctrlr forces a persisted ACDERCtrlr Available "true" back to "false".
+// disable_der_ctrlr forces both a persisted ACDERCtrlr Available "true" and Enabled "true" back to "false".
 TEST(EverestDeviceModelStorageDisableDerTest, AcDerCtrlrForcedToUnavailable) {
     const auto db_path = make_temp_db_path("ac");
     init_db_with_der_ctrlr(db_path, 1,
                            {etm::EnergyTransferMode::AC_single_phase_core, etm::EnergyTransferMode::AC_BPT_DER});
 
     ocpp::v2::DeviceModelStorageSqlite storage(db_path);
-    const auto cv =
+    const auto available_cv =
         ocpp::v2::DERComponentVariables::get_ac_component_variable(1, ocpp::v2::DERComponentVariables::Available);
-    ASSERT_TRUE(cv.variable.has_value());
+    const auto enabled_cv =
+        ocpp::v2::DERComponentVariables::get_ac_component_variable(1, ocpp::v2::DERComponentVariables::Enabled);
+    ASSERT_TRUE(available_cv.variable.has_value());
+    ASSERT_TRUE(enabled_cv.variable.has_value());
 
-    ASSERT_EQ(storage.set_variable_attribute_value(cv.component, cv.variable.value(), ocpp::v2::AttributeEnum::Actual,
-                                                   "true", "EVEREST"),
+    ASSERT_EQ(storage.set_variable_attribute_value(available_cv.component, available_cv.variable.value(),
+                                                   ocpp::v2::AttributeEnum::Actual, "true", "EVEREST"),
               ocpp::v2::SetVariableStatusEnum::Accepted);
-    ASSERT_EQ(read_der_available(storage, cv), "true");
+    ASSERT_EQ(storage.set_variable_attribute_value(enabled_cv.component, enabled_cv.variable.value(),
+                                                   ocpp::v2::AttributeEnum::Actual, "true", "EVEREST"),
+              ocpp::v2::SetVariableStatusEnum::Accepted);
+    ASSERT_EQ(read_der_available(storage, available_cv), "true");
+    ASSERT_EQ(read_der_available(storage, enabled_cv), "true");
 
     dm::disable_der_ctrlr(storage, 1);
 
-    EXPECT_EQ(read_der_available(storage, cv), "false");
+    EXPECT_EQ(read_der_available(storage, available_cv), "false");
+    EXPECT_EQ(read_der_available(storage, enabled_cv), "false");
+}
+
+// The guard only overwrites a persisted "true": an Enabled already at "false" (e.g. a CSMS-written
+// disable) is left untouched so its source marker survives an unwire/rewire cycle.
+TEST(EverestDeviceModelStorageDisableDerTest, EnabledAlreadyFalseLeftUntouched) {
+    const auto db_path = make_temp_db_path("enabled_false");
+    init_db_with_der_ctrlr(db_path, 1, {etm::EnergyTransferMode::DC_extended, etm::EnergyTransferMode::DC_BPT});
+
+    ocpp::v2::DeviceModelStorageSqlite storage(db_path);
+    const auto enabled_cv =
+        ocpp::v2::DERComponentVariables::get_dc_component_variable(1, ocpp::v2::DERComponentVariables::Enabled);
+    ASSERT_TRUE(enabled_cv.variable.has_value());
+
+    ASSERT_EQ(storage.set_variable_attribute_value(enabled_cv.component, enabled_cv.variable.value(),
+                                                   ocpp::v2::AttributeEnum::Actual, "false", "CSMS"),
+              ocpp::v2::SetVariableStatusEnum::Accepted);
+    ASSERT_EQ(read_der_available(storage, enabled_cv), "false");
+
+    dm::disable_der_ctrlr(storage, 1);
+
+    EXPECT_EQ(read_der_available(storage, enabled_cv), "false");
 }
 
 // An EVSE with no DER component is a silent no-op: no throw, nothing created.

--- a/lib/everest/ocpp_module_common/tests/grid_support_conversions_test.cpp
+++ b/lib/everest/ocpp_module_common/tests/grid_support_conversions_test.cpp
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+#include <everest/ocpp_module_common/conversions.hpp>
+
+#include <generated/types/grid_support.hpp>
+#include <ocpp/v2/ocpp_enums.hpp>
+#include <ocpp/v21/messages/NotifyDERAlarm.hpp>
+#include <ocpp/v21/messages/SetDERControl.hpp>
+
+namespace {
+
+namespace gs = types::grid_support;
+
+TEST(GridSupportConversions, VoltVarRequestPopulatesOnlyCurve) {
+    ocpp::v21::SetDERControlRequest request;
+    request.isDefault = true;
+    request.controlId = "ctrl-1";
+    request.controlType = ocpp::v2::DERControlEnum::VoltVar;
+
+    ocpp::v2::DERCurve curve;
+    curve.priority = 7;
+    curve.yUnit = ocpp::v2::DERUnitEnum::PctMaxVar;
+    curve.curveData.push_back(ocpp::v2::DERCurvePoints{1.0f, 2.0f, std::nullopt});
+    request.curve = curve;
+
+    const auto directive =
+        ocpp_module_common::conversions::to_grid_support_directive(request, "OCPP", "2026-06-16T00:00:00Z");
+
+    EXPECT_EQ(directive.directive_type, gs::DirectiveType::VoltVar);
+    EXPECT_EQ(directive.id, "ctrl-1");
+    EXPECT_TRUE(directive.is_default);
+    EXPECT_EQ(directive.priority, 7);
+    EXPECT_EQ(directive.source, "OCPP");
+    EXPECT_EQ(directive.received_at, "2026-06-16T00:00:00Z");
+
+    ASSERT_TRUE(directive.curve.has_value());
+    EXPECT_EQ(directive.curve->y_unit, gs::DERUnit::PctMaxVar);
+    ASSERT_EQ(directive.curve->curve_data.size(), 1u);
+    EXPECT_FLOAT_EQ(directive.curve->curve_data.at(0).x, 1.0f);
+    EXPECT_FLOAT_EQ(directive.curve->curve_data.at(0).y, 2.0f);
+
+    // exactly the curve payload is populated
+    EXPECT_FALSE(directive.freq_droop.has_value());
+    EXPECT_FALSE(directive.enter_service.has_value());
+    EXPECT_FALSE(directive.fixed_pf.has_value());
+    EXPECT_FALSE(directive.fixed_var.has_value());
+    EXPECT_FALSE(directive.gradient.has_value());
+    EXPECT_FALSE(directive.limit_max_discharge.has_value());
+}
+
+// Builds a minimal VoltVar curve request carrying the given fractional-seconds duration.
+gs::Directive directive_with_curve_duration(float duration_s) {
+    ocpp::v21::SetDERControlRequest request;
+    request.controlId = "ctrl-dur";
+    request.controlType = ocpp::v2::DERControlEnum::VoltVar;
+
+    ocpp::v2::DERCurve curve;
+    curve.priority = 1;
+    curve.yUnit = ocpp::v2::DERUnitEnum::PctMaxVar;
+    curve.curveData.push_back(ocpp::v2::DERCurvePoints{1.0f, 2.0f, std::nullopt});
+    curve.duration = duration_s;
+    request.curve = curve;
+
+    return ocpp_module_common::conversions::to_grid_support_directive(request, "OCPP", "2026-06-16T00:00:00Z");
+}
+
+// A NaN duration never expires in libocpp, so duration_s is left unset (unbounded).
+TEST(GridSupportConversions, NanDurationLeavesDurationUnset) {
+    const auto directive = directive_with_curve_duration(std::numeric_limits<float>::quiet_NaN());
+    EXPECT_FALSE(directive.duration_s.has_value());
+}
+
+// A negative duration never expires in libocpp, so duration_s is left unset (unbounded).
+TEST(GridSupportConversions, NegativeDurationLeavesDurationUnset) {
+    const auto directive = directive_with_curve_duration(-5.0f);
+    EXPECT_FALSE(directive.duration_s.has_value());
+}
+
+// An out-of-int-range duration is clamped to the max int rather than triggering UB.
+TEST(GridSupportConversions, OverflowingDurationClampsToIntMax) {
+    const auto directive = directive_with_curve_duration(1e12f);
+    ASSERT_TRUE(directive.duration_s.has_value());
+    EXPECT_EQ(directive.duration_s.value(), std::numeric_limits<int>::max());
+}
+
+// A fractional duration rounds to the nearest second (llround), not truncation.
+TEST(GridSupportConversions, FractionalDurationRoundsToNearestSecond) {
+    const auto directive = directive_with_curve_duration(90.7f);
+    ASSERT_TRUE(directive.duration_s.has_value());
+    EXPECT_EQ(directive.duration_s.value(), 91);
+}
+
+TEST(GridSupportConversions, FreqDroopRequestPopulatesOnlyFreqDroop) {
+    ocpp::v21::SetDERControlRequest request;
+    request.isDefault = false;
+    request.controlId = "ctrl-2";
+    request.controlType = ocpp::v2::DERControlEnum::FreqDroop;
+
+    ocpp::v2::FreqDroop freq_droop;
+    freq_droop.priority = 3;
+    freq_droop.overFreq = 50.2f;
+    freq_droop.underFreq = 49.8f;
+    freq_droop.overDroop = 0.04f;
+    freq_droop.underDroop = 0.05f;
+    freq_droop.responseTime = 1.5f;
+    request.freqDroop = freq_droop;
+
+    const auto directive =
+        ocpp_module_common::conversions::to_grid_support_directive(request, "OCPP", "2026-06-16T00:00:00Z");
+
+    EXPECT_EQ(directive.directive_type, gs::DirectiveType::FreqDroop);
+    EXPECT_FALSE(directive.is_default);
+    EXPECT_EQ(directive.priority, 3);
+
+    ASSERT_TRUE(directive.freq_droop.has_value());
+    EXPECT_FLOAT_EQ(directive.freq_droop->over_freq, 50.2f);
+    EXPECT_FLOAT_EQ(directive.freq_droop->under_freq, 49.8f);
+    EXPECT_FLOAT_EQ(directive.freq_droop->over_droop, 0.04f);
+    EXPECT_FLOAT_EQ(directive.freq_droop->under_droop, 0.05f);
+    EXPECT_FLOAT_EQ(directive.freq_droop->response_time, 1.5f);
+
+    // only freq_droop populated
+    EXPECT_FALSE(directive.curve.has_value());
+    EXPECT_FALSE(directive.enter_service.has_value());
+    EXPECT_FALSE(directive.fixed_pf.has_value());
+    EXPECT_FALSE(directive.fixed_var.has_value());
+    EXPECT_FALSE(directive.gradient.has_value());
+    EXPECT_FALSE(directive.limit_max_discharge.has_value());
+}
+
+TEST(GridSupportConversions, GridAlarmMapsToNotifyDerAlarm) {
+    gs::GridAlarm alarm;
+    alarm.fault = gs::GridEventFault::OverVoltage;
+    alarm.alarm_ended = true;
+    alarm.directive_type = gs::DirectiveType::VoltVar;
+    alarm.timestamp = "2026-06-16T00:00:00Z";
+    alarm.extra_info = "details";
+
+    const auto notify = ocpp_module_common::conversions::to_ocpp_notify_der_alarm(alarm);
+
+    EXPECT_EQ(notify.controlType, ocpp::v2::DERControlEnum::VoltVar);
+    ASSERT_TRUE(notify.gridEventFault.has_value());
+    EXPECT_EQ(notify.gridEventFault.value(), ocpp::v2::GridEventFaultEnum::OverVoltage);
+    ASSERT_TRUE(notify.alarmEnded.has_value());
+    EXPECT_TRUE(notify.alarmEnded.value());
+    ASSERT_TRUE(notify.extraInfo.has_value());
+    EXPECT_EQ(notify.extraInfo.value().get(), "details");
+}
+
+TEST(GridSupportConversions, GridAlarmWithoutDirectiveTypeThrows) {
+    gs::GridAlarm alarm;
+    alarm.fault = gs::GridEventFault::OverVoltage;
+    alarm.alarm_ended = false;
+    alarm.timestamp = "2026-06-16T00:00:00Z";
+    // directive_type intentionally unset
+
+    EXPECT_THROW(ocpp_module_common::conversions::to_ocpp_notify_der_alarm(alarm), std::invalid_argument);
+}
+
+TEST(GridSupportConversions, FixedPfInjectRequestPopulatesFixedPf) {
+    ocpp::v21::SetDERControlRequest request;
+    request.isDefault = false;
+    request.controlId = "ctrl-pf";
+    request.controlType = ocpp::v2::DERControlEnum::FixedPFInject;
+
+    ocpp::v2::FixedPF fixed_pf;
+    fixed_pf.priority = 4;
+    fixed_pf.displacement = 0.95f;
+    fixed_pf.excitation = false;
+    request.fixedPFInject = fixed_pf;
+
+    const auto directive =
+        ocpp_module_common::conversions::to_grid_support_directive(request, "OCPP", "2026-06-16T00:00:00Z");
+
+    EXPECT_EQ(directive.directive_type, gs::DirectiveType::FixedPFInject);
+    EXPECT_EQ(directive.priority, 4);
+    ASSERT_TRUE(directive.fixed_pf.has_value());
+    EXPECT_FLOAT_EQ(directive.fixed_pf->displacement, 0.95f);
+    EXPECT_FALSE(directive.fixed_pf->excitation);
+
+    EXPECT_FALSE(directive.curve.has_value());
+    EXPECT_FALSE(directive.fixed_var.has_value());
+}
+
+TEST(GridSupportConversions, LimitMaxDischargeRoundTripsNestedCurve) {
+    ocpp::v21::SetDERControlRequest request;
+    request.isDefault = false;
+    request.controlId = "ctrl-lmd";
+    request.controlType = ocpp::v2::DERControlEnum::LimitMaxDischarge;
+
+    ocpp::v2::DERCurve must_trip;
+    must_trip.priority = 9;
+    must_trip.yUnit = ocpp::v2::DERUnitEnum::PctMaxW;
+    must_trip.curveData.push_back(ocpp::v2::DERCurvePoints{10.0f, 20.0f, std::nullopt});
+
+    ocpp::v2::LimitMaxDischarge limit;
+    limit.priority = 6;
+    limit.pctMaxDischargePower = 50.0f;
+    limit.powerMonitoringMustTrip = must_trip;
+    request.limitMaxDischarge = limit;
+
+    const auto directive =
+        ocpp_module_common::conversions::to_grid_support_directive(request, "OCPP", "2026-06-16T00:00:00Z");
+
+    EXPECT_EQ(directive.directive_type, gs::DirectiveType::LimitMaxDischarge);
+    EXPECT_EQ(directive.priority, 6);
+    ASSERT_TRUE(directive.limit_max_discharge.has_value());
+    EXPECT_FLOAT_EQ(directive.limit_max_discharge->pct_max_discharge_power.value(), 50.0f);
+
+    ASSERT_TRUE(directive.limit_max_discharge->power_monitoring_must_trip.has_value());
+    const auto& nested = directive.limit_max_discharge->power_monitoring_must_trip.value();
+    // The nested must-trip curve inherits the directive's priority; a distinct curve priority is not represented.
+    EXPECT_EQ(nested.y_unit, gs::DERUnit::PctMaxW);
+    ASSERT_EQ(nested.curve_data.size(), 1u);
+    EXPECT_FLOAT_EQ(nested.curve_data.at(0).x, 10.0f);
+    EXPECT_FLOAT_EQ(nested.curve_data.at(0).y, 20.0f);
+}
+
+ocpp::v21::SetDERControlRequest make_control(const std::string& control_id, ocpp::v2::DERControlEnum control_type) {
+    ocpp::v21::SetDERControlRequest request;
+    request.controlId = control_id;
+    request.controlType = control_type;
+    return request;
+}
+
+TEST(GridSupportConversions, TranslateActiveControlsSkipsUnmappedAndContinues) {
+    const std::vector<ocpp::v21::SetDERControlRequest> controls{
+        make_control("good-1", ocpp::v2::DERControlEnum::VoltVar),
+        make_control("bad", ocpp::v2::DERControlEnum::FreqDroop),
+        make_control("good-2", ocpp::v2::DERControlEnum::VoltWatt),
+    };
+
+    // Throws for the offending control, mirroring to_grid_support_directive's std::out_of_range.
+    const auto translate = [](const ocpp::v21::SetDERControlRequest& control) -> gs::Directive {
+        if (control.controlId.get() == "bad") {
+            throw std::out_of_range("unmapped DERControlEnum");
+        }
+        gs::Directive directive;
+        directive.id = control.controlId.get();
+        directive.directive_type = ocpp_module_common::conversions::to_grid_support_directive_type(control.controlType);
+        return directive;
+    };
+
+    const auto directives = ocpp_module_common::conversions::translate_active_controls(controls, translate);
+
+    ASSERT_EQ(directives.size(), 2u);
+    EXPECT_EQ(directives.at(0).id, "good-1");
+    EXPECT_EQ(directives.at(0).directive_type, gs::DirectiveType::VoltVar);
+    EXPECT_EQ(directives.at(1).id, "good-2");
+    EXPECT_EQ(directives.at(1).directive_type, gs::DirectiveType::VoltWatt);
+}
+
+} // namespace

--- a/modules/EVSE/OCPP201/BUILD.bazel
+++ b/modules/EVSE/OCPP201/BUILD.bazel
@@ -79,6 +79,10 @@ genrule(
 # OCPP201 module
 cc_everest_module(
     name = "OCPP201",
+    srcs = [
+        "grid_support/grid_support_state.cpp",
+        "grid_support/grid_support_state.hpp",
+    ],
     data = [":ocpp201_config_files"],
     impls = IMPLS,
     deps = [
@@ -98,6 +102,7 @@ cc_test(
     name = "OCPP201_tests",
     srcs = glob([
         "*.hpp",
+        "grid_support/*.hpp",
         "ocpp_generic/*.hpp",
     ]) + [
         "generated/modules/OCPP201/ld-ev.hpp",

--- a/modules/EVSE/OCPP201/CMakeLists.txt
+++ b/modules/EVSE/OCPP201/CMakeLists.txt
@@ -41,6 +41,11 @@ target_sources(${MODULE_NAME}
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 # insert other things like install cmds etc here
+target_sources(${MODULE_NAME}
+    PRIVATE
+        "grid_support/grid_support_state.cpp"
+)
+
 if(EVEREST_CORE_BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -735,6 +735,22 @@ void OCPP201::ready() {
             for (const auto& evse_manager : this->r_evse_manager) {
                 evse_manager->call_set_plug_and_charge_configuration(pnc_config);
             }
+        } else if ((set_variable_data.component.name == "DCDERCtrlr" ||
+                    set_variable_data.component.name == "ACDERCtrlr") and
+                   set_variable_data.variable.name.get() == "Enabled" and
+                   set_variable_data.attributeType.value_or(ocpp::v2::AttributeEnum::Actual) ==
+                       ocpp::v2::AttributeEnum::Actual) {
+            if (not set_variable_data.component.evse.has_value()) {
+                EVLOG_warning << "DER Enabled write without an EVSE id; ignoring";
+                return;
+            }
+            const auto evse_id = set_variable_data.component.evse.value().id;
+            const auto enabled = set_variable_data.attributeValue.get() == "true";
+            {
+                auto state_handle = this->grid_support_state.handle();
+                state_handle->set_enabled(evse_id, enabled);
+            }
+            this->push_active_directive_sets();
         }
     };
 
@@ -1005,6 +1021,7 @@ void OCPP201::ready() {
     callbacks.der_active_directives_callback =
         [this](const std::vector<ocpp::v21::SetDERControlRequest>& active_controls) {
             if (this->r_grid_support.empty()) {
+                EVLOG_warning << "Dropping DER active directives: no grid_support interface connection configured";
                 return;
             }
 
@@ -1062,11 +1079,6 @@ void OCPP201::ready() {
         this->config.CoreDatabasePath, sql_init_path.string(), this->config.MessageLogPath,
         std::make_shared<EvseSecurity>(*this->r_security), callbacks);
 
-    if (not this->r_grid_support.empty()) {
-        this->flush_pending_grid_support();
-        this->grid_support_heartbeat_timer_start();
-    }
-
     // publish charging schedules at least once on startup
     charging_schedules_callback();
     charging_schedules_timer_start();
@@ -1119,6 +1131,12 @@ void OCPP201::ready() {
 
     const auto boot_reason = conversions::to_ocpp_boot_reason(this->r_system->call_get_boot_reason());
     this->charge_point->set_message_queue_resume_delay(std::chrono::seconds(this->config.MessageQueueResumeDelay));
+
+    if (not this->r_grid_support.empty()) {
+        this->flush_pending_grid_support();
+        this->grid_support_heartbeat_timer_start();
+    }
+
     // we can now initialize the charge point's state machine. It reads the connector availability from the internal
     // database and potentially triggers enable/disable callbacks at the evse.
     this->charge_point->start(boot_reason, false);
@@ -1230,13 +1248,15 @@ void OCPP201::charging_schedules_timer_stop() {
     charging_schedules_timer.stop();
 }
 
-OCPP201::DerEnableResult OCPP201::apply_der_capability(int32_t evse_id,
-                                                       const types::grid_support::DERCapability& capability) {
-    DerEnableResult result;
+OCPP201::DerApplyResult OCPP201::apply_der_capability(int32_t evse_id,
+                                                      const types::grid_support::DERCapability& capability) {
+    DerApplyResult result;
 
     // Handle per access: set_variables/on_der_republish re-enter der_active_directives_callback (self-deadlock).
+    std::optional<types::grid_support::DERCapability> previous;
     {
         auto state_handle = this->grid_support_state.handle();
+        previous = state_handle->capability_for(evse_id);
         state_handle->set_capability(evse_id, capability);
     }
 
@@ -1257,27 +1277,38 @@ OCPP201::DerEnableResult OCPP201::apply_der_capability(int32_t evse_id,
         };
 
     const auto reject = [&](const std::string& rejected_details) {
-        EVLOG_error << "Rejecting set_capability for EVSE " << evse_id
-                    << ": device model rejected DER capability variables: " << rejected_details;
-        auto state_handle = this->grid_support_state.handle();
-        state_handle->unregister(evse_id);
+        if (previous.has_value()) {
+            EVLOG_error << "Rejecting set_capability for EVSE " << evse_id
+                        << ": device model rejected DER capability variables: " << rejected_details
+                        << "; rolling back to last accepted capability";
+            {
+                auto state_handle = this->grid_support_state.handle();
+                state_handle->set_capability(evse_id, *previous);
+            }
+            // Best-effort restore of the previous config variables. Enabled stays untouched: the EVSE
+            // keeps running its previous accepted config.
+            // Variables the rejected capability wrote but the previous one does not define keep their new values.
+            const auto rollback_rejected = collect_rejected(this->charge_point->set_variables(
+                module::device_model::to_der_ctrlr_config_set_variables(evse_id, *previous), "internal"));
+            if (not rollback_rejected.empty()) {
+                EVLOG_warning << "DER capability rollback for EVSE " << evse_id
+                              << " partially rejected: " << rollback_rejected;
+            }
+        } else {
+            EVLOG_error << "Rejecting set_capability for EVSE " << evse_id
+                        << ": device model rejected DER capability variables: " << rejected_details;
+            auto state_handle = this->grid_support_state.handle();
+            state_handle->unregister(evse_id);
+        }
         result.accepted = false;
         result.rejected_details = rejected_details;
     };
 
-    // Phase 1: config variables only (no Available). A partial rejection here never enables the component.
+    // Config variables only (no Available/Enabled): a partial rejection leaves the component state untouched.
     const auto config_rejected = collect_rejected(this->charge_point->set_variables(
         module::device_model::to_der_ctrlr_config_set_variables(evse_id, capability), "internal"));
     if (not config_rejected.empty()) {
         reject(config_rejected);
-        return result;
-    }
-
-    // Phase 2: the single Available="true" write that enables the DER block.
-    const auto available_rejected = collect_rejected(this->charge_point->set_variables(
-        {module::device_model::to_der_ctrlr_available_set_variable(evse_id, capability)}, "internal"));
-    if (not available_rejected.empty()) {
-        reject(available_rejected);
         return result;
     }
 
@@ -1309,11 +1340,11 @@ void OCPP201::flush_pending_grid_support() {
         pending = state_handle->take_pending_capabilities();
     }
     for (const auto& [pending_evse_id, pending_capability] : pending) {
-        const auto enable_result = this->apply_der_capability(pending_evse_id, pending_capability);
-        if (not enable_result.accepted) {
+        const auto apply_result = this->apply_der_capability(pending_evse_id, pending_capability);
+        if (not apply_result.accepted) {
             EVLOG_error << "Buffered DER capability for EVSE " << pending_evse_id
                         << " rejected on flush (consumer already received Accepted, not re-notified): "
-                        << enable_result.rejected_details;
+                        << apply_result.rejected_details;
         }
     }
 }
@@ -1410,10 +1441,10 @@ void OCPP201::on_grid_support_capability(const types::grid_support::EVSECapabili
         }
     }
 
-    const auto enable_result = this->apply_der_capability(evse_id, capability);
-    if (not enable_result.accepted) {
+    const auto apply_result = this->apply_der_capability(evse_id, capability);
+    if (not apply_result.accepted) {
         EVLOG_error << "Rejecting DER capability for EVSE " << evse_id
-                    << ": device model rejected DER capability variables: " << enable_result.rejected_details;
+                    << ": device model rejected DER capability variables: " << apply_result.rejected_details;
     }
 }
 

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -1055,7 +1055,7 @@ void OCPP201::ready() {
     composed_device_model_storage->register_device_model_storage("OCPP", std::move(libocpp_device_model_storage));
     composed_device_model_storage->register_device_model_storage("EVEREST", this->everest_device_model_storage);
 
-    this->init_grid_support_routing();
+    this->init_grid_support_routing(evse_connector_structure);
 
     this->charge_point = std::make_unique<ocpp::v2::ChargePoint>(
         evse_connector_structure, std::move(composed_device_model_storage), this->ocpp_share_path.string(),
@@ -1345,10 +1345,7 @@ void OCPP201::push_active_directive_sets() {
     }
 }
 
-void OCPP201::init_grid_support_routing() {
-    if (this->r_grid_support.empty()) {
-        return;
-    }
+void OCPP201::init_grid_support_routing(const std::map<int32_t, int32_t>& evse_connector_structure) {
     for (const auto& grid_support : this->r_grid_support) {
         const auto mapping = grid_support->get_mapping();
         if (not mapping.has_value()) {
@@ -1360,6 +1357,13 @@ void OCPP201::init_grid_support_routing() {
         if (not inserted) {
             EVLOG_error << "grid_support connection on module " << grid_support->module_id << " maps evse "
                         << mapping->evse << " already served by another connection; keeping the first";
+        }
+    }
+
+    for (const auto& [evse_id, connector_count] : evse_connector_structure) {
+        if (this->grid_support_by_evse.find(evse_id) == this->grid_support_by_evse.end()) {
+            this->everest_device_model_storage->disable_der(evse_id);
+            EVLOG_info << "No grid_support connection for EVSE " << evse_id << ": DER controller disabled";
         }
     }
 }

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -14,6 +14,8 @@
 #include <everest/ocpp_module_common/device_model/composed_device_model_storage.hpp>
 #include <everest/ocpp_module_common/error_handling.hpp>
 #include <ocpp/v2/utils.hpp>
+#include <ocpp/v21/messages/NotifyDERAlarm.hpp>
+#include <ocpp/v21/messages/SetDERControl.hpp>
 
 namespace {
 void update_evcc_id_token(ocpp::v2::IdToken& id_token, const std::string& evcc_id,
@@ -474,6 +476,16 @@ void OCPP201::init() {
                     }
                 }
             });
+    }
+
+    // Capability payloads carry their own evse_id and alarms are station-level, so subscribe on every
+    // connection and forward regardless of which one raised the update.
+    for (const auto& grid_support : this->r_grid_support) {
+        grid_support->subscribe_capability([this](types::grid_support::EVSECapability evse_capability) {
+            this->on_grid_support_capability(evse_capability);
+        });
+        grid_support->subscribe_alarm(
+            [this](types::grid_support::GridAlarm alarm) { this->on_grid_support_alarm(alarm); });
     }
 
     this->init_evse_subscriptions();
@@ -990,6 +1002,25 @@ void OCPP201::ready() {
         }
     };
 
+    callbacks.der_active_directives_callback =
+        [this](const std::vector<ocpp::v21::SetDERControlRequest>& active_controls) {
+            if (this->r_grid_support.empty()) {
+                return;
+            }
+
+            const auto received_at = ocpp::DateTime().to_rfc3339();
+            auto directives = module::conversions::translate_active_controls(
+                active_controls, [&received_at](const ocpp::v21::SetDERControlRequest& control) {
+                    return module::conversions::to_grid_support_directive(control, "ocpp", received_at);
+                });
+
+            {
+                auto state_handle = this->grid_support_state.handle();
+                state_handle->set_active_directives(std::move(directives));
+            }
+            this->push_active_directive_sets();
+        };
+
     {
         auto ready_handle = this->evse_ready_map.handle();
         ready_handle.wait([this, &ready_handle]() {
@@ -1024,10 +1055,17 @@ void OCPP201::ready() {
     composed_device_model_storage->register_device_model_storage("OCPP", std::move(libocpp_device_model_storage));
     composed_device_model_storage->register_device_model_storage("EVEREST", this->everest_device_model_storage);
 
+    this->init_grid_support_routing();
+
     this->charge_point = std::make_unique<ocpp::v2::ChargePoint>(
         evse_connector_structure, std::move(composed_device_model_storage), this->ocpp_share_path.string(),
         this->config.CoreDatabasePath, sql_init_path.string(), this->config.MessageLogPath,
         std::make_shared<EvseSecurity>(*this->r_security), callbacks);
+
+    if (not this->r_grid_support.empty()) {
+        this->flush_pending_grid_support();
+        this->grid_support_heartbeat_timer_start();
+    }
 
     // publish charging schedules at least once on startup
     charging_schedules_callback();
@@ -1190,6 +1228,206 @@ void OCPP201::charging_schedules_timer_start() {
 
 void OCPP201::charging_schedules_timer_stop() {
     charging_schedules_timer.stop();
+}
+
+OCPP201::DerEnableResult OCPP201::apply_der_capability(int32_t evse_id,
+                                                       const types::grid_support::DERCapability& capability) {
+    DerEnableResult result;
+
+    // Handle per access: set_variables/on_der_republish re-enter der_active_directives_callback (self-deadlock).
+    {
+        auto state_handle = this->grid_support_state.handle();
+        state_handle->set_capability(evse_id, capability);
+    }
+
+    const auto collect_rejected =
+        [](const std::map<ocpp::v2::SetVariableData, ocpp::v2::SetVariableResult>& set_results) {
+            std::string rejected_details;
+            for (const auto& [data, set_result] : set_results) {
+                if (set_result.attributeStatus != ocpp::v2::SetVariableStatusEnum::Accepted) {
+                    if (not rejected_details.empty()) {
+                        rejected_details += ", ";
+                    }
+                    rejected_details +=
+                        set_result.variable.name.get() + "=" +
+                        ocpp::v2::conversions::set_variable_status_enum_to_string(set_result.attributeStatus);
+                }
+            }
+            return rejected_details;
+        };
+
+    const auto reject = [&](const std::string& rejected_details) {
+        EVLOG_error << "Rejecting set_capability for EVSE " << evse_id
+                    << ": device model rejected DER capability variables: " << rejected_details;
+        auto state_handle = this->grid_support_state.handle();
+        state_handle->unregister(evse_id);
+        result.accepted = false;
+        result.rejected_details = rejected_details;
+    };
+
+    // Phase 1: config variables only (no Available). A partial rejection here never enables the component.
+    const auto config_rejected = collect_rejected(this->charge_point->set_variables(
+        module::device_model::to_der_ctrlr_config_set_variables(evse_id, capability), "internal"));
+    if (not config_rejected.empty()) {
+        reject(config_rejected);
+        return result;
+    }
+
+    // Phase 2: the single Available="true" write that enables the DER block.
+    const auto available_rejected = collect_rejected(this->charge_point->set_variables(
+        {module::device_model::to_der_ctrlr_available_set_variable(evse_id, capability)}, "internal"));
+    if (not available_rejected.empty()) {
+        reject(available_rejected);
+        return result;
+    }
+
+    this->charge_point->on_der_republish_active_directives();
+
+    std::vector<types::grid_support::GridAlarm> pending_alarms;
+    {
+        auto state_handle = this->grid_support_state.handle();
+        state_handle->set_alarms_live();
+        pending_alarms = state_handle->take_pending_alarms();
+    }
+    for (const auto& alarm : pending_alarms) {
+        try {
+            this->charge_point->on_der_alarm(module::conversions::to_ocpp_notify_der_alarm(alarm));
+        } catch (const std::invalid_argument& e) {
+            EVLOG_error << "Buffered DER alarm dropped: " << e.what();
+        }
+    }
+
+    result.accepted = true;
+    return result;
+}
+
+void OCPP201::flush_pending_grid_support() {
+    std::vector<std::pair<int32_t, types::grid_support::DERCapability>> pending;
+    {
+        auto state_handle = this->grid_support_state.handle();
+        state_handle->set_capabilities_live();
+        pending = state_handle->take_pending_capabilities();
+    }
+    for (const auto& [pending_evse_id, pending_capability] : pending) {
+        const auto enable_result = this->apply_der_capability(pending_evse_id, pending_capability);
+        if (not enable_result.accepted) {
+            EVLOG_error << "Buffered DER capability for EVSE " << pending_evse_id
+                        << " rejected on flush (consumer already received Accepted, not re-notified): "
+                        << enable_result.rejected_details;
+        }
+    }
+}
+
+void OCPP201::push_active_directive_sets() {
+    if (this->r_grid_support.empty()) {
+        return;
+    }
+
+    std::vector<types::grid_support::ActiveDirectiveSet> snapshots;
+    {
+        auto state_handle = this->grid_support_state.handle();
+        const auto evses = state_handle->registered_evses();
+        snapshots.reserve(evses.size());
+        for (const auto evse_id : evses) {
+            snapshots.push_back(state_handle->build_active_set(evse_id));
+        }
+    }
+    for (const auto& snapshot : snapshots) {
+        auto* const target = this->grid_support_for_evse(snapshot.evse_id);
+        if (target == nullptr) {
+            continue;
+        }
+        const auto response = target->call_set_active_directives(snapshot);
+        if (not response.accepted) {
+            EVLOG_warning << "DER device rejected active directives for EVSE " << snapshot.evse_id
+                          << (response.reason.has_value() ? ": " + response.reason.value() : "");
+        }
+    }
+}
+
+void OCPP201::init_grid_support_routing() {
+    if (this->r_grid_support.empty()) {
+        return;
+    }
+    for (const auto& grid_support : this->r_grid_support) {
+        const auto mapping = grid_support->get_mapping();
+        if (not mapping.has_value()) {
+            EVLOG_error << "grid_support connection on module " << grid_support->module_id
+                        << " has no evse mapping; excluding it from DER routing";
+            continue;
+        }
+        const auto [it, inserted] = this->grid_support_by_evse.emplace(mapping->evse, grid_support.get());
+        if (not inserted) {
+            EVLOG_error << "grid_support connection on module " << grid_support->module_id << " maps evse "
+                        << mapping->evse << " already served by another connection; keeping the first";
+        }
+    }
+}
+
+grid_supportIntf* OCPP201::grid_support_for_evse(int32_t evse_id) const {
+    const auto it = this->grid_support_by_evse.find(evse_id);
+    if (it != this->grid_support_by_evse.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+void OCPP201::grid_support_heartbeat_timer_callback() {
+    this->push_active_directive_sets();
+}
+
+void OCPP201::grid_support_heartbeat_timer_start() {
+    if (config.grid_support_heartbeat_s > 0) {
+        const auto grid_support_heartbeat_callback = [this]() { grid_support_heartbeat_timer_callback(); };
+        grid_support_heartbeat_timer.interval(grid_support_heartbeat_callback,
+                                              std::chrono::seconds(config.grid_support_heartbeat_s));
+    }
+}
+
+void OCPP201::grid_support_heartbeat_timer_stop() {
+    grid_support_heartbeat_timer.stop();
+}
+
+void OCPP201::on_grid_support_capability(const types::grid_support::EVSECapability& evse_capability) {
+    const auto evse_id = evse_capability.evse_id;
+    const auto& capability = evse_capability.capability;
+
+    if (not capability.ac.has_value() and not capability.dc.has_value()) {
+        EVLOG_warning << "Ignoring DER capability for EVSE " << evse_id << ": no inverter class declared";
+        return;
+    }
+
+    // Route on the flag under the handle (charge_point read races flush); deliver only after releasing it.
+    {
+        auto state_handle = this->grid_support_state.handle();
+        if (not state_handle->capabilities_live()) {
+            state_handle->buffer_pending_capability(evse_id, capability);
+            return;
+        }
+    }
+
+    const auto enable_result = this->apply_der_capability(evse_id, capability);
+    if (not enable_result.accepted) {
+        EVLOG_error << "Rejecting DER capability for EVSE " << evse_id
+                    << ": device model rejected DER capability variables: " << enable_result.rejected_details;
+    }
+}
+
+void OCPP201::on_grid_support_alarm(const types::grid_support::GridAlarm& alarm) {
+    // Same rule as on_grid_support_capability; alarms_live implies charge_point exists.
+    {
+        auto state_handle = this->grid_support_state.handle();
+        if (not state_handle->alarms_live()) {
+            state_handle->buffer_pending_alarm(alarm);
+            return;
+        }
+    }
+
+    try {
+        this->charge_point->on_der_alarm(module::conversions::to_ocpp_notify_der_alarm(alarm));
+    } catch (const std::invalid_argument& e) {
+        EVLOG_warning << "Rejecting DER alarm: " << e.what();
+    }
 }
 
 void OCPP201::init_evse_subscriptions() {

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -1333,11 +1333,32 @@ OCPP201::DerApplyResult OCPP201::apply_der_capability(int32_t evse_id,
 }
 
 void OCPP201::flush_pending_grid_support() {
+    // Persisted DERCtrlr Enabled for evse_id (AC then DC controller), or nullopt if it has no DER controller.
+    const auto read_persisted_der_enabled = [this](int32_t evse_id) -> std::optional<bool> {
+        for (const auto& component_variable : {ocpp::v2::DERComponentVariables::get_ac_component_variable(
+                                                   evse_id, ocpp::v2::DERComponentVariables::Enabled),
+                                               ocpp::v2::DERComponentVariables::get_dc_component_variable(
+                                                   evse_id, ocpp::v2::DERComponentVariables::Enabled)}) {
+            const auto response = this->charge_point->request_value<bool>(
+                component_variable.component, component_variable.variable.value(), ocpp::v2::AttributeEnum::Actual);
+            if (response.status == ocpp::v2::GetVariableStatusEnum::Accepted and response.value.has_value()) {
+                return response.value.value();
+            }
+        }
+        return std::nullopt;
+    };
+
     std::vector<std::pair<int32_t, types::grid_support::DERCapability>> pending;
     {
         auto state_handle = this->grid_support_state.handle();
         state_handle->set_capabilities_live();
         pending = state_handle->take_pending_capabilities();
+        for (const auto& [evse_id, capability] : pending) {
+            const auto enabled = read_persisted_der_enabled(evse_id);
+            if (enabled.has_value()) {
+                state_handle->set_enabled(evse_id, enabled.value());
+            }
+        }
     }
     for (const auto& [pending_evse_id, pending_capability] : pending) {
         const auto apply_result = this->apply_der_capability(pending_evse_id, pending_capability);

--- a/modules/EVSE/OCPP201/OCPP201.hpp
+++ b/modules/EVSE/OCPP201/OCPP201.hpp
@@ -23,6 +23,7 @@
 #include <generated/interfaces/evse_manager/Interface.hpp>
 #include <generated/interfaces/evse_security/Interface.hpp>
 #include <generated/interfaces/external_energy_limits/Interface.hpp>
+#include <generated/interfaces/grid_support/Interface.hpp>
 #include <generated/interfaces/iso15118_extensions/Interface.hpp>
 #include <generated/interfaces/ocpp_data_transfer/Interface.hpp>
 #include <generated/interfaces/reservation/Interface.hpp>
@@ -40,6 +41,7 @@
 #include <everest/ocpp_module_common/transaction_handler.hpp>
 #include <everest/util/async/monitor.hpp>
 #include <generated/types/evse_board_support.hpp>
+#include <grid_support/grid_support_state.hpp>
 #include <ocpp/v2/charge_point.hpp>
 
 using EventQueue =
@@ -85,6 +87,7 @@ struct Conf {
     int DelayOcppStart;
     int ResetStopDelay;
     std::string CustomMrecErrorMapPath;
+    int grid_support_heartbeat_s;
 };
 
 class OCPP201 : public Everest::ModuleBase {
@@ -101,7 +104,8 @@ public:
             std::vector<std::unique_ptr<external_energy_limitsIntf>> r_evse_energy_sink,
             std::vector<std::unique_ptr<display_messageIntf>> r_display_message,
             std::vector<std::unique_ptr<reservationIntf>> r_reservation,
-            std::vector<std::unique_ptr<iso15118_extensionsIntf>> r_extensions_15118, Conf& config) :
+            std::vector<std::unique_ptr<iso15118_extensionsIntf>> r_extensions_15118,
+            std::vector<std::unique_ptr<grid_supportIntf>> r_grid_support, Conf& config) :
         ModuleBase(info),
         mqtt(mqtt_provider),
         p_auth_validator(std::move(p_auth_validator)),
@@ -118,6 +122,7 @@ public:
         r_display_message(std::move(r_display_message)),
         r_reservation(std::move(r_reservation)),
         r_extensions_15118(std::move(r_extensions_15118)),
+        r_grid_support(std::move(r_grid_support)),
         config(config){};
 
     Everest::MqttProvider& mqtt;
@@ -135,6 +140,7 @@ public:
     const std::vector<std::unique_ptr<display_messageIntf>> r_display_message;
     const std::vector<std::unique_ptr<reservationIntf>> r_reservation;
     const std::vector<std::unique_ptr<iso15118_extensionsIntf>> r_extensions_15118;
+    const std::vector<std::unique_ptr<grid_supportIntf>> r_grid_support;
     const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
@@ -143,6 +149,42 @@ public:
     void charging_schedules_timer_callback();
     void charging_schedules_timer_start();
     void charging_schedules_timer_stop();
+
+    everest::lib::util::monitor<GridSupportState> grid_support_state;
+    void grid_support_heartbeat_timer_callback();
+    void grid_support_heartbeat_timer_start();
+    void grid_support_heartbeat_timer_stop();
+
+    /// \brief Snapshot each registered EVSE's active directive set under one state handle, then push each to
+    /// the grid_support consumer after releasing the handle. No-op when no consumer is connected.
+    void push_active_directive_sets();
+
+    /// \brief Outcome of enabling DER for one EVSE via apply_der_capability.
+    struct DerEnableResult {
+        bool accepted{false};
+        /// \brief Per-variable rejection details when accepted is false; empty when accepted.
+        std::string rejected_details;
+    };
+
+    /// \brief Enable DER for \p evse_id from \p capability. Shared path for both the live set_capability
+    /// handler and the ready() flush of pre-construction buffered capabilities.
+    ///
+    /// Registers the EVSE before the enabling device-model write (so the block's construction-time emit
+    /// reaches it) and unregisters on rejection. Requires charge_point != nullptr.
+    DerEnableResult apply_der_capability(int32_t evse_id, const types::grid_support::DERCapability& capability);
+
+    /// \brief Flip capabilities live and empty the pre-construction buffered DER capabilities into libocpp
+    /// at ready(). Alarms go live per-EVSE on their first successful enable (see apply_der_capability), so
+    /// this does not touch the alarm buffer. Only meaningful when a grid_support consumer is connected.
+    void flush_pending_grid_support();
+
+    /// \brief Handle a DER capability published by the grid_support provider for one EVSE. Buffers until the
+    /// charge point exists, then enables DER via apply_der_capability.
+    void on_grid_support_capability(const types::grid_support::EVSECapability& evse_capability);
+
+    /// \brief Forward a grid alarm raised by the grid_support provider to the CSMS. Buffers until the charge
+    /// point exists.
+    void on_grid_support_alarm(const types::grid_support::GridAlarm& alarm);
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:
@@ -160,6 +202,7 @@ private:
     std::shared_ptr<device_model::EverestDeviceModelStorage> everest_device_model_storage;
     std::unique_ptr<TransactionHandler> transaction_handler;
     Everest::SteadyTimer charging_schedules_timer;
+    Everest::SteadyTimer grid_support_heartbeat_timer;
 
     std::filesystem::path ocpp_share_path;
 
@@ -185,6 +228,19 @@ private:
     void init_evse_maps();
     void init_evse_subscriptions();
     void init_module_configuration();
+
+    /// \brief evse_id -> grid_support connection serving it, from each connection's framework mapping.
+    /// Written once in ready() before charge_point exists (der_active_directives_callback fires during its
+    /// construction) and before any reader thread; read-only afterwards, so no lock.
+    std::map<int32_t, grid_supportIntf*> grid_support_by_evse;
+
+    /// \brief Populate grid_support_by_evse from the connections' framework mappings. Every connection
+    /// must carry a mapping; an unmapped connection is logged and excluded.
+    void init_grid_support_routing();
+
+    /// \brief Resolve the grid_support connection mapped to \p evse_id, or nullptr if none.
+    grid_supportIntf* grid_support_for_evse(int32_t evse_id) const;
+
     std::map<int32_t, int32_t> get_connector_structure();
     void process_session_event(const int32_t evse_id, const types::evse_manager::SessionEvent& session_event);
     void process_tx_event_effect(const int32_t evse_id, const TxEventEffect tx_event_effect,

--- a/modules/EVSE/OCPP201/OCPP201.hpp
+++ b/modules/EVSE/OCPP201/OCPP201.hpp
@@ -235,8 +235,10 @@ private:
     std::map<int32_t, grid_supportIntf*> grid_support_by_evse;
 
     /// \brief Populate grid_support_by_evse from the connections' framework mappings. Every connection
-    /// must carry a mapping; an unmapped connection is logged and excluded.
-    void init_grid_support_routing();
+    /// must carry a mapping; an unmapped connection is logged and excluded. Any EVSE without a wired
+    /// grid_support connection has its DER controller forced to Available=false, clearing any value a
+    /// previous run persisted.
+    void init_grid_support_routing(const std::map<int32_t, int32_t>& evse_connector_structure);
 
     /// \brief Resolve the grid_support connection mapped to \p evse_id, or nullptr if none.
     grid_supportIntf* grid_support_for_evse(int32_t evse_id) const;

--- a/modules/EVSE/OCPP201/OCPP201.hpp
+++ b/modules/EVSE/OCPP201/OCPP201.hpp
@@ -149,42 +149,6 @@ public:
     void charging_schedules_timer_callback();
     void charging_schedules_timer_start();
     void charging_schedules_timer_stop();
-
-    everest::lib::util::monitor<GridSupportState> grid_support_state;
-    void grid_support_heartbeat_timer_callback();
-    void grid_support_heartbeat_timer_start();
-    void grid_support_heartbeat_timer_stop();
-
-    /// \brief Snapshot each registered EVSE's active directive set under one state handle, then push each to
-    /// the grid_support consumer after releasing the handle. No-op when no consumer is connected.
-    void push_active_directive_sets();
-
-    /// \brief Outcome of enabling DER for one EVSE via apply_der_capability.
-    struct DerEnableResult {
-        bool accepted{false};
-        /// \brief Per-variable rejection details when accepted is false; empty when accepted.
-        std::string rejected_details;
-    };
-
-    /// \brief Enable DER for \p evse_id from \p capability. Shared path for both the live set_capability
-    /// handler and the ready() flush of pre-construction buffered capabilities.
-    ///
-    /// Registers the EVSE before the enabling device-model write (so the block's construction-time emit
-    /// reaches it) and unregisters on rejection. Requires charge_point != nullptr.
-    DerEnableResult apply_der_capability(int32_t evse_id, const types::grid_support::DERCapability& capability);
-
-    /// \brief Flip capabilities live and empty the pre-construction buffered DER capabilities into libocpp
-    /// at ready(). Alarms go live per-EVSE on their first successful enable (see apply_der_capability), so
-    /// this does not touch the alarm buffer. Only meaningful when a grid_support consumer is connected.
-    void flush_pending_grid_support();
-
-    /// \brief Handle a DER capability published by the grid_support provider for one EVSE. Buffers until the
-    /// charge point exists, then enables DER via apply_der_capability.
-    void on_grid_support_capability(const types::grid_support::EVSECapability& evse_capability);
-
-    /// \brief Forward a grid alarm raised by the grid_support provider to the CSMS. Buffers until the charge
-    /// point exists.
-    void on_grid_support_alarm(const types::grid_support::GridAlarm& alarm);
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:
@@ -199,6 +163,45 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+    everest::lib::util::monitor<GridSupportState> grid_support_state;
+    void grid_support_heartbeat_timer_callback();
+    void grid_support_heartbeat_timer_start();
+    void grid_support_heartbeat_timer_stop();
+
+    /// \brief Snapshot each registered EVSE's active directive set under one state handle, then push each to
+    /// the grid_support consumer after releasing the handle. No-op when no consumer is connected.
+    void push_active_directive_sets();
+
+    /// \brief Outcome of applying a DER capability for one EVSE via apply_der_capability.
+    struct DerApplyResult {
+        bool accepted{false};
+        /// \brief Per-variable rejection details when accepted is false; empty when accepted.
+        std::string rejected_details;
+    };
+
+    /// \brief Apply the DER capability config for \p evse_id from \p capability. Shared path for both the
+    /// live set_capability handler and the ready() flush of pre-construction buffered capabilities.
+    ///
+    /// Registers the EVSE before the device-model write (so a republish emit reaches it). On rejection: if
+    /// the EVSE already had an accepted capability, rolls back to it (restoring its config variables,
+    /// leaving Enabled untouched); otherwise unregisters the EVSE.
+    /// Requires charge_point != nullptr.
+    DerApplyResult apply_der_capability(int32_t evse_id, const types::grid_support::DERCapability& capability);
+
+    /// \brief Flip capabilities live and empty the pre-construction buffered DER capabilities into libocpp
+    /// at ready(). Alarms go live per-EVSE on their first successfully applied capability (see
+    /// apply_der_capability), so this does not touch the alarm buffer. Only meaningful when a grid_support
+    /// consumer is connected.
+    void flush_pending_grid_support();
+
+    /// \brief Handle a DER capability published by the grid_support provider for one EVSE. Buffers until the
+    /// charge point exists, then applies it via apply_der_capability.
+    void on_grid_support_capability(const types::grid_support::EVSECapability& evse_capability);
+
+    /// \brief Forward a grid alarm raised by the grid_support provider to the CSMS. Buffers until the charge
+    /// point exists.
+    void on_grid_support_alarm(const types::grid_support::GridAlarm& alarm);
+
     std::shared_ptr<device_model::EverestDeviceModelStorage> everest_device_model_storage;
     std::unique_ptr<TransactionHandler> transaction_handler;
     Everest::SteadyTimer charging_schedules_timer;

--- a/modules/EVSE/OCPP201/docs/index.rst
+++ b/modules/EVSE/OCPP201/docs/index.rst
@@ -122,6 +122,10 @@ At startup the module pre-provisions an ``ACDERCtrlr`` or ``DCDERCtrlr`` device-
 energy-transfer modes) with ``Available=false`` and an empty ``ModesSupported`` for every DER-capable EVSE, so no static
 device-model JSON is required for the DER controllers.
 
+Also at startup, any EVSE without a wired grid_support connection has its DER controller forced to ``Available=false``,
+even if a previous run persisted it as enabled. This prevents the CSMS from seeing DER as available after the
+grid_support wiring is removed from the configuration.
+
 The device declares its inverter capability through the ``capability`` variable. The module stores the capability, sets the
 component ``Available=true`` and writes ``ModesSupported`` through the device model (which lazily constructs the libocpp DER
 block), then pushes the current active directives filtered to the declared control types, so a freshly connected device

--- a/modules/EVSE/OCPP201/docs/index.rst
+++ b/modules/EVSE/OCPP201/docs/index.rst
@@ -119,19 +119,44 @@ EVSE's connection through the **set_active_directives** command. When libocpp ap
 expires a DER control, the snapshot is rebuilt and re-sent for every registered EVSE on its own connection.
 
 At startup the module pre-provisions an ``ACDERCtrlr`` or ``DCDERCtrlr`` device-model component (chosen by the EVSE's
-energy-transfer modes) with ``Available=false`` and an empty ``ModesSupported`` for every DER-capable EVSE, so no static
-device-model JSON is required for the DER controllers.
+energy-transfer modes) for every DER-capable EVSE, so no static device-model JSON is required for the DER controllers. The
+component is provisioned with ``Available="true"`` (``ReadOnly``, marking the presence of a DER controller for the EVSE),
+``Enabled="true"`` (``ReadWrite``, the runtime control the CSMS toggles; the module no longer toggles it), and an empty
+``ModesSupported``. A wired DER-capable EVSE is therefore enabled from boot without any runtime write. A CSMS-written
+``Enabled="false"`` persists across reboots: re-provisioning only overwrites same-origin or default-source values, and the
+module never force-enables at runtime.
 
-Also at startup, any EVSE without a wired grid_support connection has its DER controller forced to ``Available=false``,
-even if a previous run persisted it as enabled. This prevents the CSMS from seeing DER as available after the
-grid_support wiring is removed from the configuration.
+Also at startup, any EVSE without a wired grid_support connection has both ``Available`` and ``Enabled`` on its DER
+controller forced to ``"false"`` (each only when the persisted value is ``"true"``, which preserves a CSMS-written
+``"false"`` and its source). This prevents the CSMS from seeing DER as available after the grid_support wiring is removed
+from the configuration. Restoration happens through provisioning on the next boot where the EVSE is wired.
 
-The device declares its inverter capability through the ``capability`` variable. The module stores the capability, sets the
-component ``Available=true`` and writes ``ModesSupported`` through the device model (which lazily constructs the libocpp DER
-block), then pushes the current active directives filtered to the declared control types, so a freshly connected device
-immediately learns its active set. The device reports grid event faults through the ``alarm`` variable, which is forwarded
-to the CSMS as a **NotifyDERAlarm.req**. Capability and alarm updates received before the charge point is initialized are
-queued and replayed once the charge point is ready.
+The device declares its inverter capability through the ``capability`` variable. The module stores the capability, writes
+its config variables (``ModesSupported`` and the DC nameplate values) through the device model, and republishes the
+current active directives filtered to the declared control types, so a freshly connected device immediately learns its
+active set. The capability handler no longer flips ``Enabled``; the libocpp DER block is already built at boot through
+provisioning.
+
+If the device model rejects a capability re-report, the module rolls back to the last accepted capability: the stored state
+is restored and its config variables are re-applied best-effort, while ``Enabled`` is left untouched. An EVSE whose very
+first capability is rejected is unregistered.
+
+In the AC IEC EV-as-DER relay case, the wired grid_support provider publishes no ``capability`` (capabilities only come
+from a device in the DC and AC SAE cases). An EVSE that advertises an AC IEC relay energy-transfer mode (``AC_DER_IEC`` or
+``AC_BPT_DER``, not ``AC_DER_SAE``) is covered by the provisioned ``Enabled="true"``: it publishes no capability and needs
+no ``ModesSupported`` list, and is admitted through the libocpp AC accept-all path while the controller is ``Available``
+and ``Enabled``, because the EV's real capabilities are unknown before plugin. A later capability publication still applies
+its config on top, and the CSMS ``Enabled`` toggle applies unchanged.
+
+The CSMS may write the ``Enabled`` variable (``ReadWrite``). Writing ``Enabled="false"`` makes the module push an empty
+directive replacement set to that EVSE, so the device clears the EV's curves; libocpp then reports ``NotSupported`` for a
+**SetDERControl.req** whose mode no enabled EVSE supports. Writing ``Enabled="true"`` republishes the filtered active set
+for that EVSE. Alarms are not gated by ``Enabled``.
+
+The device reports grid event faults through the ``alarm`` variable, which is forwarded to the CSMS as a
+**NotifyDERAlarm.req**. Alarms raised before the backend has accepted a capability for any EVSE are buffered and delivered
+once the first capability is accepted; if no capability is ever accepted, the buffered alarms are dropped. Capability and
+alarm updates received before the charge point is initialized are queued and replayed once the charge point is ready.
 
 The configuration parameter **grid_support_heartbeat_s** sets the interval (in seconds) at which the current active
 directive set is re-sent for every registered EVSE. A value of ``0`` disables the heartbeat; the set is then sent only when

--- a/modules/EVSE/OCPP201/docs/index.rst
+++ b/modules/EVSE/OCPP201/docs/index.rst
@@ -103,6 +103,36 @@ Provides: session_cost
 
 This interface is implemented to publish session costs received by the CSMS as part of the California Pricing whitepaper extension.
 
+Requires: grid_support
+^^^^^^^^^^^^^^^^^^^^^^
+
+**Interface**: :ref:`grid_support <everest_interfaces_grid_support>`
+
+This optional requirement (0-128) connects the module to per-EVSE DER devices (inverter / grid-support hardware
+abstraction) implementing the grid_support interface, exposing the OCPP 2.1 DER / grid-code functional block (block R).
+One connection represents one EVSE and is routed by its framework ``mapping``: the connection whose mapping names an
+EVSE serves that EVSE. Each connection must be mapped to its EVSE via the framework ``mapping``; a connection without a
+mapping is a configuration error and is excluded from routing.
+
+The module maintains a per-EVSE snapshot of the DER directives currently applied by the CSMS and pushes it to that
+EVSE's connection through the **set_active_directives** command. When libocpp applies, schedules, clears, supersedes, or
+expires a DER control, the snapshot is rebuilt and re-sent for every registered EVSE on its own connection.
+
+At startup the module pre-provisions an ``ACDERCtrlr`` or ``DCDERCtrlr`` device-model component (chosen by the EVSE's
+energy-transfer modes) with ``Available=false`` and an empty ``ModesSupported`` for every DER-capable EVSE, so no static
+device-model JSON is required for the DER controllers.
+
+The device declares its inverter capability through the ``capability`` variable. The module stores the capability, sets the
+component ``Available=true`` and writes ``ModesSupported`` through the device model (which lazily constructs the libocpp DER
+block), then pushes the current active directives filtered to the declared control types, so a freshly connected device
+immediately learns its active set. The device reports grid event faults through the ``alarm`` variable, which is forwarded
+to the CSMS as a **NotifyDERAlarm.req**. Capability and alarm updates received before the charge point is initialized are
+queued and replayed once the charge point is ready.
+
+The configuration parameter **grid_support_heartbeat_s** sets the interval (in seconds) at which the current active
+directive set is re-sent for every registered EVSE. A value of ``0`` disables the heartbeat; the set is then sent only when
+it changes.
+
 Requires: evse_manager
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/modules/EVSE/OCPP201/grid_support/grid_support_state.cpp
+++ b/modules/EVSE/OCPP201/grid_support/grid_support_state.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "grid_support_state.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace module {
+
+void GridSupportState::set_capability(int32_t evse_id, const types::grid_support::DERCapability& capability) {
+    capability_by_evse[evse_id] = capability;
+}
+
+void GridSupportState::unregister(int32_t evse_id) {
+    capability_by_evse.erase(evse_id);
+}
+
+void GridSupportState::set_active_directives(std::vector<types::grid_support::Directive> directives) {
+    last_active_directives = std::move(directives);
+}
+
+types::grid_support::ActiveDirectiveSet GridSupportState::build_active_set(int32_t evse_id) const {
+    types::grid_support::ActiveDirectiveSet set;
+    set.evse_id = evse_id;
+
+    const auto capability_it = capability_by_evse.find(evse_id);
+    if (capability_it == capability_by_evse.end()) {
+        return set;
+    }
+    const auto& supported = capability_it->second.supported_types;
+
+    for (const auto& directive : last_active_directives) {
+        if (std::find(supported.begin(), supported.end(), directive.directive_type) != supported.end()) {
+            set.directives.push_back(directive);
+        }
+    }
+    return set;
+}
+
+std::vector<int32_t> GridSupportState::registered_evses() const {
+    std::vector<int32_t> evses;
+    evses.reserve(capability_by_evse.size());
+    for (const auto& [evse_id, capability] : capability_by_evse) {
+        evses.push_back(evse_id);
+    }
+    return evses;
+}
+
+void GridSupportState::buffer_pending_capability(int32_t evse_id,
+                                                 const types::grid_support::DERCapability& capability) {
+    pending_capability_by_evse[evse_id] = capability;
+}
+
+std::vector<std::pair<int32_t, types::grid_support::DERCapability>> GridSupportState::take_pending_capabilities() {
+    std::vector<std::pair<int32_t, types::grid_support::DERCapability>> taken;
+    taken.reserve(pending_capability_by_evse.size());
+    for (auto& [evse_id, capability] : pending_capability_by_evse) {
+        taken.emplace_back(evse_id, std::move(capability));
+    }
+    pending_capability_by_evse.clear();
+    return taken;
+}
+
+void GridSupportState::buffer_pending_alarm(const types::grid_support::GridAlarm& alarm) {
+    pending_alarms.push_back(alarm);
+}
+
+std::vector<types::grid_support::GridAlarm> GridSupportState::take_pending_alarms() {
+    std::vector<types::grid_support::GridAlarm> taken;
+    taken.swap(pending_alarms);
+    return taken;
+}
+
+bool GridSupportState::capabilities_live() const {
+    return capabilities_are_live;
+}
+
+void GridSupportState::set_capabilities_live() {
+    capabilities_are_live = true;
+}
+
+bool GridSupportState::alarms_live() const {
+    return alarms_are_live;
+}
+
+void GridSupportState::set_alarms_live() {
+    alarms_are_live = true;
+}
+
+} // namespace module

--- a/modules/EVSE/OCPP201/grid_support/grid_support_state.cpp
+++ b/modules/EVSE/OCPP201/grid_support/grid_support_state.cpp
@@ -12,8 +12,25 @@ void GridSupportState::set_capability(int32_t evse_id, const types::grid_support
     capability_by_evse[evse_id] = capability;
 }
 
+std::optional<types::grid_support::DERCapability> GridSupportState::capability_for(int32_t evse_id) const {
+    const auto it = capability_by_evse.find(evse_id);
+    if (it == capability_by_evse.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
 void GridSupportState::unregister(int32_t evse_id) {
     capability_by_evse.erase(evse_id);
+    disabled_evses.erase(evse_id);
+}
+
+void GridSupportState::set_enabled(int32_t evse_id, bool enabled) {
+    if (enabled) {
+        disabled_evses.erase(evse_id);
+    } else {
+        disabled_evses.insert(evse_id);
+    }
 }
 
 void GridSupportState::set_active_directives(std::vector<types::grid_support::Directive> directives) {
@@ -26,6 +43,9 @@ types::grid_support::ActiveDirectiveSet GridSupportState::build_active_set(int32
 
     const auto capability_it = capability_by_evse.find(evse_id);
     if (capability_it == capability_by_evse.end()) {
+        return set;
+    }
+    if (disabled_evses.count(evse_id) != 0) {
         return set;
     }
     const auto& supported = capability_it->second.supported_types;

--- a/modules/EVSE/OCPP201/grid_support/grid_support_state.hpp
+++ b/modules/EVSE/OCPP201/grid_support/grid_support_state.hpp
@@ -4,6 +4,8 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -26,9 +28,17 @@ public:
     /// \brief Store the latest declared DER capability for \p evse_id, registering the EVSE.
     void set_capability(int32_t evse_id, const types::grid_support::DERCapability& capability);
 
+    /// \brief The last registered capability for \p evse_id (ignores the pending buffer), or nullopt if
+    /// unregistered. Lets a caller snapshot the accepted capability before an overwrite, to roll back on reject.
+    std::optional<types::grid_support::DERCapability> capability_for(int32_t evse_id) const;
+
     /// \brief Unregister \p evse_id, undoing a speculative registration when the enabling write is
-    /// rejected. No-op if not registered.
+    /// rejected. No-op if not registered. Also clears any disabled flag.
     void unregister(int32_t evse_id);
+
+    /// \brief Enable or disable directive delivery for \p evse_id. For a registered EVSE, disabling does
+    /// not unregister it, but build_active_set carries zero directives, so the push clears the device.
+    void set_enabled(int32_t evse_id, bool enabled);
 
     /// \brief Replace the cached active directive set (the last set libocpp pushed). Stored by move.
     void set_active_directives(std::vector<types::grid_support::Directive> directives);
@@ -71,6 +81,8 @@ public:
 private:
     // Unguarded by design: every access goes through OCPP201's monitor<GridSupportState> handle (class doc).
     std::map<int32_t, types::grid_support::DERCapability> capability_by_evse;
+    // EVSEs whose DERCtrlr the CSMS disabled: still registered, but build_active_set yields no directives.
+    std::set<int32_t> disabled_evses;
     // Capabilities buffered until flush_pending_grid_support() empties this at ready(); last write per EVSE
     // wins. Distinct from capability_by_evse: entries here have not yet enabled DER on their EVSE.
     std::map<int32_t, types::grid_support::DERCapability> pending_capability_by_evse;

--- a/modules/EVSE/OCPP201/grid_support/grid_support_state.hpp
+++ b/modules/EVSE/OCPP201/grid_support/grid_support_state.hpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include <generated/types/grid_support.hpp>
+
+namespace module {
+
+/// \brief Per-EVSE DER capability registry plus the filter that derives a per-EVSE active set.
+///
+/// Module-independent (no OCPP201.hpp / charge_point / framework dependency) so it is unit-testable in
+/// isolation. libocpp owns the active-directive set; this type does not track transitions, it only
+/// remembers each EVSE's supported types and filters the cached active set down to them. No internal
+/// synchronization: the owning module wraps it in a monitor<> and holds one handle per logical operation.
+///
+/// The capabilities_live / alarms_live flags gate the handoff from pre-construction buffering to live
+/// delivery: each starts false (route to the buffer) and is flipped sticky-true once the charge point can
+/// accept that kind, so routing decisions stay inside the monitor and never race the charge_point pointer.
+class GridSupportState {
+public:
+    /// \brief Store the latest declared DER capability for \p evse_id, registering the EVSE.
+    void set_capability(int32_t evse_id, const types::grid_support::DERCapability& capability);
+
+    /// \brief Unregister \p evse_id, undoing a speculative registration when the enabling write is
+    /// rejected. No-op if not registered.
+    void unregister(int32_t evse_id);
+
+    /// \brief Replace the cached active directive set (the last set libocpp pushed). Stored by move.
+    void set_active_directives(std::vector<types::grid_support::Directive> directives);
+
+    /// \brief Filter the cached active directive set down to \p evse_id's declared supported types. An
+    /// unregistered EVSE supports no types (empty result). The returned set always has evse_id populated.
+    ///
+    /// No per-type dedup: two non-superseded controls of the same type both surface; consumers
+    /// disambiguate via is_default/id.
+    types::grid_support::ActiveDirectiveSet build_active_set(int32_t evse_id) const;
+
+    /// \brief EVSEs that have declared a capability via set_capability.
+    std::vector<int32_t> registered_evses() const;
+
+    /// \brief Buffer a capability that arrived before the charge point existed. Does NOT register the
+    /// EVSE (registration happens when the buffer is applied). Re-buffering the same evse_id is last-wins.
+    void buffer_pending_capability(int32_t evse_id, const types::grid_support::DERCapability& capability);
+
+    /// \brief Take and clear the pending-capability buffer in ascending evse_id order.
+    std::vector<std::pair<int32_t, types::grid_support::DERCapability>> take_pending_capabilities();
+
+    /// \brief Buffer an alarm that arrived before the charge point existed, preserving arrival order.
+    void buffer_pending_alarm(const types::grid_support::GridAlarm& alarm);
+
+    /// \brief Take and clear the pending-alarm buffer in arrival order.
+    std::vector<types::grid_support::GridAlarm> take_pending_alarms();
+
+    /// \brief True once capabilities deliver live instead of buffering. Default false, sticky.
+    bool capabilities_live() const;
+
+    /// \brief Mark capabilities as delivering live; idempotent.
+    void set_capabilities_live();
+
+    /// \brief True once alarms deliver live instead of buffering. Default false, sticky.
+    bool alarms_live() const;
+
+    /// \brief Mark alarms as delivering live; idempotent.
+    void set_alarms_live();
+
+private:
+    // Unguarded by design: every access goes through OCPP201's monitor<GridSupportState> handle (class doc).
+    std::map<int32_t, types::grid_support::DERCapability> capability_by_evse;
+    // Capabilities buffered until flush_pending_grid_support() empties this at ready(); last write per EVSE
+    // wins. Distinct from capability_by_evse: entries here have not yet enabled DER on their EVSE.
+    std::map<int32_t, types::grid_support::DERCapability> pending_capability_by_evse;
+    // The most recent active set libocpp pushed; build_active_set filters it per EVSE.
+    std::vector<types::grid_support::Directive> last_active_directives;
+    // Alarms buffered in arrival order until the first successful capability enable delivers them.
+    std::vector<types::grid_support::GridAlarm> pending_alarms;
+    // Sticky handoff flags: false = buffer, true = deliver live (see class doc).
+    bool capabilities_are_live = false;
+    bool alarms_are_live = false;
+};
+
+} // namespace module

--- a/modules/EVSE/OCPP201/manifest.yaml
+++ b/modules/EVSE/OCPP201/manifest.yaml
@@ -77,6 +77,10 @@ config:
       built-in defaults. Leave empty to use only the defaults.
     type: string
     default: ''
+  grid_support_heartbeat_s:
+    description: Interval (seconds) at which the current active DER directive set is republished per EVSE. 0 disables the heartbeat.
+    type: integer
+    default: 60
 provides:
   auth_validator:
     description: Validates the provided token using CSMS, AuthorizationList or AuthorizationCache
@@ -128,6 +132,10 @@ requires:
     max_connections: 1
   extensions_15118:
     interface: iso15118_extensions
+    min_connections: 0
+    max_connections: 128
+  grid_support:
+    interface: grid_support
     min_connections: 0
     max_connections: 128
 enable_external_mqtt: true

--- a/modules/EVSE/OCPP201/tests/CMakeLists.txt
+++ b/modules/EVSE/OCPP201/tests/CMakeLists.txt
@@ -12,7 +12,9 @@ target_include_directories(${TEST_TARGET_NAME} PUBLIC
 
 target_sources(${TEST_TARGET_NAME}
     PRIVATE
+    grid_support_state_test.cpp
     ocpp_conversions_test.cpp
+    ../grid_support/grid_support_state.cpp
 )
 
 target_link_libraries(${TEST_TARGET_NAME}

--- a/modules/EVSE/OCPP201/tests/grid_support_state_test.cpp
+++ b/modules/EVSE/OCPP201/tests/grid_support_state_test.cpp
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include "../grid_support/grid_support_state.hpp"
+
+#include <generated/types/grid_support.hpp>
+
+namespace {
+
+namespace gs = types::grid_support;
+
+gs::Directive make_directive(const std::string& id, gs::DirectiveType type, bool is_default = false) {
+    gs::Directive directive;
+    directive.id = id;
+    directive.directive_type = type;
+    directive.priority = 0;
+    directive.is_default = is_default;
+    directive.source = "ocpp";
+    directive.received_at = "2026-06-16T00:00:00Z";
+    return directive;
+}
+
+gs::DERCapability make_capability(const std::vector<gs::DirectiveType>& supported_types) {
+    gs::DERCapability capability;
+    capability.supported_types = supported_types;
+    capability.nameplate.max_w_W = 1000.0f;
+    capability.nameplate.max_va_VA = 1000.0f;
+    capability.nameplate.v_nom_V = 230.0f;
+    gs::ACCapability ac;
+    capability.ac = ac;
+    return capability;
+}
+
+gs::GridAlarm make_alarm(gs::GridEventFault fault, bool alarm_ended = false) {
+    gs::GridAlarm alarm;
+    alarm.fault = fault;
+    alarm.alarm_ended = alarm_ended;
+    alarm.timestamp = "2026-06-16T00:00:00Z";
+    return alarm;
+}
+
+// build_active_set returns only directives whose type the EVSE declared as supported, tagged with the EVSE id.
+TEST(GridSupportState, BuildActiveSetFiltersToSupportedTypes) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 1;
+
+    state.set_capability(evse_id, make_capability({gs::DirectiveType::VoltVar, gs::DirectiveType::FreqDroop}));
+
+    state.set_active_directives({
+        make_directive("d-voltvar", gs::DirectiveType::VoltVar),
+        make_directive("d-voltwatt", gs::DirectiveType::VoltWatt), // unsupported by this EVSE
+    });
+
+    const auto active = state.build_active_set(evse_id);
+
+    EXPECT_EQ(active.evse_id, evse_id);
+    ASSERT_EQ(active.directives.size(), 1u);
+    EXPECT_EQ(active.directives.at(0).directive_type, gs::DirectiveType::VoltVar);
+    EXPECT_EQ(active.directives.at(0).id, "d-voltvar");
+}
+
+TEST(GridSupportState, BuildActiveSetForUnregisteredEvseIsEmpty) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 9;
+
+    state.set_active_directives({make_directive("d-voltvar", gs::DirectiveType::VoltVar)});
+
+    const auto active = state.build_active_set(evse_id);
+
+    EXPECT_EQ(active.evse_id, evse_id);
+    EXPECT_TRUE(active.directives.empty());
+}
+
+TEST(GridSupportState, SetCapabilityRegistersEvse) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 2;
+
+    state.set_capability(evse_id, make_capability({gs::DirectiveType::VoltWatt}));
+
+    const auto registered = state.registered_evses();
+    ASSERT_EQ(registered.size(), 1u);
+    EXPECT_EQ(registered.at(0), evse_id);
+}
+
+// unregister exists to undo a registration when the enabling write is rejected; after it the EVSE is
+// gone from registered_evses and its active set is empty.
+TEST(GridSupportState, UnregisterRemovesEvse) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 4;
+
+    state.set_capability(evse_id, make_capability({gs::DirectiveType::VoltVar}));
+    ASSERT_EQ(state.registered_evses().size(), 1u);
+
+    state.unregister(evse_id);
+
+    EXPECT_TRUE(state.registered_evses().empty());
+    state.set_active_directives({make_directive("d", gs::DirectiveType::VoltVar)});
+    const auto active = state.build_active_set(evse_id);
+    EXPECT_TRUE(active.directives.empty());
+}
+
+TEST(GridSupportState, UnregisterUnknownEvseIsNoop) {
+    module::GridSupportState state;
+    state.unregister(99);
+    EXPECT_TRUE(state.registered_evses().empty());
+}
+
+// Buffering does not register the EVSE; registration happens only when the buffer is later applied.
+TEST(GridSupportState, BufferPendingCapabilityDoesNotRegister) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 3;
+
+    state.buffer_pending_capability(evse_id, make_capability({gs::DirectiveType::VoltVar}));
+
+    EXPECT_TRUE(state.registered_evses().empty());
+}
+
+// take_pending_capabilities clears the buffer, so a second call yields nothing.
+TEST(GridSupportState, TakePendingCapabilitiesClearsBuffer) {
+    module::GridSupportState state;
+
+    state.buffer_pending_capability(1, make_capability({gs::DirectiveType::VoltVar}));
+    state.buffer_pending_capability(2, make_capability({gs::DirectiveType::FreqDroop}));
+
+    const auto taken = state.take_pending_capabilities();
+    ASSERT_EQ(taken.size(), 2u);
+    EXPECT_EQ(taken.at(0).first, 1);
+    EXPECT_EQ(taken.at(0).second.supported_types.at(0), gs::DirectiveType::VoltVar);
+    EXPECT_EQ(taken.at(1).first, 2);
+    EXPECT_EQ(taken.at(1).second.supported_types.at(0), gs::DirectiveType::FreqDroop);
+
+    EXPECT_TRUE(state.take_pending_capabilities().empty());
+}
+
+// Re-buffering the same EVSE is last-wins: the take yields one entry carrying the latest capability.
+TEST(GridSupportState, BufferPendingCapabilityIsLastWinsPerEvse) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 5;
+
+    state.buffer_pending_capability(evse_id, make_capability({gs::DirectiveType::VoltVar}));
+    state.buffer_pending_capability(evse_id, make_capability({gs::DirectiveType::FreqDroop}));
+
+    const auto taken = state.take_pending_capabilities();
+    ASSERT_EQ(taken.size(), 1u);
+    EXPECT_EQ(taken.at(0).first, evse_id);
+    ASSERT_EQ(taken.at(0).second.supported_types.size(), 1u);
+    EXPECT_EQ(taken.at(0).second.supported_types.at(0), gs::DirectiveType::FreqDroop);
+}
+
+// set_active_directives replaces the stored set wholesale: build_active_set filters the latest set, not a union.
+TEST(GridSupportState, SetActiveDirectivesIsLastWins) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 6;
+
+    state.set_capability(evse_id, make_capability({gs::DirectiveType::VoltVar, gs::DirectiveType::FreqDroop}));
+
+    state.set_active_directives({make_directive("first", gs::DirectiveType::VoltVar)});
+    state.set_active_directives({make_directive("second", gs::DirectiveType::FreqDroop)});
+
+    const auto active = state.build_active_set(evse_id);
+    ASSERT_EQ(active.directives.size(), 1u);
+    EXPECT_EQ(active.directives.at(0).id, "second");
+
+    // Clearing the active set empties build_active_set output (no ghost directives linger).
+    state.set_active_directives({});
+    EXPECT_TRUE(state.build_active_set(evse_id).directives.empty());
+}
+
+// buffer_pending_alarm preserves arrival order; take_pending_alarms returns them and clears the buffer.
+TEST(GridSupportState, BufferPendingAlarmRoundTripPreservesOrder) {
+    module::GridSupportState state;
+
+    state.buffer_pending_alarm(make_alarm(gs::GridEventFault::OverVoltage));
+    state.buffer_pending_alarm(make_alarm(gs::GridEventFault::UnderFrequency, true));
+
+    const auto taken = state.take_pending_alarms();
+    ASSERT_EQ(taken.size(), 2u);
+    EXPECT_EQ(taken.at(0).fault, gs::GridEventFault::OverVoltage);
+    EXPECT_FALSE(taken.at(0).alarm_ended);
+    EXPECT_EQ(taken.at(1).fault, gs::GridEventFault::UnderFrequency);
+    EXPECT_TRUE(taken.at(1).alarm_ended);
+}
+
+// take_pending_alarms clears the buffer, so a second call yields nothing.
+TEST(GridSupportState, TakePendingAlarmsClearsBuffer) {
+    module::GridSupportState state;
+
+    state.buffer_pending_alarm(make_alarm(gs::GridEventFault::OverVoltage));
+
+    ASSERT_EQ(state.take_pending_alarms().size(), 1u);
+    EXPECT_TRUE(state.take_pending_alarms().empty());
+}
+
+// The live flags default false (buffer) and are sticky-true once flipped.
+TEST(GridSupportState, CapabilitiesLiveDefaultsFalseAndIsSticky) {
+    module::GridSupportState state;
+
+    EXPECT_FALSE(state.capabilities_live());
+
+    state.set_capabilities_live();
+    EXPECT_TRUE(state.capabilities_live());
+
+    state.set_capabilities_live(); // idempotent
+    EXPECT_TRUE(state.capabilities_live());
+}
+
+TEST(GridSupportState, AlarmsLiveDefaultsFalseAndIsSticky) {
+    module::GridSupportState state;
+
+    EXPECT_FALSE(state.alarms_live());
+
+    state.set_alarms_live();
+    EXPECT_TRUE(state.alarms_live());
+
+    state.set_alarms_live(); // idempotent
+    EXPECT_TRUE(state.alarms_live());
+}
+
+// Capabilities buffered before the flip are all returned by the take after the flip; the flag and the
+// buffer are independent, so flipping live does not itself empty the buffer.
+TEST(GridSupportState, CapabilitiesBufferedBeforeFlipTakenAfterFlip) {
+    module::GridSupportState state;
+
+    state.buffer_pending_capability(1, make_capability({gs::DirectiveType::VoltVar}));
+    state.buffer_pending_capability(2, make_capability({gs::DirectiveType::FreqDroop}));
+
+    state.set_capabilities_live();
+    ASSERT_TRUE(state.capabilities_live());
+
+    const auto taken = state.take_pending_capabilities();
+    ASSERT_EQ(taken.size(), 2u);
+    EXPECT_EQ(taken.at(0).first, 1);
+    EXPECT_EQ(taken.at(1).first, 2);
+}
+
+// Same contract for alarms: everything buffered before the flip survives to the post-flip take, in order.
+TEST(GridSupportState, AlarmsBufferedBeforeFlipTakenAfterFlip) {
+    module::GridSupportState state;
+
+    state.buffer_pending_alarm(make_alarm(gs::GridEventFault::OverVoltage));
+    state.buffer_pending_alarm(make_alarm(gs::GridEventFault::UnderFrequency, true));
+
+    state.set_alarms_live();
+    ASSERT_TRUE(state.alarms_live());
+
+    const auto taken = state.take_pending_alarms();
+    ASSERT_EQ(taken.size(), 2u);
+    EXPECT_EQ(taken.at(0).fault, gs::GridEventFault::OverVoltage);
+    EXPECT_EQ(taken.at(1).fault, gs::GridEventFault::UnderFrequency);
+}
+
+} // namespace

--- a/modules/EVSE/OCPP201/tests/grid_support_state_test.cpp
+++ b/modules/EVSE/OCPP201/tests/grid_support_state_test.cpp
@@ -251,4 +251,70 @@ TEST(GridSupportState, AlarmsBufferedBeforeFlipTakenAfterFlip) {
     EXPECT_EQ(taken.at(1).fault, gs::GridEventFault::UnderFrequency);
 }
 
+// capability_for returns the stored capability for a registered EVSE and nullopt for an unknown one.
+TEST(GridSupportState, CapabilityForReturnsStoredCapability) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 1;
+
+    state.set_capability(evse_id, make_capability({gs::DirectiveType::VoltVar}));
+
+    const auto stored = state.capability_for(evse_id);
+    ASSERT_TRUE(stored.has_value());
+    ASSERT_EQ(stored->supported_types.size(), 1u);
+    EXPECT_EQ(stored->supported_types.at(0), gs::DirectiveType::VoltVar);
+
+    EXPECT_FALSE(state.capability_for(99).has_value());
+}
+
+// set_enabled(false) keeps the EVSE registered but empties its built set; set_enabled(true) restores it.
+TEST(GridSupportState, SetEnabledFalseEmptiesBuildActiveSet) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 1;
+
+    state.set_capability(evse_id, make_capability({gs::DirectiveType::VoltVar}));
+    state.set_active_directives({make_directive("d-voltvar", gs::DirectiveType::VoltVar)});
+
+    state.set_enabled(evse_id, false);
+    const auto disabled = state.build_active_set(evse_id);
+    EXPECT_EQ(disabled.evse_id, evse_id);
+    EXPECT_TRUE(disabled.directives.empty());
+    // Disabling must not destroy the stored capability; the rollback path relies on it.
+    EXPECT_TRUE(state.capability_for(evse_id).has_value());
+
+    state.set_enabled(evse_id, true);
+    const auto enabled = state.build_active_set(evse_id);
+    ASSERT_EQ(enabled.directives.size(), 1u);
+    EXPECT_EQ(enabled.directives.at(0).id, "d-voltvar");
+}
+
+// A freshly registered EVSE is enabled by default; no set_enabled call is needed to build a non-empty set.
+TEST(GridSupportState, EvseDefaultsEnabled) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 2;
+
+    state.set_capability(evse_id, make_capability({gs::DirectiveType::VoltVar}));
+    state.set_active_directives({make_directive("d-voltvar", gs::DirectiveType::VoltVar)});
+
+    const auto active = state.build_active_set(evse_id);
+    ASSERT_EQ(active.directives.size(), 1u);
+    EXPECT_EQ(active.directives.at(0).id, "d-voltvar");
+}
+
+// unregister clears the disabled flag, so a re-registered EVSE comes back enabled.
+TEST(GridSupportState, UnregisterClearsDisabledFlag) {
+    module::GridSupportState state;
+    constexpr int32_t evse_id = 3;
+
+    state.set_capability(evse_id, make_capability({gs::DirectiveType::VoltVar}));
+    state.set_enabled(evse_id, false);
+    state.unregister(evse_id);
+
+    state.set_capability(evse_id, make_capability({gs::DirectiveType::VoltVar}));
+    state.set_active_directives({make_directive("d-voltvar", gs::DirectiveType::VoltVar)});
+
+    const auto active = state.build_active_set(evse_id);
+    ASSERT_EQ(active.directives.size(), 1u);
+    EXPECT_EQ(active.directives.at(0).id, "d-voltvar");
+}
+
 } // namespace

--- a/tests/ocpp_tests/test_sets/ocpp21/der.py
+++ b/tests/ocpp_tests/test_sets/ocpp21/der.py
@@ -59,6 +59,7 @@ from ocpp.v21.datatypes import (
     DERCurveType,
     DERCurvePointsType,
     GetVariableDataType,
+    SetVariableDataType,
     ComponentType,
     VariableType,
     EVSEType,
@@ -828,3 +829,111 @@ async def test_get_emits_report_der_control(
         "ReportDERControl",
         {"requestId": 104},
     )
+
+
+# -----------------------------------------------------------------------------
+# A CSMS DER disable survives a reboot.
+#
+# DERCtrlr Enabled=false persists in the device model, but the module's in-memory
+# disable state must be restored on boot, or a persisted directive is re-pushed to
+# a disabled EVSE after restart.
+# -----------------------------------------------------------------------------
+
+@grid_support_markers
+async def test_der_disable_survives_reboot(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
+    everest_core,
+):
+    """A CSMS DER disable survives a reboot: after Enabled=false and a restart,
+    a previously-persisted directive is not re-pushed to the disabled device.
+
+    Enable DER, set a default directive, disable via SetVariables Enabled=false
+    (the device is cleared), reboot, re-declare the capability, and assert the
+    device does not get the persisted directive back.
+    """
+    pushed = provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
+
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    r_set = await charge_point_v21.set_der_control_req(
+        is_default=True,
+        control_id="ctrl-reboot",
+        control_type=DERControlEnumType.freq_droop,
+        freq_droop=FREQ_DROOP,
+    )
+    assert r_set is not None and r_set.status == DERControlStatusEnumType.accepted
+
+    # The directive reaches the enabled device.
+    drain(pushed)
+    assert "FreqDroop" in latest_directive_types(pushed)
+
+    # CSMS disables the DER controller; the device is cleared.
+    disable = await charge_point_v21.set_variables_req(
+        set_variable_data=[
+            SetVariableDataType(
+                attribute_value="false",
+                attribute_type=AttributeEnumType.actual,
+                component=ComponentType(
+                    name="DCDERCtrlr", evse=EVSEType(id=DER_EVSE_ID)
+                ),
+                variable=VariableType(name="Enabled"),
+            )
+        ]
+    )
+    assert disable.set_variable_result[0]["attribute_status"] == "Accepted"
+    drain(pushed)
+    assert "FreqDroop" not in latest_directive_types(pushed)
+
+    # Reboot: only the process bounces; the device model DB (Enabled=false and the
+    # persisted directive) survives.
+    test_controller.stop()
+    await asyncio.sleep(1)
+    test_controller.start()
+
+    # The restarted manager waits for the standalone probe, whose C++ module is
+    # bound to the pre-reboot manager, so re-create it against the new session
+    # before waiting for the charge point.
+    probe_after = ProbeModule(everest_core.get_runtime_session())
+    pushed = provide_grid_support(probe_after)
+    probe_after.start()
+    await probe_after.wait_to_be_ready()
+
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    # The device re-declares its capability, re-registering the EVSE so the module
+    # pushes its active set again.
+    await enable_der(probe_after, charge_point_v21)
+
+    # The persisted directive must not return: the DER block is gated on the
+    # persisted Enabled=false, so the disabled EVSE receives an empty set.
+    drain(pushed)
+    assert "FreqDroop" not in latest_directive_types(pushed)
+
+    # Re-enabling proves the directive was persisted and merely suppressed: once
+    # Enabled=true, the stored control is rebuilt and pushed to the device again.
+    reenable = await charge_point_v21.set_variables_req(
+        set_variable_data=[
+            SetVariableDataType(
+                attribute_value="true",
+                attribute_type=AttributeEnumType.actual,
+                component=ComponentType(
+                    name="DCDERCtrlr", evse=EVSEType(id=DER_EVSE_ID)
+                ),
+                variable=VariableType(name="Enabled"),
+            )
+        ]
+    )
+    assert reenable.set_variable_result[0]["attribute_status"] == "Accepted"
+    drain(pushed)
+    assert "FreqDroop" in latest_directive_types(pushed)

--- a/tests/ocpp_tests/test_sets/ocpp21/der.py
+++ b/tests/ocpp_tests/test_sets/ocpp21/der.py
@@ -2,389 +2,746 @@
 # Copyright Pionix GmbH and Contributors to EVerest
 
 """
-Integration smoke tests for OCPP 2.1 R04 - Configure DER control settings at Charging Station.
+Acceptance suite for the OCPP 2.1 functional block R (DER control), exercised
+end-to-end over a real CSMS websocket against the d20 DC SIL.
 
-Covers the routing/availability behaviour end-to-end over a real websocket connection:
-  * CS returns NotImplemented (CALLERROR) when DCDERCtrlr/ACDERCtrlr is not available
-  * CS returns Accepted when DCDERCtrlr.Available=true and controlType is in ModesSupported
-  * CS returns NotSupported when the controlType is not in ModesSupported
-  * GetDERControl with no stored controls returns NotFound
-  * ClearDERControl with no controls returns NotFound
+The grid_support interface is inverted: the DER device is the *provider* and the
+OCPP201 module *optionally requires* it. A probe module stands in for the DER
+device. It:
 
-These tests exercise the wiring done in libocpp: the DERControl functional block
-is conditionally instantiated based on the DERCtrlr.Available variable, and
-SetDERControl/GetDERControl/ClearDERControl messages are routed to it.
+  * implements the ``set_active_directives`` command - OCPP201 calls it to push
+    the active directive set per EVSE (on a CSMS SetDERControl and on the
+    heartbeat). The handler records every call so tests can assert on it.
+  * publishes the ``capability`` variable - the device declaring its DER
+    capability for an EVSE (replaces the old set_capability command).
+  * publishes the ``alarm`` variable - the device raising a grid event fault that
+    OCPP201 forwards to the CSMS as NotifyDERAlarm (replaces the old notify_alarm
+    command).
+
+How DER gets enabled
+--------------------
+EverestDeviceModelStorage provisions a DER controller component (DCDERCtrlr for
+the DER-capable DC EVSE) disabled (Available=false, empty ModesSupported). When
+the device publishes a ``capability`` with a non-empty ``supported_types``,
+OCPP201 writes Available=true and ModesSupported (the CSV of supported control
+types) onto that component, which makes libocpp build the DERControl functional
+block and gate SetDERControl on the declared types.
+
+This write is asynchronous (it travels device -> probe MQTT -> OCPP201 ->
+device-model write), so tests must wait for it to commit before driving the CSMS.
+``enable_der`` does that by polling the device model (via GetVariables) until
+DCDERCtrlr ModesSupported reflects the published capability. Directive pushes are
+read by draining the probe's queue and taking a fresh push, since the 1s
+heartbeat also enqueues the current active set.
 """
 
+import asyncio
 import pytest
+import pytest_asyncio
 import logging
+import queue
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Dict, Iterable
 
 # fmt: off
 from everest.testing.core_utils.controller.test_controller_interface import TestController
-
-from ocpp.v21 import call as call21
-from ocpp.v21 import call_result as call_result21
-from ocpp.v21.enums import *
-from ocpp.v21.datatypes import *
-from ocpp.routing import on, create_route_map
+from everest.testing.core_utils.probe_module import ProbeModule
+from everest.testing.core_utils import EverestConfigAdjustmentStrategy
 
 from everest.testing.ocpp_utils.fixtures import *
 from everest_test_utils import *  # must come before v21 datatype re-imports
-from ocpp.v21.enums import Action, DERControlEnumType, DERControlStatusEnumType, DERUnitEnumType
-
 from everest.testing.core_utils._configuration.libocpp_configuration_helper import GenericOCPP2XConfigAdjustment
-from everest.testing.ocpp_utils.charge_point_utils import TestUtility, OcppTestConfiguration, wait_for_and_validate
+from everest.testing.ocpp_utils.charge_point_utils import wait_for_and_validate, TestUtility
+
+from ocpp.v21.datatypes import (
+    FreqDroopType,
+    DERCurveType,
+    DERCurvePointsType,
+    GetVariableDataType,
+    ComponentType,
+    VariableType,
+    EVSEType,
+)
+from ocpp.v21.enums import (
+    DERControlEnumType,
+    DERControlStatusEnumType,
+    DERUnitEnumType,
+    AttributeEnumType,
+)
 # fmt: on
 
-log = logging.getLogger("derControlTest")
+log = logging.getLogger("gridSupportTest")
 
-# The DER controller component configs were removed from the shipped library and
-# e2e config sets pending a proper interface to provide them dynamically. Without
-# DCDERCtrlr_1 present in the device model these end-to-end tests cannot configure
-# DER, so skip the whole module for now. The DER behaviour stays covered by the
-# libocpp unit tests (DERControlTest), which carry their own DCDERCtrlr_1 fixture.
-pytestmark = pytest.mark.skip(
-    reason="DER controller config removed pending a dynamic DER interface; "
-    "covered by libocpp DERControlTest unit tests for now"
-)
+# The id of the OCPP201 module in everest-config-ocpp201-sil-dc-d20-eim.yaml.
+OCPP_MODULE_ID = "ocpp"
+# The probe module is always injected under this fixed module id.
+PROBE_MODULE_ID = "probe"
+# The implementation id the probe provides and the OCPP201 grid_support
+# requirement is wired to.
+GRID_SUPPORT_IMPL_ID = "grid_support"
+
+# The DER-capable EVSE in the d20 config: a DC EvseManager wired to a bidirectional
+# DCSupplySimulator publishes DC_BPT, which classifies it DER-capable so
+# EverestDeviceModelStorage provisions a DCDERCtrlr component (disabled).
+DER_EVSE_ID = 1
+
+# Default control types a declared capability advertises as supported.
+DEFAULT_SUPPORTED_TYPES = ("FreqDroop", "VoltWatt", "VoltVar", "FixedVar")
 
 
-# -----------------------------------------------------------------------------
-# R04 - DER not available: SetDERControl is rejected as NotImplemented
-# -----------------------------------------------------------------------------
+def rfc3339_now() -> str:
+    """RFC3339 / ISO8601 timestamp with timezone, as the grid_support GridAlarm expects."""
+    return datetime.now(timezone.utc).isoformat()
 
-@pytest.mark.asyncio
-@pytest.mark.ocpp_version("ocpp2.1")
-@pytest.mark.everest_core_config(
-    get_everest_config_path_str("everest-config-ocpp201.yaml")
-)
-@pytest.mark.ocpp_config_adaptions(
-    GenericOCPP2XConfigAdjustment(
-        [
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "InternalCtrlr", "SupportedOcppVersions", "Actual"
-                ),
-                "ocpp2.1",
-            ),
+
+def make_capability(supported_types: Iterable[str] = DEFAULT_SUPPORTED_TYPES) -> dict:
+    """A DERCapability with the dc inverter class populated and the given supported types.
+
+    At least one of ac/dc must be present; we populate dc to exercise the DC DER
+    component variable writes. ``supported_types`` becomes the DCDERCtrlr
+    ModesSupported CSV that gates which control types SetDERControl accepts.
+    """
+    return {
+        "supported_types": list(supported_types),
+        "nameplate": {
+            "max_w_W": 11000.0,
+            "max_va_VA": 11000.0,
+            "v_nom_V": 400.0,
+        },
+        "dc": {
+            "manufacturer": "Pionix",
+            "model": "SIL",
+        },
+    }
+
+
+def make_evse_capability(
+    evse_id: int = DER_EVSE_ID, supported_types: Iterable[str] = DEFAULT_SUPPORTED_TYPES
+) -> dict:
+    """The EVSECapability variable value: a DERCapability tagged with its EVSE."""
+    return {"evse_id": evse_id, "capability": make_capability(supported_types)}
+
+
+class GridSupportProbeWiringAdjustment(EverestConfigAdjustmentStrategy):
+    """Wires the OCPP201 grid_support requirement to the probe's provided
+    implementation and speeds up the active-directive heartbeat.
+
+    The probe module itself is injected by the ``probe_module`` marker; this
+    strategy points the OCPP201 module's (optional) grid_support requirement at
+    the probe, so OCPP201 becomes the consumer and the probe the DER-device
+    provider. It also sets grid_support_heartbeat_s so the heartbeat fires every
+    second for fast test feedback. Because OCPP201 now requires every
+    grid_support connection to carry a framework mapping, it also maps the probe
+    module to DER_EVSE_ID so the connection is not excluded from DER routing.
+    """
+
+    def __init__(self, heartbeat_s: int = 1):
+        self._heartbeat_s = heartbeat_s
+
+    def adjust_everest_configuration(self, everest_config: Dict) -> Dict:
+        adjusted_config = deepcopy(everest_config)
+        ocpp_module = adjusted_config["active_modules"][OCPP_MODULE_ID]
+        ocpp_module.setdefault("config_module", {})["grid_support_heartbeat_s"] = self._heartbeat_s
+        ocpp_module.setdefault("connections", {})["grid_support"] = [
+            {"module_id": PROBE_MODULE_ID, "implementation_id": GRID_SUPPORT_IMPL_ID}
         ]
+        # The probe_module marker already injected the probe's active_modules entry (probe strategies run
+        # before user everest_config_adaptions), so map it to the DER EVSE here or OCPP201 excludes it.
+        probe_module = adjusted_config["active_modules"][PROBE_MODULE_ID]
+        probe_module.setdefault("mapping", {})["module"] = {"evse": DER_EVSE_ID}
+        return adjusted_config
+
+
+@pytest_asyncio.fixture
+async def probe_grid_support(started_test_controller, everest_core) -> ProbeModule:
+    """A ProbeModule connected to the running EVerest session.
+
+    Started lazily by each test (after registering the set_active_directives
+    handler) via ``probe.start()`` + ``probe.wait_to_be_ready()``.
+    """
+    module = ProbeModule(everest_core.get_runtime_session())
+    return module
+
+
+def provide_grid_support(probe: ProbeModule) -> "queue.Queue":
+    """Register the probe as the grid_support provider.
+
+    Implements the ``set_active_directives`` command and returns a queue that
+    receives every ActiveDirectiveSet OCPP201 pushes to the device. Must be
+    called before ``probe.start()``.
+    """
+    pushed_directives: "queue.Queue" = queue.Queue()
+
+    def on_set_active_directives(arg: dict) -> dict:
+        pushed_directives.put(arg["directives"])
+        return {"accepted": True}
+
+    probe.implement_command(GRID_SUPPORT_IMPL_ID, "set_active_directives", on_set_active_directives)
+    return pushed_directives
+
+
+async def wait_for_der_enabled(
+    charge_point, evse_id: int = DER_EVSE_ID, timeout_s: float = 20.0
+) -> str:
+    """Poll DCDERCtrlr ModesSupported until the async capability enable has committed.
+
+    Returns the ModesSupported CSV once non-empty. Raises if the DER controller
+    is not enabled within ``timeout_s`` (the capability write was rejected or
+    never arrived).
+    """
+    get_var = GetVariableDataType(
+        component=ComponentType(name="DCDERCtrlr", evse=EVSEType(id=evse_id)),
+        variable=VariableType(name="ModesSupported"),
+        attribute_type=AttributeEnumType.actual,
     )
+    last = None
+    for _ in range(int(timeout_s / 0.5)):
+        response = await charge_point.get_variables_req(get_variable_data=[get_var])
+        results = response.get_variable_result if response else None
+        if results:
+            last = results[0]
+            if last.get("attribute_status") == "Accepted" and last.get("attribute_value"):
+                return last["attribute_value"]
+        await asyncio.sleep(0.5)
+    raise AssertionError(
+        f"DCDERCtrlr for EVSE {evse_id} not enabled within {timeout_s}s; last GetVariables result: {last}"
+    )
+
+
+async def enable_der(
+    probe: ProbeModule,
+    charge_point,
+    evse_id: int = DER_EVSE_ID,
+    supported_types: Iterable[str] = DEFAULT_SUPPORTED_TYPES,
+) -> None:
+    """Declare DER capability for ``evse_id`` and block until the enable commits.
+
+    The device publishing ``capability`` makes OCPP201 enable the DCDERCtrlr and
+    advertise ModesSupported; this waits until that write is observable so the
+    caller can drive SetDERControl deterministically.
+    """
+    probe.publish_variable(
+        GRID_SUPPORT_IMPL_ID, "capability", make_evse_capability(evse_id, supported_types)
+    )
+    await wait_for_der_enabled(charge_point, evse_id)
+
+
+def drain(pushed: "queue.Queue") -> None:
+    """Discard every currently-queued active-directive push."""
+    while not pushed.empty():
+        pushed.get_nowait()
+
+
+def latest_directive_types(pushed: "queue.Queue", timeout_s: float = 10.0) -> set:
+    """Return the directive types in the next active-directive push for the DER EVSE."""
+    received = pushed.get(timeout=timeout_s)
+    return {d["directive_type"] for d in received["directives"]}
+
+
+FREQ_DROOP = FreqDroopType(
+    priority=0,
+    over_freq=61.0,
+    under_freq=59.0,
+    over_droop=5.0,
+    under_droop=5.0,
+    response_time=3.0,
 )
-async def test_set_der_control_der_not_available_not_implemented(
+
+
+# Common marker stack: a real CSMS over the d20 DC SIL config, OCPP 2.1, with the
+# probe wired as the grid_support provider (OCPP201 the consumer) and the OCPP201
+# heartbeat sped up to 1s.
+def grid_support_markers(func):
+    func = pytest.mark.asyncio(func)
+    func = pytest.mark.xdist_group(name="ISO15118")(func)
+    func = pytest.mark.ocpp_version("ocpp2.1")(func)
+    func = pytest.mark.everest_core_config(
+        "everest-config-ocpp201-sil-dc-d20-eim.yaml"
+    )(func)
+    func = pytest.mark.ocpp_config_adaptions(
+        GenericOCPP2XConfigAdjustment(
+            [
+                (
+                    OCPP2XConfigVariableIdentifier(
+                        "InternalCtrlr", "SupportedOcppVersions", "Actual"
+                    ),
+                    "ocpp2.1",
+                )
+            ]
+        )
+    )(func)
+    func = pytest.mark.everest_config_adaptions(
+        GridSupportProbeWiringAdjustment(heartbeat_s=1)
+    )(func)
+    func = pytest.mark.probe_module(func)
+    return func
+
+
+# -----------------------------------------------------------------------------
+# Inverted-wiring smoke test - boots without enabling DER.
+#
+# Proves the inversion: the probe provides the grid_support interface, OCPP201
+# binds it as its optional requirement, and the charge point boots. Publishing a
+# capability and an alarm exercises the OCPP201 consumer handlers.
+# -----------------------------------------------------------------------------
+
+@grid_support_markers
+async def test_inverted_wiring_boots_and_handles_publishes(
     central_system_v21: CentralSystem,
     test_controller: TestController,
     test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
 ):
-    """R04: Without DCDERCtrlr/ACDERCtrlr Available, SetDERControl returns CALLERROR NotImplemented.
-
-    The Python ocpp library suppresses CallErrors by default (returning None)
-    rather than raising, so we assert that the response is None. The underlying
-    CALLError is logged as a warning by the library.
+    """The probe provides grid_support, OCPP201 requires it, the charge point
+    boots, and publishing capability + alarm does not bring the session down.
     """
-    test_controller.start()
-    charge_point_v21 = await central_system_v21.wait_for_chargepoint()
+    provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
 
-    freq_droop = FreqDroopType(
-        priority=0,
-        over_freq=61.0,
-        under_freq=59.0,
-        over_droop=5.0,
-        under_droop=5.0,
-        response_time=3.0,
+    # Boot proves OCPP201 started with the probe bound to its grid_support
+    # requirement (a misconfigured inversion would fail the manager start).
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+    assert charge_point_v21 is not None
+
+    probe_grid_support.publish_variable(
+        GRID_SUPPORT_IMPL_ID, "capability", make_evse_capability(evse_id=1)
+    )
+    probe_grid_support.publish_variable(
+        GRID_SUPPORT_IMPL_ID,
+        "alarm",
+        {
+            "directive_type": "VoltVar",
+            "fault": "OverVoltage",
+            "alarm_ended": True,
+            "timestamp": rfc3339_now(),
+        },
+    )
+
+
+# -----------------------------------------------------------------------------
+# A published capability enables the EVSE and OCPP201 pushes its active set.
+# -----------------------------------------------------------------------------
+
+@grid_support_markers
+async def test_capability_enables_evse_and_pushes_active_set(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
+):
+    """A published capability enables the EVSE and OCPP201 pushes its active
+    directive set back to the device via set_active_directives.
+    """
+    pushed = provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
+
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    pushed_set = pushed.get(timeout=10)
+    assert pushed_set["evse_id"] == 1
+
+
+# -----------------------------------------------------------------------------
+# CSMS SetDERControl is accepted and the directive is pushed to the device.
+# -----------------------------------------------------------------------------
+
+@grid_support_markers
+async def test_set_der_control_applies_directive(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
+):
+    """CSMS SetDERControl(default FreqDroop) -> Accepted, and the directive is
+    pushed to the device via set_active_directives.
+    """
+    pushed = provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
+
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    r = await charge_point_v21.set_der_control_req(
+        is_default=True,
+        control_id="ctrl-fd",
+        control_type=DERControlEnumType.freq_droop,
+        freq_droop=FREQ_DROOP,
+    )
+    assert r is not None and r.status == DERControlStatusEnumType.accepted
+
+    # Drain stale pushes (enable republish + earlier heartbeats), then the next
+    # heartbeat push reflects the new active set containing the directive.
+    drain(pushed)
+    assert "FreqDroop" in latest_directive_types(pushed)
+
+
+# -----------------------------------------------------------------------------
+# ClearDERControl removes the directive from the pushed set.
+# -----------------------------------------------------------------------------
+
+@grid_support_markers
+async def test_clear_der_control_removes_directive(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
+):
+    """After SetDERControl, ClearDERControl removes the directive and the
+    device sees the slot drop out of the pushed set.
+    """
+    pushed = provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
+
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    r_set = await charge_point_v21.set_der_control_req(
+        is_default=True,
+        control_id="ctrl-fd",
+        control_type=DERControlEnumType.freq_droop,
+        freq_droop=FREQ_DROOP,
+    )
+    assert r_set is not None and r_set.status == DERControlStatusEnumType.accepted
+
+    r_clear = await charge_point_v21.clear_der_control_req(
+        is_default=True,
+        control_type=DERControlEnumType.freq_droop,
+    )
+    assert r_clear is not None and r_clear.status == DERControlStatusEnumType.accepted
+
+    # After the clear, a fresh push must no longer carry the FreqDroop slot.
+    drain(pushed)
+    assert "FreqDroop" not in latest_directive_types(pushed)
+
+
+# -----------------------------------------------------------------------------
+# Two distinct default directive types coexist in the pushed set.
+# -----------------------------------------------------------------------------
+
+@grid_support_markers
+async def test_multiple_directives_coexist(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
+):
+    """Two distinct default directive types coexist in the pushed set."""
+    pushed = provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
+
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    r1 = await charge_point_v21.set_der_control_req(
+        is_default=True,
+        control_id="ctrl-fd",
+        control_type=DERControlEnumType.freq_droop,
+        freq_droop=FREQ_DROOP,
+    )
+    assert r1 is not None and r1.status == DERControlStatusEnumType.accepted
+
+    volt_watt_curve = DERCurveType(
+        curve_data=[DERCurvePointsType(x=240.0, y=100.0)],
+        priority=1,
+        y_unit=DERUnitEnumType.pct_maxw,
+    )
+    r2 = await charge_point_v21.set_der_control_req(
+        is_default=True,
+        control_id="ctrl-vw",
+        control_type=DERControlEnumType.volt_watt,
+        curve=volt_watt_curve,
+    )
+    assert r2 is not None and r2.status == DERControlStatusEnumType.accepted
+
+    drain(pushed)
+    assert {"FreqDroop", "VoltWatt"}.issubset(latest_directive_types(pushed))
+
+
+# -----------------------------------------------------------------------------
+# The heartbeat re-pushes the active directive set on its interval.
+# -----------------------------------------------------------------------------
+
+@grid_support_markers
+async def test_heartbeat_re_pushes_active_directives(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
+):
+    """The OCPP201 heartbeat re-pushes the active directive set per EVSE on its
+    interval (grid_support_heartbeat_s=1), even with no state change.
+    """
+    pushed = provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
+
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    r = await charge_point_v21.set_der_control_req(
+        is_default=True,
+        control_id="ctrl-fd",
+        control_type=DERControlEnumType.freq_droop,
+        freq_droop=FREQ_DROOP,
+    )
+    assert r is not None and r.status == DERControlStatusEnumType.accepted
+
+    # Drain, then expect a subsequent heartbeat tick to re-push the set unchanged.
+    drain(pushed)
+    assert "FreqDroop" in latest_directive_types(pushed)
+    # A further drained push proves the heartbeat keeps re-pushing without a state change.
+    drain(pushed)
+    assert "FreqDroop" in latest_directive_types(pushed)
+
+
+# -----------------------------------------------------------------------------
+# A published alarm is forwarded to the CSMS as NotifyDERAlarm.
+# -----------------------------------------------------------------------------
+
+@grid_support_markers
+async def test_alarm_forwarded_to_csms(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
+):
+    """Probe publishes alarm GridAlarm{OverVoltage, ended, VoltVar} -> CSMS
+    receives NotifyDERAlarm with controlType=VoltVar, gridEventFault=OverVoltage,
+    alarmEnded=true.
+    """
+    provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
+
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    # on_der_alarm only dispatches NotifyDERAlarm once the DER block is enabled.
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    probe_grid_support.publish_variable(
+        GRID_SUPPORT_IMPL_ID,
+        "alarm",
+        {
+            "directive_type": "VoltVar",
+            "fault": "OverVoltage",
+            "alarm_ended": True,
+            "timestamp": rfc3339_now(),
+        },
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v21,
+        "NotifyDERAlarm",
+        {
+            "controlType": "VoltVar",
+            "gridEventFault": "OverVoltage",
+            "alarmEnded": True,
+        },
+    )
+
+
+# -----------------------------------------------------------------------------
+# Alarm forwarding and directive push in one bidirectional round trip.
+# -----------------------------------------------------------------------------
+
+@grid_support_markers
+async def test_alarm_then_directive_round_trip(
+    central_system_v21: CentralSystem,
+    test_controller: TestController,
+    test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
+):
+    """An alarm published by the device is forwarded to the CSMS, and a
+    subsequent CSMS directive is applied and pushed back to the device.
+    """
+    pushed = provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
+
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    probe_grid_support.publish_variable(
+        GRID_SUPPORT_IMPL_ID,
+        "alarm",
+        {
+            "directive_type": "VoltVar",
+            "fault": "OverVoltage",
+            "alarm_ended": False,
+            "timestamp": rfc3339_now(),
+        },
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v21,
+        "NotifyDERAlarm",
+        {"controlType": "VoltVar", "gridEventFault": "OverVoltage", "alarmEnded": False},
     )
 
     r = await charge_point_v21.set_der_control_req(
         is_default=True,
-        control_id="ctrl-1",
+        control_id="ctrl-fd",
         control_type=DERControlEnumType.freq_droop,
-        freq_droop=freq_droop,
+        freq_droop=FREQ_DROOP,
     )
-    # CALLError NotImplemented is suppressed to None by the library
-    assert r is None
+    assert r is not None and r.status == DERControlStatusEnumType.accepted
+
+    drain(pushed)
+    assert "FreqDroop" in latest_directive_types(pushed)
 
 
 # -----------------------------------------------------------------------------
-# R04.FR.02 - DER available + supported controlType: Accepted
+# CSMS-facing DER message FSM (R04.FR.01/30/41/44/45 and ReportDERControl),
+# driven through the inverted grid_support enable path: a published capability
+# enables the controller, then the CSMS exercises Set/Get/Clear DER control.
 # -----------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-@pytest.mark.ocpp_version("ocpp2.1")
-@pytest.mark.everest_core_config(
-    get_everest_config_path_str("everest-config-ocpp201.yaml")
-)
-@pytest.mark.ocpp_config_adaptions(
-    GenericOCPP2XConfigAdjustment(
-        [
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "InternalCtrlr", "SupportedOcppVersions", "Actual"
-                ),
-                "ocpp2.1",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrAvailable", "Actual"
-                ),
-                "true",
-            ),
-            # ModesSupported is ReadOnly; test relies on the default list in
-            # DCDERCtrlr_1.json: FreqDroop,VoltWatt,LimitMaxDischarge,VoltVar,
-            # FixedVar,EnterService,Gradients
-        ]
-    )
-)
-async def test_set_der_control_supported_type_accepted(
-    central_system_v21: CentralSystem,
-    test_controller: TestController,
-    test_utility: TestUtility,
-):
-    """R04.FR.02: With DCDERCtrlr Available and FreqDroop in ModesSupported, set default FreqDroop returns Accepted."""
-    test_controller.start()
-    charge_point_v21 = await central_system_v21.wait_for_chargepoint()
-
-    freq_droop = FreqDroopType(
-        priority=0,
-        over_freq=61.0,
-        under_freq=59.0,
-        over_droop=5.0,
-        under_droop=5.0,
-        response_time=3.0,
-    )
-
-    r: call_result21.SetDERControl = await charge_point_v21.set_der_control_req(
-        is_default=True,
-        control_id="ctrl-default-fd",
-        control_type=DERControlEnumType.freq_droop,
-        freq_droop=freq_droop,
-    )
-    assert r.status == DERControlStatusEnumType.accepted
-
-
-# -----------------------------------------------------------------------------
-# R04.FR.01 - DER available but controlType not in ModesSupported: NotSupported
-# -----------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-@pytest.mark.ocpp_version("ocpp2.1")
-@pytest.mark.everest_core_config(
-    get_everest_config_path_str("everest-config-ocpp201.yaml")
-)
-@pytest.mark.ocpp_config_adaptions(
-    GenericOCPP2XConfigAdjustment(
-        [
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "InternalCtrlr", "SupportedOcppVersions", "Actual"
-                ),
-                "ocpp2.1",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrAvailable", "Actual"
-                ),
-                "true",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrModesSupported", "Actual"
-                ),
-                # HFMustTrip is intentionally NOT in this list
-                "FreqDroop,VoltWatt",
-            ),
-        ]
-    )
-)
+@grid_support_markers
 async def test_set_der_control_unsupported_type_not_supported(
     central_system_v21: CentralSystem,
     test_controller: TestController,
     test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
 ):
-    """R04.FR.01: With DCDERCtrlr Available but controlType not in ModesSupported, returns NotSupported.
-
-    HFMustTrip is intentionally NOT in the default ModesSupported list
-    (DCDERCtrlr_1.json), so this should return NotSupported.
+    """R04.FR.01: with the controller enabled but the controlType absent from
+    ModesSupported, SetDERControl returns NotSupported.
     """
-    test_controller.start()
-    charge_point_v21 = await central_system_v21.wait_for_chargepoint()
+    provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
 
-    # HFMustTrip curve with yUnit=Not_Applicable (valid shape, unsupported type).
-    # NOTE: StrEnum auto-converts "Not_Applicable" -> Python attr `not__applicable` (double underscore).
-    curve = DERCurveType(
-        curve_data=[DERCurvePointsType(x=62.0, y=1.0)],
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    # WattVar deliberately omitted from the declared supported types.
+    await enable_der(
+        probe_grid_support, charge_point_v21, supported_types=["FreqDroop", "VoltWatt"]
+    )
+
+    watt_var_curve = DERCurveType(
+        curve_data=[DERCurvePointsType(x=100.0, y=50.0)],
         priority=0,
-        y_unit=DERUnitEnumType.not__applicable,
+        y_unit=DERUnitEnumType.pct_max_var,
     )
-
-    r: call_result21.SetDERControl = await charge_point_v21.set_der_control_req(
+    r = await charge_point_v21.set_der_control_req(
         is_default=True,
-        control_id="ctrl-hf-trip",
-        control_type=DERControlEnumType.hf_must_trip,
-        curve=curve,
+        control_id="ctrl-wv",
+        control_type=DERControlEnumType.watt_var,
+        curve=watt_var_curve,
     )
-    assert r.status == DERControlStatusEnumType.not_supported
+    assert r is not None and r.status == DERControlStatusEnumType.not_supported
 
 
-# -----------------------------------------------------------------------------
-# R04.FR.30 - GetDERControl with no stored controls: NotFound
-# -----------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-@pytest.mark.ocpp_version("ocpp2.1")
-@pytest.mark.everest_core_config(
-    get_everest_config_path_str("everest-config-ocpp201.yaml")
-)
-@pytest.mark.ocpp_config_adaptions(
-    GenericOCPP2XConfigAdjustment(
-        [
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "InternalCtrlr", "SupportedOcppVersions", "Actual"
-                ),
-                "ocpp2.1",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrAvailable", "Actual"
-                ),
-                "true",
-            ),
-            # ModesSupported is ReadOnly; test relies on the default list in
-            # DCDERCtrlr_1.json: FreqDroop,VoltWatt,LimitMaxDischarge,VoltVar,
-            # FixedVar,EnterService,Gradients
-        ]
-    )
-)
+@grid_support_markers
 async def test_get_der_control_no_controls_not_found(
     central_system_v21: CentralSystem,
     test_controller: TestController,
     test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
 ):
     """R04.FR.30: GetDERControl when no matching controls exist returns NotFound."""
-    test_controller.start()
-    charge_point_v21 = await central_system_v21.wait_for_chargepoint()
+    provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
 
-    r: call_result21.GetDERControl = await charge_point_v21.get_der_control_req(
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    r = await charge_point_v21.get_der_control_req(
         request_id=42,
         control_type=DERControlEnumType.freq_droop,
     )
-    assert r.status == DERControlStatusEnumType.not_found
+    assert r is not None and r.status == DERControlStatusEnumType.not_found
 
 
-# -----------------------------------------------------------------------------
-# R04.FR.41 - ClearDERControl with no matching controls: NotFound
-# -----------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-@pytest.mark.ocpp_version("ocpp2.1")
-@pytest.mark.everest_core_config(
-    get_everest_config_path_str("everest-config-ocpp201.yaml")
-)
-@pytest.mark.ocpp_config_adaptions(
-    GenericOCPP2XConfigAdjustment(
-        [
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "InternalCtrlr", "SupportedOcppVersions", "Actual"
-                ),
-                "ocpp2.1",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrAvailable", "Actual"
-                ),
-                "true",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrModesSupported", "Actual"
-                ),
-                "FreqDroop,VoltWatt",
-            ),
-        ]
-    )
-)
+@grid_support_markers
 async def test_clear_der_control_no_match_not_found(
     central_system_v21: CentralSystem,
     test_controller: TestController,
     test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
 ):
     """R04.FR.41: ClearDERControl when no matching controls exist returns NotFound."""
-    test_controller.start()
-    charge_point_v21 = await central_system_v21.wait_for_chargepoint()
+    provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
 
-    r: call_result21.ClearDERControl = await charge_point_v21.clear_der_control_req(
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
+    )
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    r = await charge_point_v21.clear_der_control_req(
         is_default=True,
         control_type=DERControlEnumType.freq_droop,
     )
-    assert r.status == DERControlStatusEnumType.not_found
+    assert r is not None and r.status == DERControlStatusEnumType.not_found
 
 
-# -----------------------------------------------------------------------------
-# TC_R_102 end-to-end - Clearing controlTypes
-# (R04.FR.02, FR.30, FR.33, FR.41, FR.44, FR.45)
-#
-# Exercises the cross-message state evolution that the unit tests can't:
-# Set defaults of two distinct types, Clear-by-type one of them, verify the
-# other survives, then Clear-all and verify the table is empty. Multi-row
-# Report payload ordering itself is unit-tested in
-# DERControlTest.GetDERControl_ReportOrdersMultiRowByIsSuperseded; this test
-# locks in that the persisted state evolves correctly across messages.
-# -----------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-@pytest.mark.ocpp_version("ocpp2.1")
-@pytest.mark.everest_core_config(
-    get_everest_config_path_str("everest-config-ocpp201.yaml")
-)
-@pytest.mark.ocpp_config_adaptions(
-    GenericOCPP2XConfigAdjustment(
-        [
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "InternalCtrlr", "SupportedOcppVersions", "Actual"
-                ),
-                "ocpp2.1",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrAvailable", "Actual"
-                ),
-                "true",
-            ),
-            # ModesSupported is ReadOnly; relies on the default list in
-            # DCDERCtrlr_1.json which includes both FreqDroop and VoltWatt.
-        ]
-    )
-)
-async def test_tc_r_102_clear_by_type_then_clear_all(
+@grid_support_markers
+async def test_clear_by_type_then_clear_all(
     central_system_v21: CentralSystem,
     test_controller: TestController,
     test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
 ):
-    """TC_R_102: Set two defaults of distinct types, clear one by type, verify
-    the other survives, then clear all and verify the table is empty.
+    """TC_R_102 (R04.FR.30/44/45): set two defaults of distinct types, clear one by
+    type, verify the other survives, then clear all and verify the table is empty.
     """
-    test_controller.start()
-    charge_point_v21 = await central_system_v21.wait_for_chargepoint()
+    provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
 
-    # Step 1: SetDERControl default FreqDroop (R04.FR.02)
-    freq_droop = FreqDroopType(
-        priority=0,
-        over_freq=61.0,
-        under_freq=59.0,
-        over_droop=5.0,
-        under_droop=5.0,
-        response_time=3.0,
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
     )
-    r: call_result21.SetDERControl = await charge_point_v21.set_der_control_req(
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    r = await charge_point_v21.set_der_control_req(
         is_default=True,
         control_id="ctrl-default-fd",
         control_type=DERControlEnumType.freq_droop,
-        freq_droop=freq_droop,
+        freq_droop=FREQ_DROOP,
     )
     assert r.status == DERControlStatusEnumType.accepted
 
-    # Step 2: SetDERControl default VoltWatt
     volt_watt_curve = DERCurveType(
         curve_data=[DERCurvePointsType(x=240.0, y=100.0)],
         priority=1,
@@ -398,187 +755,73 @@ async def test_tc_r_102_clear_by_type_then_clear_all(
     )
     assert r.status == DERControlStatusEnumType.accepted
 
-    # Step 3: GetDERControl FreqDroop -> Accepted (the row exists)
-    r_get: call_result21.GetDERControl = await charge_point_v21.get_der_control_req(
-        request_id=1,
-        is_default=True,
-        control_type=DERControlEnumType.freq_droop,
-    )
-    assert r_get.status == DERControlStatusEnumType.accepted
-
-    # Step 4: GetDERControl VoltWatt -> Accepted (the row exists)
+    # Both rows exist.
     r_get = await charge_point_v21.get_der_control_req(
-        request_id=2,
-        is_default=True,
-        control_type=DERControlEnumType.volt_watt,
+        request_id=1, is_default=True, control_type=DERControlEnumType.freq_droop
+    )
+    assert r_get.status == DERControlStatusEnumType.accepted
+    r_get = await charge_point_v21.get_der_control_req(
+        request_id=2, is_default=True, control_type=DERControlEnumType.volt_watt
     )
     assert r_get.status == DERControlStatusEnumType.accepted
 
-    # Step 5: ClearDERControl by type=FreqDroop (R04.FR.45)
-    r_clear: call_result21.ClearDERControl = (
-        await charge_point_v21.clear_der_control_req(
-            is_default=True,
-            control_type=DERControlEnumType.freq_droop,
-        )
+    # Clear by type=FreqDroop; VoltWatt survives.
+    r_clear = await charge_point_v21.clear_der_control_req(
+        is_default=True, control_type=DERControlEnumType.freq_droop
     )
     assert r_clear.status == DERControlStatusEnumType.accepted
-
-    # Step 6: GetDERControl FreqDroop -> NotFound (the row was cleared, R04.FR.30)
     r_get = await charge_point_v21.get_der_control_req(
-        request_id=3,
-        is_default=True,
-        control_type=DERControlEnumType.freq_droop,
+        request_id=3, is_default=True, control_type=DERControlEnumType.freq_droop
     )
     assert r_get.status == DERControlStatusEnumType.not_found
-
-    # Step 7: GetDERControl VoltWatt -> Accepted (untouched by the targeted clear)
     r_get = await charge_point_v21.get_der_control_req(
-        request_id=4,
-        is_default=True,
-        control_type=DERControlEnumType.volt_watt,
+        request_id=4, is_default=True, control_type=DERControlEnumType.volt_watt
     )
     assert r_get.status == DERControlStatusEnumType.accepted
 
-    # Step 8: ClearDERControl with no controlType / controlId,
-    # isDefault=true -> clear ALL matching defaults (R04.FR.44)
+    # Clear all defaults; the table is empty.
     r_clear = await charge_point_v21.clear_der_control_req(is_default=True)
     assert r_clear.status == DERControlStatusEnumType.accepted
-
-    # Step 9: GetDERControl any default -> NotFound (table is empty)
     r_get = await charge_point_v21.get_der_control_req(
-        request_id=5,
-        is_default=True,
-        control_type=DERControlEnumType.volt_watt,
+        request_id=5, is_default=True, control_type=DERControlEnumType.volt_watt
     )
     assert r_get.status == DERControlStatusEnumType.not_found
 
 
-# -----------------------------------------------------------------------------
-# TC_R_103 - SetDERControl with unsupported controlType returns NotSupported.
-# (R04.FR.01) Locks in the spec contract that prior log analysis showed the
-# certification tool can violate by picking a supported type for this step.
-# -----------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-@pytest.mark.ocpp_version("ocpp2.1")
-@pytest.mark.everest_core_config(
-    get_everest_config_path_str("everest-config-ocpp201.yaml")
-)
-@pytest.mark.ocpp_config_adaptions(
-    GenericOCPP2XConfigAdjustment(
-        [
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "InternalCtrlr", "SupportedOcppVersions", "Actual"
-                ),
-                "ocpp2.1",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrAvailable", "Actual"
-                ),
-                "true",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrModesSupported", "Actual"
-                ),
-                # WattVar deliberately omitted.
-                "FreqDroop,VoltWatt,VoltVar,FixedVar,LimitMaxDischarge,EnterService,Gradients",
-            ),
-        ]
-    )
-)
-async def test_tc_r_103_unsupported_control_type_returns_not_supported(
+@grid_support_markers
+async def test_get_emits_report_der_control(
     central_system_v21: CentralSystem,
     test_controller: TestController,
     test_utility: TestUtility,
+    probe_grid_support: ProbeModule,
 ):
-    """TC_R_103 step 2: SetDERControl with controlType not in ModesSupported -> NotSupported."""
-    test_controller.start()
-    charge_point_v21 = await central_system_v21.wait_for_chargepoint()
-
-    watt_var_curve = DERCurveType(
-        curve_data=[DERCurvePointsType(x=100.0, y=50.0)],
-        priority=0,
-        y_unit=DERUnitEnumType.pct_max_var,
-    )
-
-    r: call_result21.SetDERControl = await charge_point_v21.set_der_control_req(
-        is_default=True,
-        control_id="ctrl-wv",
-        control_type=DERControlEnumType.watt_var,
-        curve=watt_var_curve,
-    )
-    assert r.status == DERControlStatusEnumType.not_supported
-
-
-# -----------------------------------------------------------------------------
-# TC_R_104 - GetDERControl Accepted MUST be followed by an outbound
-# ReportDERControl message. (R04.FR.32-33). Regression guard for a libocpp bug
-# where MessageType::ReportDERControl was missing from the enum, causing the
-# outbound Call to throw and emit a FormationViolation CallError instead.
-# -----------------------------------------------------------------------------
-
-@pytest.mark.asyncio
-@pytest.mark.ocpp_version("ocpp2.1")
-@pytest.mark.everest_core_config(
-    get_everest_config_path_str("everest-config-ocpp201.yaml")
-)
-@pytest.mark.ocpp_config_adaptions(
-    GenericOCPP2XConfigAdjustment(
-        [
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "InternalCtrlr", "SupportedOcppVersions", "Actual"
-                ),
-                "ocpp2.1",
-            ),
-            (
-                OCPP2XConfigVariableIdentifier(
-                    "DCDERCtrlr_1", "DCDERCtrlrAvailable", "Actual"
-                ),
-                "true",
-            ),
-        ]
-    )
-)
-async def test_tc_r_104_get_emits_report_der_control(
-    central_system_v21: CentralSystem,
-    test_controller: TestController,
-    test_utility: TestUtility,
-):
-    """TC_R_104: SetDERControl(default FreqDroop), then GetDERControl. CS must
-    respond with GetDERControlResponse(status=Accepted) AND then emit a separate
-    ReportDERControl message carrying the stored control.
+    """TC_R_104 (R04.FR.32-33): GetDERControl(Accepted) is followed by an outbound
+    ReportDERControl carrying the stored control. Regression guard for a libocpp
+    bug where ReportDERControl was missing from the message-type enum.
     """
-    test_controller.start()
-    charge_point_v21 = await central_system_v21.wait_for_chargepoint()
+    provide_grid_support(probe_grid_support)
+    probe_grid_support.start()
+    await probe_grid_support.wait_to_be_ready()
 
-    freq_droop = FreqDroopType(
-        priority=0,
-        over_freq=61.0,
-        under_freq=59.0,
-        over_droop=5.0,
-        under_droop=5.0,
-        response_time=3.0,
+    charge_point_v21 = await central_system_v21.wait_for_chargepoint(
+        wait_for_bootnotification=True
     )
-    r_set: call_result21.SetDERControl = await charge_point_v21.set_der_control_req(
+
+    await enable_der(probe_grid_support, charge_point_v21)
+
+    r_set = await charge_point_v21.set_der_control_req(
         is_default=True,
         control_id="ctrl-r104",
         control_type=DERControlEnumType.freq_droop,
-        freq_droop=freq_droop,
+        freq_droop=FREQ_DROOP,
     )
     assert r_set.status == DERControlStatusEnumType.accepted
 
-    r_get: call_result21.GetDERControl = await charge_point_v21.get_der_control_req(
-        request_id=104,
-        is_default=True,
-        control_type=DERControlEnumType.freq_droop,
+    r_get = await charge_point_v21.get_der_control_req(
+        request_id=104, is_default=True, control_type=DERControlEnumType.freq_droop
     )
     assert r_get.status == DERControlStatusEnumType.accepted
 
-    # The wire-level message that the libocpp bug used to suppress.
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v21,


### PR DESCRIPTION
Add the OCPP 2.1 DER functional block with a construct-on-enable lifecycle (built when a DCDERCtrlr/ACDERCtrlr component reports Available), libocpp ownership of the active-directive set emitted via a single callback, and an OCPP201 grid_support provider that generates the DER device-model components, translates the active set, and forwards it per EVSE.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

