### PR TITLE
fix(EvseManager): refresh Inoperative error when the active fatal cause set changes

### DIFF
--- a/modules/EVSE/EvseManager/ErrorHandling.cpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.cpp
@@ -158,13 +158,17 @@ void ErrorHandling::clear_over_voltage_error() {
 
 // Find out if the current error set is fatal to charging or not
 void ErrorHandling::process_error() {
+    // Called from every requirement's error callbacks (potentially on different threads). Holding the monitor handle
+    // serializes the whole inoperative_causes read-compare-clear-raise sequence below so it cannot interleave.
+    auto causes = inoperative_causes.handle();
+
     const auto fatal = errors_prevent_charging();
-    if (fatal) {
-        // signal to charger a new error has been set that prevents charging
-        raise_inoperative_error(*fatal);
+    if (not fatal.empty()) {
+        // signal to charger that errors are active that prevent charging
+        raise_inoperative_error(fatal, *causes);
     } else {
         // signal an error that does not prevent charging
-        clear_inoperative_error();
+        clear_inoperative_error(*causes);
     }
 
     // All errors cleared signal is for OCPP 1.6. It is triggered when there are no errors anymore,
@@ -189,117 +193,127 @@ void ErrorHandling::process_error() {
     }
 }
 
-// Check all errors from p_evse and all requirements to see if they block charging
-std::optional<Everest::error::Error> ErrorHandling::errors_prevent_charging() {
+// Collect all errors from p_evse and all requirements that block charging, in detection order.
+std::vector<Everest::error::Error> ErrorHandling::errors_prevent_charging() {
+    std::vector<Everest::error::Error> fatal_errors;
 
-    auto is_fatal = [](auto errors, auto ignore_list) -> std::optional<Everest::error::Error> {
+    auto collect_fatal = [&fatal_errors](const auto& errors, const auto& ignore_list) {
         for (const auto& e : errors) {
-            if (std::none_of(ignore_list.begin(), ignore_list.end(), [e](const auto& ign) { return e->type == ign; })) {
-                return *e;
+            if (std::none_of(ignore_list.begin(), ignore_list.end(),
+                             [&e](const auto& ign) { return e->type == ign; })) {
+                fatal_errors.push_back(*e);
             }
         }
-        return std::nullopt;
     };
 
-    auto fatal = is_fatal(p_evse->error_state_monitor->get_active_errors(), ignore_errors.evse);
-    if (fatal) {
-        return fatal;
-    }
-
-    fatal = is_fatal(r_bsp->error_state_monitor->get_active_errors(), ignore_errors.bsp);
-    if (fatal) {
-        return fatal;
-    }
-
+    collect_fatal(p_evse->error_state_monitor->get_active_errors(), ignore_errors.evse);
+    collect_fatal(r_bsp->error_state_monitor->get_active_errors(), ignore_errors.bsp);
     if (r_connector_lock.size() > 0) {
-        fatal = is_fatal(r_connector_lock[0]->error_state_monitor->get_active_errors(), ignore_errors.connector_lock);
-        if (fatal) {
-            return fatal;
-        }
+        collect_fatal(r_connector_lock[0]->error_state_monitor->get_active_errors(), ignore_errors.connector_lock);
     }
-
     if (r_ac_rcd.size() > 0) {
-        fatal = is_fatal(r_ac_rcd[0]->error_state_monitor->get_active_errors(), ignore_errors.ac_rcd);
-        if (fatal) {
-            return fatal;
-        }
+        collect_fatal(r_ac_rcd[0]->error_state_monitor->get_active_errors(), ignore_errors.ac_rcd);
     }
-
     if (r_imd.size() > 0) {
-        fatal = is_fatal(r_imd[0]->error_state_monitor->get_active_errors(), ignore_errors.imd);
-        if (fatal) {
-            return fatal;
-        }
+        collect_fatal(r_imd[0]->error_state_monitor->get_active_errors(), ignore_errors.imd);
     }
-
     if (r_powersupply.size() > 0) {
-        fatal = is_fatal(r_powersupply[0]->error_state_monitor->get_active_errors(), ignore_errors.powersupply);
-        if (fatal) {
-            return fatal;
-        }
+        collect_fatal(r_powersupply[0]->error_state_monitor->get_active_errors(), ignore_errors.powersupply);
     }
-
     if (r_powermeter.size() > 0) {
-        fatal = is_fatal(r_powermeter[0]->error_state_monitor->get_active_errors(), ignore_errors.powermeter);
-        if (fatal) {
-            return fatal;
-        }
+        collect_fatal(r_powermeter[0]->error_state_monitor->get_active_errors(), ignore_errors.powermeter);
     }
-
     if (r_slac.size() > 0) {
-        fatal = is_fatal(r_slac[0]->error_state_monitor->get_active_errors(), ignore_errors.slac);
-        if (fatal) {
-            return fatal;
-        }
+        collect_fatal(r_slac[0]->error_state_monitor->get_active_errors(), ignore_errors.slac);
     }
-
     if (r_hlc.size() > 0) {
-        fatal = is_fatal(r_hlc[0]->error_state_monitor->get_active_errors(), ignore_errors.hlc);
-        if (fatal) {
-            return fatal;
-        }
+        collect_fatal(r_hlc[0]->error_state_monitor->get_active_errors(), ignore_errors.hlc);
     }
-
     if (r_over_voltage_monitor.size() > 0) {
-        fatal = is_fatal(r_over_voltage_monitor[0]->error_state_monitor->get_active_errors(),
-                         ignore_errors.over_voltage_monitor);
-        if (fatal) {
-            return fatal;
-        }
+        collect_fatal(r_over_voltage_monitor[0]->error_state_monitor->get_active_errors(),
+                      ignore_errors.over_voltage_monitor);
     }
 
-    return std::nullopt;
+    return fatal_errors;
 }
 
-void ErrorHandling::raise_inoperative_error(const Everest::error::Error& caused_by) {
-    if (p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", "")) {
-        // dont raise if already raised
+// Caller must hold the inoperative_causes monitor handle (this mutates it).
+void ErrorHandling::raise_inoperative_error(const std::vector<Everest::error::Error>& causes,
+                                            InoperativeCauses& inoperative_causes) {
+    if (causes.empty()) {
         return;
     }
 
-    // raise externally
+    auto is_emergency = [](const auto& errors) {
+        return std::any_of(errors.begin(), errors.end(), [](const Everest::error::Error& cause) {
+            return cause.severity == Everest::error::Severity::High;
+        });
+    };
+
+    // Everest::error::Error has no operator==, so compare the two sets by their (type, sub_type) keys via the
+    // comparator: same size and every corresponding element equivalent under ErrorCauseLess.
+    auto same_causes = [](const InoperativeCauses& a, const InoperativeCauses& b) {
+        const ErrorCauseLess less;
+        return a.size() == b.size() &&
+               std::equal(a.begin(), a.end(), b.begin(),
+                          [&less](const Everest::error::Error& x, const Everest::error::Error& y) {
+                              return not less(x, y) and not less(y, x);
+                          });
+    };
+
+    // Key the causes on (type, sub_type); the set makes change-detection independent of detection order.
+    const InoperativeCauses current(causes.begin(), causes.end());
+
+    const bool already_raised = p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", "");
+    if (already_raised && same_causes(current, inoperative_causes)) {
+        // Same set of causes, nothing to update.
+        return;
+    }
+
+    const bool was_emergency = is_emergency(inoperative_causes);
+
+    if (already_raised) {
+        // Causes changed: the framework has no in-place update, so clear and re-raise. No
+        // AllErrorsPreventingChargingCleared is emitted, keeping the charger shut down across the refresh.
+        p_evse->clear_error("evse_manager/Inoperative");
+    }
+
+    // First cause drives message and vendor_id; the description lists every active cause. Downstream consumers with
+    // shorter limits (e.g. OCPP 1.6 StatusNotification, CiString<50>) truncate it themselves.
+    const auto& primary = causes.front();
+    std::string description = generate_description(primary);
+    for (auto it = std::next(causes.begin()); it != causes.end(); ++it) {
+        description += ", " + generate_description(*it);
+    }
+
     Everest::error::Error error_object = p_evse->error_factory->create_error(
-        "evse_manager/Inoperative", "", caused_by.type, Everest::error::Severity::High);
-    error_object.description = generate_description(caused_by);
-    if (inoperative_error_use_vendor_id && !caused_by.vendor_id.empty()) {
-        error_object.vendor_id = caused_by.vendor_id;
+        "evse_manager/Inoperative", "", primary.type, Everest::error::Severity::High);
+    error_object.description = description;
+    if (inoperative_error_use_vendor_id && !primary.vendor_id.empty()) {
+        error_object.vendor_id = primary.vendor_id;
     } else {
         error_object.vendor_id = "EVerest";
     }
     p_evse->raise_error(error_object);
+    // Track what we just raised, so the next call detects a changed cause set.
+    inoperative_causes = current;
 
-    // shutdown based on severity
-    if (caused_by.severity == Everest::error::Severity::High) {
-        signal_error(ErrorHandlingEvents::ForceEmergencyShutdown);
-    } else {
-        signal_error(ErrorHandlingEvents::ForceErrorShutdown);
+    // Emergency shutdown if any active cause is high severity, otherwise error shutdown. Only (re)signal on a genuine
+    // transition -- the first raise or a change of shutdown type. A pure description refresh must not re-signal:
+    // downstream this cancels an active reservation again (EvseManager) on every refresh, and the charger already
+    // stays shut down without a repeat.
+    const bool emergency = is_emergency(causes);
+    if (not already_raised or emergency != was_emergency) {
+        signal_error(emergency ? ErrorHandlingEvents::ForceEmergencyShutdown : ErrorHandlingEvents::ForceErrorShutdown);
     }
 }
 
-void ErrorHandling::clear_inoperative_error() {
+// Caller must hold the inoperative_causes monitor handle (this mutates it).
+void ErrorHandling::clear_inoperative_error(InoperativeCauses& inoperative_causes) {
     // clear externally
     if (p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", "")) {
         p_evse->clear_error("evse_manager/Inoperative");
+        inoperative_causes.clear();
         signal_error(ErrorHandlingEvents::AllErrorsPreventingChargingCleared);
     }
 }

--- a/modules/EVSE/EvseManager/ErrorHandling.hpp
+++ b/modules/EVSE/EvseManager/ErrorHandling.hpp
@@ -19,8 +19,13 @@
 
 #include <chrono>
 #include <mutex>
-#include <optional>
 #include <queue>
+#include <set>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <everest/util/async/monitor.hpp>
 
 #include <generated/interfaces/ISO15118_charger/Interface.hpp>
 #include <generated/interfaces/ac_rcd/Interface.hpp>
@@ -103,12 +108,22 @@ public:
     void clear_voltage_plausibility_fault();
 
 protected:
-    void raise_inoperative_error(const Everest::error::Error& caused_by);
+    // Orders errors by (type, sub_type) only, so inoperative_causes tracks the identity of the active fatal set
+    // regardless of detection order.
+    struct ErrorCauseLess {
+        bool operator()(const Everest::error::Error& a, const Everest::error::Error& b) const {
+            return std::tie(a.type, a.sub_type) < std::tie(b.type, b.sub_type);
+        }
+    };
+    using InoperativeCauses = std::set<Everest::error::Error, ErrorCauseLess>;
+
+    void raise_inoperative_error(const std::vector<Everest::error::Error>& causes,
+                                 InoperativeCauses& inoperative_causes);
 
 private:
     void process_error();
-    void clear_inoperative_error();
-    std::optional<Everest::error::Error> errors_prevent_charging();
+    void clear_inoperative_error(InoperativeCauses& inoperative_causes);
+    std::vector<Everest::error::Error> errors_prevent_charging();
 
     const std::unique_ptr<evse_board_supportIntf>& r_bsp;
     const std::vector<std::unique_ptr<ISO15118_chargerIntf>>& r_hlc;
@@ -121,6 +136,13 @@ private:
     const std::vector<std::unique_ptr<slacIntf>>& r_slac;
     const std::vector<std::unique_ptr<over_voltage_monitorIntf>>& r_over_voltage_monitor;
     const bool inoperative_error_use_vendor_id;
+
+    // The fatal causes the raised Inoperative error currently describes; empty while Inoperative is not raised. Used
+    // to refresh that error when the active fatal set changes. The monitor bundles the state with the mutex that
+    // guards it: process_error() holds the handle across the whole read-compare-clear-raise sequence, which runs from
+    // every requirement's error callbacks (potentially on different threads). Passing the guarded set explicitly into
+    // raise_/clear_inoperative_error() also makes it impossible to mutate it without holding the lock.
+    everest::lib::util::monitor<InoperativeCauses> inoperative_causes;
 };
 
 } // namespace module

--- a/modules/EVSE/EvseManager/tests/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${TEST_TARGET_NAME} PRIVATE
     everest::framework
     everest::helpers
     pugixml::pugixml
+    everest::util
     sigslot
 )
 
@@ -72,6 +73,7 @@ target_link_libraries(${CHARGER_TEST_TARGET_NAME} PRIVATE
     GTest::gtest_main
     everest::framework
     everest::helpers
+    everest::util
     sigslot
 )
 

--- a/modules/EVSE/EvseManager/tests/ErrorHandlingTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ErrorHandlingTest.cpp
@@ -22,7 +22,9 @@ bool operator==(const Error& lhs, const Error& rhs) {
 namespace {
 
 struct ErrorHandlingTest : public module::ErrorHandling {
+    using module::ErrorHandling::ErrorCauseLess;
     using module::ErrorHandling::ErrorHandling;
+    using module::ErrorHandling::InoperativeCauses;
     using module::ErrorHandling::raise_inoperative_error;
 };
 
@@ -140,6 +142,10 @@ struct ErrorHandlingTesting : public testing::Test {
 
     std::unique_ptr<ErrorHandlingTest> error_handler;
 
+    // Cause-tracking set that production code keeps inside the inoperative_causes monitor; the tests drive
+    // raise_inoperative_error() directly, so they own it and pass it across calls to exercise the refresh logic.
+    ErrorHandlingTest::InoperativeCauses inoperative_causes;
+
     void construct(bool _inoperative_error_use_vendor_id, bool connect_slac = false, bool connect_hlc = false) {
         error_types_map = {{"evse_board_support/VendorWarning", "warning"},
                            {"generic/CommunicationFault", "communication fault"},
@@ -156,6 +162,7 @@ struct ErrorHandlingTesting : public testing::Test {
         adapter.hlc_active_errors.clear();
         r_slac.clear();
         r_hlc.clear();
+        inoperative_causes.clear();
         for (const auto& [error, description] : error_types_map) {
             adapter.error_list.push_back(error);
         }
@@ -188,7 +195,7 @@ struct ErrorHandlingTesting : public testing::Test {
         error.message = "message";
         error.description = default_description;
         error.vendor_id = default_vendor_id;
-        error_handler->raise_inoperative_error(error);
+        error_handler->raise_inoperative_error({error}, inoperative_causes);
 
         EXPECT_EQ(adapter.active_errors.size(), 1);
         auto& active = adapter.active_errors.front();
@@ -349,7 +356,7 @@ TEST_F(ErrorHandlingTesting, NoVendorId) {
     raised_error.vendor_id = "";
 
     construct(true);
-    error_handler->raise_inoperative_error(raised_error);
+    error_handler->raise_inoperative_error({raised_error}, inoperative_causes);
     EXPECT_EQ(adapter.active_errors.size(), 1);
     auto& error = adapter.active_errors.front();
     EXPECT_EQ(error.type, "evse_manager/Inoperative");
@@ -359,7 +366,7 @@ TEST_F(ErrorHandlingTesting, NoVendorId) {
     EXPECT_EQ(error.vendor_id, default_no_vendor_id);
 
     construct(false);
-    error_handler->raise_inoperative_error(raised_error);
+    error_handler->raise_inoperative_error({raised_error}, inoperative_causes);
     EXPECT_EQ(adapter.active_errors.size(), 1);
     error = adapter.active_errors.front();
     EXPECT_EQ(error.type, "evse_manager/Inoperative");
@@ -380,7 +387,7 @@ TEST_F(ErrorHandlingTesting, IsActive) {
     construct(true);
     EXPECT_FALSE(p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", ""));
 
-    error_handler->raise_inoperative_error(first_error);
+    error_handler->raise_inoperative_error({first_error}, inoperative_causes);
     EXPECT_EQ(adapter.active_errors.size(), 1);
     auto error = adapter.active_errors.front();
     EXPECT_EQ(error.type, "evse_manager/Inoperative");
@@ -398,13 +405,43 @@ TEST_F(ErrorHandlingTesting, IsActive) {
     raised_error.description = "new-description";
     raised_error.vendor_id = "new-vendor_id";
 
-    // should not be a new error
-    error_handler->raise_inoperative_error(raised_error);
+    // The fatal cause changed: the Inoperative error is refreshed to the new cause, not frozen at the first.
+    error_handler->raise_inoperative_error({raised_error}, inoperative_causes);
     EXPECT_EQ(adapter.active_errors.size(), 1);
     error = adapter.active_errors.front();
-    // should be first error
     EXPECT_EQ(error.type, "evse_manager/Inoperative");
     EXPECT_EQ(error.sub_type, "");
+    EXPECT_EQ(error.message, raised_error.type);
+    EXPECT_EQ(error.description, "new-type/new-sub-type");
+    EXPECT_EQ(error.vendor_id, raised_error.vendor_id);
+
+    EXPECT_TRUE(p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", ""));
+}
+
+TEST_F(ErrorHandlingTesting, SameCausesDoNotRefresh) {
+    Everest::error::Error first_error{};
+    first_error.type = "module/type";
+    first_error.sub_type = "sub-type";
+    first_error.message = "message";
+    first_error.description = "description";
+    first_error.vendor_id = "vendor_id";
+
+    construct(true);
+    error_handler->raise_inoperative_error({first_error}, inoperative_causes);
+    EXPECT_EQ(adapter.active_errors.size(), 1);
+
+    // The same set of causes must not clear / re-raise: the existing Inoperative error keeps its original fields
+    // (and, in production, its uuid + timestamp).
+    Everest::error::Error same_cause{};
+    same_cause.type = "module/type";
+    same_cause.sub_type = "sub-type";
+    same_cause.message = "different-message";
+    same_cause.description = "different-description";
+    same_cause.vendor_id = "different-vendor_id";
+
+    error_handler->raise_inoperative_error({same_cause}, inoperative_causes);
+    EXPECT_EQ(adapter.active_errors.size(), 1);
+    const auto& error = adapter.active_errors.front();
     EXPECT_EQ(error.message, first_error.type);
     EXPECT_EQ(error.description, "type/sub-type");
     EXPECT_EQ(error.vendor_id, first_error.vendor_id);
@@ -457,6 +494,56 @@ TEST_F(ErrorHandlingTesting, HlcVendorWarningIsNotFatal) {
     raise_hlc_error("generic/VendorWarning");
 
     EXPECT_FALSE(p_evse->error_state_monitor->is_error_active("evse_manager/Inoperative", ""));
+}
+
+TEST_F(ErrorHandlingTesting, DescriptionAggregatesAllCauses) {
+    Everest::error::Error cause_a{};
+    cause_a.type = "module/type-a";
+    cause_a.sub_type = "sub-a";
+    cause_a.vendor_id = "vendor-a";
+    cause_a.severity = Everest::error::Severity::High;
+
+    Everest::error::Error cause_b{};
+    cause_b.type = "module/type-b";
+    cause_b.sub_type = "";
+    cause_b.vendor_id = "vendor-b";
+    cause_b.severity = Everest::error::Severity::Medium;
+
+    construct(true);
+    error_handler->raise_inoperative_error({cause_a, cause_b}, inoperative_causes);
+    EXPECT_EQ(adapter.active_errors.size(), 1);
+    const auto& error = adapter.active_errors.front();
+    EXPECT_EQ(error.type, "evse_manager/Inoperative");
+    // message and vendor_id come from the first cause; the description lists every active cause.
+    EXPECT_EQ(error.message, cause_a.type);
+    EXPECT_EQ(error.vendor_id, cause_a.vendor_id);
+    EXPECT_EQ(error.description, "type-a/sub-a, type-b");
+}
+
+TEST_F(ErrorHandlingTesting, RefreshWhenACauseClears) {
+    Everest::error::Error cause_a{};
+    cause_a.type = "module/type-a";
+    cause_a.sub_type = "sub-a";
+    cause_a.vendor_id = "vendor-a";
+
+    Everest::error::Error cause_b{};
+    cause_b.type = "module/type-b";
+    cause_b.sub_type = "sub-b";
+    cause_b.vendor_id = "vendor-b";
+
+    construct(true);
+    error_handler->raise_inoperative_error({cause_a, cause_b}, inoperative_causes);
+    EXPECT_EQ(adapter.active_errors.size(), 1);
+    EXPECT_EQ(adapter.active_errors.front().description, "type-a/sub-a, type-b/sub-b");
+
+    // cause_a clears, cause_b remains: the Inoperative error is refreshed to the remaining cause, not frozen at
+    // cause_a.
+    error_handler->raise_inoperative_error({cause_b}, inoperative_causes);
+    EXPECT_EQ(adapter.active_errors.size(), 1);
+    const auto& error = adapter.active_errors.front();
+    EXPECT_EQ(error.message, cause_b.type);
+    EXPECT_EQ(error.vendor_id, cause_b.vendor_id);
+    EXPECT_EQ(error.description, "type-b/sub-b");
 }
 
 } // namespace


### PR DESCRIPTION
## Describe your changes

`EvseManager` raises a single aggregate `evse_manager/Inoperative` error whenever any non-ignored sub-module error is active. Today its type / description / vendor_id / uuid / timestamp are captured from the **first** active cause and never updated: `raise_inoperative_error()` early-returns while `Inoperative` is already raised, and `errors_prevent_charging()` only ever returns the first fatal error. After the original cause clears but other fatal errors remain, `Inoperative` stays raised yet still describes the now-cleared first cause — misleading for technicians.

### Observed

On a bench DC unit with an E-Stop pressed at boot **plus** a lost-DAB-heartbeat communication fault and a cable-over-temp stop all active, `Inoperative` was raised with description `MREC8EmergencyStop`. After **releasing** the E-Stop, `evse_board_support/MREC8EmergencyStop` cleared but `Inoperative` remained — still described as `MREC8EmergencyStop`, with its original boot timestamp/uuid — even though the actual remaining causes were `power_supply_DC/CommunicationFault` and `evse_board_support/MREC19CableOverTempStop`.

### What this changes

- `errors_prevent_charging()` now returns **every** active non-ignored error (in detection order) instead of only the first.
- `raise_inoperative_error()` takes the full set and:
  - builds the description from **all** currently-active fatal causes, so technicians see everything keeping the EVSE inoperative (not just the first);
  - tracks the `(type, sub_type)` set it last raised and **refreshes** the error (clear + re-raise, since the framework has no in-place error update) whenever that set changes, so the description follows the current causes instead of freezing at the first;
  - keeps the **first** cause driving `message`/`vendor_id` (preserving the behaviour added in #1175), and uses the **maximum** severity across all active causes to decide emergency vs. error shutdown.
- The refresh deliberately does **not** emit `AllErrorsPreventingChargingCleared`, so the charger stays shut down across a refresh.
- `process_error()` is serialized with a mutex: it is invoked from every requirement's error callbacks, and now mutates shared state (`inoperative_causes`), so the read-compare-clear-raise sequence must be atomic.

Downstream consumers with shorter limits (e.g. the OCPP 1.6 `StatusNotification` `vendorErrorCode`, a `CiString<50>`) already truncate the description themselves, so no length handling is added here.

### Notes / related

- This intentionally keeps the single "primary cause" semantics introduced in #1175 for `message`/`vendor_id`, while fixing the staleness and adding the full-cause aggregation in the description.
- Related but separate: #1368 (proposal to base error handling purely on severity) and #2368 (subscribing `EvseManager` to SLAC/HLC errors) — both also touch this area, so there may be a light merge to coordinate.

## Issue ticket number and link

N/A (reported internally; happy to file a tracking issue if preferred).

## Test plan

- Updated/added `modules/EVSE/EvseManager/tests/ErrorHandlingTest.cpp`:
  - `IsActive` now asserts the error **refreshes** to the new cause instead of staying frozen.
  - `SameCausesDoNotRefresh` — re-evaluating the same cause set is a no-op (no clear/re-raise; uuid/timestamp preserved).
  - `DescriptionAggregatesAllCauses` — description lists every active cause; `message`/`vendor_id` come from the first.
  - `RefreshWhenACauseClears` — when one of several causes clears, the error refreshes to the remaining cause(s).
- `EvseManager` unit tests build and pass (16/16) locally.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the contribution documentation and made sure that my changes meet its requirements
