### PR TITLE
system: allow skipping reset after update

### DIFF
--- a/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/disable_reset_after_update_strategy.py
+++ b/applications/utils/everest-testing/src/everest/testing/core_utils/_configuration/everest_configuration_strategies/disable_reset_after_update_strategy.py
@@ -1,0 +1,19 @@
+from copy import deepcopy
+from typing import Dict
+
+from everest.testing.core_utils._configuration.everest_configuration_strategies.everest_configuration_strategy import \
+    EverestConfigAdjustmentStrategy
+
+
+class DisableResetAfterUpdateStrategy(EverestConfigAdjustmentStrategy):
+    def adjust_everest_configuration(self, config: Dict) -> Dict:
+
+        adjusted_config = deepcopy(config)
+
+        for module_id, module_config in adjusted_config.get("active_modules", {}).items():
+            if module_config.get("module") == "System":
+                if "config_module" not in module_config:
+                    module_config["config_module"] = {}
+                module_config["config_module"]["ResetAfterUpdate"] = False
+
+        return adjusted_config

--- a/modules/Misc/System/System.hpp
+++ b/modules/Misc/System/System.hpp
@@ -26,6 +26,7 @@ struct Conf {
     double DefaultRetries;
     double DefaultRetryInterval;
     int ResetDelay;
+    bool ResetAfterUpdate;
 };
 
 class System : public Everest::ModuleBase {

--- a/modules/Misc/System/main/systemImpl.cpp
+++ b/modules/Misc/System/main/systemImpl.cpp
@@ -358,14 +358,22 @@ void systemImpl::install_signed_firmware(const types::system::FirmwareUpdateRequ
                             return CmdControl::Continue;
                         });
         if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::Installed) {
-            if (!this->mod->r_store.empty()) {
-                this->mod->r_store.at(0)->call_store(boot_reason_key,
-                                                     boot_reason_to_string(types::system::BootReason::FirmwareUpdate));
-            }
+            if (this->mod->config.ResetAfterUpdate) {
+                firmware_status.firmware_update_status = types::system::FirmwareUpdateStatusEnum::InstallRebooting;
+                this->publish_firmware_update_status(firmware_status);
 
-            auto reset_type = types::system::ResetType::Hard;
-            bool firmware_installation_running_copy = this->firmware_installation_running;
-            this->handle_reset(reset_type, firmware_installation_running_copy);
+                if (!this->mod->r_store.empty()) {
+                    this->mod->r_store.at(0)->call_store(
+                        boot_reason_key, boot_reason_to_string(types::system::BootReason::FirmwareUpdate));
+                }
+
+                auto reset_type = types::system::ResetType::Hard;
+                bool firmware_installation_running_copy = this->firmware_installation_running;
+                this->handle_reset(reset_type, firmware_installation_running_copy);
+            } else {
+                EVLOG_info << "Firmware installed but ResetAfterUpdate is false - skipping reset.";
+                this->firmware_installation_running = false;
+            }
         } else {
             // Installation finished without reaching Installed, so no reset is triggered.
             // Clear the flag so that a subsequent firmware update request is not rejected

--- a/modules/Misc/System/manifest.yaml
+++ b/modules/Misc/System/manifest.yaml
@@ -18,6 +18,13 @@ config:
     type: integer
     minimum: 0
     default: 0
+  ResetAfterUpdate:
+    description: >-
+      Whether the System module triggers a device reset after a firmware update has been installed.
+      Defaults to true. Set to false to keep the device running after install (e.g. for updates that
+      keep connectors available and must not interrupt ongoing sessions).
+    type: boolean
+    default: true
 provides:
   main:
     description: Implements the system interface

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -11,6 +11,8 @@ import pytest
 from everest.testing.core_utils.controller.test_controller_interface import (
     TestController,
 )
+from everest.testing.core_utils._configuration.everest_configuration_strategies.disable_reset_after_update_strategy import \
+    DisableResetAfterUpdateStrategy
 
 # fmt: off
 
@@ -6903,8 +6905,16 @@ async def test_signed_update_firmware(
         call.SignedFirmwareStatusNotification(FirmwareStatus.installed, 1),
     )
 
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "SignedFirmwareStatusNotification",
+        call.SignedFirmwareStatusNotification(FirmwareStatus.install_rebooting, 1),
+    )
+
 @pytest.mark.asyncio
 @pytest.mark.xdist_group(name="FTP")
+@pytest.mark.everest_config_adaptions(DisableResetAfterUpdateStrategy())
 async def test_signed_update_firmware_keep_connectors_available(
     test_config: OcppTestConfiguration,
     charge_point_v16: ChargePoint16,

--- a/tests/ocpp_tests/test_sets/ocpp201/firmware_management.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/firmware_management.py
@@ -12,6 +12,8 @@ import pytest
 from everest.testing.core_utils.controller.test_controller_interface import (
     TestController,
 )
+from everest.testing.core_utils._configuration.everest_configuration_strategies.disable_reset_after_update_strategy import \
+    DisableResetAfterUpdateStrategy
 
 sys.path.append(os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../..")))
@@ -125,10 +127,18 @@ async def test_L01_secure_firmware_update_disable_connectors(
         {"status": "Installed", "requestId": 1},
     )
 
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v201,
+        "FirmwareStatusNotification",
+        {"status": "InstallRebooting", "requestId": 1},
+    )
+
 
 @pytest.mark.asyncio
 @pytest.mark.ocpp_version("ocpp2.0.1")
 @pytest.mark.everest_core_config("everest-config-ocpp201.yaml")
+@pytest.mark.everest_config_adaptions(DisableResetAfterUpdateStrategy())
 @pytest.mark.xdist_group(name="FTP")
 async def test_L01_secure_firmware_update_keep_connectors_available(
     test_config: OcppTestConfiguration,


### PR DESCRIPTION
## Describe your changes

#2392 already mitigated the flakiness of the test_signed_update_firmware_keep_connectors_available testcase. However the system module should not trigger a reset in the first place, if the connectors are supposed to stay available during the update.
This PR adds an option to the system module to prevent this from happening.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

