### PR TITLE
system_API: Expose new firmware_update_metadata field on the stable API

### DIFF
--- a/docs/source/reference/EVerest_API/system_API.yaml
+++ b/docs/source/reference/EVerest_API/system_API.yaml
@@ -523,6 +523,10 @@ components:
             Id of the request. Use the request_id from the corresponding
             FirmwareUpdateRequest.
           type: integer
+        firmware_update_metadata:
+          description: Metadata about the firmware update
+          type: object
+          $ref: '#/components/schemas/FirmwareUpdateMetadata'
     FirmwareUpdateStatusEnum:
       description: |
         State describing the current download/upload status of a firmware update of the system:
@@ -556,6 +560,14 @@ components:
         - InstallVerificationFailed
         - InvalidSignature
         - SignatureVerified
+    FirmwareUpdateMetadata:
+      description: Type carrying metadata about a firmware update
+      type: object
+      properties:
+        disable_connectors_during_install:
+          description: Whether all connectors should be made unavailable (disabled) for the duration of the firmware install
+          type: boolean
+          default: true
     LogStatusEnum:
       description: |
         State describing the current status of log upload of the system:
@@ -715,4 +727,4 @@ components:
 
     HeartBeatId:
       type: integer
-      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached" 
+      description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"

--- a/lib/everest/everest_api_types/include/everest_api_types/system/API.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/system/API.hpp
@@ -100,9 +100,14 @@ struct LogStatus {
     int32_t request_id;
 };
 
