### PR TITLE
feat(EVSE): wire ISO 15118-20 AC DER (IEC) module layer

### DIFF
--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -235,6 +235,19 @@ void ISO15118_chargerImpl::ready() {
 
     setup_config.selecting_sap_based_on_energy_service = mod->config.selecting_sap_based_on_energy_service;
 
+    // TODO(ml): hardcoded safe DER limits; populate real limits from the grid_support interface once available.
+    // der_setup_config is intentionally left unset: libiso15118 defaults it to {GridFollowing, GridConnected},
+    // which is exactly the minimal IEC setup we want.
+    {
+        const auto& services = setup_config.supported_energy_services;
+        if (std::find(services.begin(), services.end(), dt::ServiceCategory::AC_DER_IEC) != services.end()) {
+            auto& der_limits = setup_config.der_limits.emplace();
+            der_limits.nominal_charge_power = dt::from_float(11000);
+            der_limits.nominal_discharge_power = dt::from_float(11000);
+            der_limits.max_discharge_power = dt::from_float(11000);
+        }
+    }
+
     controller = std::make_unique<iso15118::TbdController>(tbd_config, callbacks, setup_config);
 
     // if the vas providers report their supported vas services before the controller exists,
@@ -438,7 +451,7 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
         } else if (const auto* ac_bpt_transfer_mode = std::get_if<dt::BPT_AC_CPDReqEnergyTransferMode>(&limits)) {
             publish_ac_ev_power_limits(fill_ac_ev_power_limits(*ac_bpt_transfer_mode));
         } else if (const auto* der_iec_transfer_mode = std::get_if<dt::DER_AC_CPDReqEnergyTransferMode>(&limits)) {
-            // todo(SL)
+            publish_ac_ev_power_limits(fill_ac_ev_power_limits(*der_iec_transfer_mode));
         }
     };
 
@@ -477,6 +490,23 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
                 ev_dynamic_values.min_v2x_energy_request =
                     convert_from_optional(bpt_dynamic_mode->min_v2x_energy_request);
                 publish_ac_ev_dynamic_control_mode(ev_dynamic_values);
