### PR TITLE
feat(run_application): cancellable stop and output-accumulation opt-out

### DIFF
--- a/lib/everest/run_application/CMakeLists.txt
+++ b/lib/everest/run_application/CMakeLists.txt
@@ -46,3 +46,7 @@ if (DISABLE_EDM)
         TYPE STATIC
     )
 endif()
+
+if (BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/lib/everest/run_application/include/everest/run_application/run_application.hpp
+++ b/lib/everest/run_application/include/everest/run_application/run_application.hpp
@@ -2,8 +2,13 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <cstddef>
 #include <functional>
+#include <memory>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace everest::run_application {
@@ -15,18 +20,75 @@ enum class CmdControl {
     Terminate ///< Terminate application
 };
 
+/// \brief Accumulation policy: retain every line of stdout (the default).
+struct RetainAll {};
+
+/// \brief Accumulation policy: retain nothing. output and split_output stay empty; the per-line callback still fires.
+/// This is pure discard, so no omissions are counted.
+struct RetainNone {};
+
+/// \brief Accumulation policy: retain the newest lines, evicting the oldest once a cap is exceeded.
+struct RetainTail {
+    std::size_t max_lines; ///< Maximum number of retained lines
+    std::size_t max_bytes; ///< Maximum retained content bytes (Σ line.size(), excluding the '\n' separator)
+};
+
+/// \brief Accumulation policy: retain the contiguous oldest prefix, dropping everything from the first line that would
+/// breach a cap onward.
+struct RetainHead {
+    std::size_t max_lines; ///< Maximum number of retained lines
+    std::size_t max_bytes; ///< Maximum retained content bytes (Σ line.size(), excluding the '\n' separator)
+};
+
+/// \brief Accumulation policy: retain a contiguous head prefix plus a newest-lines tail, silently dropping the middle.
+struct RetainHeadTail {
+    std::size_t head_lines; ///< Maximum number of retained head lines
+    std::size_t head_bytes; ///< Maximum retained head content bytes (excluding '\n')
+    std::size_t tail_lines; ///< Maximum number of retained tail lines
+    std::size_t tail_bytes; ///< Maximum retained tail content bytes (excluding '\n')
+};
+
+/// \brief Selects how run_application retains child stdout. Illegal parameter combinations are unrepresentable.
+using AccumulationPolicy = std::variant<RetainAll, RetainNone, RetainTail, RetainHead, RetainHeadTail>;
+
 /// \brief Output and exit code of an application ran by run_application
 struct CmdOutput {
-    std::string output;                    ///< Full stdout output
-    std::vector<std::string> split_output; ///< The stdout output split after every line
+    std::string output;                    ///< Σ(line + "\n") over the retained lines, in final order
+    std::vector<std::string> split_output; ///< The retained stdout lines (no trailing newline), always whole lines
     int exit_code;                         ///< Exit code of the application
 };
+
+/// \brief Options controlling a run_application invocation.
+struct RunOptions {
+    /// Called after every line of stdout with that line. Returning CmdControl::Terminate breaks the read loop and
+    /// terminates the child. Fires for every line under every accumulation policy (including RetainNone).
+    std::function<CmdControl(const std::string& output_line)> callback = nullptr;
+    /// How stdout is retained in CmdOutput. Independent of the callback.
+    AccumulationPolicy accumulation = RetainAll{};
+    /// Optional cancellation flag. When non-null, a watcher thread terminates the child (SIGTERM, then SIGKILL after
+    /// terminate_grace) once it is set; exit_code then reflects the terminating signal.
+    std::shared_ptr<std::atomic_bool> stop_requested = nullptr;
+    /// When true, sets PR_SET_PDEATHSIG(SIGKILL) on the child (Linux only) so the kernel kills it when the calling
+    /// THREAD dies. Note this is thread death, not process death (Linux semantics): a caller that invokes
+    /// run_application on a transient worker thread will have the child killed when that worker thread exits, even if
+    /// the process lives on. Use for long-lived children that must never outlive this process even when it is aborted
+    /// without running destructors (e.g. a module process killed on shutdown), and only from a thread whose lifetime
+    /// matches the process's.
+    bool kill_child_on_parent_death = false;
+    /// Grace period between SIGTERM and the escalating SIGKILL when stop_requested fires.
+    std::chrono::milliseconds terminate_grace = std::chrono::seconds(2);
+};
+
+/// \brief Run the application specified by its \p name which can either be a full path or a binary name in PATH with
+/// the provided \p args, governed by \p opts. This overload holds all of the process logic.
+CmdOutput run_application(const std::string& name, std::vector<std::string> args, RunOptions opts);
 
 /// \brief Run the application specified by its \p name which can either be a full path or a binary name in PATH with
 /// the provided \p args.
 /// A \p output_callback can be provided that gets called after every line of stdout that is also passed to this
 /// callback. The callback must return a CmdContol of either Continue or Terminate, which decide if the application will
-/// continue running or terminated early
+/// continue running or terminated early.
+/// For cancellation, bounded output retention, or kill-on-parent-death, use the RunOptions overload above.
 CmdOutput run_application(const std::string& name, std::vector<std::string> args,
                           const std::function<CmdControl(const std::string& output_line)> output_callback = nullptr);
 

--- a/lib/everest/run_application/src/run_application.cpp
+++ b/lib/everest/run_application/src/run_application.cpp
@@ -7,22 +7,121 @@
 #include <boost/process/v1/args.hpp>
 #include <boost/process/v1/child.hpp>
 #include <boost/process/v1/cmd.hpp>
+#include <boost/process/v1/extend.hpp>
 #include <boost/process/v1/io.hpp>
 #include <boost/process/v1/pipe.hpp>
 #include <boost/process/v1/search_path.hpp>
 namespace everest_boost_process = boost::process::v1;
 #else
 #include <boost/process.hpp>
+#include <boost/process/extend.hpp>
 namespace everest_boost_process = boost::process;
 #endif
+
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <csignal>
+#include <cstddef>
+#include <deque>
+#include <exception>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <utility>
+#include <variant>
+#include <vector>
 
 #include <fmt/core.h>
 
 #include <everest/logging.hpp>
 
 namespace everest::run_application {
-CmdOutput run_application(const std::string& name, std::vector<std::string> args,
-                          const std::function<CmdControl(const std::string& output_line)> output_callback) {
+
+namespace {
+
+// Applies an AccumulationPolicy to the child's stdout lines, retaining only what the policy permits.
+// Never stores a partial line: a line that cannot fit under a cap is dropped whole.
+class Accumulator {
+public:
+    explicit Accumulator(const AccumulationPolicy& policy) : policy(policy) {
+    }
+
+    void add(const std::string& line) {
+        if (std::holds_alternative<RetainAll>(policy)) {
+            head.push_back(line);
+        } else if (std::holds_alternative<RetainNone>(policy)) {
+            // discard
+        } else if (const auto* p = std::get_if<RetainHead>(&policy)) {
+            add_head(line, p->max_lines, p->max_bytes);
+        } else if (const auto* p = std::get_if<RetainTail>(&policy)) {
+            add_tail(line, p->max_lines, p->max_bytes);
+        } else if (const auto* p = std::get_if<RetainHeadTail>(&policy)) {
+            add_head_tail(line, *p);
+        }
+    }
+
+    std::vector<std::string> take_retained() {
+        std::vector<std::string> result = std::move(head);
+        result.insert(result.end(), std::make_move_iterator(tail.begin()), std::make_move_iterator(tail.end()));
+        return result;
+    }
+
+private:
+    // Contiguous prefix: once a line breaches either cap, that line and every line after it are dropped.
+    void add_head(const std::string& line, std::size_t max_lines, std::size_t max_bytes) {
+        if (head_full) {
+            return;
+        }
+        if (head.size() >= max_lines || head_bytes + line.size() > max_bytes) {
+            head_full = true;
+            return;
+        }
+        head.push_back(line);
+        head_bytes += line.size();
+    }
+
+    // Newest lines: append, then evict from the front while over either cap.
+    void add_tail(const std::string& line, std::size_t max_lines, std::size_t max_bytes) {
+        tail.push_back(line);
+        tail_bytes += line.size();
+        while (tail.size() > max_lines || tail_bytes > max_bytes) {
+            tail_bytes -= tail.front().size();
+            tail.pop_front();
+        }
+    }
+
+    // Contiguous head first; once full every subsequent line feeds a bounded tail deque (the dropped middle).
+    void add_head_tail(const std::string& line, const RetainHeadTail& p) {
+        if (!head_full) {
+            if (head.size() >= p.head_lines || head_bytes + line.size() > p.head_bytes) {
+                head_full = true; // fall through to the tail
+            } else {
+                head.push_back(line);
+                head_bytes += line.size();
+                return;
+            }
+        }
+        add_tail(line, p.tail_lines, p.tail_bytes);
+    }
+
+    const AccumulationPolicy& policy;
+    std::vector<std::string> head; // RetainAll/RetainHead result, or the head prefix of RetainHeadTail
+    std::deque<std::string> tail;  // RetainTail result, or the tail suffix of RetainHeadTail
+    std::size_t head_bytes = 0;
+    std::size_t tail_bytes = 0;
+    bool head_full = false;
+};
+
+} // namespace
+
+CmdOutput run_application(const std::string& name, std::vector<std::string> args, RunOptions opts) {
 
     // search_path requires basename and not a full path
     boost::filesystem::path path = name;
@@ -37,19 +136,78 @@ CmdOutput run_application(const std::string& name, std::vector<std::string> args
     }
 
     everest_boost_process::ipstream stream;
-    everest_boost_process::child cmd(path, everest_boost_process::args(args), everest_boost_process::std_out > stream);
-    std::string output;
-    std::vector<std::string> split_output;
-    std::string temp;
-    auto condition = CmdControl::Continue;
-    while (std::getline(stream, temp)) {
-        output += temp + "\n";
-        if (output_callback != nullptr) {
-            condition = output_callback(temp);
+    const bool kill_child_on_parent_death = opts.kill_child_on_parent_death;
+    auto on_child_setup = [kill_child_on_parent_death](auto&) {
+#ifdef __linux__
+        if (kill_child_on_parent_death) {
+            ::prctl(PR_SET_PDEATHSIG, SIGKILL);
         }
-        split_output.push_back(temp);
-        if (condition != CmdControl::Continue) {
-            break;
+#else
+        (void)kill_child_on_parent_death;
+#endif
+    };
+    everest_boost_process::child cmd(path, everest_boost_process::args(args), everest_boost_process::std_out > stream,
+                                     everest_boost_process::extend::on_exec_setup(on_child_setup));
+
+    // On cancel: SIGTERM, then SIGKILL after the terminate_grace, which closes stdout and unblocks the read loop.
+    const auto terminate_grace = opts.terminate_grace;
+    std::atomic<bool> read_finished{false};
+    std::thread stop_watcher;
+    if (opts.stop_requested != nullptr) {
+        auto stop_requested = opts.stop_requested;
+        stop_watcher = std::thread([&, stop_requested] {
+            using namespace std::chrono_literals;
+            try {
+                while (!read_finished.load()) {
+                    if (!stop_requested->load()) {
+                        std::this_thread::sleep_for(100ms);
+                        continue;
+                    }
+                    std::error_code ec;
+                    const auto pid = cmd.id();
+                    if (pid > 0 && ::kill(pid, SIGTERM) != 0) {
+                        EVLOG_warning << fmt::format("run_application: failed to send SIGTERM to {}: {}", pid,
+                                                     std::error_code(errno, std::generic_category()).message());
+                    }
+                    const auto deadline = std::chrono::steady_clock::now() + terminate_grace;
+                    while (cmd.running(ec) && std::chrono::steady_clock::now() < deadline) {
+                        std::this_thread::sleep_for(50ms);
+                    }
+                    if (cmd.running(ec)) {
+                        cmd.terminate(ec); // SIGKILL
+                        cmd.wait(ec);      // reap so exit_code() reflects the kill signal
+                    }
+                    return;
+                }
+            } catch (const std::exception& e) {
+                EVLOG_error << "run_application stop watcher failed: " << e.what();
+            }
+        });
+    }
+
+    Accumulator accumulator{opts.accumulation};
+    auto condition = CmdControl::Continue;
+    {
+        struct WatcherGuard {
+            std::atomic<bool>& read_finished;
+            std::thread& watcher;
+            ~WatcherGuard() {
+                read_finished.store(true);
+                if (watcher.joinable()) {
+                    watcher.join();
+                }
+            }
+        } watcher_guard{read_finished, stop_watcher};
+
+        std::string temp;
+        while (std::getline(stream, temp)) {
+            accumulator.add(temp);
+            if (opts.callback != nullptr) {
+                condition = opts.callback(temp);
+            }
+            if (condition != CmdControl::Continue) {
+                break;
+            }
         }
     }
     if (condition == CmdControl::Continue) {
@@ -57,6 +215,21 @@ CmdOutput run_application(const std::string& name, std::vector<std::string> args
     } else {
         cmd.terminate();
     }
-    return CmdOutput{output, split_output, cmd.exit_code()};
+
+    CmdOutput result;
+    result.split_output = accumulator.take_retained();
+    for (const auto& line : result.split_output) {
+        result.output += line + "\n";
+    }
+    result.exit_code = cmd.exit_code();
+    return result;
 }
+
+CmdOutput run_application(const std::string& name, std::vector<std::string> args,
+                          const std::function<CmdControl(const std::string& output_line)> output_callback) {
+    RunOptions opts;
+    opts.callback = output_callback;
+    return run_application(name, std::move(args), std::move(opts));
+}
+
 } // namespace everest::run_application

--- a/lib/everest/run_application/tests/CMakeLists.txt
+++ b/lib/everest/run_application/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(everest_run_application_tests
+    run_application_test.cpp
+)
+target_link_libraries(everest_run_application_tests
+    PRIVATE
+        GTest::gtest_main
+        everest::run_application
+)
+include(GoogleTest)
+gtest_discover_tests(everest_run_application_tests TEST_PREFIX "run_application.")

--- a/lib/everest/run_application/tests/run_application_test.cpp
+++ b/lib/everest/run_application/tests/run_application_test.cpp
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <everest/run_application/run_application.hpp>
+
+#ifdef __linux__
+#include <algorithm>
+#include <csignal>
+#include <cstdlib>
+#include <dirent.h>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+using namespace everest::run_application;
+
+TEST(RunApplication, StopRequestedTerminatesSilentChild) {
+    auto stop = std::make_shared<std::atomic_bool>(false);
+
+    std::thread setter([stop] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        *stop = true;
+    });
+
+    RunOptions opts;
+    opts.stop_requested = stop;
+
+    const auto start = std::chrono::steady_clock::now();
+    run_application("/usr/bin/sleep", {"60"}, opts);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    setter.join();
+
+    EXPECT_LT(elapsed, std::chrono::seconds(5));
+}
+
+TEST(RunApplication, StopRequestedEscalatesToSigkill) {
+    // The child ignores SIGTERM, so the 2 s grace must elapse and SIGKILL must be used. This
+    // exercises the escalation path that a SIGTERM-responsive child would skip.
+    auto stop = std::make_shared<std::atomic_bool>(false);
+
+    std::thread setter([stop] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        *stop = true;
+    });
+
+    RunOptions opts;
+    opts.stop_requested = stop;
+
+    const auto start = std::chrono::steady_clock::now();
+    run_application("/usr/bin/python3",
+                    {"-c", "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"}, opts);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    setter.join();
+
+    // SIGTERM is ignored, so termination cannot happen before the ~2 s grace (proving SIGTERM alone
+    // did not kill it), and must happen well before the child's own 60 s sleep.
+    EXPECT_GE(elapsed, std::chrono::milliseconds(1900));
+    EXPECT_LT(elapsed, std::chrono::seconds(5));
+}
+
+TEST(RunApplication, NullStopRequestedRunsToCompletion) {
+    const auto result = run_application("/usr/bin/echo", {"hello"});
+
+    EXPECT_NE(result.output.find("hello"), std::string::npos);
+    EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(RunApplication, ArmedStopFlagNeverSetRunsToCompletion) {
+    // A non-null flag that is never set spawns the watcher but lets the child finish normally,
+    // exercising a clean watcher spawn + join on the completion path (the nullptr test does not
+    // create a watcher at all).
+    auto stop = std::make_shared<std::atomic_bool>(false);
+
+    RunOptions opts;
+    opts.stop_requested = stop;
+
+    const auto result = run_application("/usr/bin/echo", {"hello"}, opts);
+
+    EXPECT_NE(result.output.find("hello"), std::string::npos);
+    EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(RunApplication, AccumulateOutputFalseStreamsWithoutRetaining) {
+    // RetainNone must not buffer stdout in CmdOutput (the unbounded-growth case for long-lived
+    // children), but the per-line callback must still fire and the exit code stay valid.
+    std::vector<std::string> streamed;
+
+    RunOptions opts;
+    opts.accumulation = RetainNone{};
+    opts.callback = [&streamed](const std::string& line) {
+        streamed.push_back(line);
+        return CmdControl::Continue;
+    };
+
+    const auto result = run_application("/usr/bin/echo", {"hello"}, opts);
+
+    EXPECT_TRUE(result.output.empty());
+    EXPECT_TRUE(result.split_output.empty());
+    ASSERT_EQ(streamed.size(), 1u);
+    EXPECT_EQ(streamed[0], "hello");
+    EXPECT_EQ(result.exit_code, 0);
+}
+
+#ifdef __linux__
+namespace {
+
+// Return the pid of a running process whose cmdline contains needle, or -1 if none.
+pid_t find_process_with_arg(const std::string& needle) {
+    DIR* proc = opendir("/proc");
+    if (proc == nullptr) {
+        return -1;
+    }
+    pid_t found = -1;
+    while (dirent* entry = readdir(proc)) {
+        char* end = nullptr;
+        const long pid = std::strtol(entry->d_name, &end, 10);
+        if (end == entry->d_name || *end != '\0') {
+            continue; // not a pid directory
+        }
+        std::ifstream cmdline(std::string("/proc/") + entry->d_name + "/cmdline", std::ios::binary);
+        if (!cmdline) {
+            continue;
+        }
+        std::string content((std::istreambuf_iterator<char>(cmdline)), std::istreambuf_iterator<char>());
+        std::replace(content.begin(), content.end(), '\0', ' '); // cmdline is NUL-separated
+        if (content.find(needle) != std::string::npos) {
+            found = static_cast<pid_t>(pid);
+            break;
+        }
+    }
+    closedir(proc);
+    return found;
+}
+
+bool wait_until(const std::function<bool()>& pred, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (pred()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return pred();
+}
+
+} // namespace
+
+TEST(RunApplication, KillChildOnParentDeathReapsChildWhenParentDies) {
+    // A unique sleep duration lets us pinpoint exactly this grandchild in /proc.
+    const std::string unique_arg = "314159";
+    const std::string needle = "/usr/bin/sleep " + unique_arg;
+    ASSERT_EQ(find_process_with_arg(needle), -1) << "a stale sleeper is present before the test";
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << "fork failed";
+    if (child == 0) {
+        // Intermediate child: spawn a long-lived grandchild that must die with us via PR_SET_PDEATHSIG.
+        RunOptions opts;
+        opts.accumulation = RetainNone{};
+        opts.kill_child_on_parent_death = true;
+        run_application("/usr/bin/sleep", {unique_arg}, opts);
+        _exit(0);
+    }
+
+    ASSERT_TRUE(wait_until([&] { return find_process_with_arg(needle) > 0; }, std::chrono::seconds(5)))
+        << "grandchild sleeper never started";
+
+    // Kill the intermediate child abruptly — no destructors, no clean shutdown.
+    ASSERT_EQ(kill(child, SIGKILL), 0);
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+
+    const bool reaped = wait_until([&] { return find_process_with_arg(needle) == -1; }, std::chrono::seconds(5));
+
+    // Safety net: never leak the sleeper into the test host even if the assertion fails.
+    const pid_t leaked = find_process_with_arg(needle);
+    if (leaked > 0) {
+        kill(leaked, SIGKILL);
+    }
+
+    EXPECT_TRUE(reaped) << "grandchild outlived its parent — PR_SET_PDEATHSIG did not fire";
+}
+#endif
+
+namespace {
+constexpr std::size_t kUnbounded = std::numeric_limits<std::size_t>::max();
+
+// Assert the CmdOutput invariant: output == concat(split_output[i] + "\n").
+void expect_output_matches_split(const CmdOutput& result) {
+    std::string expected;
+    for (const auto& line : result.split_output) {
+        expected += line + "\n";
+    }
+    EXPECT_EQ(result.output, expected);
+}
+} // namespace
+
+TEST(RunApplication, RetainAllViaOptionsMatchesFullBuffer) {
+    RunOptions opts;
+    opts.accumulation = RetainAll{};
+
+    const auto result = run_application("/usr/bin/seq", {"1", "5"}, opts);
+
+    EXPECT_EQ(result.exit_code, 0);
+    ASSERT_EQ(result.split_output.size(), 5u);
+    EXPECT_EQ(result.split_output.front(), "1");
+    EXPECT_EQ(result.split_output.back(), "5");
+    EXPECT_EQ(result.output, "1\n2\n3\n4\n5\n");
+    expect_output_matches_split(result);
+}
+
+TEST(RunApplication, RetainNoneViaOptionsStreamsButRetainsNothing) {
+    std::vector<std::string> streamed;
+    RunOptions opts;
+    opts.accumulation = RetainNone{};
+    opts.callback = [&streamed](const std::string& line) {
+        streamed.push_back(line);
+        return CmdControl::Continue;
+    };
+
+    const auto result = run_application("/usr/bin/seq", {"1", "5"}, opts);
+
+    EXPECT_TRUE(result.output.empty());
+    EXPECT_TRUE(result.split_output.empty());
+    EXPECT_EQ(result.exit_code, 0);
+    ASSERT_EQ(streamed.size(), 5u);
+    EXPECT_EQ(streamed.front(), "1");
+    EXPECT_EQ(streamed.back(), "5");
+}
+
+TEST(RunApplication, RetainHeadLineCapBinds) {
+    RunOptions opts;
+    opts.accumulation = RetainHead{/*max_lines=*/10, /*max_bytes=*/kUnbounded};
+
+    const auto result = run_application("/usr/bin/seq", {"1", "100"}, opts);
+
+    EXPECT_EQ(result.exit_code, 0);
+    ASSERT_EQ(result.split_output.size(), 10u);
+    EXPECT_EQ(result.split_output.front(), "1");
+    EXPECT_EQ(result.split_output.back(), "10");
+    expect_output_matches_split(result);
+}
+
+TEST(RunApplication, RetainHeadByteCapBindsBeforeLineCap) {
+    // 100 lines of exactly 10 bytes each. max_bytes=25 admits only 2 lines (20 <= 25, 30 > 25),
+    // even though max_lines is effectively unbounded.
+    RunOptions opts;
+    opts.accumulation = RetainHead{/*max_lines=*/kUnbounded, /*max_bytes=*/25};
+
+    const auto result = run_application("/usr/bin/python3", {"-c", "for i in range(100): print('x'*10)"}, opts);
+
+    EXPECT_EQ(result.exit_code, 0);
+    ASSERT_EQ(result.split_output.size(), 2u);
+    EXPECT_EQ(result.split_output[0], "xxxxxxxxxx");
+    EXPECT_EQ(result.split_output[1], "xxxxxxxxxx");
+    expect_output_matches_split(result);
+}
+
+TEST(RunApplication, RetainTailLineCapKeepsNewest) {
+    RunOptions opts;
+    opts.accumulation = RetainTail{/*max_lines=*/10, /*max_bytes=*/kUnbounded};
+
+    const auto result = run_application("/usr/bin/seq", {"1", "100"}, opts);
+
+    EXPECT_EQ(result.exit_code, 0);
+    ASSERT_EQ(result.split_output.size(), 10u);
+    EXPECT_EQ(result.split_output.front(), "91");
+    EXPECT_EQ(result.split_output.back(), "100");
+    expect_output_matches_split(result);
+}
+
+TEST(RunApplication, RetainTailSingleLineLargerThanByteCapEvicted) {
+    // One line of 10 bytes, byte cap of 5: appended then immediately evicted, keeping memory bounded.
+    RunOptions opts;
+    opts.accumulation = RetainTail{/*max_lines=*/kUnbounded, /*max_bytes=*/5};
+
+    const auto result = run_application("/usr/bin/python3", {"-c", "print('x'*10)"}, opts);
+
+    EXPECT_EQ(result.exit_code, 0);
+    EXPECT_TRUE(result.split_output.empty());
+    EXPECT_TRUE(result.output.empty());
+}
+
+TEST(RunApplication, RetainHeadTailKeepsPrefixAndSuffix) {
+    RunOptions opts;
+    opts.accumulation = RetainHeadTail{/*head_lines=*/3, /*head_bytes=*/kUnbounded,
+                                       /*tail_lines=*/3, /*tail_bytes=*/kUnbounded};
+
+    const auto result = run_application("/usr/bin/seq", {"1", "100"}, opts);
+
+    EXPECT_EQ(result.exit_code, 0);
+    ASSERT_EQ(result.split_output.size(), 6u);
+    const std::vector<std::string> expected{"1", "2", "3", "98", "99", "100"};
+    EXPECT_EQ(result.split_output, expected);
+    EXPECT_EQ(result.output, "1\n2\n3\n98\n99\n100\n");
+    expect_output_matches_split(result);
+}
+
+TEST(RunApplication, TerminateGraceShortenPathIsFasterThanDefault) {
+    // A SIGTERM-ignoring child forces the escalation-to-SIGKILL path. With a short grace the
+    // kill must land well before the default 2 s grace would allow.
+    auto stop = std::make_shared<std::atomic_bool>(false);
+    std::thread setter([stop] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        *stop = true;
+    });
+
+    RunOptions opts;
+    opts.stop_requested = stop;
+    opts.terminate_grace = std::chrono::milliseconds(300);
+
+    const auto start = std::chrono::steady_clock::now();
+    run_application("/usr/bin/python3",
+                    {"-c", "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"}, opts);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    setter.join();
+
+    // 200 ms until stop is set + 300 ms grace ~= 0.5 s; comfortably under the 2 s default grace path.
+    EXPECT_LT(elapsed, std::chrono::milliseconds(1500));
+}


### PR DESCRIPTION
## Describe your changes

Adds a `run_application(name, args, RunOptions)` overload for supervising long-lived children (e.g. a gRPC sidecar). The existing `run_application(name, args, callback)` is unchanged, so all current callers are unaffected.

`RunOptions` bundles:

- **`callback`** — per-line stdout callback (as before).
- **`accumulation`** — an `AccumulationPolicy` variant selecting how stdout is retained: `RetainAll`, `RetainNone`, or bounded `RetainHead` / `RetainTail` / `RetainHeadTail` with line and byte caps. Bounded policies keep whole lines only.
- **`stop_requested`** (`shared_ptr<atomic_bool>`) — cancellation flag; a watcher sends `SIGTERM`, then `SIGKILL` after `terminate_grace`, unblocking a silent child so the call returns. On cancellation `exit_code` reflects the terminating signal.
- **`kill_child_on_parent_death`** — sets `PR_SET_PDEATHSIG(SIGKILL)` so the kernel reaps the child if the spawning thread dies (Linux only).

Covered by `lib/everest/run_application/tests/run_application_test.cpp`.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