+struct FirmwareUpdateMetadata {
+    std::optional<bool> disable_connectors_during_install;
+};
+
 struct FirmwareUpdateStatus {
     FirmwareUpdateStatusEnum firmware_update_status;
     int32_t request_id;
+    std::optional<FirmwareUpdateMetadata> firmware_update_metadata;
 };
 
 struct ResetRequest {

--- a/lib/everest/everest_api_types/include/everest_api_types/system/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/system/codec.hpp
@@ -19,6 +19,7 @@ std::string serialize(FirmwareUpdateRequest const& val) noexcept;
 std::string serialize(UploadLogsRequest const& val) noexcept;
 std::string serialize(UploadLogsResponse const& val) noexcept;
 std::string serialize(LogStatus const& val) noexcept;
+std::string serialize(FirmwareUpdateMetadata const& val) noexcept;
 std::string serialize(FirmwareUpdateStatus const& val) noexcept;
 std::string serialize(ResetRequest const& val) noexcept;
 
@@ -31,6 +32,7 @@ std::ostream& operator<<(std::ostream& os, BootReason const& val);
 std::ostream& operator<<(std::ostream& os, FirmwareUpdateRequest const& val);
 std::ostream& operator<<(std::ostream& os, UploadLogsRequest const& val);
 std::ostream& operator<<(std::ostream& os, LogStatus const& val);
+std::ostream& operator<<(std::ostream& os, FirmwareUpdateMetadata const& val);
 std::ostream& operator<<(std::ostream& os, FirmwareUpdateStatus const& val);
 std::ostream& operator<<(std::ostream& os, UploadLogsResponse const& val);
 std::ostream& operator<<(std::ostream& os, ResetRequest const& val);

--- a/lib/everest/everest_api_types/private_include/everest_api_types/system/json_codec.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/system/json_codec.hpp
@@ -22,6 +22,9 @@ void from_json(const json& j, UploadLogsResponse& k);
 void to_json(json& j, const LogStatus& k) noexcept;
 void from_json(const json& j, LogStatus& k);
 
+void to_json(json& j, const FirmwareUpdateMetadata& k) noexcept;
+void from_json(const json& j, FirmwareUpdateMetadata& k);
+
 void to_json(json& j, const FirmwareUpdateStatus& k) noexcept;
 void from_json(const json& j, FirmwareUpdateStatus& k);
 

--- a/lib/everest/everest_api_types/private_include/everest_api_types/system/wrapper.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/system/wrapper.hpp
@@ -70,6 +70,12 @@ using LogStatus_External = LogStatus;
 LogStatus_Internal to_internal_api(LogStatus_External const& val);
 LogStatus_External to_external_api(LogStatus_Internal const& val);
 
+using FirmwareUpdateMetadata_Internal = ::types::system::FirmwareUpdateMetadata;
+using FirmwareUpdateMetadata_External = FirmwareUpdateMetadata;
+
+FirmwareUpdateMetadata_Internal to_internal_api(FirmwareUpdateMetadata_External const& val);
+FirmwareUpdateMetadata_External to_external_api(FirmwareUpdateMetadata_Internal const& val);
+
 using FirmwareUpdateStatus_Internal = ::types::system::FirmwareUpdateStatus;
 using FirmwareUpdateStatus_External = FirmwareUpdateStatus;
 

--- a/lib/everest/everest_api_types/src/everest_api_types/system/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/system/codec.cpp
@@ -54,6 +54,10 @@ std::string serialize(LogStatus const& val) noexcept {
     return utilities::dump_json(val);
 }
 
+std::string serialize(FirmwareUpdateMetadata const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
 std::string serialize(FirmwareUpdateStatus const& val) noexcept {
     return utilities::dump_json(val);
 }
@@ -103,6 +107,11 @@ std::ostream& operator<<(std::ostream& os, UploadLogsRequest const& val) {
 }
 
 std::ostream& operator<<(std::ostream& os, LogStatus const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, FirmwareUpdateMetadata const& val) {
     os << serialize(val);
     return os;
 }
@@ -160,6 +169,10 @@ template <> UploadLogsResponse deserialize(std::string_view val) {
 
 template <> LogStatus deserialize(std::string_view val) {
     return utilities::parse_json<LogStatus>(val);
+}
+
+template <> FirmwareUpdateMetadata deserialize(std::string_view val) {
+    return utilities::parse_json<FirmwareUpdateMetadata>(val);
 }
 
 template <> FirmwareUpdateStatus deserialize(std::string_view val) {

--- a/lib/everest/everest_api_types/src/everest_api_types/system/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/system/json_codec.cpp
@@ -132,15 +132,34 @@ void from_json(const json& j, LogStatus& k) {
     k.request_id = j.at("request_id");
 }
 
+void to_json(json& j, const FirmwareUpdateMetadata& k) noexcept {
+    j = json::object();
+    if (k.disable_connectors_during_install.has_value()) {
+        j["disable_connectors_during_install"] = k.disable_connectors_during_install.value();
+    }
+}
+
+void from_json(const json& j, FirmwareUpdateMetadata& k) {
+    if (j.contains("disable_connectors_during_install")) {
+        k.disable_connectors_during_install = j.at("disable_connectors_during_install");
+    }
+}
+
 void to_json(json& j, const FirmwareUpdateStatus& k) noexcept {
     j = json{
         {"firmware_update_status", k.firmware_update_status},
         {"request_id", k.request_id},
     };
+    if (k.firmware_update_metadata.has_value()) {
+        j["firmware_update_metadata"] = k.firmware_update_metadata.value();
+    }
 }
 void from_json(const json& j, FirmwareUpdateStatus& k) {
     k.firmware_update_status = j.at("firmware_update_status");
     k.request_id = j.at("request_id");
+    if (j.contains("firmware_update_metadata")) {
+        k.firmware_update_metadata = j.at("firmware_update_metadata");
+    }
 }
 
 void to_json(json& j, const ResetRequest& k) noexcept {

--- a/lib/everest/everest_api_types/src/everest_api_types/system/wrapper.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/system/wrapper.cpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
 
 #include "system/wrapper.hpp"
+#include "system/API.hpp"
 #include "system/codec.hpp"
 #include <stdexcept>
 #include <string>
@@ -344,16 +345,33 @@ LogStatus_External to_external_api(LogStatus_Internal const& val) {
     return result;
 }
 
+FirmwareUpdateMetadata_Internal to_internal_api(FirmwareUpdateMetadata_External const& val) {
+    FirmwareUpdateMetadata_Internal result;
+    result.disable_connectors_during_install = val.disable_connectors_during_install;
+    return result;
+}
+FirmwareUpdateMetadata_External to_external_api(FirmwareUpdateMetadata_Internal const& val) {
+    FirmwareUpdateMetadata_External result;
+    result.disable_connectors_during_install = val.disable_connectors_during_install;
+    return result;
+}
+
 FirmwareUpdateStatus_Internal to_internal_api(FirmwareUpdateStatus_External const& val) {
     FirmwareUpdateStatus_Internal result;
     result.firmware_update_status = to_internal_api(val.firmware_update_status);
     result.request_id = val.request_id;
+    if (val.firmware_update_metadata.has_value()) {
+        result.firmware_update_metadata.emplace(to_internal_api(val.firmware_update_metadata.value()));
+    }
     return result;
 }
 FirmwareUpdateStatus_External to_external_api(FirmwareUpdateStatus_Internal const& val) {
     FirmwareUpdateStatus_External result;
     result.firmware_update_status = to_external_api(val.firmware_update_status);
     result.request_id = val.request_id;
+    if (val.firmware_update_metadata.has_value()) {
+        result.firmware_update_metadata.emplace(to_external_api(val.firmware_update_metadata.value()));
+    }
     return result;
 }
 


### PR DESCRIPTION
## Describe your changes

The firmware_update_metadata fiels was introduced in #2327. Currently it carries only one value that allows turning off the behaviour that libocpp disables all connectors before a firmware update.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #2336 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #2327 
<!-- GitButler Footer Boundary Bottom -->