+            } else if (const auto* der_scheduled_mode =
+                           std::get_if<dt::DER_Scheduled_AC_CLReqControlMode>(ac_control_mode)) {
+                publish_ac_ev_power_limits(fill_ac_ev_power_limits(*der_scheduled_mode));
+                publish_ac_ev_present_powers(fill_ac_ev_present_power_values(*der_scheduled_mode));
+                // TODO(ml): reactive-power fields and grid_event_condition are not yet surfaced.
+            } else if (const auto* der_dynamic_mode =
+                           std::get_if<dt::DER_Dynamic_AC_CLReqControlMode>(ac_control_mode)) {
+                publish_ac_ev_power_limits(fill_ac_ev_power_limits(*der_dynamic_mode));
+                publish_ac_ev_present_powers(fill_ac_ev_present_power_values(*der_dynamic_mode));
+                auto ev_dynamic_values = fill_ac_ev_dynamic_control_mode(*der_dynamic_mode);
+                ev_dynamic_values.max_v2x_energy_request =
+                    convert_from_optional(der_dynamic_mode->max_v2x_energy_request);
+                ev_dynamic_values.min_v2x_energy_request =
+                    convert_from_optional(der_dynamic_mode->min_v2x_energy_request);
+                publish_ac_ev_dynamic_control_mode(ev_dynamic_values);
+                // TODO(ml): reactive-power fields, grid_event_condition and
+                // session_total_discharge_energy_available are not yet surfaced.
             }
         } else if (const auto* display_parameters = std::get_if<dt::DisplayParameters>(&ac_charge_loop_req)) {
             publish_display_parameters(convert_display_parameters(*display_parameters));

--- a/modules/EVSE/Evse15118D20/charger/utils.cpp
+++ b/modules/EVSE/Evse15118D20/charger/utils.cpp
@@ -265,191 +265,118 @@ convert_parameter_set_list(const std::vector<types::iso15118_vas::ParameterSet>&
     return out;
 }
 
+namespace {
+// Sum the per-phase AC power components (L1 mandatory) into a Power carrying the total and per-phase breakdown.
+types::units::Power make_ac_power(const dt::RationalNumber& l1, const std::optional<dt::RationalNumber>& l2,
+                                  const std::optional<dt::RationalNumber>& l3) {
+    const auto v1 = dt::from_RationalNumber(l1);
+    const auto v2 = convert_from_optional(l2);
+    const auto v3 = convert_from_optional(l3);
+    return {v1 + v2.value_or(0.0) + v3.value_or(0.0), std::make_optional<float>(v1), v2, v3};
+}
+
+// Same, but every phase is optional: returns nullopt unless at least one phase is present.
+std::optional<types::units::Power> make_ac_power(const std::optional<dt::RationalNumber>& l1,
+                                                 const std::optional<dt::RationalNumber>& l2,
+                                                 const std::optional<dt::RationalNumber>& l3) {
+    const auto v1 = convert_from_optional(l1);
+    const auto v2 = convert_from_optional(l2);
+    const auto v3 = convert_from_optional(l3);
+    if (not v1.has_value() and not v2.has_value() and not v3.has_value()) {
+        return std::nullopt;
+    }
+    return types::units::Power{v1.value_or(0.0) + v2.value_or(0.0) + v3.value_or(0.0), v1, v2, v3};
+}
+} // namespace
+
 types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::AC_CPDReqEnergyTransferMode& mode) {
-    const auto max_charge_L1 = dt::from_RationalNumber(mode.max_charge_power);
-    const auto max_charge_L2 = convert_from_optional(mode.max_charge_power_L2);
-    const auto max_charge_L3 = convert_from_optional(mode.max_charge_power_L3);
-    const auto max_charge_total = max_charge_L1 + max_charge_L2.value_or(0.0) + max_charge_L3.value_or(0.0);
-
-    const auto min_charge_L1 = dt::from_RationalNumber(mode.min_charge_power);
-    const auto min_charge_L2 = convert_from_optional(mode.min_charge_power_L2);
-    const auto min_charge_L3 = convert_from_optional(mode.min_charge_power_L3);
-    const auto min_charge_total = min_charge_L1 + min_charge_L2.value_or(0.0) + min_charge_L3.value_or(0.0);
-
-    types::iso15118::AcEvPowerLimits ac_ev_power_limits;
-
-    ac_ev_power_limits.max_charge_power = {max_charge_total, std::make_optional<float>(max_charge_L1), max_charge_L2,
-                                           max_charge_L3};
-    ac_ev_power_limits.min_charge_power = {min_charge_total, std::make_optional<float>(min_charge_L1), min_charge_L2,
-                                           min_charge_L3};
-
-    return ac_ev_power_limits;
+    types::iso15118::AcEvPowerLimits limits;
+    limits.max_charge_power = make_ac_power(mode.max_charge_power, mode.max_charge_power_L2, mode.max_charge_power_L3);
+    limits.min_charge_power = make_ac_power(mode.min_charge_power, mode.min_charge_power_L2, mode.min_charge_power_L3);
+    return limits;
 }
 
 types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::BPT_AC_CPDReqEnergyTransferMode& mode) {
-    const auto max_charge_L1 = dt::from_RationalNumber(mode.max_charge_power);
-    const auto max_charge_L2 = convert_from_optional(mode.max_charge_power_L2);
-    const auto max_charge_L3 = convert_from_optional(mode.max_charge_power_L3);
-    const auto max_charge_total = max_charge_L1 + max_charge_L2.value_or(0.0) + max_charge_L3.value_or(0.0);
-
-    const auto min_charge_L1 = dt::from_RationalNumber(mode.min_charge_power);
-    const auto min_charge_L2 = convert_from_optional(mode.min_charge_power_L2);
-    const auto min_charge_L3 = convert_from_optional(mode.min_charge_power_L3);
-    const auto min_charge_total = min_charge_L1 + min_charge_L2.value_or(0.0) + min_charge_L3.value_or(0.0);
-
-    const auto max_discharge_L1 = dt::from_RationalNumber(mode.max_discharge_power);
-    const auto max_discharge_L2 = convert_from_optional(mode.max_discharge_power_L2);
-    const auto max_discharge_L3 = convert_from_optional(mode.max_discharge_power_L3);
-    const auto max_discharge_total = max_discharge_L1 + max_discharge_L2.value_or(0.0) + max_discharge_L3.value_or(0.0);
-
-    const auto min_discharge_L1 = dt::from_RationalNumber(mode.min_discharge_power);
-    const auto min_discharge_L2 = convert_from_optional(mode.min_discharge_power_L2);
-    const auto min_discharge_L3 = convert_from_optional(mode.min_discharge_power_L3);
-    const auto min_discharge_total = min_discharge_L1 + min_discharge_L2.value_or(0.0) + min_discharge_L3.value_or(0.0);
-
-    types::iso15118::AcEvPowerLimits ac_ev_power_limits;
-
-    ac_ev_power_limits.max_charge_power = {max_charge_total, std::make_optional<float>(max_charge_L1), max_charge_L2,
-                                           max_charge_L3};
-    ac_ev_power_limits.min_charge_power = {min_charge_total, std::make_optional<float>(min_charge_L1), min_charge_L2,
-                                           min_charge_L3};
-    ac_ev_power_limits.max_discharge_power = {max_discharge_total, std::make_optional<float>(max_discharge_L1),
-                                              max_discharge_L2, max_discharge_L3};
-    ac_ev_power_limits.min_discharge_power = {min_discharge_total, std::make_optional<float>(min_discharge_L1),
-                                              min_discharge_L2, min_discharge_L3};
-
-    return ac_ev_power_limits;
+    types::iso15118::AcEvPowerLimits limits;
+    limits.max_charge_power = make_ac_power(mode.max_charge_power, mode.max_charge_power_L2, mode.max_charge_power_L3);
+    limits.min_charge_power = make_ac_power(mode.min_charge_power, mode.min_charge_power_L2, mode.min_charge_power_L3);
+    limits.max_discharge_power =
+        make_ac_power(mode.max_discharge_power, mode.max_discharge_power_L2, mode.max_discharge_power_L3);
+    limits.min_discharge_power =
+        make_ac_power(mode.min_discharge_power, mode.min_discharge_power_L2, mode.min_discharge_power_L3);
+    return limits;
 }
 
 types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::Dynamic_AC_CLReqControlMode& mode) {
-    const auto max_charge_L1 = dt::from_RationalNumber(mode.max_charge_power);
-    const auto max_charge_L2 = convert_from_optional(mode.max_charge_power_L2);
-    const auto max_charge_L3 = convert_from_optional(mode.max_charge_power_L3);
-    const auto max_charge_total = max_charge_L1 + max_charge_L2.value_or(0.0) + max_charge_L3.value_or(0.0);
-
-    const auto min_charge_L1 = dt::from_RationalNumber(mode.min_charge_power);
-    const auto min_charge_L2 = convert_from_optional(mode.min_charge_power_L2);
-    const auto min_charge_L3 = convert_from_optional(mode.min_charge_power_L3);
-    const auto min_charge_total = min_charge_L1 + min_charge_L2.value_or(0.0) + min_charge_L3.value_or(0.0);
-
-    types::iso15118::AcEvPowerLimits ac_ev_power_limits;
-
-    ac_ev_power_limits.max_charge_power = {max_charge_total, std::make_optional<float>(max_charge_L1), max_charge_L2,
-                                           max_charge_L3};
-    ac_ev_power_limits.min_charge_power = {min_charge_total, std::make_optional<float>(min_charge_L1), min_charge_L2,
-                                           min_charge_L3};
-
-    return ac_ev_power_limits;
+    types::iso15118::AcEvPowerLimits limits;
+    limits.max_charge_power = make_ac_power(mode.max_charge_power, mode.max_charge_power_L2, mode.max_charge_power_L3);
+    limits.min_charge_power = make_ac_power(mode.min_charge_power, mode.min_charge_power_L2, mode.min_charge_power_L3);
+    return limits;
 }
 
 types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::BPT_Dynamic_AC_CLReqControlMode& mode) {
-    const auto max_charge_L1 = dt::from_RationalNumber(mode.max_charge_power);
-    const auto max_charge_L2 = convert_from_optional(mode.max_charge_power_L2);
-    const auto max_charge_L3 = convert_from_optional(mode.max_charge_power_L3);
-    const auto max_charge_total = max_charge_L1 + max_charge_L2.value_or(0.0) + max_charge_L3.value_or(0.0);
-
-    const auto min_charge_L1 = dt::from_RationalNumber(mode.min_charge_power);
-    const auto min_charge_L2 = convert_from_optional(mode.min_charge_power_L2);
-    const auto min_charge_L3 = convert_from_optional(mode.min_charge_power_L3);
-    const auto min_charge_total = min_charge_L1 + min_charge_L2.value_or(0.0) + min_charge_L3.value_or(0.0);
-
-    const auto max_discharge_L1 = dt::from_RationalNumber(mode.max_discharge_power);
-    const auto max_discharge_L2 = convert_from_optional(mode.max_discharge_power_L2);
-    const auto max_discharge_L3 = convert_from_optional(mode.max_discharge_power_L3);
-    const auto max_discharge_total = max_discharge_L1 + max_discharge_L2.value_or(0.0) + max_discharge_L3.value_or(0.0);
-
-    const auto min_discharge_L1 = dt::from_RationalNumber(mode.min_discharge_power);
-    const auto min_discharge_L2 = convert_from_optional(mode.min_discharge_power_L2);
-    const auto min_discharge_L3 = convert_from_optional(mode.min_discharge_power_L3);
-    const auto min_discharge_total = min_discharge_L1 + min_discharge_L2.value_or(0.0) + min_discharge_L3.value_or(0.0);
-
-    types::iso15118::AcEvPowerLimits ac_ev_power_limits;
-
-    ac_ev_power_limits.max_charge_power = {max_charge_total, std::make_optional<float>(max_charge_L1), max_charge_L2,
-                                           max_charge_L3};
-    ac_ev_power_limits.min_charge_power = {min_charge_total, std::make_optional<float>(min_charge_L1), min_charge_L2,
-                                           min_charge_L3};
-    ac_ev_power_limits.max_discharge_power = {max_discharge_total, std::make_optional<float>(max_discharge_L1),
-                                              max_discharge_L2, max_discharge_L3};
-    ac_ev_power_limits.min_discharge_power = {min_discharge_total, std::make_optional<float>(min_discharge_L1),
-                                              min_discharge_L2, min_discharge_L3};
-
-    return ac_ev_power_limits;
+    types::iso15118::AcEvPowerLimits limits;
+    limits.max_charge_power = make_ac_power(mode.max_charge_power, mode.max_charge_power_L2, mode.max_charge_power_L3);
+    limits.min_charge_power = make_ac_power(mode.min_charge_power, mode.min_charge_power_L2, mode.min_charge_power_L3);
+    limits.max_discharge_power =
+        make_ac_power(mode.max_discharge_power, mode.max_discharge_power_L2, mode.max_discharge_power_L3);
+    limits.min_discharge_power =
+        make_ac_power(mode.min_discharge_power, mode.min_discharge_power_L2, mode.min_discharge_power_L3);
+    return limits;
 }
 
 types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::Scheduled_AC_CLReqControlMode& mode) {
-    const auto max_charge_L1 = convert_from_optional(mode.max_charge_power);
-    const auto max_charge_L2 = convert_from_optional(mode.max_charge_power_L2);
-    const auto max_charge_L3 = convert_from_optional(mode.max_charge_power_L3);
-    const auto max_charge_total =
-        max_charge_L1.value_or(0.0) + max_charge_L2.value_or(0.0) + max_charge_L3.value_or(0.0);
-
-    const auto min_charge_L1 = convert_from_optional(mode.min_charge_power);
-    const auto min_charge_L2 = convert_from_optional(mode.min_charge_power_L2);
-    const auto min_charge_L3 = convert_from_optional(mode.min_charge_power_L3);
-    const auto min_charge_total =
-        min_charge_L1.value_or(0.0) + min_charge_L2.value_or(0.0) + min_charge_L3.value_or(0.0);
-
-    types::iso15118::AcEvPowerLimits ac_ev_power_limits;
-
-    ac_ev_power_limits.max_charge_power =
-        (max_charge_L1.has_value() or max_charge_L2.has_value() or max_charge_L3.has_value())
-            ? std::make_optional<types::units::Power>({max_charge_total, max_charge_L1, max_charge_L2, max_charge_L3})
-            : std::nullopt;
-    ac_ev_power_limits.min_charge_power =
-        (max_charge_L1.has_value() or max_charge_L2.has_value() or max_charge_L3.has_value())
-            ? std::make_optional<types::units::Power>({min_charge_total, min_charge_L1, min_charge_L2, min_charge_L3})
-            : std::nullopt;
-
-    return ac_ev_power_limits;
+    types::iso15118::AcEvPowerLimits limits;
+    limits.max_charge_power = make_ac_power(mode.max_charge_power, mode.max_charge_power_L2, mode.max_charge_power_L3);
+    limits.min_charge_power = make_ac_power(mode.min_charge_power, mode.min_charge_power_L2, mode.min_charge_power_L3);
+    return limits;
 }
 
 types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::BPT_Scheduled_AC_CLReqControlMode& mode) {
-    const auto max_charge_L1 = convert_from_optional(mode.max_charge_power);
-    const auto max_charge_L2 = convert_from_optional(mode.max_charge_power_L2);
-    const auto max_charge_L3 = convert_from_optional(mode.max_charge_power_L3);
-    const auto max_charge_total =
-        max_charge_L1.value_or(0.0) + max_charge_L2.value_or(0.0) + max_charge_L3.value_or(0.0);
+    types::iso15118::AcEvPowerLimits limits;
+    limits.max_charge_power = make_ac_power(mode.max_charge_power, mode.max_charge_power_L2, mode.max_charge_power_L3);
+    limits.min_charge_power = make_ac_power(mode.min_charge_power, mode.min_charge_power_L2, mode.min_charge_power_L3);
+    limits.max_discharge_power =
+        make_ac_power(mode.max_discharge_power, mode.max_discharge_power_L2, mode.max_discharge_power_L3);
+    limits.min_discharge_power =
+        make_ac_power(mode.min_discharge_power, mode.min_discharge_power_L2, mode.min_discharge_power_L3);
+    return limits;
+}
 
