### PR TITLE
fix(EvseManager): register OVM plausibility subscription once at init

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -632,6 +632,9 @@ void EvseManager::ready() {
                     if (internal_over_voltage_monitor) {
                         internal_over_voltage_monitor->update_voltage(voltage_V);
                     }
+                    if (voltage_plausibility_monitor) {
+                        voltage_plausibility_monitor->update_over_voltage_monitor_voltage(voltage_V);
+                    }
                 });
             }
 
@@ -881,12 +884,6 @@ void EvseManager::ready() {
                 if (not r_over_voltage_monitor.empty()) {
                     r_over_voltage_monitor[0]->call_set_limits(get_emergency_over_voltage_threshold(),
                                                                get_error_over_voltage_threshold());
-                    // Subscribe to voltage measurements from over_voltage_monitor for plausibility check
-                    r_over_voltage_monitor[0]->subscribe_voltage_measurement_V([this](float voltage_V) {
-                        if (voltage_plausibility_monitor) {
-                            voltage_plausibility_monitor->update_over_voltage_monitor_voltage(voltage_V);
-                        }
-                    });
                 }
                 if (internal_over_voltage_monitor) {
                     internal_over_voltage_monitor->set_limits(get_emergency_over_voltage_threshold(),


### PR DESCRIPTION
Avoid accumulating duplicate voltage_measurement_V handlers on every dc_ev_maximum_limits message by moving the plausibility feed to the static OVM subscription.

Fixes EVerest/EVerest#2163

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

