### PR TITLE
Fix/iso15118 disconnect teardown

### DIFF
--- a/lib/everest/iso15118/include/iso15118/detail/io/socket_helper.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/io/socket_helper.hpp
@@ -14,4 +14,6 @@ bool check_and_update_interface(std::string& interface_name);
 bool get_first_sockaddr_in6_for_interface(const std::string& interface_name, sockaddr_in6& address);
 
 std::unique_ptr<char[]> sockaddr_in6_to_name(const sockaddr_in6&);
+
+bool set_tcp_keepalive(int fd);
 } // namespace iso15118::io

--- a/lib/everest/iso15118/include/iso15118/io/connection_abstract.hpp
+++ b/lib/everest/iso15118/include/iso15118/io/connection_abstract.hpp
@@ -24,7 +24,8 @@ using ConnectionEventCallback = std::function<void(ConnectionEvent)>;
 struct ReadResult {
     bool would_block{true};
     size_t bytes_read{0};
-    bool connection_closed{false}; //!< peer closed the connection (EOF / TLS close_notify) during this read
+    bool connection_closed{false}; //!< connection ended during this read (EOF / TLS close_notify, or a fatal
+                                   //!< socket error such as ECONNRESET / keepalive ETIMEDOUT)
 };
 
 struct IConnection {

--- a/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
+++ b/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -14,6 +15,7 @@
 #include <iso15118/d20/config.hpp>
 #include <iso15118/d20/control_event.hpp>
 #include <iso15118/d20/limits.hpp>
+#include <iso15118/io/connection_abstract.hpp>
 #include <iso15118/io/poll_manager.hpp>
 #include <iso15118/io/sdp_server.hpp>
 #include <iso15118/io/time.hpp>
@@ -32,10 +34,20 @@ struct TbdConfig {
 
 class TbdController {
 public:
+    // Creates the connection for sessions when the SDP server is disabled.
+    using ConnectionFactory =
+        std::function<std::unique_ptr<io::IConnection>(io::PollManager&, const std::string& interface_name)>;
+
     TbdController(TbdConfig, session::feedback::Callbacks, d20::EvseSetupConfig);
+    TbdController(TbdConfig, session::feedback::Callbacks, d20::EvseSetupConfig, ConnectionFactory);
     ~TbdController();
 
     void loop();
+    void tick();
+
+    bool has_active_session() const {
+        return session != nullptr;
+    }
 
     void shutdown();
 
@@ -62,6 +74,10 @@ private:
     std::unique_ptr<Session> session;
 
     std::atomic_bool shutdown_active{false};
+    std::atomic_bool terminate_session_requested{false};
+
+    bool shutdown_signaled{false};
+    TimePoint next_event{};
 
     // callbacks for sdp server
     void handle_sdp_server_input();
@@ -77,6 +93,8 @@ private:
 
     static constexpr uint32_t V2G_COMMUNICATION_SETUP_TIMEOUT_MS{18000};
     std::optional<Timeout> communication_setup_timeout;
+
+    ConnectionFactory connection_factory;
 };
 
 } // namespace iso15118

--- a/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
@@ -3,6 +3,7 @@
 #include <iso15118/io/connection_plain.hpp>
 
 #include <cassert>
+#include <cerrno>
 #include <chrono>
 #include <cinttypes>
 #include <cstring>
@@ -99,13 +100,18 @@ ReadResult ConnectionPlain::read(uint8_t* buf, size_t len) {
         return {did_block, static_cast<size_t>(read_result)};
     }
 
-    // should be an error
-    if (errno != EAGAIN) {
-        // in case the error is not due to blocking, log it
-        logf_error("ConnectionPlain::read failed with error code: %d", errno);
+    // read_result < 0: distinguish a genuine would-block from a fatal error.
+    // EAGAIN/EWOULDBLOCK/EINTR mean "retry"; anything else (ECONNRESET, or
+    // ETIMEDOUT from the TCP keepalive, ...) is terminal, so report it as a
+    // closed connection. Otherwise the level-triggered poll would spin on the
+    // dead socket until the 60 s sequence timeout instead of tearing the
+    // session down within one tick.
+    if (errno == EAGAIN or errno == EWOULDBLOCK or errno == EINTR) {
+        return {true, 0, false};
     }
 
-    return {did_block, 0};
+    logf_warning("ConnectionPlain::read failed with error code: %d", errno);
+    return {false, 0, true};
 }
 
 void ConnectionPlain::handle_connect() {
@@ -116,6 +122,10 @@ void ConnectionPlain::handle_connect() {
     const auto accept_fd = accept4(fd, reinterpret_cast<struct sockaddr*>(&address), &address_len, SOCK_NONBLOCK);
     if (accept_fd == -1) {
         log_and_throw("Failed to accept4");
+    }
+
+    if (not set_tcp_keepalive(accept_fd)) {
+        logf_warning("Failed to configure TCP keepalive on accepted connection");
     }
 
     const auto address_name = sockaddr_in6_to_name(address);

--- a/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_ssl.cpp
@@ -263,6 +263,10 @@ void ConnectionSSL::handle_connect() {
 
     call_if_available(event_callback, ConnectionEvent::ACCEPTED);
 
+    if (not set_tcp_keepalive(accepted_fd)) {
+        logf_warning("Failed to configure TCP keepalive on accepted TLS connection");
+    }
+
     ssl->connection = ssl->server->wrap_accepted_fd(accepted_fd, host, service);
     if (ssl->connection == nullptr) {
         ::close(accepted_fd);
@@ -310,6 +314,14 @@ void ConnectionSSL::close() {
     // Idempotency / re-entry guard: the connection is reset before CLOSED is
     // delivered below, so a re-entrant or repeated close() is a no-op.
     if (ssl->connection == nullptr) {
+        // Never-connected teardown: the listener is still registered because
+        // handle_connect never ran. Release it and fire CLOSED once.
+        if (ssl->listen_fd != -1) {
+            poll_manager.unregister_fd(ssl->listen_fd);
+            ::close(ssl->listen_fd);
+            ssl->listen_fd = -1;
+            call_if_available(event_callback, ConnectionEvent::CLOSED);
+        }
         return;
     }
 

--- a/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/socket_helper.cpp
@@ -9,6 +9,8 @@
 #include <net/if.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
 
 #include <iso15118/detail/helper.hpp>
 
@@ -106,6 +108,38 @@ bool get_first_sockaddr_in6_for_interface(const std::string& interface_name, soc
 
     // Todo(sl): What to do if interface was not found?
     return found_interface;
+}
+
+bool set_tcp_keepalive(int fd) {
+    constexpr int TCP_KEEPALIVE_IDLE_S = 10;
+    constexpr int TCP_KEEPALIVE_INTERVAL_S = 3;
+    constexpr int TCP_KEEPALIVE_PROBE_COUNT = 3;
+
+    int enable = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &enable, sizeof(enable)) == -1) {
+        logf_error("Failed to enable SO_KEEPALIVE");
+        return false;
+    }
+
+    int idle = TCP_KEEPALIVE_IDLE_S;
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle)) == -1) {
+        logf_error("Failed to set TCP_KEEPIDLE");
+        return false;
+    }
+
+    int interval = TCP_KEEPALIVE_INTERVAL_S;
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &interval, sizeof(interval)) == -1) {
+        logf_error("Failed to set TCP_KEEPINTVL");
+        return false;
+    }
+
+    int count = TCP_KEEPALIVE_PROBE_COUNT;
+    if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count)) == -1) {
+        logf_error("Failed to set TCP_KEEPCNT");
+        return false;
+    }
+
+    return true;
 }
 
 std::unique_ptr<char[]> sockaddr_in6_to_name(const sockaddr_in6& address) {

--- a/lib/everest/iso15118/src/iso15118/session/iso.cpp
+++ b/lib/everest/iso15118/src/iso15118/session/iso.cpp
@@ -215,7 +215,7 @@ TimePoint const& Session::poll() {
 
         for (const auto& timeout : reached) {
             if (timeout == d20::TimeoutType::SEQUENCE) {
-                logf_error("Sequence Timeout 40secs is reached. Stopping the session");
+                logf_error("Sequence timeout (60s) reached. Stopping the session");
                 ctx.session_stopped = true;
                 break;
             } else {
@@ -348,6 +348,8 @@ void Session::handle_connection_event(io::ConnectionEvent event) {
 
 void Session::close() {
     connection->close();
+    // transport gone; a rate-limiter-deferred response is undeliverable
+    [[maybe_unused]] auto res = message_exchange.check_and_clear_response();
     ctx.feedback.signal(session::feedback::Signal::DLINK_TERMINATE);
     ctx.session_stopped = true;
 }

--- a/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
+++ b/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
@@ -14,11 +14,22 @@
 
 namespace iso15118 {
 
+static constexpr auto POLL_MANAGER_TIMEOUT_MS = 50;
+
 TbdController::TbdController(TbdConfig config_, session::feedback::Callbacks callbacks_, d20::EvseSetupConfig setup_) :
+    TbdController(std::move(config_), std::move(callbacks_), std::move(setup_),
+                  [](io::PollManager& poll_manager_, const std::string& interface_name_) {
+                      return std::make_unique<io::ConnectionPlain>(poll_manager_, interface_name_);
+                  }) {
+}
+
+TbdController::TbdController(TbdConfig config_, session::feedback::Callbacks callbacks_, d20::EvseSetupConfig setup_,
+                             ConnectionFactory connection_factory_) :
     config(std::move(config_)),
     callbacks(std::move(callbacks_)),
     evse_setup(std::move(setup_)),
-    interface_name(config.interface_name) {
+    interface_name(config.interface_name),
+    connection_factory(std::move(connection_factory_)) {
 
     const auto result_interface_check = io::check_and_update_interface(interface_name);
     if (result_interface_check) {
@@ -41,18 +52,10 @@ TbdController::~TbdController() {
 }
 
 void TbdController::loop() {
-    static constexpr auto POLL_MANAGER_TIMEOUT_MS = 50;
-
     shutdown_active.store(false);
-    bool shutdown_signaled{false};
+    shutdown_signaled = false;
 
-    if (not config.enable_sdp_server) {
-        auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, interface_name);
-        session = std::make_unique<Session>(std::move(connection), d20::SessionConfig(*evse_setup.handle()), callbacks,
-                                            pause_ctx);
-    }
-
-    auto next_event = get_current_time_point();
+    next_event = get_current_time_point();
 
     while (session or not shutdown_active.load()) {
         const auto poll_timeout_ms = get_timeout_ms_until(next_event, POLL_MANAGER_TIMEOUT_MS);
@@ -64,44 +67,55 @@ void TbdController::loop() {
             break;
         }
 
-        next_event = offset_time_point_by_ms(get_current_time_point(), POLL_MANAGER_TIMEOUT_MS);
-
-        if (communication_setup_timeout && communication_setup_timeout->is_reached()) {
-            logf_warning("V2G communication setup timeout (18s) expired before session was established");
-            communication_setup_timeout.reset();
-            if (sdp_server) {
-                sdp_server->set_dlink_ready(false);
-            }
-            callbacks.signal(session::feedback::Signal::DLINK_ERROR);
-        }
-
-        if (session and shutdown_active.load() and not shutdown_signaled) {
-            session->request_shutdown(); // Stopping the session
-            shutdown_signaled = true;
-        }
-
-        if (session) {
-            try {
-                const auto next_session_event = session->poll();
-                next_event = std::min(next_event, next_session_event);
-            } catch (const std::runtime_error& e) {
-                logf_error("Shutting down session because of: %s", e.what());
-                logf_info("Restarting session ...");
-                session->close();
-            }
-
-            if (session->is_finished()) {
-                session.reset();
-
-                if (not shutdown_active.load() and not config.enable_sdp_server) {
-                    auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, interface_name);
-                    session = std::make_unique<Session>(std::move(connection), d20::SessionConfig(*evse_setup.handle()),
-                                                        callbacks, pause_ctx);
-                }
-            }
-        }
+        tick();
     }
     logf_info("Exiting TbdController loop gracefully");
+}
+
+void TbdController::tick() {
+    next_event = offset_time_point_by_ms(get_current_time_point(), POLL_MANAGER_TIMEOUT_MS);
+
+    if (communication_setup_timeout && communication_setup_timeout->is_reached()) {
+        logf_warning("V2G communication setup timeout (18s) expired before session was established");
+        communication_setup_timeout.reset();
+        if (sdp_server) {
+            sdp_server->set_dlink_ready(false);
+        }
+        callbacks.signal(session::feedback::Signal::DLINK_ERROR);
+    }
+
+    if (session and shutdown_active.load() and not shutdown_signaled) {
+        session->request_shutdown(); // Stopping the session
+        shutdown_signaled = true;
+    }
+
+    // Consume the flag unconditionally so a request raised while no session is
+    // active cannot tear down a later session.
+    const bool terminate = terminate_session_requested.exchange(false);
+    if (session and terminate) {
+        logf_info("Data link lost; terminating active V2G session");
+        session->close();
+    }
+
+    if (session) {
+        try {
+            const auto next_session_event = session->poll();
+            next_event = std::min(next_event, next_session_event);
+        } catch (const std::runtime_error& e) {
+            logf_error("Shutting down session because of: %s", e.what());
+            logf_info("Restarting session ...");
+            session->close();
+        }
+
+        if (session->is_finished()) {
+            session.reset();
+        }
+    }
+
+    if (not session and not shutdown_active.load() and not config.enable_sdp_server) {
+        session = std::make_unique<Session>(connection_factory(poll_manager, interface_name),
+                                            d20::SessionConfig(*evse_setup.handle()), callbacks, pause_ctx);
+    }
 }
 
 void TbdController::shutdown() {
@@ -192,6 +206,7 @@ void TbdController::set_dlink_ready(bool ready) {
         logf_info("V2G communication setup timeout started (%u ms)", V2G_COMMUNICATION_SETUP_TIMEOUT_MS);
     } else {
         communication_setup_timeout.reset();
+        terminate_session_requested.store(true);
     }
 }
 
@@ -226,6 +241,9 @@ void TbdController::handle_sdp_server_input() {
     }
 
     if (session) {
+        // A reconnect SDP arriving in the same poll cycle as a pending teardown
+        // is dropped here; the EVCC retransmits its SDP request (~250 ms) and
+        // recovers.
         logf_warning("Ignoring sdp request message because a session is already created and running");
         return;
     }
@@ -269,6 +287,11 @@ void TbdController::handle_sdp_server_input() {
                                         pause_ctx);
     communication_setup_timeout.reset();
 
+    // Deliberately do not clear terminate_session_requested here. A data-link
+    // loss that races this session creation must win: tick() consumes the flag
+    // and reaps whatever session exists, fresh or not. The EVCC retransmits its
+    // SDP request (~250 ms) so a session torn down this way recovers, whereas
+    // swallowing the flag would strand a session on a dead link.
     sdp_server->send_response(request, ipv6_endpoint);
 }
 

--- a/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/io/CMakeLists.txt
@@ -14,6 +14,16 @@ add_executable(test_sdp_server sdp_server_test.cpp)
 target_link_libraries(test_sdp_server PRIVATE iso15118 Catch2::Catch2WithMain)
 catch_discover_tests(test_sdp_server)
 
+add_executable(test_socket_keepalive socket_keepalive.cpp)
+target_link_libraries(test_socket_keepalive PRIVATE iso15118 Catch2::Catch2WithMain)
+catch_discover_tests(test_socket_keepalive)
+
+add_executable(test_connection_plain connection_plain.cpp)
+target_link_libraries(test_connection_plain PRIVATE iso15118 Catch2::Catch2WithMain)
+catch_discover_tests(test_connection_plain
+    PROPERTIES RESOURCE_LOCK iso15118_tls_port_50000
+)
+
 add_executable(connection_openssl_test)
 add_custom_command(
     TARGET connection_openssl_test POST_BUILD

--- a/lib/everest/iso15118/test/iso15118/io/connection_openssl.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/connection_openssl.cpp
@@ -511,6 +511,42 @@ SCENARIO("ConnectionSSL tears down when the peer closes during the handshake") {
     }
 }
 
+SCENARIO("ConnectionSSL close before connect releases the listener") {
+
+    GIVEN("A ConnectionSSL configured with a single SECC chain and no client") {
+        iso15118::io::set_logging_callback([](iso15118::LogLevel, const std::string&) {});
+
+        iso15118::io::PollManager poll_manager;
+        const auto ssl_cfg = make_ssl_config(false, "/tmp", false);
+
+        std::atomic<int> closed_count{0};
+
+        WHEN("close() is called before any client connects, then the connection is destroyed") {
+            {
+                iso15118::io::ConnectionSSL connection(poll_manager, LOOPBACK_IFACE, ssl_cfg);
+                connection.set_event_callback([&](iso15118::io::ConnectionEvent event) {
+                    if (event == iso15118::io::ConnectionEvent::CLOSED) {
+                        closed_count.fetch_add(1);
+                    }
+                });
+
+                connection.close();
+                connection.close(); // repeated close after listener release must be a no-op
+            }
+
+            // Pre-fix, close() early-returned without releasing the listener or
+            // firing CLOSED, leaving a this-capturing handle_connect callback
+            // registered on listen_fd (a latent UAF once the fd became readable).
+            // Polling after destruction confirms no dangling registration remains.
+            poll_manager.poll(0);
+
+            THEN("close() emits exactly one CLOSED and releases the listener") {
+                REQUIRE(closed_count.load() == 1);
+            }
+        }
+    }
+}
+
 SCENARIO("ConnectionSSL writes an SSLKEYLOGFILE-format keylog when enabled") {
 
     GIVEN("A ConnectionSSL configured with key logging enabled and a writable keylog dir") {

--- a/lib/everest/iso15118/test/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/connection_plain.cpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <future>
+#include <thread>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iso15118/io/connection_plain.hpp>
+#include <iso15118/io/logging.hpp>
+#include <iso15118/io/poll_manager.hpp>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr auto LOOPBACK_IFACE = "lo";
+constexpr auto SERVER_PORT = 50000;
+
+// Drive poll_manager until predicate returns true or the deadline expires.
+template <typename Predicate>
+bool poll_until(iso15118::io::PollManager& pm, Predicate done, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        pm.poll(50);
+        if (done()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Connect to the server on loopback, send data the server will NOT read, then
+// abort with SO_LINGER {1,0}. Because unread data is still queued at the peer,
+// the close sends a RST, so the server's next read() fails with ECONNRESET
+// rather than a clean EOF. Signals `reset_done` once the abort has been issued.
+bool run_resetting_client(std::atomic<bool>& reset_done) {
+    sockaddr_in6 addr{};
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(SERVER_PORT);
+    if (inet_pton(AF_INET6, "::1", &addr.sin6_addr) != 1) {
+        return false;
+    }
+
+    const int fd = ::socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return false;
+    }
+
+    int connected = -1;
+    for (int i = 0; i < 50; ++i) {
+        connected = ::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+        if (connected == 0) {
+            break;
+        }
+        std::this_thread::sleep_for(20ms);
+    }
+    if (connected != 0) {
+        ::close(fd);
+        return false;
+    }
+
+    const std::array<uint8_t, 8> payload{};
+    [[maybe_unused]] auto res = ::write(fd, payload.data(), payload.size());
+    // Give the server kernel time to buffer the bytes so they are still unread
+    // when the abortive close arrives.
+    std::this_thread::sleep_for(100ms);
+
+    struct linger lin {};
+    lin.l_onoff = 1;
+    lin.l_linger = 0;
+    ::setsockopt(fd, SOL_SOCKET, SO_LINGER, &lin, sizeof(lin));
+
+    ::close(fd);
+    reset_done.store(true);
+    return true;
+}
+
+} // namespace
+
+SCENARIO("ConnectionPlain::read reports a fatal errno as a closed connection") {
+
+    GIVEN("A ConnectionPlain listening on loopback") {
+        iso15118::io::set_logging_callback([](iso15118::LogLevel, const std::string&) {});
+
+        iso15118::io::PollManager poll_manager;
+        iso15118::io::ConnectionPlain connection(poll_manager, LOOPBACK_IFACE);
+
+        std::atomic<bool> connection_open{false};
+        std::atomic<bool> reset_done{false};
+        std::atomic<bool> saw_reset_read{false};
+        std::atomic<bool> reset_read_reported_closed{false};
+        connection.set_event_callback([&](iso15118::io::ConnectionEvent event) {
+            if (event == iso15118::io::ConnectionEvent::OPEN) {
+                connection_open.store(true);
+            } else if (event == iso15118::io::ConnectionEvent::NEW_DATA) {
+                // Withhold the read until the peer has aborted, so that unread
+                // data is still queued when the abortive close fires and the
+                // peer therefore sends a RST rather than a clean FIN.
+                if (not reset_done.load()) {
+                    return;
+                }
+                std::array<uint8_t, 64> buf{};
+                errno = 0;
+                const auto r = connection.read(buf.data(), buf.size());
+                if (errno == ECONNRESET) {
+                    // The read that hits the reset must be surfaced as a closed
+                    // connection, not masked as would_block.
+                    reset_read_reported_closed.store(r.connection_closed);
+                    saw_reset_read.store(true);
+                }
+            }
+        });
+
+        WHEN("the peer aborts the connection with a RST and the server reads") {
+            auto client_future = std::async(std::launch::async, [&]() { return run_resetting_client(reset_done); });
+
+            const bool got_open = poll_until(
+                poll_manager, [&]() { return connection_open.load(); }, 5s);
+
+            const bool got_reset = poll_until(
+                poll_manager, [&]() { return saw_reset_read.load(); }, 5s);
+
+            const auto client_connected = client_future.get();
+
+            THEN("read() surfaces connection_closed instead of would_block") {
+                REQUIRE(client_connected);
+                REQUIRE(got_open);
+                REQUIRE(got_reset);
+                REQUIRE(reset_read_reported_closed.load());
+            }
+        }
+
+        if (connection_open.load()) {
+            connection.close();
+        }
+    }
+}

--- a/lib/everest/iso15118/test/iso15118/io/socket_keepalive.cpp
+++ b/lib/everest/iso15118/test/iso15118/io/socket_keepalive.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <catch2/catch_test_macros.hpp>
+
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iso15118/detail/io/socket_helper.hpp>
+
+SCENARIO("set_tcp_keepalive configures the socket") {
+
+    GIVEN("An open TCP/IPv6 socket") {
+        const int fd = ::socket(AF_INET6, SOCK_STREAM, 0);
+        REQUIRE(fd >= 0);
+
+        WHEN("set_tcp_keepalive is called") {
+            const auto ok = iso15118::io::set_tcp_keepalive(fd);
+
+            THEN("keepalive is enabled with the configured idle/interval/count") {
+                REQUIRE(ok);
+
+                int value = 0;
+                socklen_t len = sizeof(value);
+
+                REQUIRE(::getsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &value, &len) == 0);
+                REQUIRE(value == 1);
+
+                REQUIRE(::getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &value, &len) == 0);
+                REQUIRE(value == 10);
+
+                REQUIRE(::getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &value, &len) == 0);
+                REQUIRE(value == 3);
+
+                REQUIRE(::getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &value, &len) == 0);
+                REQUIRE(value == 3);
+            }
+        }
+
+        ::close(fd);
+    }
+}

--- a/lib/everest/iso15118/test/iso15118/session/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/session/CMakeLists.txt
@@ -9,3 +9,23 @@ target_link_libraries(test_feedback
 )
 
 catch_discover_tests(test_feedback)
+
+add_executable(test_session_teardown session_teardown.cpp)
+
+target_link_libraries(test_session_teardown
+    PRIVATE
+        iso15118
+        Catch2::Catch2WithMain
+)
+
+catch_discover_tests(test_session_teardown)
+
+add_executable(test_tbd_controller_teardown tbd_controller_teardown.cpp)
+
+target_link_libraries(test_tbd_controller_teardown
+    PRIVATE
+        iso15118
+        Catch2::Catch2WithMain
+)
+
+catch_discover_tests(test_tbd_controller_teardown)

--- a/lib/everest/iso15118/test/iso15118/session/mock_connection.hpp
+++ b/lib/everest/iso15118/test/iso15118/session/mock_connection.hpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+#include <arpa/inet.h>
+
+#include <iso15118/io/connection_abstract.hpp>
+#include <iso15118/io/sdp.hpp>
+#include <iso15118/io/sdp_packet.hpp>
+
+namespace iso15118::test {
+
+// Test double for io::IConnection. Records close() and lets the test drive
+// connection events and read results without any real socket or sleep.
+class MockConnection final : public io::IConnection {
+public:
+    void set_event_callback(const io::ConnectionEventCallback& callback) override {
+        event_callback = callback;
+    }
+
+    io::Ipv6EndPoint get_public_endpoint() const override {
+        return {};
+    }
+
+    void write(const uint8_t*, size_t) override {
+    }
+
+    io::ReadResult read(uint8_t* buf, size_t len) override {
+        if (read_pos < read_buffer.size()) {
+            const auto available = read_buffer.size() - read_pos;
+            const auto count = std::min(len, available);
+            std::memcpy(buf, read_buffer.data() + read_pos, count);
+            read_pos += count;
+            return {false, count, false};
+        }
+        return next_read_result;
+    }
+
+    void close() override {
+        closed = true;
+        fire(io::ConnectionEvent::CLOSED);
+    }
+
+    std::optional<io::sha512_hash_t> get_vehicle_cert_hash() const override {
+        return std::nullopt;
+    }
+
+    // Inject a connection event through the stored callback.
+    void fire(io::ConnectionEvent event) {
+        if (event_callback) {
+            event_callback(event);
+        }
+    }
+
+    // Queue a full V2GTP frame (8-byte header + payload) for read() to deliver.
+    void queue_v2gtp_packet(io::v2gtp::PayloadType payload_type, const uint8_t* payload, std::size_t payload_len) {
+        read_buffer.resize(io::SdpPacket::V2GTP_HEADER_SIZE + payload_len);
+        read_buffer[0] = io::SDP_PROTOCOL_VERSION;
+        read_buffer[1] = io::SDP_INVERSE_PROTOCOL_VERSION;
+
+        const uint16_t type = htons(static_cast<uint16_t>(payload_type));
+        std::memcpy(read_buffer.data() + 2, &type, sizeof(type));
+
+        const uint32_t len = htonl(static_cast<uint32_t>(payload_len));
+        std::memcpy(read_buffer.data() + 4, &len, sizeof(len));
+
+        std::memcpy(read_buffer.data() + io::SdpPacket::V2GTP_HEADER_SIZE, payload, payload_len);
+        read_pos = 0;
+    }
+
+    io::ReadResult next_read_result{};
+    bool closed{false};
+
+private:
+    io::ConnectionEventCallback event_callback;
+    std::vector<uint8_t> read_buffer;
+    std::size_t read_pos{0};
+};
+
+} // namespace iso15118::test

--- a/lib/everest/iso15118/test/iso15118/session/session_teardown.cpp
+++ b/lib/everest/iso15118/test/iso15118/session/session_teardown.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <memory>
+#include <optional>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <iso15118/d20/config.hpp>
+#include <iso15118/d20/context.hpp>
+#include <iso15118/session/feedback.hpp>
+#include <iso15118/session/iso.hpp>
+#include <iso15118/session/logger.hpp>
+
+#include "mock_connection.hpp"
+
+using iso15118::test::MockConnection;
+
+namespace {
+
+// Captured SupportedAppProtocolReq offering the -20:AC namespace.
+constexpr uint8_t sap_req[] = {0x80, 0x00, 0xf3, 0xab, 0x93, 0x71, 0xd3, 0x4b, 0x9b, 0x79, 0xd3, 0x9b, 0xa3,
+                               0x21, 0xd3, 0x4b, 0x9b, 0x79, 0xd1, 0x89, 0xa9, 0x89, 0x89, 0xc1, 0xd1, 0x69,
+                               0x91, 0x81, 0xd2, 0x0a, 0x18, 0x01, 0x00, 0x00, 0x04, 0x00, 0x40};
+
+// Captured SessionSetupReq with a zeroed session id (starts a new session).
+constexpr uint8_t session_setup_req[] = {0x80, 0x8c, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x9f,
+                                         0x9c, 0x2b, 0xd0, 0x62, 0x0b, 0x2b, 0xa6, 0xa4, 0xab, 0x18, 0x99, 0x19, 0x9a,
+                                         0x1a, 0x9b, 0x1b, 0x9c, 0x1c, 0x98, 0x20, 0xa1, 0x21, 0xa2, 0x22, 0xac, 0x00};
+
+} // namespace
+
+SCENARIO("Session teardown primitives") {
+    // The Session FSM logs a state transition on construction through the
+    // process-global session log callback, which starts null.
+    iso15118::session::logging::set_session_log_callback([](std::size_t, const auto&) {});
+
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [](auto) {};
+
+    const iso15118::d20::SessionConfig session_config{iso15118::d20::EvseSetupConfig{}};
+    std::optional<iso15118::d20::PauseContext> pause_ctx{std::nullopt};
+
+    auto connection = std::make_unique<MockConnection>();
+    auto* conn = connection.get();
+
+    iso15118::Session session{std::move(connection), session_config, callbacks, pause_ctx};
+
+    GIVEN("a never-connected session") {
+        WHEN("close() is called") {
+            session.close();
+
+            THEN("the session is finished") {
+                REQUIRE(session.is_finished());
+            }
+        }
+    }
+
+    GIVEN("a connected session with a peer-closed read") {
+        conn->fire(iso15118::io::ConnectionEvent::ACCEPTED);
+        conn->next_read_result = {false, 0, true};
+        conn->fire(iso15118::io::ConnectionEvent::NEW_DATA);
+
+        WHEN("poll() reads the closed connection") {
+            session.poll();
+
+            THEN("the session is finished") {
+                REQUIRE(session.is_finished());
+            }
+        }
+    }
+
+    GIVEN("a connected session with a rate-limiter-deferred response") {
+        conn->fire(iso15118::io::ConnectionEvent::ACCEPTED);
+
+        // First response goes out immediately and latches the tx timestamp.
+        conn->queue_v2gtp_packet(iso15118::io::v2gtp::PayloadType::SAP, sap_req, sizeof(sap_req));
+        conn->fire(iso15118::io::ConnectionEvent::NEW_DATA);
+        session.poll();
+
+        // Second response is generated but held back by the 100 ms rate limiter.
+        conn->queue_v2gtp_packet(iso15118::io::v2gtp::PayloadType::Part20Main, session_setup_req,
+                                 sizeof(session_setup_req));
+        conn->fire(iso15118::io::ConnectionEvent::NEW_DATA);
+        session.poll();
+
+        REQUIRE_FALSE(session.is_finished());
+
+        WHEN("close() is called with a response still pending") {
+            session.close();
+
+            THEN("the session is finished") {
+                REQUIRE(session.is_finished());
+            }
+        }
+    }
+}

--- a/lib/everest/iso15118/test/iso15118/session/tbd_controller_teardown.cpp
+++ b/lib/everest/iso15118/test/iso15118/session/tbd_controller_teardown.cpp
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <memory>
+#include <optional>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <iso15118/d20/config.hpp>
+#include <iso15118/session/feedback.hpp>
+#include <iso15118/session/iso.hpp>
+#include <iso15118/session/logger.hpp>
+#include <iso15118/tbd_controller.hpp>
+
+#include "mock_connection.hpp"
+
+using iso15118::test::MockConnection;
+
+namespace {
+
+// Tracks every connection the controller creates so tests can drive the
+// current session's transport and observe session recreation.
+struct MockConnectionFactory {
+    MockConnection* last{nullptr};
+    int calls{0};
+
+    iso15118::TbdController::ConnectionFactory fn() {
+        return [this](iso15118::io::PollManager&, const std::string&) -> std::unique_ptr<iso15118::io::IConnection> {
+            auto connection = std::make_unique<MockConnection>();
+            last = connection.get();
+            ++calls;
+            return connection;
+        };
+    }
+};
+
+iso15118::TbdController make_controller(const iso15118::session::feedback::Callbacks& callbacks,
+                                        MockConnectionFactory& factory) {
+    return iso15118::TbdController{iso15118::TbdConfig{{},
+                                                       "lo",
+                                                       iso15118::config::TlsNegotiationStrategy::ACCEPT_CLIENT_OFFER,
+                                                       /*enable_sdp_server=*/false},
+                                   callbacks, iso15118::d20::EvseSetupConfig{}, factory.fn()};
+}
+
+// Captured SupportedAppProtocolReq offering the -20:AC namespace.
+constexpr uint8_t sap_req[] = {0x80, 0x00, 0xf3, 0xab, 0x93, 0x71, 0xd3, 0x4b, 0x9b, 0x79, 0xd3, 0x9b, 0xa3,
+                               0x21, 0xd3, 0x4b, 0x9b, 0x79, 0xd1, 0x89, 0xa9, 0x89, 0x89, 0xc1, 0xd1, 0x69,
+                               0x91, 0x81, 0xd2, 0x0a, 0x18, 0x01, 0x00, 0x00, 0x04, 0x00, 0x40};
+
+// Captured SessionSetupReq with a zeroed session id (starts a new session).
+constexpr uint8_t session_setup_req[] = {0x80, 0x8c, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x9f,
+                                         0x9c, 0x2b, 0xd0, 0x62, 0x0b, 0x2b, 0xa6, 0xa4, 0xab, 0x18, 0x99, 0x19, 0x9a,
+                                         0x1a, 0x9b, 0x1b, 0x9c, 0x1c, 0x98, 0x20, 0xa1, 0x21, 0xa2, 0x22, 0xac, 0x00};
+
+// Drive the current session until a response is deferred by the 100 ms rate limiter.
+void arm_deferred_response(iso15118::TbdController& controller, MockConnection& conn) {
+    conn.queue_v2gtp_packet(iso15118::io::v2gtp::PayloadType::SAP, sap_req, sizeof(sap_req));
+    conn.fire(iso15118::io::ConnectionEvent::NEW_DATA);
+    controller.tick();
+
+    conn.queue_v2gtp_packet(iso15118::io::v2gtp::PayloadType::Part20Main, session_setup_req, sizeof(session_setup_req));
+    conn.fire(iso15118::io::ConnectionEvent::NEW_DATA);
+    controller.tick();
+}
+
+} // namespace
+
+SCENARIO("Data-link loss tears down the active session") {
+    iso15118::session::logging::set_session_log_callback([](std::size_t, const auto&) {});
+
+    bool terminate_signaled = false;
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [&](iso15118::session::feedback::Signal s) {
+        if (s == iso15118::session::feedback::Signal::DLINK_TERMINATE) {
+            terminate_signaled = true;
+        }
+    };
+
+    MockConnectionFactory factory;
+    auto controller = make_controller(callbacks, factory);
+
+    controller.tick();
+    REQUIRE(factory.last != nullptr);
+    factory.last->fire(iso15118::io::ConnectionEvent::ACCEPTED);
+
+    terminate_signaled = false;
+
+    WHEN("the data link drops and the loop ticks") {
+        controller.set_dlink_ready(false);
+        controller.tick();
+
+        THEN("the session is torn down") {
+            REQUIRE(terminate_signaled);
+        }
+    }
+}
+
+SCENARIO("Data-link loss tears down a session with a deferred response") {
+    iso15118::session::logging::set_session_log_callback([](std::size_t, const auto&) {});
+
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [](auto) {};
+
+    MockConnectionFactory factory;
+    auto controller = make_controller(callbacks, factory);
+
+    controller.tick();
+    REQUIRE(factory.calls == 1);
+    factory.last->fire(iso15118::io::ConnectionEvent::ACCEPTED);
+    arm_deferred_response(controller, *factory.last);
+
+    WHEN("the data link drops and the loop ticks") {
+        controller.set_dlink_ready(false);
+        controller.tick();
+
+        THEN("the session with the pending response is reaped and replaced") {
+            REQUIRE(factory.calls == 2);
+        }
+    }
+}
+
+SCENARIO("Data-link loss reaps a never-connected session") {
+    iso15118::session::logging::set_session_log_callback([](std::size_t, const auto&) {});
+
+    bool terminate_signaled = false;
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [&](iso15118::session::feedback::Signal s) {
+        if (s == iso15118::session::feedback::Signal::DLINK_TERMINATE) {
+            terminate_signaled = true;
+        }
+    };
+
+    MockConnectionFactory factory;
+    auto controller = make_controller(callbacks, factory);
+
+    controller.tick();
+    REQUIRE(factory.last != nullptr);
+
+    terminate_signaled = false;
+
+    WHEN("the data link drops and the loop ticks") {
+        controller.set_dlink_ready(false);
+        controller.tick();
+
+        THEN("the never-connected session is torn down") {
+            REQUIRE(terminate_signaled);
+        }
+    }
+}
+
+SCENARIO("A terminate racing session creation wins over the fresh session") {
+    iso15118::session::logging::set_session_log_callback([](std::size_t, const auto&) {});
+
+    bool terminate_signaled = false;
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [&](iso15118::session::feedback::Signal s) {
+        if (s == iso15118::session::feedback::Signal::DLINK_TERMINATE) {
+            terminate_signaled = true;
+        }
+    };
+
+    MockConnectionFactory factory;
+    auto controller = make_controller(callbacks, factory);
+
+    GIVEN("a session that exists when a data-link terminate is raised") {
+        controller.tick();
+        REQUIRE(factory.calls == 1);
+        factory.last->fire(iso15118::io::ConnectionEvent::ACCEPTED);
+
+        // A terminate raised while the session is live (as a dlink drop racing an
+        // SDP-created session would) must not be swallowed.
+        controller.set_dlink_ready(false);
+        terminate_signaled = false;
+
+        WHEN("the loop ticks") {
+            controller.tick();
+
+            THEN("the session is reaped and a subsequent request creates a fresh one") {
+                REQUIRE(terminate_signaled);
+                REQUIRE(factory.calls == 2);
+
+                AND_WHEN("the fresh session is accepted and the loop ticks again") {
+                    factory.last->fire(iso15118::io::ConnectionEvent::ACCEPTED);
+                    terminate_signaled = false;
+                    controller.tick();
+
+                    THEN("the recovered session survives") {
+                        REQUIRE_FALSE(terminate_signaled);
+                        REQUIRE(controller.has_active_session());
+                        REQUIRE(factory.calls == 2);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/IsoMux/charger/ISO15118_chargerImpl.cpp
@@ -591,6 +591,16 @@ void ISO15118_chargerImpl::handle_ac_contactor_closed(bool& status) {
 }
 
 void ISO15118_chargerImpl::handle_dlink_ready(bool& value) {
+    if (not value) {
+        // Data-link loss is a broadcast teardown: forward to both children so the
+        // active session's owner tears down regardless of the current selection.
+        // Out of scope (follow-up): keepalive on IsoMux's own EV-facing accepted
+        // socket and teardown of IsoMux's own proxy connection
+        // (connection/connection.cpp "v2g-session already running") on disconnect.
+        mod->r_iso20->call_dlink_ready(value);
+        mod->r_iso2->call_dlink_ready(value);
+        return;
+    }
     if (mod->selected_iso20()) {
         mod->r_iso20->call_dlink_ready(value);
     } else {


### PR DESCRIPTION
## Describe your changes

> **Note:** this PR is stacked on #2225 (branch `refactor/tls-iso15118-adapter`); please review and merge that one first. The diff shown here includes #2225's changes until it lands.

When the EV side of an ISO 15118-20 session disappears without a clean shutdown (contactor drop, cable pull, EV-side crash — the hard-disconnect case from #2010), the SECC kept the session object alive: nothing on the wire signaled the loss, the poll loop kept spinning on the dead socket, and every reconnect SDP request from the returning EVCC was rejected with "session is already created and running" until the sequence timeout finally reaped the session. The EV could not start a new charging session for up to a minute after replugging. This PR makes the SECC tear the session down promptly through two independent paths — the data-link-ready signal from SLAC, and dead-peer detection on the TCP transport itself — so a reconnecting EV's SDP request is accepted within one poll cycle.

**iso15118 library — session teardown on data-link loss**

- `TbdController::set_dlink_ready(false)` now requests termination of the active session: `tick()` consumes an atomic `terminate_session_requested` flag and closes whatever session exists, whether it completed the V2G handshake or never got past SDP. Previously the dlink signal only reset the communication-setup timeout, so an established-but-dead session lingered until the 60 s sequence timeout. Behavior is the same for AC and DC.
- The flag is deliberately *not* cleared when `handle_sdp_server_input` creates a fresh session: a data-link loss racing session creation must win, so `tick()` reaps the fresh session too. This is safe because the EVCC retransmits its SDP request (~250 ms) and recovers; swallowing the terminate would instead strand a session on a dead link. The flag is consumed unconditionally each tick so a request raised while no session exists cannot tear down a later one.
- `Session::close()` drops a rate-limiter-deferred response: the transport is gone, the response is undeliverable, and keeping it queued held `is_finished()` false so the controller never reaped the session.
- The body of `loop()` is factored into a `tick()` method (plus `has_active_session()`), and the session connection now comes from an injectable `ConnectionFactory` (defaulting to `ConnectionPlain` as before). This is what lets the new teardown tests drive the controller through its public API without a network; production behavior is unchanged.

**iso15118 library — dead-peer detection on the transport**

- Accepted sockets (both plain TCP and TLS) now enable TCP keepalive (10 s idle, 3 s interval, 3 probes ≈ 19 s dead-peer detection), so a peer that vanished without a FIN/RST is detected at the transport layer even if the dlink signal never arrives.
- `ConnectionPlain::read` mapped *every* `read()` error to `would_block` — including `ECONNRESET` and the `ETIMEDOUT` raised by the keepalive — so the level-triggered poll spun on the dead socket until the sequence timeout. Only `EAGAIN`/`EWOULDBLOCK`/`EINTR` are treated as would-block now; any other errno reports the connection closed, which routes into the canonical session close. `ReadResult::connection_closed` is documented to cover fatal socket errors in addition to EOF / TLS `close_notify`.
- `ConnectionSSL::close()` handles the never-connected case: if teardown happens before a peer ever connected, the listening socket is now unregistered from the poll manager, closed, and a single `CLOSED` event is emitted — previously the listener stayed registered as a dangling poll entry.

**IsoMux module**

- `handle_dlink_ready(false)` is forwarded to *both* children (ISO 15118-2 and -20) instead of only the currently selected one. Data-link loss is a broadcast teardown: the session may be owned by the non-selected child, and it must be torn down regardless of which stack the mux currently points at. `dlink_ready(true)` still goes only to the selected child. (Keepalive on IsoMux's own EV-facing socket and teardown of its proxy connection are noted in-code as follow-ups.)

**Tests**

New GTest suites under `lib/everest/iso15118/test/`:

- `session/tbd_controller_teardown.cpp` — drives `TbdController` through `set_dlink_ready` / `tick()` via the injectable connection factory: dlink loss terminates an active session, a terminate racing a fresh session wins, and a stale terminate does not affect a later session.
- `session/session_teardown.cpp` (with `mock_connection.hpp`) — session close on connection-closed read results and the deferred-response drop.
- `io/connection_plain.cpp` — errno classification in `read()` (would-block vs. fatal-error-as-closed).
- `io/socket_keepalive.cpp` — keepalive options are applied to accepted sockets.
- `io/connection_openssl.cpp` — never-connected `ConnectionSSL::close()` releases the listener and emits exactly one `CLOSED`.

## Issue ticket number and link

Fixes #2010

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