-    const auto min_charge_L1 = convert_from_optional(mode.min_charge_power);
-    const auto min_charge_L2 = convert_from_optional(mode.min_charge_power_L2);
-    const auto min_charge_L3 = convert_from_optional(mode.min_charge_power_L3);
-    const auto min_charge_total =
-        min_charge_L1.value_or(0.0) + min_charge_L2.value_or(0.0) + min_charge_L3.value_or(0.0);
+types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::DER_AC_CPDReqEnergyTransferMode& mode) {
+    // TODO(ml): surface the DER-only fields (processing, session_total_discharge_energy_available,
+    // reactive_power_limits) once needed.
+    types::iso15118::AcEvPowerLimits limits;
+    limits.max_charge_power = make_ac_power(mode.max_charge_power, mode.max_charge_power_L2, mode.max_charge_power_L3);
+    limits.min_charge_power = make_ac_power(mode.min_charge_power, mode.min_charge_power_L2, mode.min_charge_power_L3);
+    limits.max_discharge_power =
+        make_ac_power(mode.max_discharge_power, mode.max_discharge_power_L2, mode.max_discharge_power_L3);
+    limits.min_discharge_power =
+        make_ac_power(mode.min_discharge_power, mode.min_discharge_power_L2, mode.min_discharge_power_L3);
+    return limits;
+}
 
