### PR TITLE
Improve EvseV2G startup procedure

### DIFF
--- a/interfaces/ISO15118_charger.yaml
+++ b/interfaces/ISO15118_charger.yaml
@@ -480,3 +480,5 @@ vars:
       The EV termination code as described in ISO15118-20.
     type: object
     $ref: /iso15118#/EvTermination
+errors:
+  - reference: /errors/generic

--- a/modules/EVSE/EvseV2G/EvseV2G.cpp
+++ b/modules/EVSE/EvseV2G/EvseV2G.cpp
@@ -9,8 +9,10 @@
 #include <everest/logging.hpp>
 
 #include <csignal>
+#include <cstdlib>
 #include <everest/tls/openssl_util.hpp>
 #include <stdexcept>
+#include <unistd.h>
 namespace {
 void log_handler(openssl::log_level_t level, const std::string& str) {
     switch (level) {
@@ -83,48 +85,127 @@ void EvseV2G::init() {
 }
 
 void EvseV2G::ready() {
-    int rv = 0;
+    run_network_lifecycle();
+}
 
+void EvseV2G::run_network_lifecycle() {
+    dlog(DLOG_LEVEL_DEBUG, "Starting V2G network lifecycle");
+
+    while (!v2g_ctx->shutdown) {
+        v2g_ctx->if_name = config.device.c_str();
+
+        if (try_start_network()) {
+            invoke_ready(*p_charger);
+            invoke_ready(*p_extensions);
+
+            telemetry_publisher->publish_all();
+
+            if (config.enable_sdp_server) {
+                if (sdp_listen(v2g_ctx) == -1) {
+                    dlog(DLOG_LEVEL_ERROR, "sdp_listen() failed");
+                }
+            } else {
+                wait_for_shutdown();
+            }
+            return;
+        }
+
+        if (!v2g_ctx->shutdown) {
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }
+}
+
+bool EvseV2G::try_start_network() {
     dlog(DLOG_LEVEL_DEBUG, "Starting SDP responder");
 
-    rv = connection_init(v2g_ctx);
-
-    if (rv == -1) {
-        dlog(DLOG_LEVEL_ERROR, "Failed to initialize connection");
-        goto err_out;
+    std::string failure_detail;
+    if (connection_init(v2g_ctx, &failure_detail) == -1) {
+        report_network_startup_failure("Failed to initialize connection: " + failure_detail);
+        return false;
     }
 
-    if (config.enable_sdp_server) {
-        rv = sdp_init(v2g_ctx);
-
-        if (rv == -1) {
-            dlog(DLOG_LEVEL_ERROR, "Failed to start SDP responder");
-            goto err_out;
-        }
+    if (config.enable_sdp_server && sdp_init(v2g_ctx, &failure_detail) == -1) {
+        report_network_startup_failure("Failed to start SDP responder: " + failure_detail);
+        cleanup_failed_network_start();
+        return false;
     }
 
     dlog(DLOG_LEVEL_DEBUG, "starting socket server(s)");
     if (connection_start_servers(v2g_ctx)) {
-        dlog(DLOG_LEVEL_ERROR, "start_connection_servers() failed");
-        goto err_out;
+        report_network_startup_failure("start_connection_servers() failed");
+        cleanup_failed_network_start();
+        return false;
     }
 
-    invoke_ready(*p_charger);
-    invoke_ready(*p_extensions);
+    clear_network_startup_failure();
+    return true;
+}
 
-    telemetry_publisher->publish_all();
+void EvseV2G::cleanup_failed_network_start() {
+    connection_cleanup(v2g_ctx);
 
-    rv = sdp_listen(v2g_ctx);
+    if (v2g_ctx->sdp_socket != -1) {
+        close(v2g_ctx->sdp_socket);
+        v2g_ctx->sdp_socket = -1;
+    }
+}
 
-    if (rv == -1) {
-        dlog(DLOG_LEVEL_ERROR, "sdp_listen() failed");
-        goto err_out;
+void EvseV2G::wait_for_shutdown() {
+    while (!v2g_ctx->shutdown) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+}
+
+std::string EvseV2G::network_device_label() const {
+    // When "device: auto" is configured, and the interface name is resolved, this returns
+    // the resolved interface name. Fall back to config.device if still unresolved.
+    if (v2g_ctx != nullptr && v2g_ctx->if_name != nullptr) {
+        const std::string resolved = v2g_ctx->if_name;
+        if (!resolved.empty() && resolved != "auto") {
+            return resolved;
+        }
+    }
+    return config.device;
+}
+
+void EvseV2G::report_network_startup_failure(const std::string& reason) {
+    const auto message = "Device " + network_device_label() + ": " + reason;
+
+    if (startup_fault_message == message) {
+        if (!startup_fault_raised && p_charger->error_factory && p_charger->error_manager) {
+            p_charger->raise_error(p_charger->error_factory->create_error("generic/CommunicationFault", "", message));
+            startup_fault_raised = true;
+        }
+        return;
     }
 
-    return;
+    if (startup_fault_raised && p_charger->error_manager) {
+        p_charger->clear_error("generic/CommunicationFault");
+        startup_fault_raised = false;
+    }
 
-err_out:
-    throw std::runtime_error("Could not initialise EvseV2G module");
+    startup_fault_message = message;
+    dlog(DLOG_LEVEL_WARNING, "V2G network startup failed, retrying: %s", message.c_str());
+
+    if (p_charger->error_factory && p_charger->error_manager) {
+        p_charger->raise_error(p_charger->error_factory->create_error("generic/CommunicationFault", "", message));
+        startup_fault_raised = true;
+    }
+}
+
+void EvseV2G::clear_network_startup_failure() {
+    if (startup_fault_message.empty()) {
+        return;
+    }
+
+    dlog(DLOG_LEVEL_INFO, "V2G network startup recovered: Device %s is available", network_device_label().c_str());
+    startup_fault_message.clear();
+
+    if (startup_fault_raised && p_charger->error_manager) {
+        p_charger->clear_error("generic/CommunicationFault");
+        startup_fault_raised = false;
+    }
 }
 
 EvseV2G::~EvseV2G() {

--- a/modules/EVSE/EvseV2G/EvseV2G.hpp
+++ b/modules/EVSE/EvseV2G/EvseV2G.hpp
@@ -23,6 +23,7 @@
 #include "telemetry_publisher.hpp"
 #include "v2g_ctx.hpp"
 #include <everest/tls/tls.hpp>
+#include <string>
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {
@@ -81,6 +82,15 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+    void run_network_lifecycle();
+    bool try_start_network();
+    void cleanup_failed_network_start();
+    void wait_for_shutdown();
+    void report_network_startup_failure(const std::string& reason);
+    void clear_network_startup_failure();
+    std::string network_device_label() const;
+    std::string startup_fault_message;
+    bool startup_fault_raised{false};
     tls::Server tls_server;
     std::unique_ptr<V2gTelemetryPublisher> telemetry_publisher;
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1

--- a/modules/EVSE/EvseV2G/connection/connection.cpp
+++ b/modules/EVSE/EvseV2G/connection/connection.cpp
@@ -44,6 +44,12 @@ using V2gEvElectricalTracker = everest::lib::util::change_tracker<telemetry_type
 using V2gPaymentServiceTracker = everest::lib::util::change_tracker<telemetry_types::V2gPaymentService>;
 using V2gChargerStatusTracker = everest::lib::util::change_tracker<telemetry_types::V2gChargerStatus>;
 
+static void set_failure_detail(std::string* failure_detail, const std::string& detail) {
+    if (failure_detail != nullptr) {
+        *failure_detail = detail;
+    }
+}
+
 /*!
  * \brief connection_create_socket This function creates a tcp/tls socket
  * \param sockaddr to bind the socket to an interface
@@ -114,8 +120,9 @@ static int connection_create_socket(struct sockaddr_in6* sockaddr) {
  * \param sockaddr to bind the socket to an interface
  * \return Returns \c 0 on success, otherwise \c -1
  */
-int check_interface(struct v2g_context* v2g_ctx) {
+int check_interface(struct v2g_context* v2g_ctx, std::string* failure_detail) {
     if (v2g_ctx == nullptr || v2g_ctx->if_name == nullptr) {
+        set_failure_detail(failure_detail, "No interface configured");
         return -1;
     }
 
@@ -123,20 +130,52 @@ int check_interface(struct v2g_context* v2g_ctx) {
     std::memset(&mreq, 0, sizeof(mreq));
 
     if (strcmp(v2g_ctx->if_name, "auto") == 0) {
-        v2g_ctx->if_name = choose_first_ipv6_interface();
+        v2g_ctx->if_name = choose_first_ipv6_interface(failure_detail);
     }
 
     if (v2g_ctx->if_name == nullptr) {
+        if (failure_detail == nullptr || failure_detail->empty()) {
+            set_failure_detail(failure_detail, "No interface with an IPv6 address found");
+        }
         return -1;
     }
 
     mreq.ipv6mr_interface = if_nametoindex(v2g_ctx->if_name);
     if (!mreq.ipv6mr_interface) {
-        dlog(DLOG_LEVEL_ERROR, "No such interface: %s", v2g_ctx->if_name);
+        set_failure_detail(failure_detail, std::string("No such interface: ") + v2g_ctx->if_name);
+        if (failure_detail == nullptr) {
+            dlog(DLOG_LEVEL_ERROR, "No such interface: %s", v2g_ctx->if_name);
+        }
         return -1;
     }
 
     return (v2g_ctx->if_name == nullptr) ? -1 : 0;
+}
+
+void connection_cleanup(struct v2g_context* ctx) {
+    if (ctx == nullptr) {
+        return;
+    }
+
+    if (ctx->tls_server != nullptr) {
+        ctx->tls_server->stop();
+        ctx->tls_server->wait_stopped();
+    }
+
+    if (ctx->tcp_socket != -1) {
+        close(ctx->tcp_socket);
+        ctx->tcp_socket = -1;
+    }
+
+    if (ctx->tls_socket.fd != -1) {
+        close(ctx->tls_socket.fd);
+        ctx->tls_socket.fd = -1;
+    }
+
+    free(ctx->local_tcp_addr);
+    ctx->local_tcp_addr = nullptr;
+    free(ctx->local_tls_addr);
+    ctx->local_tls_addr = nullptr;
 }
 
 /*!
@@ -145,13 +184,20 @@ int check_interface(struct v2g_context* v2g_ctx) {
  * \return Returns \c 0 on success, otherwise \c -1
  */
 int connection_init(struct v2g_context* v2g_ctx) {
-    if (check_interface(v2g_ctx) == -1) {
+    return connection_init(v2g_ctx, nullptr);
+}
+
+int connection_init(struct v2g_context* v2g_ctx, std::string* failure_detail) {
+    set_failure_detail(failure_detail, "Failed to initialize connection");
+
+    if (check_interface(v2g_ctx, failure_detail) == -1) {
         return -1;
     }
 
     if (v2g_ctx->tls_security != TLS_SECURITY_FORCE) {
         v2g_ctx->local_tcp_addr = static_cast<sockaddr_in6*>(calloc(1, sizeof(*v2g_ctx->local_tcp_addr)));
         if (v2g_ctx->local_tcp_addr == nullptr) {
+            set_failure_detail(failure_detail, "Failed to allocate memory for TCP address");
             dlog(DLOG_LEVEL_ERROR, "Failed to allocate memory for TCP address");
             return -1;
         }
@@ -160,110 +206,133 @@ int connection_init(struct v2g_context* v2g_ctx) {
     if (v2g_ctx->tls_security != TLS_SECURITY_PROHIBIT) {
         v2g_ctx->local_tls_addr = static_cast<sockaddr_in6*>(calloc(1, sizeof(*v2g_ctx->local_tls_addr)));
         if (!v2g_ctx->local_tls_addr) {
+            set_failure_detail(failure_detail, "Failed to allocate memory for TLS address");
             dlog(DLOG_LEVEL_ERROR, "Failed to allocate memory for TLS address");
+            connection_cleanup(v2g_ctx);
             return -1;
         }
     }
 
-    while (1) {
-        if (v2g_ctx->local_tcp_addr) {
-            get_interface_ipv6_address(v2g_ctx->if_name, ADDR6_TYPE_LINKLOCAL, v2g_ctx->local_tcp_addr);
-            if (v2g_ctx->local_tls_addr) {
-                // Handle allowing TCP with TLS (TLS_SECURITY_ALLOW)
-                memcpy(v2g_ctx->local_tls_addr, v2g_ctx->local_tcp_addr, sizeof(*v2g_ctx->local_tls_addr));
+    if (v2g_ctx->local_tcp_addr) {
+        if (get_interface_ipv6_address(v2g_ctx->if_name, ADDR6_TYPE_LINKLOCAL, v2g_ctx->local_tcp_addr) == -1) {
+            set_failure_detail(failure_detail,
+                               std::string("No IPv6 link-local address found on interface ") + v2g_ctx->if_name);
+            if (failure_detail == nullptr) {
+                dlog(DLOG_LEVEL_WARNING,
+                     "No IPv6 link-local address found on interface %s, connection setup will be retried",
+                     v2g_ctx->if_name);
+            }
+            connection_cleanup(v2g_ctx);
+            return -1;
+        }
+        if (v2g_ctx->local_tls_addr) {
+            // Handle allowing TCP with TLS (TLS_SECURITY_ALLOW)
+            memcpy(v2g_ctx->local_tls_addr, v2g_ctx->local_tcp_addr, sizeof(*v2g_ctx->local_tls_addr));
+        }
+    } else {
+        // Handle forcing TLS security (TLS_SECURITY_FORCE)
+        if (get_interface_ipv6_address(v2g_ctx->if_name, ADDR6_TYPE_LINKLOCAL, v2g_ctx->local_tls_addr) == -1) {
+            set_failure_detail(failure_detail,
+                               std::string("No IPv6 link-local address found on interface ") + v2g_ctx->if_name);
+            if (failure_detail == nullptr) {
+                dlog(DLOG_LEVEL_WARNING,
+                     "No IPv6 link-local address found on interface %s, connection setup will be retried",
+                     v2g_ctx->if_name);
+            }
+            connection_cleanup(v2g_ctx);
+            return -1;
+        }
+    }
+
+    if (v2g_ctx->local_tcp_addr) {
+        char buffer[INET6_ADDRSTRLEN];
+
+        /*
+         * When we bind with port = 0, the kernel assigns a dynamic port from the range configured
+         * in /proc/sys/net/ipv4/ip_local_port_range. This is on a recent Ubuntu Linux e.g.
+         * $ cat /proc/sys/net/ipv4/ip_local_port_range
+         * 32768   60999
+         * However, in ISO15118 spec the IANA range with 49152 to 65535 is referenced. So we have the
+         * problem that the kernel (without further configuration - and we want to avoid this) could
+         * hand out a port which is not "range compatible".
+         * To fulfill the ISO15118 standard, we simply try to bind to static port numbers.
+         */
+        v2g_ctx->local_tcp_addr->sin6_port = htons(DEFAULT_TCP_PORT);
+        v2g_ctx->tcp_socket = connection_create_socket(v2g_ctx->local_tcp_addr);
+        if (v2g_ctx->tcp_socket < 0) {
+            set_failure_detail(failure_detail,
+                               std::string("Failed to create TCP server socket on interface ") + v2g_ctx->if_name);
+            connection_cleanup(v2g_ctx);
+            return -1;
+        }
+        if (inet_ntop(AF_INET6, &v2g_ctx->local_tcp_addr->sin6_addr, buffer, sizeof(buffer)) != nullptr) {
+            dlog(DLOG_LEVEL_INFO, "TCP server on %s is listening on port [%s%%%" PRIu32 "]:%" PRIu16, v2g_ctx->if_name,
+                 buffer, v2g_ctx->local_tcp_addr->sin6_scope_id, ntohs(v2g_ctx->local_tcp_addr->sin6_port));
+            if (v2g_ctx->telemetry_publisher) {
+                v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+                    transport.set(&telemetry_types::V2gTransport::tcp_listener_status,
+                                  telemetry_types::V2gServerStatus::Active);
+                    transport.set(&telemetry_types::V2gTransport::tcp_discovery_enable, true);
+                    transport.set(&telemetry_types::V2gTransport::tcp_security_required, false);
+                    transport.set(&telemetry_types::V2gTransport::tcp_port_number,
+                                  ntohs(v2g_ctx->local_tcp_addr->sin6_port));
+                });
             }
         } else {
-            // Handle forcing TLS security (TLS_SECURITY_FORCE)
-            get_interface_ipv6_address(v2g_ctx->if_name, ADDR6_TYPE_LINKLOCAL, v2g_ctx->local_tls_addr);
+            set_failure_detail(failure_detail, std::string("TCP server inet_ntop failed: ") + strerror(errno));
+            dlog(DLOG_LEVEL_ERROR, "TCP server on %s is listening, but inet_ntop failed: %s", v2g_ctx->if_name,
+                 strerror(errno));
+            connection_cleanup(v2g_ctx);
+            return -1;
         }
-
-        if (v2g_ctx->local_tcp_addr) {
-            char buffer[INET6_ADDRSTRLEN];
-
-            /*
-             * When we bind with port = 0, the kernel assigns a dynamic port from the range configured
-             * in /proc/sys/net/ipv4/ip_local_port_range. This is on a recent Ubuntu Linux e.g.
-             * $ cat /proc/sys/net/ipv4/ip_local_port_range
-             * 32768   60999
-             * However, in ISO15118 spec the IANA range with 49152 to 65535 is referenced. So we have the
-             * problem that the kernel (without further configuration - and we want to avoid this) could
-             * hand out a port which is not "range compatible".
-             * To fulfill the ISO15118 standard, we simply try to bind to static port numbers.
-             */
-            v2g_ctx->local_tcp_addr->sin6_port = htons(DEFAULT_TCP_PORT);
-            v2g_ctx->tcp_socket = connection_create_socket(v2g_ctx->local_tcp_addr);
-            if (v2g_ctx->tcp_socket < 0) {
-                /* retry until interface is ready */
-                sleep(1);
-                continue;
-            }
-            if (inet_ntop(AF_INET6, &v2g_ctx->local_tcp_addr->sin6_addr, buffer, sizeof(buffer)) != nullptr) {
-                dlog(DLOG_LEVEL_INFO, "TCP server on %s is listening on port [%s%%%" PRIu32 "]:%" PRIu16,
-                     v2g_ctx->if_name, buffer, v2g_ctx->local_tcp_addr->sin6_scope_id,
-                     ntohs(v2g_ctx->local_tcp_addr->sin6_port));
-                if (v2g_ctx->telemetry_publisher) {
-                    v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
-                        transport.set(&telemetry_types::V2gTransport::tcp_listener_status,
-                                      telemetry_types::V2gServerStatus::Active);
-                        transport.set(&telemetry_types::V2gTransport::tcp_discovery_enable, true);
-                        transport.set(&telemetry_types::V2gTransport::tcp_security_required, false);
-                        transport.set(&telemetry_types::V2gTransport::tcp_port_number,
-                                      ntohs(v2g_ctx->local_tcp_addr->sin6_port));
-                    });
-                }
-            } else {
-                dlog(DLOG_LEVEL_ERROR, "TCP server on %s is listening, but inet_ntop failed: %s", v2g_ctx->if_name,
-                     strerror(errno));
-                return -1;
-            }
-        }
-
-        if (v2g_ctx->local_tls_addr) {
-            char buffer[INET6_ADDRSTRLEN];
-
-            /* see comment above for reason */
-            v2g_ctx->local_tls_addr->sin6_port = htons(DEFAULT_TLS_PORT);
-
-            v2g_ctx->tls_socket.fd = connection_create_socket(v2g_ctx->local_tls_addr);
-            if (v2g_ctx->tls_socket.fd < 0) {
-                if (v2g_ctx->tcp_socket != -1) {
-                    /* free the TCP socket */
-                    close(v2g_ctx->tcp_socket);
-                }
-                /* retry until interface is ready */
-                sleep(1);
-                continue;
-            }
-
-            if (inet_ntop(AF_INET6, &v2g_ctx->local_tls_addr->sin6_addr, buffer, sizeof(buffer)) != nullptr) {
-                dlog(DLOG_LEVEL_INFO, "TLS server on %s is listening on port [%s%%%" PRIu32 "]:%" PRIu16,
-                     v2g_ctx->if_name, buffer, v2g_ctx->local_tls_addr->sin6_scope_id,
-                     ntohs(v2g_ctx->local_tls_addr->sin6_port));
-                if (v2g_ctx->telemetry_publisher) {
-                    v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
-                        transport.set(&telemetry_types::V2gTransport::tcp_security_enable, true);
-                        transport.set(&telemetry_types::V2gTransport::tcp_security_required,
-                                      v2g_ctx->tls_security == TLS_SECURITY_FORCE);
-                        if (!v2g_ctx->local_tcp_addr) {
-                            transport.set(&telemetry_types::V2gTransport::tcp_listener_status,
-                                          telemetry_types::V2gServerStatus::Active);
-                            transport.set(&telemetry_types::V2gTransport::tcp_port_number,
-                                          ntohs(v2g_ctx->local_tls_addr->sin6_port));
-                        }
-                    });
-                }
-            } else {
-                dlog(DLOG_LEVEL_INFO, "TLS server on %s is listening, but inet_ntop failed: %s", v2g_ctx->if_name,
-                     strerror(errno));
-                return -1;
-            }
-        }
-        /* Sockets should be ready, leave the loop */
-        break;
     }
 
     if (v2g_ctx->local_tls_addr) {
-        return tls::connection_init(v2g_ctx);
+        char buffer[INET6_ADDRSTRLEN];
+
+        /* see comment above for reason */
+        v2g_ctx->local_tls_addr->sin6_port = htons(DEFAULT_TLS_PORT);
+
+        v2g_ctx->tls_socket.fd = connection_create_socket(v2g_ctx->local_tls_addr);
+        if (v2g_ctx->tls_socket.fd < 0) {
+            set_failure_detail(failure_detail,
+                               std::string("Failed to create TLS server socket on interface ") + v2g_ctx->if_name);
+            connection_cleanup(v2g_ctx);
+            return -1;
+        }
+
+        if (inet_ntop(AF_INET6, &v2g_ctx->local_tls_addr->sin6_addr, buffer, sizeof(buffer)) != nullptr) {
+            dlog(DLOG_LEVEL_INFO, "TLS server on %s is listening on port [%s%%%" PRIu32 "]:%" PRIu16, v2g_ctx->if_name,
+                 buffer, v2g_ctx->local_tls_addr->sin6_scope_id, ntohs(v2g_ctx->local_tls_addr->sin6_port));
+            if (v2g_ctx->telemetry_publisher) {
+                v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
+                    transport.set(&telemetry_types::V2gTransport::tcp_security_enable, true);
+                    transport.set(&telemetry_types::V2gTransport::tcp_security_required,
+                                  v2g_ctx->tls_security == TLS_SECURITY_FORCE);
+                    if (!v2g_ctx->local_tcp_addr) {
+                        transport.set(&telemetry_types::V2gTransport::tcp_listener_status,
+                                      telemetry_types::V2gServerStatus::Active);
+                        transport.set(&telemetry_types::V2gTransport::tcp_port_number,
+                                      ntohs(v2g_ctx->local_tls_addr->sin6_port));
+                    }
+                });
+            }
+        } else {
+            set_failure_detail(failure_detail, std::string("TLS server inet_ntop failed: ") + strerror(errno));
+            dlog(DLOG_LEVEL_INFO, "TLS server on %s is listening, but inet_ntop failed: %s", v2g_ctx->if_name,
+                 strerror(errno));
+            connection_cleanup(v2g_ctx);
+            return -1;
+        }
+    }
+
+    if (v2g_ctx->local_tls_addr) {
+        const auto result = tls::connection_init(v2g_ctx);
+        if (result == -1) {
+            set_failure_detail(failure_detail, "Failed to initialize TLS connection");
+            connection_cleanup(v2g_ctx);
+        }
+        return result;
     }
     return 0;
 }

--- a/modules/EVSE/EvseV2G/connection/connection.hpp
+++ b/modules/EVSE/EvseV2G/connection/connection.hpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <netinet/in.h>
+#include <string>
 
 #include "v2g_ctx.hpp"
 
@@ -16,6 +17,13 @@
  * \return 0 on success
  */
 int connection_init(struct v2g_context* ctx);
+int connection_init(struct v2g_context* ctx, std::string* failure_detail);
+
+/*!
+ * \brief clean up TCP/TLS server state, sockets and bound addresses
+ * \param ctx the V2G context
+ */
+void connection_cleanup(struct v2g_context* ctx);
 
 /*!
  * \brief start TCP/TLS servers

--- a/modules/EVSE/EvseV2G/sdp.cpp
+++ b/modules/EVSE/EvseV2G/sdp.cpp
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <string>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -59,6 +60,16 @@ struct sdp_query {
     enum sdp_security security_requested;
     enum sdp_transport_protocol proto_requested;
 };
+
+static void set_sdp_failure_detail(std::string* failure_detail, const std::string& detail) {
+    if (failure_detail != nullptr) {
+        *failure_detail = detail;
+    }
+}
+
+static bool should_log_sdp_init_failure(const std::string* failure_detail) {
+    return failure_detail == nullptr;
+}
 
 /*
  * Fills the SDP header into a given buffer
@@ -215,44 +226,72 @@ int sdp_send_response(int sdp_socket, struct sdp_query* sdp_query) {
 }
 
 int sdp_init(struct v2g_context* v2g_ctx) {
+    return sdp_init(v2g_ctx, nullptr);
+}
+
+int sdp_init(struct v2g_context* v2g_ctx, std::string* failure_detail) {
     struct sockaddr_in6 sdp_addr = {AF_INET6, htons(SDP_SRV_PORT)};
     struct ipv6_mreq mreq = {{IN6ADDR_ALLNODES}, 0};
     int enable = 1;
+    const auto log_setup_failures = should_log_sdp_init_failure(failure_detail);
+
+    set_sdp_failure_detail(failure_detail, "Failed to initialize SDP socket");
 
     mreq.ipv6mr_interface = if_nametoindex(v2g_ctx->if_name);
     if (!mreq.ipv6mr_interface) {
-        dlog(DLOG_LEVEL_ERROR, "No such interface: %s", v2g_ctx->if_name);
+        set_sdp_failure_detail(failure_detail, std::string("No such interface: ") + v2g_ctx->if_name);
+        if (log_setup_failures) {
+            dlog(DLOG_LEVEL_ERROR, "No such interface: %s", v2g_ctx->if_name);
+        }
+        v2g_ctx->sdp_socket = -1;
         return -1;
     }
 
     /* create receiving socket */
     v2g_ctx->sdp_socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
     if (v2g_ctx->sdp_socket == -1) {
-        dlog(DLOG_LEVEL_ERROR, "socket() failed: %s", strerror(errno));
+        const auto error = std::string(strerror(errno));
+        set_sdp_failure_detail(failure_detail, "socket() failed: " + error);
+        if (log_setup_failures) {
+            dlog(DLOG_LEVEL_ERROR, "socket() failed: %s", error.c_str());
+        }
         return -1;
     }
 
     if (setsockopt(v2g_ctx->sdp_socket, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable)) == -1) {
-        dlog(DLOG_LEVEL_ERROR, "setsockopt(SO_REUSEPORT) failed: %s", strerror(errno));
+        const auto error = std::string(strerror(errno));
+        set_sdp_failure_detail(failure_detail, "setsockopt(SO_REUSEPORT) failed: " + error);
+        if (log_setup_failures) {
+            dlog(DLOG_LEVEL_ERROR, "setsockopt(SO_REUSEPORT) failed: %s", error.c_str());
+        }
         close(v2g_ctx->sdp_socket);
+        v2g_ctx->sdp_socket = -1;
         return -1;
     }
 
     sdp_addr.sin6_addr = in6addr_any;
 
     if (bind(v2g_ctx->sdp_socket, (struct sockaddr*)&sdp_addr, sizeof(sdp_addr)) == -1) {
-        dlog(DLOG_LEVEL_ERROR, "bind() failed: %s", strerror(errno));
+        const auto error = std::string(strerror(errno));
+        set_sdp_failure_detail(failure_detail, "bind() failed: " + error);
+        if (log_setup_failures) {
+            dlog(DLOG_LEVEL_ERROR, "bind() failed: %s", error.c_str());
+        }
         close(v2g_ctx->sdp_socket);
+        v2g_ctx->sdp_socket = -1;
         return -1;
     }
-
-    dlog(DLOG_LEVEL_INFO, "SDP socket setup succeeded");
 
     /* bind only to specified device */
     if (setsockopt(v2g_ctx->sdp_socket, SOL_SOCKET, SO_BINDTODEVICE, v2g_ctx->if_name, strlen(v2g_ctx->if_name)) ==
         -1) {
-        dlog(DLOG_LEVEL_ERROR, "setsockopt(SO_BINDTODEVICE) failed: %s", strerror(errno));
+        const auto error = std::string(strerror(errno));
+        set_sdp_failure_detail(failure_detail, "setsockopt(SO_BINDTODEVICE) failed: " + error);
+        if (log_setup_failures) {
+            dlog(DLOG_LEVEL_ERROR, "setsockopt(SO_BINDTODEVICE) failed: %s", error.c_str());
+        }
         close(v2g_ctx->sdp_socket);
+        v2g_ctx->sdp_socket = -1;
         return -1;
     }
 
@@ -260,12 +299,18 @@ int sdp_init(struct v2g_context* v2g_ctx) {
 
     /* join multicast group */
     if (setsockopt(v2g_ctx->sdp_socket, IPPROTO_IPV6, IPV6_JOIN_GROUP, &mreq, sizeof(mreq)) == -1) {
-        dlog(DLOG_LEVEL_ERROR, "setsockopt(IPV6_JOIN_GROUP) failed: %s", strerror(errno));
+        const auto error = std::string(strerror(errno));
+        set_sdp_failure_detail(failure_detail, "setsockopt(IPV6_JOIN_GROUP) failed: " + error);
+        if (log_setup_failures) {
+            dlog(DLOG_LEVEL_ERROR, "setsockopt(IPV6_JOIN_GROUP) failed: %s", error.c_str());
+        }
         close(v2g_ctx->sdp_socket);
+        v2g_ctx->sdp_socket = -1;
         return -1;
     }
 
     dlog(DLOG_LEVEL_TRACE, "joined multicast group");
+    dlog(DLOG_LEVEL_INFO, "SDP socket setup succeeded");
 
     if (v2g_ctx->telemetry_publisher) {
         v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
@@ -374,6 +419,8 @@ int sdp_listen(struct v2g_context* v2g_ctx) {
     if (close(v2g_ctx->sdp_socket) == -1) {
         dlog(DLOG_LEVEL_ERROR, "close() failed: %s", strerror(errno));
     }
+    v2g_ctx->sdp_socket = -1;
+
     if (v2g_ctx->telemetry_publisher) {
         v2g_ctx->telemetry_publisher->update_transport([&](V2gTransportTracker& transport) {
             transport.set(&telemetry_types::V2gTransport::udp_server_status,

--- a/modules/EVSE/EvseV2G/sdp.hpp
+++ b/modules/EVSE/EvseV2G/sdp.hpp
@@ -5,6 +5,7 @@
 #define SDP_H
 
 #include "v2g.hpp"
+#include <string>
 
 enum sdp_security {
     SDP_SECURITY_TLS = 0x00,
@@ -21,6 +22,7 @@ int sdp_validate_header(uint8_t* buffer, uint16_t expected_payload_type, uint32_
 int sdp_create_response(uint8_t* buffer, struct sockaddr_in6* addr, enum sdp_security security,
                         enum sdp_transport_protocol proto);
 int sdp_init(struct v2g_context* v2g_ctx);
+int sdp_init(struct v2g_context* v2g_ctx, std::string* failure_detail);
 int sdp_listen(struct v2g_context* v2g_ctx);
 void sdp_set_dlink_ready(struct v2g_context* v2g_ctx, bool ready);
 

--- a/modules/EVSE/EvseV2G/tools.cpp
+++ b/modules/EVSE/EvseV2G/tools.cpp
@@ -11,6 +11,7 @@
 #include <ifaddrs.h>
 #include <iomanip>
 #include <math.h>
+#include <netinet/in.h>
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
@@ -59,24 +60,40 @@ int generate_random_data(void* dest, size_t dest_len) {
 }
 
 const char* choose_first_ipv6_interface() {
-    struct ifaddrs *ifaddr, *ifa;
-    char buffer[INET6_ADDRSTRLEN];
+    return choose_first_ipv6_interface(nullptr);
+}
 
-    if (getifaddrs(&ifaddr) == -1)
+const char* choose_first_ipv6_interface(std::string* failure_detail) {
+    struct ifaddrs *ifaddr, *ifa;
+    static std::string selected_interface;
+
+    if (getifaddrs(&ifaddr) == -1) {
+        if (failure_detail != nullptr) {
+            *failure_detail = std::string("Failed to enumerate network interfaces: ") + strerror(errno);
+        }
         return NULL;
+    }
 
     for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
         if (!ifa->ifa_addr)
             continue;
 
-        if (ifa->ifa_addr->sa_family == AF_INET6) {
-            inet_ntop(AF_INET6, &ifa->ifa_addr->sa_data, buffer, sizeof(buffer));
-            if (strstr(buffer, "fe80") != NULL) {
-                return ifa->ifa_name;
-            }
+        if (ifa->ifa_addr->sa_family != AF_INET6)
+            continue;
+
+        const auto* addr = reinterpret_cast<struct sockaddr_in6*>(ifa->ifa_addr);
+        if (IN6_IS_ADDR_LINKLOCAL(&addr->sin6_addr)) {
+            selected_interface = ifa->ifa_name;
+            freeifaddrs(ifaddr);
+            return selected_interface.c_str();
         }
     }
-    dlog(DLOG_LEVEL_ERROR, "No necessary IPv6 link-local address was found!");
+    freeifaddrs(ifaddr);
+    if (failure_detail != nullptr) {
+        *failure_detail = "No IPv6 link-local interface found";
+    } else {
+        dlog(DLOG_LEVEL_ERROR, "No necessary IPv6 link-local address was found!");
+    }
     return NULL;
 }
 

--- a/modules/EVSE/EvseV2G/tools.hpp
+++ b/modules/EVSE/EvseV2G/tools.hpp
@@ -40,6 +40,7 @@ enum Addr6Type {
 };
 
 const char* choose_first_ipv6_interface();
+const char* choose_first_ipv6_interface(std::string* failure_detail);
 int get_interface_ipv6_address(const char* if_name, enum Addr6Type type, struct sockaddr_in6* addr);
 
 void set_normalized_timespec(struct timespec* ts, time_t sec, int64_t nsec);


### PR DESCRIPTION
## Describe your changes

### Summary
 Makes EvseV2G tolerate unavailable PLC/network interfaces during startup by retrying network setup instead of aborting module initialization. This fixes a start up race for certain architectures.
 ### Details
  - Replaces fatal startup failure with a retrying network lifecycle.
  - Reports network startup failures through `generic/CommunicationFault`.
  - Logs and raises repeated startup failures only when the failure reason changes.
  - Clears the startup communication fault once network setup succeeds.
  - Preserves the configured device name across retries, including `auto`.
  - Moves retry handling from low-level connection setup into the module startup lifecycle.
  - Cleans up partially initialized TCP, TLS, and SDP state before retrying.
  - Allows the ISO15118 charger interface to raise generic errors.


### Related PRs
#2368    This PR implements the changes that make the EvseManager aware of Fault status.
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

