### PR TITLE
fix(System,Linux_Systemd_Rauc): restrict diagnostics upload protocols

### DIFF
--- a/modules/Misc/Linux_Systemd_Rauc/diagnostics_uploader.sh
+++ b/modules/Misc/Linux_Systemd_Rauc/diagnostics_uploader.sh
@@ -9,7 +9,7 @@
 
 echo "$UPLOADING"
 sleep 2
-curl -L --progress-bar --proto =ftp,ftps,http,https --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
+curl -L --progress-bar --proto =ftp,ftps,http,https --proto-default https --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
 curl_exit_code=$?
 if [[ $curl_exit_code -eq 0 ]]; then
     echo "$UPLOADED"

--- a/modules/Misc/Linux_Systemd_Rauc/diagnostics_uploader.sh
+++ b/modules/Misc/Linux_Systemd_Rauc/diagnostics_uploader.sh
@@ -5,7 +5,6 @@
 # Copyright Pionix GmbH and Contributors to EVerest
 #
 
-
 . "${1}"
 
 echo "$UPLOADING"

--- a/modules/Misc/Linux_Systemd_Rauc/diagnostics_uploader.sh
+++ b/modules/Misc/Linux_Systemd_Rauc/diagnostics_uploader.sh
@@ -10,7 +10,7 @@
 
 echo "$UPLOADING"
 sleep 2
-curl -L --progress-bar --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
+curl -L --progress-bar --proto =ftp,ftps,http,https --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
 curl_exit_code=$?
 if [[ $curl_exit_code -eq 0 ]]; then
     echo "$UPLOADED"

--- a/modules/Misc/System/diagnostics_uploader.sh
+++ b/modules/Misc/System/diagnostics_uploader.sh
@@ -4,7 +4,7 @@
 
 echo "$UPLOADING"
 sleep 2
-curl --progress-bar --ssl --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
+curl --progress-bar --ssl --proto =ftp,ftps,http,https --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
 curl_exit_code=$?
 if [[ $curl_exit_code -eq 0 ]]; then
     echo "$UPLOADED"

--- a/modules/Misc/System/diagnostics_uploader.sh
+++ b/modules/Misc/System/diagnostics_uploader.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+#
+
 . "${1}"
 
 echo "$UPLOADING"

--- a/modules/Misc/System/diagnostics_uploader.sh
+++ b/modules/Misc/System/diagnostics_uploader.sh
@@ -9,7 +9,7 @@
 
 echo "$UPLOADING"
 sleep 2
-curl --progress-bar --ssl --proto =ftp,ftps,http,https --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
+curl --progress-bar --ssl --proto =ftp,ftps,http,https --proto-default https --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
 curl_exit_code=$?
 if [[ $curl_exit_code -eq 0 ]]; then
     echo "$UPLOADED"


### PR DESCRIPTION
## Describe your changes
Restricts the permissible protocols for diagnostics uploads to FTP,FTPS,HTTP and HTTPS

This is the same list of protocols supported by the OCPP SupportedFileTransferProtocols configuration key.

Use HTTPS as default protocol in diagnostics uploads 
## Issue ticket number and link
Ultimately this should be made configurable via OCPP: https://github.com/EVerest/EVerest/issues/2376
Possibly extending the `system` interface and `EVerestAPI` to provide this information to (external) implementations as well.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