-    const auto max_discharge_L1 = convert_from_optional(mode.max_discharge_power);
-    const auto max_discharge_L2 = convert_from_optional(mode.max_discharge_power_L2);
-    const auto max_discharge_L3 = convert_from_optional(mode.max_discharge_power_L3);
-    const auto max_discharge_total =
-        max_discharge_L1.value_or(0.0) + max_discharge_L2.value_or(0.0) + max_discharge_L3.value_or(0.0);
+types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::DER_Scheduled_AC_CLReqControlMode& mode) {
+    // Charge fields are optional (Scheduled base); discharge L1 is mandatory in the DER variant.
+    types::iso15118::AcEvPowerLimits limits;
+    limits.max_charge_power = make_ac_power(mode.max_charge_power, mode.max_charge_power_L2, mode.max_charge_power_L3);
+    limits.min_charge_power = make_ac_power(mode.min_charge_power, mode.min_charge_power_L2, mode.min_charge_power_L3);
+    limits.max_discharge_power =
+        make_ac_power(mode.max_discharge_power, mode.max_discharge_power_L2, mode.max_discharge_power_L3);
+    limits.min_discharge_power =
+        make_ac_power(mode.min_discharge_power, mode.min_discharge_power_L2, mode.min_discharge_power_L3);
+    return limits;
+}
 
