### PR TITLE
fix(framework): preload tzdb before threads start

### DIFF
--- a/lib/everest/framework/include/utils/date.hpp
+++ b/lib/everest/framework/include/utils/date.hpp
@@ -9,6 +9,13 @@
 namespace Everest {
 namespace Date {
 
+// Force single-threaded initialization of the HowardHinnant date tzdb / leap-second
+// singleton. Call once at process start, before any worker thread. The tzdb is
+// initialized lazily on first use; letting that first use happen concurrently from
+// multiple threads races the initialization and can crash inside the leap-second
+// lookup. Warming it up single-threaded closes that window.
+void preload_tzdb();
+
 std::string to_rfc3339(const std::chrono::time_point<date::utc_clock>& t);
 
 std::chrono::time_point<date::utc_clock> from_rfc3339_slow(const std::string& t);

--- a/lib/everest/framework/include/utils/date.hpp
+++ b/lib/everest/framework/include/utils/date.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #ifndef UTILS_DATE_HPP
 #define UTILS_DATE_HPP
 
@@ -9,11 +9,13 @@
 namespace Everest {
 namespace Date {
 
-// Force single-threaded initialization of the HowardHinnant date tzdb / leap-second
-// singleton. Call once at process start, before any worker thread. The tzdb is
-// initialized lazily on first use; letting that first use happen concurrently from
-// multiple threads races the initialization and can crash inside the leap-second
-// lookup. Warming it up single-threaded closes that window.
+/// \brief Force single-threaded initialization of the HowardHinnant date tzdb /
+/// leap-second singleton.
+///
+/// Call once at process start, before any worker thread. The tzdb is initialized
+/// lazily on first use; letting that first use happen concurrently from multiple
+/// threads races the initialization and can crash inside the leap-second lookup.
+/// Warming it up single-threaded closes that window.
 void preload_tzdb();
 
 std::string to_rfc3339(const std::chrono::time_point<date::utc_clock>& t);

--- a/lib/everest/framework/lib/date.cpp
+++ b/lib/everest/framework/lib/date.cpp
@@ -1,12 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2026 Pionix GmbH and Contributors to EVerest
 #include <charconv>
+#include <exception>
 #include <string_view>
 
+#include <everest/logging.hpp>
 #include <utils/date.hpp>
 
 namespace Everest {
 namespace Date {
+
+void preload_tzdb() {
+    try {
+        date::get_tzdb();
+    } catch (const std::exception& e) {
+        EVLOG_warning << "tzdb preload failed; timestamps may be unreliable: " << e.what();
+    }
+}
 
 std::string to_rfc3339(const std::chrono::time_point<date::utc_clock>& t) {
     return date::format("%FT%TZ", std::chrono::time_point_cast<std::chrono::milliseconds>(t));

--- a/lib/everest/framework/lib/runtime.cpp
+++ b/lib/everest/framework/lib/runtime.cpp
@@ -3,6 +3,7 @@
 
 #include <framework/runtime.hpp>
 #include <utils/config/storage_sqlite.hpp>
+#include <utils/date.hpp>
 #include <utils/error.hpp>
 #include <utils/error/error_factory.hpp>
 #include <utils/error/error_json.hpp>
@@ -447,6 +448,8 @@ int ModuleLoader::initialize() {
         return EXIT_FAILURE;
     }
     Logging::init(this->logging_config_file.string(), this->module_id);
+
+    Date::preload_tzdb();
 
     const auto start_time = std::chrono::steady_clock::now();
 

--- a/lib/everest/framework/src/controller/controller.cpp
+++ b/lib/everest/framework/src/controller/controller.cpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 
 #include <everest/logging.hpp>
+#include <utils/date.hpp>
 
 #include "command_api.hpp"
 #include "ipc.hpp"
@@ -30,6 +31,8 @@ int run_controller() {
     const auto config_params = message.json.at("params");
 
     Everest::Logging::init(config_params.at("logging_config_file"), "everest_ctrl");
+
+    Everest::Date::preload_tzdb();
 
     EVLOG_debug << "everest controller process started ...";
 

--- a/lib/everest/framework/src/manager.cpp
+++ b/lib/everest/framework/src/manager.cpp
@@ -28,6 +28,7 @@
 #include <framework/everest.hpp>
 #include <framework/runtime.hpp>
 #include <utils/config.hpp>
+#include <utils/date.hpp>
 #include <utils/mqtt_abstraction.hpp>
 #include <utils/status_fifo.hpp>
 
@@ -639,6 +640,8 @@ int boot(const po::variables_map& vm) {
     }
 
     Logging::init(ms.runtime_settings.logging_config_file.string());
+
+    Date::preload_tzdb();
 
     EVLOG_info << "  \033[0;1;35;95m_\033[0;1;31;91m__\033[0;1;33;93m__\033[0;1;32;92m__\033[0;1;36;96m_\033[0m      "
                   "\033[0;1;31;91m_\033[0;1;33;93m_\033[0m                \033[0;1;36;96m_\033[0m   ";

--- a/lib/everest/framework/tests/test_conversions.cpp
+++ b/lib/everest/framework/tests/test_conversions.cpp
@@ -2,8 +2,11 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #include <catch2/catch_all.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <iostream>
+#include <thread>
+#include <vector>
 
 #include <utils/conversions.hpp>
 #include <utils/date.hpp>
@@ -70,6 +73,50 @@ SCENARIO("Check conversions", "[!throws]") {
             const auto tp_from_slow = Everest::Date::from_rfc3339_slow(now_str);
             const auto tp_from_fast = Everest::Date::from_rfc3339(now_str);
             CHECK(tp_from_slow == tp_from_fast);
+        }
+    }
+}
+
+SCENARIO("tzdb preload makes concurrent utc_clock::now() safe", "[!throws]") {
+    GIVEN("A single-threaded tzdb preload before any worker thread") {
+        Everest::Date::preload_tzdb();
+
+        WHEN("Many threads call utc_clock::now() concurrently") {
+            constexpr int thread_count = 16;
+            constexpr int iterations = 2000;
+            std::atomic<int> parked{0};
+            std::atomic<bool> go{false};
+            std::atomic<int> failures{0};
+
+            std::vector<std::thread> threads;
+            threads.reserve(thread_count);
+            for (int i = 0; i < thread_count; ++i) {
+                threads.emplace_back([&] {
+                    parked.fetch_add(1);
+                    while (!go.load()) {
+                    }
+                    for (int k = 0; k < iterations; ++k) {
+                        try {
+                            const auto ts = Everest::Date::to_rfc3339(date::utc_clock::now());
+                            if (ts.empty()) {
+                                failures.fetch_add(1);
+                            }
+                        } catch (...) {
+                            failures.fetch_add(1);
+                        }
+                    }
+                });
+            }
+            while (parked.load() < thread_count) {
+            }
+            go.store(true);
+            for (auto& t : threads) {
+                t.join();
+            }
+
+            THEN("No call crashes, throws, or yields an empty timestamp") {
+                CHECK(failures.load() == 0);
+            }
         }
     }
 }


### PR DESCRIPTION
## Describe your changes

`date::utc_clock::now()` lazily initializes the HowardHinnant `date` tzdb/leap-second
singleton on first use. When that first use happens concurrently from multiple threads,
initialization races and `get_tzdb()` can return a tzdb with a null internal pointer,
crashing (SIGSEGV) inside the leap-second lookup in `date::utc_clock::from_sys`.

Adds `Everest::Date::preload_tzdb()` (`lib/everest/framework/lib/date.cpp`) and calls it
single-threaded, before any worker thread starts, in the framework's three process
entry points: `ModuleLoader::initialize` (`runtime.cpp`), `boot` (`manager.cpp`), and
`run_controller` (`controller.cpp`).

Verified with the new Catch2 scenario in `test_conversions.cpp`
(`ninja -C build everest-framework_tests && ./build/lib/everest/framework/tests/everest-framework_tests`,
327 assertions / 34 test cases, all passing).

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
