### PR TITLE
fix(ocpp): Allow RetryBackoffRandomRange to bet set externally

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_configuration.cpp
@@ -3866,6 +3866,18 @@ std::optional<ConfigurationStatus> ChargePointConfiguration::set(const CiString<
         } catch (const std::out_of_range& e) {
             return ConfigurationStatus::Rejected;
         }
+    } else if (key == "RetryBackoffRandomRange") {
+        try {
+            auto [valid, retry_backoff_random_range] = is_positive_integer(value.get());
+            if (!valid) {
+                return ConfigurationStatus::Rejected;
+            }
+            this->setRetryBackoffRandomRange(retry_backoff_random_range);
+        } catch (const std::invalid_argument& e) {
+            return ConfigurationStatus::Rejected;
+        } catch (const std::out_of_range& e) {
+            return ConfigurationStatus::Rejected;
+        }
     } else if (key == "WaitForStopTransactionsOnResetTimeout") {
         try {
             auto [valid, wait_for_stop_transactions_on_reset_timeout] = is_positive_integer(value.get());

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
@@ -404,7 +404,7 @@ class TestOCPP16GenericInterfaceIntegration:
                             "component": {"name": "IGNORED"},
                             "variable": {"name": "RetryBackoffRandomRange"},
                         },
-                        # not custom - will be Rejected
+                        # standard (non-custom), writable key; will be Accepted.
                         "value": "99",
                     },
                     {
@@ -440,7 +440,7 @@ class TestOCPP16GenericInterfaceIntegration:
                     "component": {"name": "IGNORED"},
                     "variable": {"name": "RetryBackoffRandomRange"},
                 },
-                "status": "Rejected",
+                "status": "Accepted",
             },
             {
                 "component_variable": {


### PR DESCRIPTION

## Describe your changes

RetryBackoffRandomRange is defined ReadWrite but could not be set via v16::ChargePointConfiguration, because the set clause for it was just missing.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