-    const auto min_discharge_L1 = convert_from_optional(mode.min_discharge_power);
-    const auto min_discharge_L2 = convert_from_optional(mode.min_discharge_power_L2);
-    const auto min_discharge_L3 = convert_from_optional(mode.min_discharge_power_L3);
-    const auto min_discharge_total =
-        min_discharge_L1.value_or(0.0) + min_discharge_L2.value_or(0.0) + min_discharge_L3.value_or(0.0);
-
-    types::iso15118::AcEvPowerLimits ac_ev_power_limits;
-
-    ac_ev_power_limits.max_charge_power =
-        (max_charge_L1.has_value() or max_charge_L2.has_value() or max_charge_L3.has_value())
-            ? std::make_optional<types::units::Power>({max_charge_total, max_charge_L1, max_charge_L2, max_charge_L3})
-            : std::nullopt;
-    ac_ev_power_limits.min_charge_power =
-        (min_charge_L1.has_value() or min_charge_L2.has_value() or min_charge_L3.has_value())
-            ? std::make_optional<types::units::Power>({min_charge_total, min_charge_L1, min_charge_L2, min_charge_L3})
-            : std::nullopt;
-    ac_ev_power_limits.max_discharge_power =
-        (max_discharge_L1.has_value() or max_discharge_L2.has_value() or max_discharge_L3.has_value())
-            ? std::make_optional<types::units::Power>(
-                  {max_discharge_total, max_discharge_L1, max_discharge_L2, max_discharge_L3})
-            : std::nullopt;
-    ac_ev_power_limits.min_discharge_power =
-        (min_discharge_L1.has_value() or min_discharge_L2.has_value() or min_discharge_L3.has_value())
-            ? std::make_optional<types::units::Power>(
-                  {min_discharge_total, min_discharge_L1, min_discharge_L2, min_discharge_L3})
-            : std::nullopt;
-    return ac_ev_power_limits;
+types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::DER_Dynamic_AC_CLReqControlMode& mode) {
+    types::iso15118::AcEvPowerLimits limits;
+    limits.max_charge_power = make_ac_power(mode.max_charge_power, mode.max_charge_power_L2, mode.max_charge_power_L3);
+    limits.min_charge_power = make_ac_power(mode.min_charge_power, mode.min_charge_power_L2, mode.min_charge_power_L3);
+    limits.max_discharge_power =
+        make_ac_power(mode.max_discharge_power, mode.max_discharge_power_L2, mode.max_discharge_power_L3);
+    limits.min_discharge_power =
+        make_ac_power(mode.min_discharge_power, mode.min_discharge_power_L2, mode.min_discharge_power_L3);
+    return limits;
 }
 
 types::iso15118::AcEvPresentPowerValues fill_ac_ev_present_power_values(const dt::Dynamic_AC_CLReqControlMode& mode) {

--- a/modules/EVSE/Evse15118D20/charger/utils.hpp
+++ b/modules/EVSE/Evse15118D20/charger/utils.hpp
@@ -12,6 +12,8 @@
 #include <iso15118/d20/ev_information.hpp>
 #include <iso15118/message/ac_charge_loop.hpp>
 #include <iso15118/message/ac_charge_parameter_discovery.hpp>
+#include <iso15118/message/ac_der_iec_charge_loop.hpp>
+#include <iso15118/message/ac_der_iec_charge_parameter_discovery.hpp>
 #include <iso15118/message/dc_charge_loop.hpp>
 #include <iso15118/message/service_detail.hpp>
 #include <iso15118/message/type.hpp>
@@ -145,6 +147,9 @@ types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::Dynamic_AC_CL
 types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::BPT_Dynamic_AC_CLReqControlMode& mode);
 types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::Scheduled_AC_CLReqControlMode& mode);
 types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::BPT_Scheduled_AC_CLReqControlMode& mode);
