### PR TITLE
fix(tls): set server thread id before m_running

### DIFF
--- a/lib/everest/tls/src/tls.cpp
+++ b/lib/everest/tls/src/tls.cpp
@@ -1242,13 +1242,15 @@ Server::state_t Server::serve(const ConnectionHandler& handler) {
         break;
     }
 
+    // set before publishing m_running so stop() never reads a stale (zero) id
+    m_server_thread = pthread_self(); // for use by stop()
+
     // wakeup wait_running()
     {
         std::lock_guard lock(m_cv_mutex);
         m_running = true;
     }
     m_cv.notify_all();
-    m_server_thread = pthread_self(); // for use by stop()
 
     if (result) {
         m_exit = false;


### PR DESCRIPTION
serve() set m_server_thread after notifying wait_running(), so stop() could pthread_kill() a zero thread id and segfault.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

