### PR TITLE
fix(ocpp): Race conidition in OCPP FW update tests 

### DIFF
--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-ocpp201.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-ocpp201.yaml
@@ -149,5 +149,7 @@ active_modules:
           implementation_id: powermeter
   system:
     module: System
+    config_module:
+      ResetDelay: 1
 
 x-module-layout: {}

--- a/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp.yaml
+++ b/tests/ocpp_tests/test_sets/everest-aux/config/everest-config-sil-ocpp.yaml
@@ -103,4 +103,6 @@ active_modules:
         implementation_id: powermeter
   system:
     module: System
+    config_module:
+      ResetDelay: 1
 x-module-layout: {}


### PR DESCRIPTION


## Describe your changes

A race condition between the Installed firmware-status notification and the immediate hard reset that firmware installation triggers. Tests that were influenced/flaky:

test_signed_update_firmware
test_signed_update_firmware_keep_connectors_available
test_L01_secure_firmware_update_disable_connectors
test_L01_secure_firmware_update_keep_connectors_available

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