+types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::DER_AC_CPDReqEnergyTransferMode& mode);
+types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::DER_Scheduled_AC_CLReqControlMode& mode);
+types::iso15118::AcEvPowerLimits fill_ac_ev_power_limits(const dt::DER_Dynamic_AC_CLReqControlMode& mode);
 
 types::iso15118::AcEvPresentPowerValues fill_ac_ev_present_power_values(const dt::Dynamic_AC_CLReqControlMode& mode);
 types::iso15118::AcEvPresentPowerValues fill_ac_ev_present_power_values(const dt::Scheduled_AC_CLReqControlMode& mode);


### PR DESCRIPTION
## Describe your changes

Wires the EVerest **module layer** for ISO 15118-20 **AC DER (IEC)** on top of the
libiso15118 AC DER IEC state machine. With this, the SECC offers `AC_DER_IEC` and
completes ChargeParameterDiscovery without shutting the session down.

**EvseManager** (`modules/EVSE/EvseManager/`)
- Offers `AC_DER_IEC` as a supported AC energy-transfer mode when export capabilities are
  present. The advertise logic (`get_supported_ac_energy_transfers`) was lifted out of the
  anonymous namespace in `EvseManager.cpp` into a standalone, unit-tested translation unit
  `ac_energy_transfer.{hpp,cpp}`.
