### PR TITLE
fix(InfyPower): guard caps against cross-thread data race

### DIFF
--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/main/power_supply_DCImpl.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/main/power_supply_DCImpl.cpp
@@ -78,7 +78,10 @@ void power_supply_DCImpl::init() {
         new_caps.max_export_voltage_V = min_max_output_voltage;
         new_caps.min_export_voltage_V = max_min_output_voltage;
         new_caps.conversion_efficiency_export = mod->config.conversion_efficiency_export;
-        caps = new_caps;
+        {
+            std::lock_guard<std::mutex> lock(caps_mutex);
+            caps = new_caps;
+        }
         EVLOG_info << "Infy: Capabilities updated: " << new_caps.max_export_voltage_V << "V / "
                    << new_caps.min_export_voltage_V << "V, " << new_caps.max_export_current_A << "A, power "
                    << new_caps.max_export_power_W << "W";
@@ -139,6 +142,7 @@ void power_supply_DCImpl::ready() {
 
 void power_supply_DCImpl::handle_setMode(types::power_supply_DC::Mode& mode,
                                          types::power_supply_DC::ChargingPhase& phase) {
+    std::lock_guard<std::mutex> command_lock(command_mutex);
     EVLOG_info << "Set mode via CAN: " << mode << " with phase " << phase;
     if (mode == types::power_supply_DC::Mode::Off) {
         mod->acdc->switch_on_off(false);
@@ -154,15 +158,19 @@ void power_supply_DCImpl::handle_setMode(types::power_supply_DC::Mode& mode,
 };
 
 void power_supply_DCImpl::handle_setExportVoltageCurrent(double& voltage, double& current) {
-    if (voltage > caps.max_export_voltage_V)
-        voltage = caps.max_export_voltage_V;
-    else if (voltage < caps.min_export_voltage_V)
-        voltage = caps.min_export_voltage_V;
+    std::lock_guard<std::mutex> command_lock(command_mutex);
+    {
+        std::lock_guard<std::mutex> caps_lock(caps_mutex);
+        if (voltage > caps.max_export_voltage_V)
+            voltage = caps.max_export_voltage_V;
+        else if (voltage < caps.min_export_voltage_V)
+            voltage = caps.min_export_voltage_V;
 
-    if (current > caps.max_export_current_A)
-        current = caps.max_export_current_A;
-    else if (current < caps.min_export_current_A)
-        current = caps.min_export_current_A;
+        if (current > caps.max_export_current_A)
+            current = caps.max_export_current_A;
+        else if (current < caps.min_export_current_A)
+            current = caps.min_export_current_A;
+    }
 
     exportVoltage.store(voltage);
     exportCurrentLimit.store(current);
@@ -181,18 +189,26 @@ void power_supply_DCImpl::handle_setExportVoltageCurrent(double& voltage, double
 };
 
 void power_supply_DCImpl::handle_setImportVoltageCurrent(double& voltage, double& current) {
-    if (caps.min_import_voltage_V.has_value() && caps.max_import_voltage_V.has_value() &&
-        caps.min_import_current_A.has_value() && caps.max_import_current_A.has_value()) {
-        if (voltage > caps.max_import_voltage_V.value())
-            voltage = caps.max_import_voltage_V.value();
-        else if (voltage < caps.min_import_voltage_V.value())
-            voltage = caps.min_import_voltage_V.value();
+    std::lock_guard<std::mutex> command_lock(command_mutex);
+    bool has_import_caps = false;
+    {
+        std::lock_guard<std::mutex> caps_lock(caps_mutex);
+        has_import_caps = caps.min_import_voltage_V.has_value() && caps.max_import_voltage_V.has_value() &&
+                          caps.min_import_current_A.has_value() && caps.max_import_current_A.has_value();
+        if (has_import_caps) {
+            if (voltage > caps.max_import_voltage_V.value())
+                voltage = caps.max_import_voltage_V.value();
+            else if (voltage < caps.min_import_voltage_V.value())
+                voltage = caps.min_import_voltage_V.value();
 
-        if (current > caps.max_import_current_A.value())
-            current = caps.max_import_current_A.value();
-        else if (current < caps.min_import_current_A.value())
-            current = caps.min_import_current_A.value();
+            if (current > caps.max_import_current_A.value())
+                current = caps.max_import_current_A.value();
+            else if (current < caps.min_import_current_A.value())
+                current = caps.min_import_current_A.value();
+        }
+    }
 
+    if (has_import_caps) {
         minImportVoltage.store(voltage);
         importCurrentLimit.store(current);
 

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/main/power_supply_DCImpl.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/main/power_supply_DCImpl.hpp
@@ -16,6 +16,7 @@
 // insert your custom include headers here
 #include <atomic>
 #include <memory>
+#include <mutex>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
 namespace module {
@@ -58,10 +59,21 @@ private:
     std::atomic<double> exportCurrentLimit{0.};
     std::atomic<double> minImportVoltage{0.};
     std::atomic<double> importCurrentLimit{0.};
+
+    // caps is written only on the CAN rx thread (sigslot callbacks) and read on the
+    // command thread (handle_setExport/ImportVoltageCurrent), so it must be guarded.
+    mutable std::mutex caps_mutex;
     types::power_supply_DC::Capabilities caps;
 
+    // Serializes the command handlers (setMode/setExport/setImportVoltageCurrent) so a
+    // single "compute + push to modules" sequence cannot interleave when the same handler
+    // runs concurrently on the command thread and the CAN rx thread (settings restore).
+    std::mutex command_mutex;
+
     bool firsttime{true};
-    uint8_t last_module_count{0};
+    // last_module_count has a single writer (CAN rx thread) and is read on the command
+    // thread, so atomic access is sufficient.
+    std::atomic<uint8_t> last_module_count{0};
     uint8_t throttle_cnt{0};
 
     // Error handling helpers


### PR DESCRIPTION
caps is written on the CAN rx thread (signalCapabilitiesUpdate callback) and read on the command thread (handle_setExport/ImportVoltageCurrent), with no synchronization. Capabilities is a plain struct of double and std::optional<double>, so the concurrent access is a data race and can yield inconsistent optionals and wrong voltage/current clamping.

Guard caps with a mutex and make last_module_count atomic (single writer on the CAN thread). Additionally serialize the command handlers with a command mutex so a single compute-and-push sequence cannot interleave when handle_setExportVoltageCurrent runs concurrently on the command thread and the CAN rx thread (settings-restore path on module-count change).

## Describe your changes

## Issue ticket number and link
https://github.com/EVerest/EVerest/issues/2299

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

