### PR TITLE
Update EvseManager fault handling

### DIFF
--- a/modules/EVSE/EvseManager/ErrorHandling.cpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.cpp
@@ -43,6 +43,8 @@ static const struct IgnoreErrors {
     ErrorList imd{"isolation_monitor/VendorWarning"};
     ErrorList powersupply{"power_supply_DC/VendorWarning"};
     ErrorList powermeter{"generic/VendorWarning"};
+    ErrorList slac{"generic/VendorWarning"};
+    ErrorList hlc{"generic/VendorWarning"};
     ErrorList over_voltage_monitor{"over_voltage_monitor/VendorWarning"};
 } ignore_errors;
 
@@ -54,6 +56,7 @@ ErrorHandling::ErrorHandling(const std::unique_ptr<evse_board_supportIntf>& _r_b
                              const std::vector<std::unique_ptr<isolation_monitorIntf>>& _r_imd,
                              const std::vector<std::unique_ptr<power_supply_DCIntf>>& _r_powersupply,
                              const std::vector<std::unique_ptr<powermeterIntf>>& _r_powermeter,
+                             const std::vector<std::unique_ptr<slacIntf>>& _r_slac,
                              const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& _r_over_voltage_monitor,
                              bool _inoperative_error_use_vendor_id) :
     r_bsp(_r_bsp),