- The offer is gated by a compile-time `offer_iso_ac_der_iec` constant — a deliberate
  throwaway trigger (default `false`) that stands in until the `grid_support`
  `set_der_capability` push supplies this at runtime. It is intentionally **not** a
  module-config option.

**Evse15118D20** (`modules/EVSE/Evse15118D20/charger/`)
- Populates hardcoded safe `der_limits` in `ready()` so AC_DER_IEC ChargeParameterDiscovery
  no longer returns `FAILED_WrongChargeParameter` and shuts the session down.
  `der_setup_config` is left unset and relies on libiso15118's
  `{GridFollowing, GridConnected}` default.
- Handles the DER transfer-mode and control-mode variants (`DER_AC_CPDReq`, `DER_Scheduled`,
  `DER_Dynamic`) in the AC feedback callbacks (`ISO15118_chargerImpl.cpp`).
- Consolidates the per-phase AC power-limit conversion behind a single `make_ac_power`
  helper in `utils.cpp`, replacing nine near-duplicate `fill_ac_ev_power_limits` overloads.
  This also removes a latent bug where scheduled-mode `min_charge_power` was gated on the
  `max_charge_*` fields' presence.
- Fixes the `AC_DER_SAE` conversion case that `return`ed instead of `break`ing, which
  silently dropped any energy-transfer modes listed after it.

### Scope and limitations
- **IEC only.** No SAE state machine exists in libiso15118 yet, so SAE is out of scope here
  (only the `AC_DER_SAE` enum-mapping drop is fixed).
- **Hardcoded DER values** are safe placeholders until the `grid_support` interface lands
  (marked `TODO(ml)`). No new EVerest DER types are introduced.
- **No EV-side support.** PyEvJosev does not implement AC_DER, so a full end-to-end DER
  charge loop in SIL is not achievable. Verification is that the service is offered and the
  session survives ChargeParameterDiscovery, backed by the libiso15118 DER FSM tests and
  the new EvseManager unit tests.

### Stacked PR
Based on `feat/libiso15118-ac-der-iec-state-machine` (the libiso15118 AC DER IEC state
machine). **Review and merge that branch first** — this PR's diff is only the module-layer
wiring stacked on top of it.

### Verification
- `ninja -C build install` — clean build (warnings-as-errors enabled).
- `ctest -R AcEnergyTransfer` — EvseManager advertise unit tests pass (9 cases).
- `ctest -R "der iec"` — libiso15118 DER FSM tests stay green (4/4).
- `ctest -R EvseManager` — no regression (3/3 targets).

## Issue ticket number and link

N/A — module-layer follow-up stacked on the libiso15118 AC DER IEC state machine.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
