### PR TITLE
fix(EvseV2G): report EVSE_Shutdown status after EV stop request

### DIFF
--- a/modules/EVSE/EvseV2G/din_server.cpp
+++ b/modules/EVSE/EvseV2G/din_server.cpp
@@ -819,7 +819,7 @@ static enum v2g_event handle_din_charge_parameter(struct v2g_connection* conn) {
  * \param conn is the structure with the V2G msg pair.
  * \return Returns the next V2G-event.
  */
-static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
+enum v2g_event states::handle_din_power_delivery(struct v2g_connection* conn) {
     struct din_PowerDeliveryReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.PowerDeliveryReq;
     struct din_PowerDeliveryResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.PowerDeliveryRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
@@ -828,6 +828,16 @@ static enum v2g_event handle_din_power_delivery(struct v2g_connection* conn) {
     publish_din_power_delivery_req(conn->ctx, req);
 
     if (req->ReadyToChargeState == (int)0) {
+        /* The EV requested to stop the charging session. Mark the remaining phases as shut down, so that
+         * PowerDeliveryRes and WeldingDetectionRes report EVSE_Shutdown [IEC 61851-23:2023 CC.7.5.19]. More
+         * specific status codes like EVSE_UtilityInterruptEvent or EVSE_Malfunction are preserved. */
+        for (const auto phase : {PHASE_CHARGE, PHASE_WELDING}) {
+            uint8_t& status_code = conn->ctx->evse_v2g_data.evse_status_code[phase];
+            if ((status_code == din_DC_EVSEStatusCodeType_EVSE_NotReady) ||
+                (status_code == din_DC_EVSEStatusCodeType_EVSE_Ready)) {
+                status_code = din_DC_EVSEStatusCodeType_EVSE_Shutdown;
+            }
+        }
         conn->ctx->p_charger->publish_current_demand_finished(nullptr);
         conn->ctx->p_charger->publish_dc_open_contactor(nullptr);
         conn->ctx->session.is_charging = false;
@@ -1077,7 +1087,7 @@ static enum v2g_event handle_din_current_demand(struct v2g_connection* conn) {
  * \param conn is the structure with the V2G msg pair.
  * \return Returns the next V2G-event.
  */
-static enum v2g_event handle_din_welding_detection(struct v2g_connection* conn) {
+enum v2g_event states::handle_din_welding_detection(struct v2g_connection* conn) {
     struct din_WeldingDetectionReqType* req = &conn->exi_in.dinEXIDocument->V2G_Message.Body.WeldingDetectionReq;
     struct din_WeldingDetectionResType* res = &conn->exi_out.dinEXIDocument->V2G_Message.Body.WeldingDetectionRes;
     enum v2g_event nextEvent = V2G_EVENT_NO_EVENT;
@@ -1244,7 +1254,7 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
         }
         exi_out->V2G_Message.Body.PowerDeliveryRes_isUsed = 1u;
         init_din_PowerDeliveryResType(&exi_out->V2G_Message.Body.PowerDeliveryRes);
-        next_v2g_event = handle_din_power_delivery(conn);
+        next_v2g_event = states::handle_din_power_delivery(conn);
     } else if (exi_in->V2G_Message.Body.ChargingStatusReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "ChargingStatus request is not supported in DIN 70121");
         conn->ctx->current_v2g_msg = V2G_UNKNOWN_MSG;
@@ -1273,7 +1283,7 @@ enum v2g_event din_handle_request(v2g_connection* conn) {
         }
         exi_out->V2G_Message.Body.WeldingDetectionRes_isUsed = 1u;
         init_din_WeldingDetectionResType(&exi_out->V2G_Message.Body.WeldingDetectionRes);
-        next_v2g_event = handle_din_welding_detection(conn);
+        next_v2g_event = states::handle_din_welding_detection(conn);
     } else if (exi_in->V2G_Message.Body.SessionStopReq_isUsed) {
         dlog(DLOG_LEVEL_TRACE, "Handling SessionStopReq");
         conn->ctx->current_v2g_msg = V2G_SESSION_STOP_MSG;

--- a/modules/EVSE/EvseV2G/din_server.hpp
+++ b/modules/EVSE/EvseV2G/din_server.hpp
@@ -114,6 +114,8 @@ namespace states {
 enum v2g_event handle_din_session_setup(struct v2g_connection* conn);
 enum v2g_event handle_din_service_discovery(struct v2g_connection* conn);
 enum v2g_event handle_din_contract_authentication(struct v2g_connection* conn);
+enum v2g_event handle_din_power_delivery(struct v2g_connection* conn);
+enum v2g_event handle_din_welding_detection(struct v2g_connection* conn);
 
 } // namespace states
 

--- a/modules/EVSE/EvseV2G/iso_server.cpp
+++ b/modules/EVSE/EvseV2G/iso_server.cpp
@@ -258,6 +258,23 @@ static telemetry_types::ChargeProgress to_telemetry_charge_progress(iso2_chargeP
     }
 }
 
+/*!
+ * \brief set_dc_shutdown_status_code This function marks the remaining DC phases as shut down after the EV requested
+ * to stop the charging session, so that PowerDeliveryRes and WeldingDetectionRes report EVSE_Shutdown
+ * [IEC 61851-23:2023 CC.7.5.19]. More specific status codes like EVSE_UtilityInterruptEvent or EVSE_Malfunction are
+ * preserved.
+ * \param ctx points to the V2G context.
+ */
+static void set_dc_shutdown_status_code(struct v2g_context* ctx) {
+    for (const auto phase : {PHASE_CHARGE, PHASE_WELDING}) {
+        uint8_t& status_code = ctx->evse_v2g_data.evse_status_code[phase];
+        if ((status_code == iso2_DC_EVSEStatusCodeType_EVSE_NotReady) ||
+            (status_code == iso2_DC_EVSEStatusCodeType_EVSE_Ready)) {
+            status_code = iso2_DC_EVSEStatusCodeType_EVSE_Shutdown;
+        }
+    }
+}
+
 //=============================================
 //             Publishing request msg
 //=============================================
@@ -1763,6 +1780,7 @@ static enum v2g_event handle_iso_power_delivery(struct v2g_connection* conn) {
             // state is checked by other module
             conn->ctx->p_charger->publish_ac_open_contactor(nullptr);
         } else {
+            set_dc_shutdown_status_code(conn->ctx);
             conn->ctx->p_charger->publish_current_demand_finished(nullptr);
             conn->ctx->p_charger->publish_dc_open_contactor(nullptr);
         }

--- a/modules/EVSE/EvseV2G/tests/din_server_test.cpp
+++ b/modules/EVSE/EvseV2G/tests/din_server_test.cpp
@@ -560,4 +560,124 @@ TEST_F(DinServerTest, din_validate_response_code_V2G_DC_665) {
     EXPECT_GE(given_response_code, min_expected_response_code);
 }
 
+class DinServerPowerDeliveryTest : public DinServerTest {
+protected:
+    void SetUp() override {
+        DinServerTest::SetUp();
+
+        exi_in->V2G_Message.Body.PowerDeliveryReq_isUsed = true;
+        init_din_PowerDeliveryReqType(&exi_in->V2G_Message.Body.PowerDeliveryReq);
+
+        exi_out->V2G_Message.Body.PowerDeliveryRes_isUsed = 1u;
+        init_din_PowerDeliveryResType(&exi_out->V2G_Message.Body.PowerDeliveryRes);
+
+        ctx->is_dc_charger = true;
+        ctx->current_v2g_msg = V2G_POWER_DELIVERY_MSG;
+        ctx->last_v2g_msg = V2G_CURRENT_DEMAND_MSG;
+        ctx->state = WAIT_FOR_CURRENTDEMAND_POWERDELIVERY;
+        ctx->evse_v2g_data.session_id = 0;
+        ctx->ev_v2g_data.received_session_id = 0;
+    }
+
+    static void set_dc_ev_status(struct din_DC_EVStatusType& dc_ev_status, bool ev_ready) {
+        dc_ev_status.EVReady = ev_ready ? 1 : 0;
+        dc_ev_status.EVErrorCode = din_DC_EVErrorCodeType_NO_ERROR;
+        dc_ev_status.EVRESSSOC = 50;
+    }
+
+    void set_power_delivery_req(bool ready_to_charge) {
+        auto& req = exi_in->V2G_Message.Body.PowerDeliveryReq;
+        req.ReadyToChargeState = ready_to_charge ? 1 : 0;
+        // In a DC charging session the EV includes the DC_EVPowerDeliveryParameter
+        req.DC_EVPowerDeliveryParameter_isUsed = 1u;
+        set_dc_ev_status(req.DC_EVPowerDeliveryParameter.DC_EVStatus, ready_to_charge);
+        req.DC_EVPowerDeliveryParameter.ChargingComplete = 0;
+    }
+};
+
+TEST_F(DinServerPowerDeliveryTest, power_delivery_stop_sets_shutdown_status_code) {
+    // [IEC 61851-23:2023 CC.7.5.19] After the EV requested to stop the charging session
+    // (ReadyToChargeState = false), the PowerDeliveryRes and the subsequent WeldingDetectionRes
+    // shall report EVSE_Shutdown (or EVSE_UtilityInterruptEvent) instead of EVSE_Ready
+    set_power_delivery_req(false);
+
+    ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE] = din_DC_EVSEStatusCodeType_EVSE_Ready;
+    ctx->evse_v2g_data.evse_status_code[PHASE_WELDING] = din_DC_EVSEStatusCodeType_EVSE_NotReady;
+
+    EXPECT_EQ(states::handle_din_power_delivery(conn.get()), V2G_EVENT_NO_EVENT);
+
+    auto& res = exi_out->V2G_Message.Body.PowerDeliveryRes;
+    EXPECT_EQ(res.ResponseCode, din_responseCodeType_OK);
+    EXPECT_EQ(res.DC_EVSEStatus.EVSEStatusCode, din_DC_EVSEStatusCodeType_EVSE_Shutdown);
+    EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_WELDING], din_DC_EVSEStatusCodeType_EVSE_Shutdown);
+    EXPECT_EQ(ctx->state, WAIT_FOR_WELDINGDETECTION_SESSIONSTOP);
+    EXPECT_EQ(ctx->session.is_charging, false);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_ERROR).size(), 0);
+}
+
+TEST_F(DinServerPowerDeliveryTest, power_delivery_stop_preserves_more_specific_status_code) {
+    // A more specific status code like EVSE_UtilityInterruptEvent must not be overwritten
+    // by EVSE_Shutdown when the EV requests to stop the charging session
+    set_power_delivery_req(false);
+
+    ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE] = din_DC_EVSEStatusCodeType_EVSE_UtilityInterruptEvent;
+    ctx->evse_v2g_data.evse_status_code[PHASE_WELDING] = din_DC_EVSEStatusCodeType_EVSE_UtilityInterruptEvent;
+
+    EXPECT_EQ(states::handle_din_power_delivery(conn.get()), V2G_EVENT_NO_EVENT);
+
+    auto& res = exi_out->V2G_Message.Body.PowerDeliveryRes;
+    EXPECT_EQ(res.DC_EVSEStatus.EVSEStatusCode, din_DC_EVSEStatusCodeType_EVSE_UtilityInterruptEvent);
+    EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_WELDING], din_DC_EVSEStatusCodeType_EVSE_UtilityInterruptEvent);
+}
+
+TEST_F(DinServerPowerDeliveryTest, welding_detection_after_stop_reports_shutdown_status_code) {
+    // [IEC 61851-23:2023 CC.7.5.19] After the EV requested to stop the charging session,
+    // the WeldingDetectionRes shall report EVSE_Shutdown instead of EVSE_Ready
+    set_power_delivery_req(false);
+
+    ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE] = din_DC_EVSEStatusCodeType_EVSE_Ready;
+    ctx->evse_v2g_data.evse_status_code[PHASE_WELDING] = din_DC_EVSEStatusCodeType_EVSE_NotReady;
+
+    EXPECT_EQ(states::handle_din_power_delivery(conn.get()), V2G_EVENT_NO_EVENT);
+
+    // The EV follows up with a WeldingDetectionReq
+    exi_in->V2G_Message.Body.PowerDeliveryReq_isUsed = false;
+    exi_in->V2G_Message.Body.WeldingDetectionReq_isUsed = true;
+    init_din_WeldingDetectionReqType(&exi_in->V2G_Message.Body.WeldingDetectionReq);
+    set_dc_ev_status(exi_in->V2G_Message.Body.WeldingDetectionReq.DC_EVStatus, false);
+
+    exi_out->V2G_Message.Body.PowerDeliveryRes_isUsed = 0u;
+    exi_out->V2G_Message.Body.WeldingDetectionRes_isUsed = 1u;
+    init_din_WeldingDetectionResType(&exi_out->V2G_Message.Body.WeldingDetectionRes);
+
+    ctx->last_v2g_msg = V2G_POWER_DELIVERY_MSG;
+    ctx->current_v2g_msg = V2G_WELDING_DETECTION_MSG;
+
+    EXPECT_EQ(states::handle_din_welding_detection(conn.get()), V2G_EVENT_NO_EVENT);
+
+    auto& res = exi_out->V2G_Message.Body.WeldingDetectionRes;
+    EXPECT_EQ(res.ResponseCode, din_responseCodeType_OK);
+    EXPECT_EQ(res.DC_EVSEStatus.EVSEStatusCode, din_DC_EVSEStatusCodeType_EVSE_Shutdown);
+    EXPECT_EQ(ctx->state, WAIT_FOR_WELDINGDETECTION_SESSIONSTOP);
+    EXPECT_EQ(module::stub::get_logs(dloglevel_t::DLOG_LEVEL_ERROR).size(), 0);
+}
+
+TEST_F(DinServerPowerDeliveryTest, power_delivery_start_keeps_ready_status_code) {
+    // A PowerDeliveryReq with ReadyToChargeState = true must not touch the status codes
+    set_power_delivery_req(true);
+
+    ctx->last_v2g_msg = V2G_PRE_CHARGE_MSG;
+    ctx->state = WAIT_FOR_PRECHARGE_POWERDELIVERY;
+    ctx->evse_v2g_data.evse_status_code[PHASE_CHARGE] = din_DC_EVSEStatusCodeType_EVSE_Ready;
+    ctx->evse_v2g_data.evse_status_code[PHASE_WELDING] = din_DC_EVSEStatusCodeType_EVSE_NotReady;
+
+    EXPECT_EQ(states::handle_din_power_delivery(conn.get()), V2G_EVENT_NO_EVENT);
+
+    auto& res = exi_out->V2G_Message.Body.PowerDeliveryRes;
+    EXPECT_EQ(res.ResponseCode, din_responseCodeType_OK);
+    EXPECT_EQ(res.DC_EVSEStatus.EVSEStatusCode, din_DC_EVSEStatusCodeType_EVSE_Ready);
+    EXPECT_EQ(ctx->evse_v2g_data.evse_status_code[PHASE_WELDING], din_DC_EVSEStatusCodeType_EVSE_NotReady);
+    EXPECT_EQ(ctx->state, WAIT_FOR_CURRENTDEMAND);
+}
+
 } // namespace


### PR DESCRIPTION

## Describe your changes

- Mark the charge and welding phases as shut down when the EV sends PowerDeliveryReq with ReadyToChargeState = false, so that PowerDeliveryRes and the subsequent WeldingDetectionRes report EVSE_Shutdown instead of EVSE_Ready [IEC 61851-23:2023 CC.7.5.19].
- More specific status codes like EVSE_UtilityInterruptEvent or EVSE_Malfunction are preserved. Applies to both DIN 70121 and ISO 15118-2.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