@@ -64,12 +67,19 @@ ErrorHandling::ErrorHandling(const std::unique_ptr<evse_board_supportIntf>& _r_b
     r_imd(_r_imd),
     r_powersupply(_r_powersupply),
     r_powermeter(_r_powermeter),
+    r_slac(_r_slac),
     r_over_voltage_monitor(_r_over_voltage_monitor),
     inoperative_error_use_vendor_id(_inoperative_error_use_vendor_id) {
 
     // Subscribe to bsp driver to receive Errors from the bsp hardware
     r_bsp->subscribe_all_errors([this](const Everest::error::Error& error) { process_error(); },
                                 [this](const Everest::error::Error& error) { process_error(); });
+
+    // Subscribe to HLC to receive errors from ISO15118 charger module
+    if (r_hlc.size() > 0) {
+        r_hlc[0]->subscribe_all_errors([this](const Everest::error::Error& error) { process_error(); },
+                                       [this](const Everest::error::Error& error) { process_error(); });
+    }
 
     // Subscribe to connector lock to receive errors from connector lock hardware
     if (r_connector_lock.size() > 0) {
@@ -99,6 +109,12 @@ ErrorHandling::ErrorHandling(const std::unique_ptr<evse_board_supportIntf>& _r_b
     if (r_powermeter.size() > 0) {
         r_powermeter[0]->subscribe_all_errors([this](const Everest::error::Error& error) { process_error(); },
                                               [this](const Everest::error::Error& error) { process_error(); });
+    }
+
+    // Subscribe to slac to receive errors from SLAC module
+    if (r_slac.size() > 0) {
+        r_slac[0]->subscribe_all_errors([this](const Everest::error::Error& error) { process_error(); },
+                                        [this](const Everest::error::Error& error) { process_error(); });
     }
 
     // Subscribe to over_voltage_monitor to receive errors from over voltage monitor hardware
@@ -162,11 +178,11 @@ void ErrorHandling::process_error() {
         }
     };
 
-    const int error_count = p_evse->error_state_monitor->get_active_errors().size() +
-                            r_bsp->error_state_monitor->get_active_errors().size() +
-                            number_of_active_errors(r_connector_lock) + number_of_active_errors(r_ac_rcd) +
-                            number_of_active_errors(r_imd) + number_of_active_errors(r_powersupply) +
-                            number_of_active_errors(r_powermeter);
+    const int error_count =
+        p_evse->error_state_monitor->get_active_errors().size() +
+        r_bsp->error_state_monitor->get_active_errors().size() + number_of_active_errors(r_connector_lock) +
+        number_of_active_errors(r_ac_rcd) + number_of_active_errors(r_imd) + number_of_active_errors(r_powersupply) +
+        number_of_active_errors(r_powermeter) + number_of_active_errors(r_slac) + number_of_active_errors(r_hlc);
 
     if (error_count == 0) {
         signal_all_errors_cleared();
@@ -225,6 +241,20 @@ std::optional<Everest::error::Error> ErrorHandling::errors_prevent_charging() {
 
     if (r_powermeter.size() > 0) {
         fatal = is_fatal(r_powermeter[0]->error_state_monitor->get_active_errors(), ignore_errors.powermeter);
+        if (fatal) {
+            return fatal;
+        }
+    }
+
+    if (r_slac.size() > 0) {
+        fatal = is_fatal(r_slac[0]->error_state_monitor->get_active_errors(), ignore_errors.slac);
+        if (fatal) {
+            return fatal;
+        }
+    }
+
+    if (r_hlc.size() > 0) {
+        fatal = is_fatal(r_hlc[0]->error_state_monitor->get_active_errors(), ignore_errors.hlc);
         if (fatal) {
             return fatal;
         }

--- a/modules/EVSE/EvseManager/ErrorHandling.hpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.hpp
@@ -32,6 +32,7 @@
 #include <generated/interfaces/over_voltage_monitor/Interface.hpp>
 #include <generated/interfaces/power_supply_DC/Interface.hpp>
 #include <generated/interfaces/powermeter/Interface.hpp>
+#include <generated/interfaces/slac/Interface.hpp>
 #include <sigslot/signal.hpp>
 
 #include "Timeout.hpp"
@@ -67,6 +68,7 @@ public:
                            const std::vector<std::unique_ptr<isolation_monitorIntf>>& _r_imd,
                            const std::vector<std::unique_ptr<power_supply_DCIntf>>& _r_powersupply,
                            const std::vector<std::unique_ptr<powermeterIntf>>& _r_powermeter,
+                           const std::vector<std::unique_ptr<slacIntf>>& _r_slac,
                            const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& _r_over_voltage_monitor,
                            bool _inoperative_error_use_vendor_id);
 
@@ -116,6 +118,7 @@ private:
     const std::vector<std::unique_ptr<isolation_monitorIntf>>& r_imd;
     const std::vector<std::unique_ptr<power_supply_DCIntf>>& r_powersupply;
     const std::vector<std::unique_ptr<powermeterIntf>>& r_powermeter;
+    const std::vector<std::unique_ptr<slacIntf>>& r_slac;
     const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& r_over_voltage_monitor;
     const bool inoperative_error_use_vendor_id;
 };

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -327,7 +327,7 @@ void EvseManager::ready() {
     // otherwise we provide an empty vector of pointers to the powermeter interface
     error_handling = std::unique_ptr<ErrorHandling>(
         new ErrorHandling(r_bsp, r_hlc, r_connector_lock, r_ac_rcd, p_evse, r_imd, r_powersupply_DC,
-                          config.fail_on_powermeter_errors ? r_powermeter_billing() : EMPTY_POWERMETER_VECTOR,
+                          config.fail_on_powermeter_errors ? r_powermeter_billing() : EMPTY_POWERMETER_VECTOR, r_slac,
                           r_over_voltage_monitor, config.inoperative_error_use_vendor_id));
 
     internal_over_voltage_monitor = std::make_unique<OverVoltageMonitor>(

--- a/modules/EVSE/EvseManager/SessionLog.cpp
+++ b/modules/EVSE/EvseManager/SessionLog.cpp
@@ -33,7 +33,12 @@ SessionLog::~SessionLog() {
 }
 
 void SessionLog::setPath(const std::string& path) {
-    logpath_root = std::filesystem::weakly_canonical(std::filesystem::path(path));
+    try {
+        logpath_root = std::filesystem::weakly_canonical(std::filesystem::path(path));
+    } catch (const std::filesystem::filesystem_error& e) {
+        EVLOG_error << fmt::format("Cannot resolve session logpath {}: {}", path, e.what());
+        logpath_root = std::filesystem::path(path);
+    }
 }
 
 void SessionLog::setMqtt(mqtt_publish_ftor const& mqtt_provider) {
@@ -50,19 +55,26 @@ std::optional<std::filesystem::path> SessionLog::startSession(const std::string&
             stopSession();
         }
 
-        // create general log directory if it does not exist
-        if (!std::filesystem::exists(logpath_root)) {
-            try {
+        try {
+            // create general log directory if it does not exist
+            if (!std::filesystem::exists(logpath_root)) {
                 std::filesystem::create_directories(logpath_root);
-            } catch (std::filesystem::filesystem_error& e) {
-                EVLOG_error << fmt::format("Cannot create logpath {}: {}", logpath_root.string(), e.what());
-                return std::nullopt;
             }
+        } catch (const std::filesystem::filesystem_error& e) {
+            EVLOG_error << fmt::format("Cannot create logpath {}: {}", logpath_root.string(), e.what());
+            return std::nullopt;
         }
 
         std::string ts = Everest::Date::to_rfc3339(date::utc_clock::now());
         auto ts_suffix_string = fmt::format("{}-{}", ts, suffix_string);
-        auto logpath_with_suffix = std::filesystem::weakly_canonical(logpath_root / ts_suffix_string);
+        std::filesystem::path logpath_with_suffix;
+        try {
+            logpath_with_suffix = std::filesystem::weakly_canonical(logpath_root / ts_suffix_string);
+        } catch (const std::filesystem::filesystem_error& e) {
+            EVLOG_error << fmt::format("Cannot resolve session logpath {}: {}",
+                                       (logpath_root / ts_suffix_string).string(), e.what());
+            return std::nullopt;
+        }
 
         const auto [root_it, suffix_ix] = std::mismatch(logpath_root.begin(), logpath_root.end(),
                                                         logpath_with_suffix.begin(), logpath_with_suffix.end());
@@ -74,9 +86,14 @@ std::optional<std::filesystem::path> SessionLog::startSession(const std::string&
 
         logpath = logpath_with_suffix;
 
-        // create sessionlog directory if it does not exist
-        if (!std::filesystem::exists(logpath)) {
-            std::filesystem::create_directories(logpath);
+        try {
+            // create sessionlog directory if it does not exist
+            if (!std::filesystem::exists(logpath)) {
+                std::filesystem::create_directories(logpath);
+            }
+        } catch (const std::filesystem::filesystem_error& e) {
+            EVLOG_error << fmt::format("Cannot create session logpath {}: {}", logpath.string(), e.what());
+            return std::nullopt;
         }
 
         // open new file

--- a/modules/EVSE/EvseManager/tests/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/tests/CMakeLists.txt
@@ -19,12 +19,15 @@ target_sources(${TEST_TARGET_NAME} PRIVATE
     ErrorHandlingTest.cpp
     IECStateMachineTest.cpp
     OverVoltageMonitorTest.cpp
+    SessionLogTest.cpp
     VoltagePlausibilityMonitorTest.cpp
     ../ErrorHandling.cpp
     ../IECStateMachine.cpp
+    ../SessionLog.cpp
     ../backtrace.cpp
     ../over_voltage/OverVoltageMonitor.cpp
     ../voltage_plausibility/VoltagePlausibilityMonitor.cpp
+    ../v2gMessage.cpp
 )
 
 target_compile_definitions(${TEST_TARGET_NAME} PRIVATE
@@ -37,6 +40,7 @@ target_link_libraries(${TEST_TARGET_NAME} PRIVATE
     everest::log
     everest::framework
     everest::helpers
+    pugixml::pugixml
     sigslot
 )
 

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -57,6 +57,7 @@ struct ChargerTest : public testing::Test {
     std::vector<std::unique_ptr<isolation_monitorIntf>> error_handler_imd;
     std::vector<std::unique_ptr<power_supply_DCIntf>> error_handler_powersupply;
     std::vector<std::unique_ptr<powermeterIntf>> error_handler_powermeter;
+    std::vector<std::unique_ptr<slacIntf>> error_handler_slac;
     std::vector<std::unique_ptr<over_voltage_monitorIntf>> error_handler_over_voltage_monitor;
 
     std::unique_ptr<ChargerDerived> charger;
@@ -65,7 +66,7 @@ struct ChargerTest : public testing::Test {
         charger_error_handling(std::make_unique<ErrorHandling>(
             error_handler_bsp, error_handler_hlc, error_handler_connector_lock, error_handler_ac_rcd,
             error_handler_evse, error_handler_imd, error_handler_powersupply, error_handler_powermeter,
-            error_handler_over_voltage_monitor, false)) {
+            error_handler_slac, error_handler_over_voltage_monitor, false)) {
     }
 
     void SetUp() override {
@@ -848,6 +849,7 @@ ErrorHandling::ErrorHandling(const std::unique_ptr<evse_board_supportIntf>& r_bs
                              const std::vector<std::unique_ptr<isolation_monitorIntf>>& _r_imd,
                              const std::vector<std::unique_ptr<power_supply_DCIntf>>& _r_powersupply,
                              const std::vector<std::unique_ptr<powermeterIntf>>& _r_powermeter,
+                             const std::vector<std::unique_ptr<slacIntf>>& _r_slac,
                              const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& _r_over_voltage_monitor,
                              bool _inoperative_error_use_vendor_id) :
     r_bsp(r_bsp),
@@ -858,6 +860,7 @@ ErrorHandling::ErrorHandling(const std::unique_ptr<evse_board_supportIntf>& r_bs
     r_imd(_r_imd),
     r_powersupply(r_powersupply),
     r_powermeter(_r_powermeter),
+    r_slac(_r_slac),
     r_over_voltage_monitor(_r_over_voltage_monitor),
     inoperative_error_use_vendor_id(_inoperative_error_use_vendor_id) {
 }

--- a/modules/EVSE/EvseManager/tests/ErrorHandlingTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ErrorHandlingTest.cpp
@@ -56,13 +56,20 @@ struct ErrorDatabaseStub : public Everest::error::ErrorDatabase {
 struct EvseManagerModuleAdapterStub : public module::stub::EvseManagerModuleAdapter {
     std::shared_ptr<Everest::error::ErrorTypeMap> error_type_map;
     std::shared_ptr<ErrorDatabaseStub> error_database;
+    std::shared_ptr<ErrorDatabaseStub> slac_error_database;
+    std::shared_ptr<ErrorDatabaseStub> hlc_error_database;
     std::list<Everest::error::ErrorType> error_list;
+    std::list<Everest::error::ErrorType> requirement_error_list;
     std::list<Everest::error::Error> active_errors;
+    std::list<Everest::error::Error> slac_active_errors;
+    std::list<Everest::error::Error> hlc_active_errors;
 
     EvseManagerModuleAdapterStub() :
         module::stub::EvseManagerModuleAdapter(),
         error_type_map(std::make_shared<Everest::error::ErrorTypeMap>()),
         error_database(std::make_shared<ErrorDatabaseStub>(active_errors)),
+        slac_error_database(std::make_shared<ErrorDatabaseStub>(slac_active_errors)),
+        hlc_error_database(std::make_shared<ErrorDatabaseStub>(hlc_active_errors)),
         error_list{} {
     }
 
@@ -88,12 +95,23 @@ struct EvseManagerModuleAdapterStub : public module::stub::EvseManagerModuleAdap
 
     virtual std::shared_ptr<Everest::error::ErrorManagerReq> get_error_manager_req_fn(const Requirement& req) {
         return std::make_shared<Everest::error::ErrorManagerReq>(
-            error_type_map, std::make_shared<Everest::error::ErrorDatabaseMap>(), error_list,
+            error_type_map, std::make_shared<Everest::error::ErrorDatabaseMap>(), requirement_error_list,
             [this](const Everest::error::ErrorType& error_type, const Everest::error::ErrorCallback& callback,
                    const Everest::error::ErrorCallback& clear_callback) {
                 error_raise[error_type] = callback;
                 error_clear[error_type] = clear_callback;
             });
+    }
+
+    virtual std::shared_ptr<Everest::error::ErrorStateMonitor> get_error_state_monitor_req_fn(const Requirement& req) {
+        if (req.id == "slac") {
+            return std::make_shared<Everest::error::ErrorStateMonitor>(slac_error_database);
+        }
+        if (req.id == "hlc") {
+            return std::make_shared<Everest::error::ErrorStateMonitor>(hlc_error_database);
+        }
+        return std::make_shared<Everest::error::ErrorStateMonitor>(
+            std::make_shared<Everest::error::ErrorDatabaseMap>());
     }
 
     virtual std::shared_ptr<Everest::error::ErrorFactory> get_error_factory_fn(const std::string&) {
@@ -110,30 +128,53 @@ struct ErrorHandlingTesting : public testing::Test {
     std::map<Everest::error::ErrorType, std::string> error_types_map;
 
     std::unique_ptr<evse_board_supportIntf> r_bsp{};
-    const std::vector<std::unique_ptr<ISO15118_chargerIntf>> r_hlc{};
+    std::vector<std::unique_ptr<ISO15118_chargerIntf>> r_hlc{};
     const std::vector<std::unique_ptr<connector_lockIntf>> r_connector_lock{};
     const std::vector<std::unique_ptr<ac_rcdIntf>> r_ac_rcd{};
     std::unique_ptr<evse_managerImplBase> p_evse{};
     const std::vector<std::unique_ptr<isolation_monitorIntf>> _r_imd{};
     const std::vector<std::unique_ptr<power_supply_DCIntf>> _r_powersupply{};
     const std::vector<std::unique_ptr<powermeterIntf>> _r_powermeter{};
+    std::vector<std::unique_ptr<slacIntf>> r_slac{};
     const std::vector<std::unique_ptr<over_voltage_monitorIntf>> _r_over_voltage_monitor{};
 
     std::unique_ptr<ErrorHandlingTest> error_handler;
 
-    void construct(bool _inoperative_error_use_vendor_id) {
+    void construct(bool _inoperative_error_use_vendor_id, bool connect_slac = false, bool connect_hlc = false) {
         error_types_map = {{"evse_board_support/VendorWarning", "warning"},
+                           {"generic/CommunicationFault", "communication fault"},
+                           {"generic/VendorError", "vendor error"},
+                           {"generic/VendorWarning", "vendor warning"},
                            {"evse_manager/Inoperative", "inoperative"}};
         adapter.error_type_map->load_error_types_map(error_types_map);
         adapter.active_errors.clear();
+        adapter.error_list.clear();
+        adapter.requirement_error_list.clear();
+        adapter.error_raise.clear();
+        adapter.error_clear.clear();
+        adapter.slac_active_errors.clear();
+        adapter.hlc_active_errors.clear();
+        r_slac.clear();
+        r_hlc.clear();
         for (const auto& [error, description] : error_types_map) {
             adapter.error_list.push_back(error);
         }
+        adapter.requirement_error_list = {"evse_board_support/VendorWarning", "generic/CommunicationFault",
+                                          "generic/VendorError", "generic/VendorWarning"};
+        adapter.error_raise["evse_manager/Inoperative"] = [](const Everest::error::Error&) {};
+        adapter.error_clear["evse_manager/Inoperative"] = [](const Everest::error::Error&) {};
         r_bsp = std::make_unique<module::stub::evse_board_supportIntfStub>(adapter);
+        if (connect_slac) {
+            r_slac.push_back(std::make_unique<slacIntf>(&adapter, Requirement{"slac", 1}, "slac", std::nullopt));
+        }
+        if (connect_hlc) {
+            r_hlc.push_back(
+                std::make_unique<ISO15118_chargerIntf>(&adapter, Requirement{"hlc", 1}, "hlc", std::nullopt));
+        }
         p_evse = std::make_unique<module::stub::evse_managerImplStub>(&adapter, "manager");
         error_handler = std::make_unique<ErrorHandlingTest>(r_bsp, r_hlc, r_connector_lock, r_ac_rcd, p_evse, _r_imd,
-                                                            _r_powersupply, _r_powermeter, _r_over_voltage_monitor,
-                                                            _inoperative_error_use_vendor_id);
+                                                            _r_powersupply, _r_powermeter, r_slac,
+                                                            _r_over_voltage_monitor, _inoperative_error_use_vendor_id);
     }
 
     static constexpr std::string_view default_description{"description"};
@@ -155,6 +196,26 @@ struct ErrorHandlingTesting : public testing::Test {
         EXPECT_EQ(active.sub_type, "");
         EXPECT_EQ(active.message, error.type);
         return active;
+    }
+
+    void raise_slac_error(const std::string& type) {
+        Everest::error::Error error{};
+        error.type = type;
+        error.sub_type = "";
+        error.message = "message";
+        error.description = "description";
+        adapter.slac_active_errors.push_back(error);
+        adapter.error_raise.at(type)(error);
+    }
+
+    void raise_hlc_error(const std::string& type) {
+        Everest::error::Error error{};
+        error.type = type;
+        error.sub_type = "";
+        error.message = "message";
+        error.description = "description";
+        adapter.hlc_active_errors.push_back(error);
+        adapter.error_raise.at(type)(error);
     }
 };
 
@@ -347,6 +408,55 @@ TEST_F(ErrorHandlingTesting, IsActive) {
     EXPECT_EQ(error.message, first_error.type);
     EXPECT_EQ(error.description, "type/sub-type");
     EXPECT_EQ(error.vendor_id, first_error.vendor_id);
+}
+
+TEST_F(ErrorHandlingTesting, SlacCommunicationFaultIsFatal) {
+    construct(false, true);
+
+    raise_slac_error("generic/CommunicationFault");
+
+    ASSERT_EQ(adapter.active_errors.size(), 1);
+    const auto& error = adapter.active_errors.front();
+    EXPECT_EQ(error.type, "evse_manager/Inoperative");
+    EXPECT_EQ(error.message, "generic/CommunicationFault");
+}
+
+TEST_F(ErrorHandlingTesting, SlacVendorErrorIsFatal) {
+    construct(false, true);
+
+    raise_slac_error("generic/VendorError");
+
+    ASSERT_EQ(adapter.active_errors.size(), 1);
+    const auto& error = adapter.active_errors.front();
+    EXPECT_EQ(error.type, "evse_manager/Inoperative");
+    EXPECT_EQ(error.message, "generic/VendorError");
+}
+
+TEST_F(ErrorHandlingTesting, OtherSlacErrorsAreNotFatal) {
+    construct(false, true);
+
+    raise_slac_error("generic/VendorWarning");
+
+    EXPECT_FALSE(p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", ""));
+}
+
+TEST_F(ErrorHandlingTesting, HlcCommunicationFaultIsFatal) {
+    construct(false, false, true);
+
+    raise_hlc_error("generic/CommunicationFault");
+
+    ASSERT_EQ(adapter.active_errors.size(), 1);
+    const auto& error = adapter.active_errors.front();
+    EXPECT_EQ(error.type, "evse_manager/Inoperative");
+    EXPECT_EQ(error.message, "generic/CommunicationFault");
+}
+
+TEST_F(ErrorHandlingTesting, HlcVendorWarningIsNotFatal) {
+    construct(false, false, true);
+
+    raise_hlc_error("generic/VendorWarning");
+
+    EXPECT_FALSE(p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", ""));
 }
 
 } // namespace

--- a/modules/EVSE/EvseManager/tests/SessionLogTest.cpp
+++ b/modules/EVSE/EvseManager/tests/SessionLogTest.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "SessionLog.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <system_error>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace module {
+namespace {
+
+struct TemporaryDirectory {
+    std::filesystem::path path;
+
+    explicit TemporaryDirectory(const std::string& prefix) {
+        const auto suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+        path = std::filesystem::temp_directory_path() / (prefix + std::to_string(suffix));
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+};
+
+} // namespace
+
+TEST(SessionLogTest, StartSessionCreatesSessionDirectory) {
+    TemporaryDirectory temp("everest-session-log-test-");
+
+    SessionLog log;
+    log.setPath(temp.path.string());
+    log.setMqtt([](const nlohmann::json&) {});
+    log.enable();
+
+    const auto logpath = log.startSession("session");
+
+    ASSERT_TRUE(logpath.has_value());
+    EXPECT_TRUE(std::filesystem::is_directory(*logpath));
+    EXPECT_EQ(logpath->parent_path(), std::filesystem::weakly_canonical(temp.path));
+
+    log.stopSession();
+}
+
+TEST(SessionLogTest, StartSessionReturnsNulloptWhenDirectoryCannotBeCreated) {
+    SessionLog log;
+    log.setPath("/dev/null/everest-session-log-test");
+    log.enable();
+
+    std::optional<std::filesystem::path> logpath;
+    EXPECT_NO_THROW(logpath = log.startSession("session"));
+    EXPECT_FALSE(logpath.has_value());
+}
+
+} // namespace module


### PR DESCRIPTION
## Describe your changes

  Updates EvseManager error handling so SLAC and HLC requirement errors can make the EVSE inoperative when they represent charging-relevant faults.

### Details

  - Subscribes EvseManager error handling to SLAC requirement errors.
  - Subscribes EvseManager error handling to HLC requirement errors.
  - Treats SLAC communication and vendor errors as fatal for charging.
  - Treats HLC communication and vendor errors as fatal for charging.
  - Keeps vendor warnings ignored for SLAC and HLC, matching the existing ignore-list pattern used for other requirements.
  - Makes session log path setup handle filesystem errors without terminating the process.
  - Adds test coverage for SLAC/HLC fatal and ignored error behavior.
  - Adds test coverage for session log filesystem failure handling.

### Related PRs
#2369 Raises comm fault error for EvseV2G
#1935 Raises comm fault for SLAC

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

