### PR TITLE
feat(OCPP201): delegate configure_network to the system provider

### DIFF
--- a/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/conversions.hpp
+++ b/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/conversions.hpp
@@ -14,6 +14,7 @@
 #include <generated/types/evse_manager.hpp>
 #include <generated/types/grid_support.hpp>
 #include <generated/types/iso15118.hpp>
+#include <generated/types/network.hpp>
 #include <generated/types/ocpp.hpp>
 #include <generated/types/reservation.hpp>
 #include <generated/types/system.hpp>
@@ -318,6 +319,19 @@ ocpp::v2::ChangeAvailabilityRequest
 to_ocpp_change_availability_request(const types::ocpp::ChangeAvailabilityRequest& request);
 types::ocpp::ChangeAvailabilityResponse
 to_everest_change_availability_response(const ocpp::v2::ChangeAvailabilityResponse& response);
+
+/// \brief Converts a given ocpp::v2::OCPPInterfaceEnum \p iface to a types::network::InterfaceClass.
+types::network::InterfaceClass to_everest_interface_class(const ocpp::v2::OCPPInterfaceEnum iface);
+
+/// \brief Converts a given ocpp::v2::APN \p apn to a types::network::APN.
+types::network::APN to_everest_network_apn(const ocpp::v2::APN& apn);
+
+/// \brief Converts a given ocpp::v2::VPN \p vpn to a types::network::VPN.
+types::network::VPN to_everest_network_vpn(const ocpp::v2::VPN& vpn);
+
+/// \brief Converts \p profile and \p request_id (correlation id) to a types::network::ConfigureNetworkRequest.
+types::network::ConfigureNetworkRequest
+to_everest_configure_network_request(const int32_t request_id, const ocpp::v2::NetworkConnectionProfile& profile);
 
 /// \brief Converts a given ocpp::v2::DERControlEnum \p control_type to a types::grid_support::DirectiveType.
 /// \details Total over the 22 OCPP DERControlEnum values; the 6 ISO-only DirectiveType values have no OCPP producer.

--- a/lib/everest/ocpp_module_common/src/conversions.cpp
+++ b/lib/everest/ocpp_module_common/src/conversions.cpp
@@ -1976,6 +1976,110 @@ to_everest_change_availability_response(const ocpp::v2::ChangeAvailabilityRespon
     return result;
 }
 
+types::network::InterfaceClass to_everest_interface_class(const ocpp::v2::OCPPInterfaceEnum iface) {
+    switch (iface) {
+    case ocpp::v2::OCPPInterfaceEnum::Wired0:
+        return types::network::InterfaceClass::Wired0;
+    case ocpp::v2::OCPPInterfaceEnum::Wired1:
+        return types::network::InterfaceClass::Wired1;
+    case ocpp::v2::OCPPInterfaceEnum::Wired2:
+        return types::network::InterfaceClass::Wired2;
+    case ocpp::v2::OCPPInterfaceEnum::Wired3:
+        return types::network::InterfaceClass::Wired3;
+    case ocpp::v2::OCPPInterfaceEnum::Wireless0:
+        return types::network::InterfaceClass::Wireless0;
+    case ocpp::v2::OCPPInterfaceEnum::Wireless1:
+        return types::network::InterfaceClass::Wireless1;
+    case ocpp::v2::OCPPInterfaceEnum::Wireless2:
+        return types::network::InterfaceClass::Wireless2;
+    case ocpp::v2::OCPPInterfaceEnum::Wireless3:
+        return types::network::InterfaceClass::Wireless3;
+    case ocpp::v2::OCPPInterfaceEnum::Any:
+        return types::network::InterfaceClass::Any;
+    }
+    throw std::out_of_range("Could not convert OCPPInterfaceEnum to types::network::InterfaceClass");
+}
+
+/// \brief Converts a given ocpp::v2::APNAuthenticationEnum \p authentication to a types::network::Apn_authentication.
+static types::network::Apn_authentication
+to_everest_apn_authentication(const ocpp::v2::APNAuthenticationEnum authentication) {
+    switch (authentication) {
+    case ocpp::v2::APNAuthenticationEnum::PAP:
+        return types::network::Apn_authentication::PAP;
+    case ocpp::v2::APNAuthenticationEnum::CHAP:
+        return types::network::Apn_authentication::CHAP;
+    case ocpp::v2::APNAuthenticationEnum::NONE:
+        return types::network::Apn_authentication::NONE;
+    case ocpp::v2::APNAuthenticationEnum::AUTO:
+        return types::network::Apn_authentication::AUTO;
+    }
+    throw std::out_of_range("Could not convert APNAuthenticationEnum to types::network::Apn_authentication");
+}
+
+/// \brief Converts a given ocpp::v2::VPNEnum \p type to a types::network::Type.
+static types::network::Type to_everest_vpn_type(const ocpp::v2::VPNEnum type) {
+    switch (type) {
+    case ocpp::v2::VPNEnum::IKEv2:
+        return types::network::Type::IKEv2;
+    case ocpp::v2::VPNEnum::IPSec:
+        return types::network::Type::IPSec;
+    case ocpp::v2::VPNEnum::L2TP:
+        return types::network::Type::L2TP;
+    case ocpp::v2::VPNEnum::PPTP:
+        return types::network::Type::PPTP;
+    }
+    throw std::out_of_range("Could not convert VPNEnum to types::network::Type");
+}
+
+types::network::APN to_everest_network_apn(const ocpp::v2::APN& apn) {
+    types::network::APN result;
+    result.apn = apn.apn.get();
+    result.apn_authentication = to_everest_apn_authentication(apn.apnAuthentication);
+    if (apn.apnUserName.has_value()) {
+        result.apn_user_name = apn.apnUserName.value().get();
+    }
+    if (apn.apnPassword.has_value()) {
+        result.apn_password = apn.apnPassword.value().get();
+    }
+    if (apn.simPin.has_value()) {
+        result.sim_pin = std::to_string(apn.simPin.value());
+    }
+    if (apn.preferredNetwork.has_value()) {
+        result.preferred_network = apn.preferredNetwork.value().get();
+    }
+    if (apn.useOnlyPreferredNetwork.has_value()) {
+        result.use_only_preferred_network = apn.useOnlyPreferredNetwork.value();
+    }
+    return result;
+}
+
+types::network::VPN to_everest_network_vpn(const ocpp::v2::VPN& vpn) {
+    types::network::VPN result;
+    result.server = vpn.server.get();
+    result.user = vpn.user.get();
+    result.password = vpn.password.get();
+    result.key = vpn.key.get();
+    result.type = to_everest_vpn_type(vpn.type);
+    if (vpn.group.has_value()) {
+        result.group = vpn.group.value().get();
+    }
+    return result;
+}
+
+types::network::ConfigureNetworkRequest
+to_everest_configure_network_request(const int32_t request_id, const ocpp::v2::NetworkConnectionProfile& profile) {
+    types::network::ConfigureNetworkRequest request;
+    request.request_id = request_id;
+    request.interface = to_everest_interface_class(profile.ocppInterface);
+    if (profile.apn.has_value()) {
+        request.apn = to_everest_network_apn(profile.apn.value());
+    }
+    if (profile.vpn.has_value()) {
+        request.vpn = to_everest_network_vpn(profile.vpn.value());
+    }
+    return request;
+}
+
 types::grid_support::DirectiveType to_grid_support_directive_type(const ocpp::v2::DERControlEnum control_type) {
     switch (control_type) {
     case ocpp::v2::DERControlEnum::EnterService:

--- a/lib/everest/ocpp_module_common/tests/CMakeLists.txt
+++ b/lib/everest/ocpp_module_common/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${TEST_TARGET_NAME}
     error_handling_tests.cpp
     everest_device_model_storage_test.cpp
     grid_support_conversions_test.cpp
+    network_conversions_test.cpp
     transaction_handler_tests.cpp
 )
 

--- a/lib/everest/ocpp_module_common/tests/network_conversions_test.cpp
+++ b/lib/everest/ocpp_module_common/tests/network_conversions_test.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <everest/ocpp_module_common/conversions.hpp>
+
+namespace {
+
+using ocpp_module_common::conversions::to_everest_configure_network_request;
+using ocpp_module_common::conversions::to_everest_interface_class;
+using ocpp_module_common::conversions::to_everest_network_apn;
+using ocpp_module_common::conversions::to_everest_network_vpn;
+
+TEST(NetworkConversions, interface_class_all_mappings) {
+    EXPECT_EQ(to_everest_interface_class(ocpp::v2::OCPPInterfaceEnum::Wired0), types::network::InterfaceClass::Wired0);
+    EXPECT_EQ(to_everest_interface_class(ocpp::v2::OCPPInterfaceEnum::Wired1), types::network::InterfaceClass::Wired1);
+    EXPECT_EQ(to_everest_interface_class(ocpp::v2::OCPPInterfaceEnum::Wired2), types::network::InterfaceClass::Wired2);
+    EXPECT_EQ(to_everest_interface_class(ocpp::v2::OCPPInterfaceEnum::Wired3), types::network::InterfaceClass::Wired3);
+    EXPECT_EQ(to_everest_interface_class(ocpp::v2::OCPPInterfaceEnum::Wireless0),
+              types::network::InterfaceClass::Wireless0);
+    EXPECT_EQ(to_everest_interface_class(ocpp::v2::OCPPInterfaceEnum::Wireless1),
+              types::network::InterfaceClass::Wireless1);
+    EXPECT_EQ(to_everest_interface_class(ocpp::v2::OCPPInterfaceEnum::Wireless2),
+              types::network::InterfaceClass::Wireless2);
+    EXPECT_EQ(to_everest_interface_class(ocpp::v2::OCPPInterfaceEnum::Wireless3),
+              types::network::InterfaceClass::Wireless3);
+    EXPECT_EQ(to_everest_interface_class(ocpp::v2::OCPPInterfaceEnum::Any), types::network::InterfaceClass::Any);
+}
+
+TEST(NetworkConversions, apn_all_optionals_set) {
+    ocpp::v2::APN apn;
+    apn.apn = "internet";
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::CHAP;
+    apn.apnUserName = "user";
+    apn.apnPassword = "pass";
+    apn.simPin = 1234;
+    apn.preferredNetwork = "LTE";
+    apn.useOnlyPreferredNetwork = true;
+
+    const auto result = to_everest_network_apn(apn);
+
+    EXPECT_EQ(result.apn, "internet");
+    ASSERT_TRUE(result.apn_authentication.has_value());
+    EXPECT_EQ(result.apn_authentication.value(), types::network::Apn_authentication::CHAP);
+    ASSERT_TRUE(result.apn_user_name.has_value());
+    EXPECT_EQ(result.apn_user_name.value(), "user");
+    ASSERT_TRUE(result.apn_password.has_value());
+    EXPECT_EQ(result.apn_password.value(), "pass");
+    ASSERT_TRUE(result.sim_pin.has_value());
+    EXPECT_EQ(result.sim_pin.value(), "1234");
+    ASSERT_TRUE(result.preferred_network.has_value());
+    EXPECT_EQ(result.preferred_network.value(), "LTE");
+    ASSERT_TRUE(result.use_only_preferred_network.has_value());
+    EXPECT_TRUE(result.use_only_preferred_network.value());
+}
+
+TEST(NetworkConversions, apn_only_required_fields) {
+    ocpp::v2::APN apn;
+    apn.apn = "internet";
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::NONE;
+
+    const auto result = to_everest_network_apn(apn);
+
+    EXPECT_EQ(result.apn, "internet");
+    ASSERT_TRUE(result.apn_authentication.has_value());
+    EXPECT_EQ(result.apn_authentication.value(), types::network::Apn_authentication::NONE);
+    EXPECT_FALSE(result.apn_user_name.has_value());
+    EXPECT_FALSE(result.apn_password.has_value());
+    EXPECT_FALSE(result.sim_pin.has_value());
+    EXPECT_FALSE(result.preferred_network.has_value());
+    EXPECT_FALSE(result.use_only_preferred_network.has_value());
+}
+
+TEST(NetworkConversions, apn_authentication_all_mappings) {
+    ocpp::v2::APN apn;
+    apn.apn = "internet";
+
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::PAP;
+    EXPECT_EQ(to_everest_network_apn(apn).apn_authentication.value(), types::network::Apn_authentication::PAP);
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::CHAP;
+    EXPECT_EQ(to_everest_network_apn(apn).apn_authentication.value(), types::network::Apn_authentication::CHAP);
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::NONE;
+    EXPECT_EQ(to_everest_network_apn(apn).apn_authentication.value(), types::network::Apn_authentication::NONE);
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::AUTO;
+    EXPECT_EQ(to_everest_network_apn(apn).apn_authentication.value(), types::network::Apn_authentication::AUTO);
+}
+
+TEST(NetworkConversions, apn_sim_pin_int_to_string) {
+    ocpp::v2::APN apn;
+    apn.apn = "internet";
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::NONE;
+    apn.simPin = 1234;
+
+    const auto result = to_everest_network_apn(apn);
+    ASSERT_TRUE(result.sim_pin.has_value());
+    EXPECT_EQ(result.sim_pin.value(), "1234");
+}
+
+TEST(NetworkConversions, vpn_full) {
+    ocpp::v2::VPN vpn;
+    vpn.server = "vpn.example.com";
+    vpn.user = "vpnuser";
+    vpn.password = "vpnpass";
+    vpn.key = "secretkey";
+    vpn.type = ocpp::v2::VPNEnum::IKEv2;
+    vpn.group = "vpngroup";
+
+    const auto result = to_everest_network_vpn(vpn);
+
+    EXPECT_EQ(result.server, "vpn.example.com");
+    EXPECT_EQ(result.user, "vpnuser");
+    EXPECT_EQ(result.password, "vpnpass");
+    EXPECT_EQ(result.key, "secretkey");
+    EXPECT_EQ(result.type, types::network::Type::IKEv2);
+    ASSERT_TRUE(result.group.has_value());
+    EXPECT_EQ(result.group.value(), "vpngroup");
+}
+
+TEST(NetworkConversions, vpn_without_group) {
+    ocpp::v2::VPN vpn;
+    vpn.server = "vpn.example.com";
+    vpn.user = "vpnuser";
+    vpn.password = "vpnpass";
+    vpn.key = "secretkey";
+    vpn.type = ocpp::v2::VPNEnum::IPSec;
+
+    const auto result = to_everest_network_vpn(vpn);
+
+    EXPECT_EQ(result.type, types::network::Type::IPSec);
+    EXPECT_FALSE(result.group.has_value());
+}
+
+TEST(NetworkConversions, vpn_type_all_mappings) {
+    ocpp::v2::VPN vpn;
+    vpn.server = "s";
+    vpn.user = "u";
+    vpn.password = "p";
+    vpn.key = "k";
+
+    vpn.type = ocpp::v2::VPNEnum::IKEv2;
+    EXPECT_EQ(to_everest_network_vpn(vpn).type, types::network::Type::IKEv2);
+    vpn.type = ocpp::v2::VPNEnum::IPSec;
+    EXPECT_EQ(to_everest_network_vpn(vpn).type, types::network::Type::IPSec);
+    vpn.type = ocpp::v2::VPNEnum::L2TP;
+    EXPECT_EQ(to_everest_network_vpn(vpn).type, types::network::Type::L2TP);
+    vpn.type = ocpp::v2::VPNEnum::PPTP;
+    EXPECT_EQ(to_everest_network_vpn(vpn).type, types::network::Type::PPTP);
+}
+
+TEST(NetworkConversions, configure_network_request_with_apn_and_vpn) {
+    ocpp::v2::NetworkConnectionProfile profile{};
+    profile.ocppInterface = ocpp::v2::OCPPInterfaceEnum::Wireless0;
+    profile.ocppCsmsUrl = "wss://csms.example.com"; // must NOT leak
+
+    ocpp::v2::APN apn;
+    apn.apn = "internet";
+    apn.apnAuthentication = ocpp::v2::APNAuthenticationEnum::CHAP;
+    profile.apn = apn;
+
+    ocpp::v2::VPN vpn;
+    vpn.server = "vpn.example.com";
+    vpn.user = "u";
+    vpn.password = "p";
+    vpn.key = "k";
+    vpn.type = ocpp::v2::VPNEnum::L2TP;
+    profile.vpn = vpn;
+
+    const auto result = to_everest_configure_network_request(42, profile);
+
+    EXPECT_EQ(result.request_id, 42);
+    EXPECT_EQ(result.interface, types::network::InterfaceClass::Wireless0);
+    EXPECT_FALSE(result.interface_name.has_value());
+    ASSERT_TRUE(result.apn.has_value());
+    EXPECT_EQ(result.apn.value().apn, "internet");
+    ASSERT_TRUE(result.vpn.has_value());
+    EXPECT_EQ(result.vpn.value().type, types::network::Type::L2TP);
+}
+
+TEST(NetworkConversions, configure_network_request_without_apn_or_vpn) {
+    ocpp::v2::NetworkConnectionProfile profile{};
+    profile.ocppInterface = ocpp::v2::OCPPInterfaceEnum::Wired1;
+
+    const auto result = to_everest_configure_network_request(7, profile);
+
+    EXPECT_EQ(result.request_id, 7);
+    EXPECT_EQ(result.interface, types::network::InterfaceClass::Wired1);
+    EXPECT_FALSE(result.interface_name.has_value());
+    EXPECT_FALSE(result.apn.has_value());
+    EXPECT_FALSE(result.vpn.has_value());
+}
+
+} // namespace

--- a/modules/EVSE/OCPPmulti/generic_chargepoint_interface.hpp
+++ b/modules/EVSE/OCPPmulti/generic_chargepoint_interface.hpp
@@ -78,7 +78,9 @@ struct GenericChargePointCallbacks {
                                    const types::iso15118::ChargingNeeds& charging_needs) = 0;
     virtual ocpp::v2::ClearDisplayMessageResponse
     cb_clear_display_message(const ocpp::v2::ClearDisplayMessageRequest& request) = 0;
-    virtual std::future<ocpp::ConfigNetworkResult> cb_configure_network_connection_profile() = 0;
+    virtual std::future<ocpp::ConfigNetworkResult>
+    cb_configure_network_connection_profile(std::int32_t configuration_slot,
+                                            const ocpp::v2::NetworkConnectionProfile& network_connection_profile) = 0;
     virtual bool cb_connector_effective_operative_status(std::int32_t evse_id, std::int32_t connector_id,
                                                          ocpp::v2::OperationalStatusEnum new_status) = 0;
     virtual void cb_connection_state_changed(bool is_connected, ocpp::OcppProtocolVersion protocol_version) = 0;

--- a/modules/EVSE/OCPPmulti/generic_ocpp.cpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.cpp
@@ -12,6 +12,8 @@
 #include <ld-ev.hpp>
 #include <ocpp/v2/ctrlr_component_variables.hpp>
 
+#include <thread>
+
 namespace fs = std::filesystem;
 
 namespace {
@@ -573,6 +575,18 @@ void GenericOcpp::init_subscribe() {
     mv_requires.system.subscribe_firmware_update_status([this](auto arg) { cb_firmware_update_status(arg); });
     mv_requires.system.subscribe_log_status([this](auto arg) { cb_log_status(arg); });
 
+    mv_requires.system.subscribe_configure_network_status([this](const types::network::ConfigureNetworkStatus status) {
+        if (status.status != types::network::ConfigureNetworkStatusEnum::Ready) {
+            EVLOG_warning << "configure_network_status for request_id " << status.request_id << " reported "
+                          << types::network::configure_network_status_enum_to_string(status.status)
+                          << "; treating as failure";
+        }
+        ocpp::ConfigNetworkResult result{};
+        result.success = (status.status == types::network::ConfigureNetworkStatusEnum::Ready);
+        result.interface_address = status.interface_address;
+        fulfill_network_request(status.request_id, result);
+    });
+
     if (!mv_requires.reservation.empty() && mv_requires.reservation.at(0) != nullptr) {
         mv_requires.reservation.at(0)->subscribe_reservation_update([this](auto arg) { cb_reservation_update(arg); });
     }
@@ -858,12 +872,114 @@ GenericOcpp::cb_clear_display_message(const ocpp::v2::ClearDisplayMessageRequest
     return result;
 }
 
-std::future<ocpp::ConfigNetworkResult> GenericOcpp::cb_configure_network_connection_profile() {
+void GenericOcpp::fulfill_network_request(std::int32_t request_id, const ocpp::ConfigNetworkResult& result) {
+    std::promise<ocpp::ConfigNetworkResult> promise;
+    {
+        auto handle = mv_pending_network_config_requests.handle();
+        auto it = handle->find(request_id);
+        if (it == handle->end()) {
+            EVLOG_debug << "no pending network request for id " << request_id << " - late/orphaned";
+            return;
+        }
+        promise = std::move(it->second.promise);
+        handle->erase(it);
+    }
+    // set_value outside the lock
+    promise.set_value(result);
+}
+
+void GenericOcpp::drain_pending_network_config_requests() {
+    std::vector<std::promise<ocpp::ConfigNetworkResult>> pending;
+    {
+        auto handle = mv_pending_network_config_requests.handle();
+        for (auto& [request_id, request] : *handle) {
+            pending.push_back(std::move(request.promise));
+        }
+        handle->clear();
+    }
+    for (auto& promise : pending) {
+        ocpp::ConfigNetworkResult result{};
+        result.success = false;
+        promise.set_value(result); // set_value outside the lock, like fulfill_network_request
+    }
+}
+
+std::future<ocpp::ConfigNetworkResult> GenericOcpp::cb_configure_network_connection_profile(
+    std::int32_t configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile) {
     std::promise<ocpp::ConfigNetworkResult> promise;
     std::future<ocpp::ConfigNetworkResult> future = promise.get_future();
-    ocpp::ConfigNetworkResult result;
-    result.success = true;
-    promise.set_value(result);
+
+    if (mv_shutting_down.load()) {
+        ocpp::ConfigNetworkResult result{};
+        result.success = false;
+        promise.set_value(result);
+        return future;
+    }
+
+    // Drop any still-pending attempt for the same slot, fulfilling it with failure rather than just
+    // erasing: libocpp may still be waiting on that future, and a broken promise would throw in get().
+    std::int32_t request_id;
+    std::vector<std::promise<ocpp::ConfigNetworkResult>> stale_promises;
+    {
+        auto handle = mv_pending_network_config_requests.handle();
+        for (auto it = handle->begin(); it != handle->end();) {
+            if (it->second.configuration_slot == configuration_slot) {
+                stale_promises.push_back(std::move(it->second.promise));
+                it = handle->erase(it);
+            } else {
+                ++it;
+            }
+        }
+        request_id = mv_next_network_config_request_id++;
+        (*handle)[request_id] = PendingNetworkConfigRequest{configuration_slot, std::move(promise)};
+    }
+    for (auto& stale : stale_promises) {
+        ocpp::ConfigNetworkResult result{};
+        result.success = false;
+        stale.set_value(result); // set_value outside the lock, like fulfill_network_request
+    }
+
+    try {
+        const auto request =
+            module::conversions::to_everest_configure_network_request(request_id, network_connection_profile);
+        const auto response = mv_requires.system.call_configure_network(request);
+
+        ocpp::ConfigNetworkResult result{};
+        bool fulfill = true;
+        switch (response.status) {
+        case types::network::ConfigureNetworkStatusEnum::Ready:
+            result.success = true;
+            result.interface_address = response.interface_address;
+            break;
+        case types::network::ConfigureNetworkStatusEnum::Failed:
+        case types::network::ConfigureNetworkStatusEnum::Rejected:
+            result.success = false;
+            break;
+        case types::network::ConfigureNetworkStatusEnum::NotSupported:
+            // legacy parity: connect as before, no interface_address
+            result.success = true;
+            break;
+        case types::network::ConfigureNetworkStatusEnum::Processing:
+            // Provider returns Processing promptly; the status-var subscription fulfills the promise later.
+            fulfill = false;
+            break;
+        default:
+            result.success = false;
+            EVLOG_error << "Unexpected configure_network status for slot " << configuration_slot << " (request_id "
+                        << request_id << ")";
+            break;
+        }
+        if (fulfill) {
+            fulfill_network_request(request_id, result);
+        }
+    } catch (const std::exception& e) {
+        EVLOG_error << "call_configure_network threw for slot " << configuration_slot << " (request_id " << request_id
+                    << ", " << e.what() << ")";
+        ocpp::ConfigNetworkResult result{};
+        result.success = false;
+        fulfill_network_request(request_id, result);
+    }
+
     return future;
 }
 
@@ -1734,7 +1850,10 @@ void GenericOcpp::shutdown() {
     mv_shutting_down.store(true);
     charging_schedules_timer_stop();
     grid_support_heartbeat_timer_stop();
-    std::lock_guard<std::mutex> lock(recompute_mutex);
+    { std::lock_guard<std::mutex> lock(recompute_mutex); }
+
+    // Unblock any ConnectivityManager thread waiting on a pending configure_network future.
+    drain_pending_network_config_requests();
 }
 
 bool GenericOcpp::ocpp_2_selected() const {

--- a/modules/EVSE/OCPPmulti/generic_ocpp.cpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.cpp
@@ -576,13 +576,13 @@ void GenericOcpp::init_subscribe() {
     mv_requires.system.subscribe_log_status([this](auto arg) { cb_log_status(arg); });
 
     mv_requires.system.subscribe_configure_network_status([this](const types::network::ConfigureNetworkStatus status) {
-        if (status.status != types::network::ConfigureNetworkStatusEnum::Ready) {
+        if (status.status != types::network::ConfigureNetworkFinalStatusEnum::Ready) {
             EVLOG_warning << "configure_network_status for request_id " << status.request_id << " reported "
-                          << types::network::configure_network_status_enum_to_string(status.status)
+                          << types::network::configure_network_final_status_enum_to_string(status.status)
                           << "; treating as failure";
         }
         ocpp::ConfigNetworkResult result{};
-        result.success = (status.status == types::network::ConfigureNetworkStatusEnum::Ready);
+        result.success = (status.status == types::network::ConfigureNetworkFinalStatusEnum::Ready);
         result.interface_address = status.interface_address;
         fulfill_network_request(status.request_id, result);
     });

--- a/modules/EVSE/OCPPmulti/generic_ocpp.hpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.hpp
@@ -45,6 +45,8 @@
 #include <everest/ocpp_module_common/error_handling.hpp>
 #include <everest/ocpp_module_common/transaction_handler.hpp>
 
+#include <future>
+#include <map>
 #include <mutex>
 #include <queue>
 #include <utility>
@@ -171,6 +173,19 @@ private:
     everest::lib::util::monitor<std::map<std::int32_t, std::string>> mv_evse_evcc_id;
     everest::lib::util::monitor<std::map<std::int32_t, bool>> mv_evse_ready_map;
     everest::lib::util::monitor<std::map<std::int32_t, std::optional<float>>> mv_evse_soc_map;
+
+    // Pending configure_network requests, keyed by a unique request_id (not configuration_slot, which
+    // repeats across libocpp's per-slot retries). The stored slot lets a re-request drop the stale attempt.
+    struct PendingNetworkConfigRequest {
+        std::int32_t configuration_slot;
+        std::promise<ocpp::ConfigNetworkResult> promise;
+    };
+    std::int32_t mv_next_network_config_request_id{1}; // guarded by the monitor lock below
+    everest::lib::util::monitor<std::map<std::int32_t, PendingNetworkConfigRequest>> mv_pending_network_config_requests;
+
+    /// \brief Fails all pending configure_network promises so a ConnectivityManager blocked on one of the
+    /// futures does not have to run into its NetworkConfigTimeout during shutdown.
+    void drain_pending_network_config_requests();
 
     // these need to be thread safe - used by libocpp and this object
     std::shared_ptr<module::device_model::EverestDeviceModelStorage> m_everest_device_model_storage;
@@ -309,6 +324,11 @@ protected:
     void ready_module_configuration();
     void ready_transaction_handler();
 
+    // Pop-and-set discipline for configure_network promises: find the pending request keyed by \p request_id
+    // under the monitor lock, move the promise out and erase it while holding the lock, then release the lock
+    // and only THEN call set_value. First popper wins; if the entry is already gone this is a no-op.
+    void fulfill_network_request(std::int32_t request_id, const ocpp::ConfigNetworkResult& result);
+
     // every Event alternative needs an overload; a missing one is a compile error
     void visit_impl(std::int32_t, const std::monostate&) {
     }
@@ -328,7 +348,8 @@ protected:
     void cb_charging_needs(std::int32_t extensions_id, const types::iso15118::ChargingNeeds& charging_needs) override;
     ocpp::v2::ClearDisplayMessageResponse
     cb_clear_display_message(const ocpp::v2::ClearDisplayMessageRequest& request) override;
-    std::future<ocpp::ConfigNetworkResult> cb_configure_network_connection_profile() override;
+    std::future<ocpp::ConfigNetworkResult> cb_configure_network_connection_profile(
+        std::int32_t configuration_slot, const ocpp::v2::NetworkConnectionProfile& network_connection_profile) override;
     bool cb_connector_effective_operative_status(std::int32_t evse_id, std::int32_t connector_id,
                                                  ocpp::v2::OperationalStatusEnum new_status) override;
     void cb_connection_state_changed(bool is_connected, ocpp::OcppProtocolVersion protocol_version) override;

--- a/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.cpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.cpp
@@ -1116,7 +1116,6 @@ std::shared_ptr<Everest::config::ConfigServiceClient> ModuleAdapter::get_config_
 
 std::optional<json> ModuleAdapter::get_cmd_response(const std::optional<json>& default_response) {
     auto result = default_response;
-    std::lock_guard<std::mutex> lock(m_cmd_response_mutex);
     if (!m_cmd_response_list.empty()) {
         result = m_cmd_response_list.front();
         m_cmd_response_list.pop_front();
@@ -1153,7 +1152,6 @@ void ModuleAdapter::publish(const Requirement& req, const std::string& fn, json 
 }
 
 void ModuleAdapter::add_cmd_result(const json& data) {
-    std::lock_guard<std::mutex> lock(m_cmd_response_mutex);
     m_cmd_response_list.push_back(data);
 }
 

--- a/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.cpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.cpp
@@ -813,6 +813,33 @@ std::optional<json> ModuleAdapter::system_call_reset(const Requirement& req, con
     return {};
 }
 
+std::optional<json> ModuleAdapter::system_call_configure_network(const Requirement& req, const json& args) {
+    // system interface
+    // configure_network:
+    //   description: >-
+    //     Request preparation of the given network interface (e.g. modem/APN/VPN bring-up). May answer directly
+    //     with Ready/Failed/Rejected, or with Processing, in which case the final outcome is published on the
+    //     configure_network_status var with the same request_id. Providers without network-configuration support
+    //     return NotSupported.
+    //   arguments:
+    //     request:
+    //       description: The network configuration request
+    //       type: object
+    //       $ref: /network#/ConfigureNetworkRequest
+    //   result:
+    //     description: Direct response to the configuration request
+    //     type: object
+    //     $ref: /network#/ConfigureNetworkResponse
+
+    EVLOG_debug << "Call configure_network: " << args.dump();
+    publish_fn("system", "call_configure_network", args);
+    auto result = get_cmd_response(R"({"status":"NotSupported"})"_json);
+    if (result) {
+        EVLOG_debug << "result:               " << result.value().dump();
+    }
+    return result;
+}
+
 std::optional<json> ModuleAdapter::system_call_set_system_time(const Requirement& req, const json& args) {
     // system interface
     // set_system_time:
@@ -966,6 +993,7 @@ ModuleAdapter::ModuleAdapter() : m_error_type_map(std::make_shared<Everest::erro
     m_call_implementations.insert({"cancel_reservation", &ModuleAdapter::reservation_call_cancel_reservation});
     m_call_implementations.insert(
         {"clear_display_message", &ModuleAdapter::display_message_call_clear_display_message});
+    m_call_implementations.insert({"configure_network", &ModuleAdapter::system_call_configure_network});
     m_call_implementations.insert({"data_transfer", &ModuleAdapter::ocpp_data_transfer_call_data_transfer});
     m_call_implementations.insert({"enable_disable", &ModuleAdapter::evse_manager_call_enable_disable});
     m_call_implementations.insert({"exists_reservation", &ModuleAdapter::reservation_call_exists_reservation});
@@ -1088,6 +1116,7 @@ std::shared_ptr<Everest::config::ConfigServiceClient> ModuleAdapter::get_config_
 
 std::optional<json> ModuleAdapter::get_cmd_response(const std::optional<json>& default_response) {
     auto result = default_response;
+    std::lock_guard<std::mutex> lock(m_cmd_response_mutex);
     if (!m_cmd_response_list.empty()) {
         result = m_cmd_response_list.front();
         m_cmd_response_list.pop_front();
@@ -1124,6 +1153,7 @@ void ModuleAdapter::publish(const Requirement& req, const std::string& fn, json 
 }
 
 void ModuleAdapter::add_cmd_result(const json& data) {
+    std::lock_guard<std::mutex> lock(m_cmd_response_mutex);
     m_cmd_response_list.push_back(data);
 }
 

--- a/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
@@ -17,7 +17,6 @@
 
 #include <list>
 #include <memory>
-#include <mutex>
 #include <string>
 
 namespace stubs {
@@ -121,8 +120,6 @@ private:
     void publish_fn(const std::string& interface, const std::string& variable, int instance, const json& value);
 
     var_cb_list_t m_subscribe_var_callbacks;
-    // guarded by m_cmd_response_mutex: commands may be invoked from module threads concurrently
-    std::mutex m_cmd_response_mutex;
     std::list<json> m_cmd_response_list;
 
 protected:

--- a/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
@@ -17,6 +17,7 @@
 
 #include <list>
 #include <memory>
+#include <mutex>
 #include <string>
 
 namespace stubs {
@@ -120,6 +121,8 @@ private:
     void publish_fn(const std::string& interface, const std::string& variable, int instance, const json& value);
 
     var_cb_list_t m_subscribe_var_callbacks;
+    // guarded by m_cmd_response_mutex: commands may be invoked from module threads concurrently
+    std::mutex m_cmd_response_mutex;
     std::list<json> m_cmd_response_list;
 
 protected:
@@ -155,6 +158,7 @@ protected:
     virtual std::optional<json> reservation_call_exists_reservation(const Requirement& req, const json& args);
     virtual std::optional<json> reservation_call_reserve_now(const Requirement& req, const json& args);
     virtual std::optional<json> system_call_allow_firmware_installation(const Requirement& req, const json& args);
+    virtual std::optional<json> system_call_configure_network(const Requirement& req, const json& args);
     virtual std::optional<json> system_call_get_boot_reason(const Requirement& req, const json& args);
     virtual std::optional<json> system_call_is_reset_allowed(const Requirement& req, const json& args);
     virtual std::optional<json> system_call_reset(const Requirement& req, const json& args);

--- a/modules/EVSE/OCPPmulti/tests/stubs/v2_chargepoint_stub.hpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/v2_chargepoint_stub.hpp
@@ -129,7 +129,8 @@ struct GenericChargePointCallbacksMock : public ocpp_multi::GenericChargePointCa
                 (std::int32_t extensions_id, const types::iso15118::ChargingNeeds& charging_needs), (override));
     MOCK_METHOD(ocpp::v2::ClearDisplayMessageResponse, cb_clear_display_message,
                 (const ocpp::v2::ClearDisplayMessageRequest& request), (override));
-    MOCK_METHOD(std::future<ocpp::ConfigNetworkResult>, cb_configure_network_connection_profile, (), (override));
+    MOCK_METHOD(std::future<ocpp::ConfigNetworkResult>, cb_configure_network_connection_profile,
+                (std::int32_t, const ocpp::v2::NetworkConnectionProfile&), (override));
     MOCK_METHOD(bool, cb_connector_effective_operative_status,
                 (std::int32_t evse_id, std::int32_t connector_id, ocpp::v2::OperationalStatusEnum new_status),
                 (override));

--- a/modules/EVSE/OCPPmulti/tests/systemIntf_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/systemIntf_tests.cpp
@@ -9,13 +9,20 @@
 //   reset:                         <used>
 //   set_system_time:               <used>
 //   get_boot_reason:               <used> (tested in GenericOcppTester, init)
+//   configure_network:             <used>
 //
 // vars:
 //   firmware_update_status:        <used>
 //   log_status:                    <used>
+//   configure_network_status:      <used>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <chrono>
+#include <future>
+#include <mutex>
+#include <thread>
 
 #include <generic_ocpp.hpp>
 
@@ -23,12 +30,32 @@
 #include "generic_chargepoint_interface.hpp"
 #include "ocpp/common/types.hpp"
 #include "ocpp/v2/messages/GetLog.hpp"
+#include "ocpp/v2/messages/SetNetworkProfile.hpp"
 #include "ocpp/v2/messages/UpdateFirmware.hpp"
 #include "ocpp/v2/ocpp_enums.hpp"
 #include "stubs/generic_ocpp_stub.hpp"
 
 namespace {
 using namespace stubs;
+
+// Bounded poll for a condition that may be satisfied from a subscription callback.
+bool wait_for_condition(const std::function<bool()>& condition,
+                        std::chrono::milliseconds timeout = std::chrono::milliseconds(5000)) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (condition()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return condition();
+}
+
+ocpp::v2::NetworkConnectionProfile network_profile(const ocpp::v2::OCPPInterfaceEnum iface) {
+    ocpp::v2::NetworkConnectionProfile profile{};
+    profile.ocppInterface = iface;
+    return profile;
+}
 
 TEST_F(GenericOcppRequiresTester, callUpdateFirmware) {
     // call_update_firmware() used in cb_update_firmware_request()
@@ -238,6 +265,154 @@ TEST_F(GenericOcppRequiresTester, subscribeLogStatus) {
     interfaces->publish(0, "log_status", update);
     update.log_status = LogStatusEnum::Idle;
     interfaces->publish(0, "log_status", update);
+}
+
+// ----------------------------------------------------------------------------
+// configure_network: cb_configure_network_connection_profile() delegates to call_configure_network()
+// synchronously; a Processing answer defers the outcome to the configure_network_status var subscription.
+// Discipline: queue cmd results BEFORE invoking the cb.
+
+class ConfigureNetworkTester : public GenericOcppRequiresTester {
+protected:
+    void SetUp() override {
+        GenericOcppRequiresTester::SetUp();
+        interfaces->subscribe_var("system", "call_configure_network",
+                                  [this](const auto&, const auto&, const auto& data) {
+                                      std::lock_guard<std::mutex> lock(m_mutex);
+                                      m_received.push_back(data);
+                                  });
+    }
+
+    std::size_t received_count() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_received.size();
+    }
+
+    json received_request(std::size_t index) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_received.at(index).at("request");
+    }
+
+    std::mutex m_mutex;
+    std::vector<json> m_received;
+};
+
+TEST_F(ConfigureNetworkTester, callConfigureNetworkReady) {
+    // Ready direct answer resolves the future successfully and forwards the interface address
+
+    interfaces->add_cmd_result(R"({"status":"Ready","interface_address":"192.168.5.1"})"_json);
+
+    auto future = ocpp->cb_configure_network_connection_profile(1, network_profile(ocpp::v2::OCPPInterfaceEnum::Any));
+
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    const auto result = future.get();
+    EXPECT_TRUE(result.success);
+    ASSERT_TRUE(result.interface_address.has_value());
+    EXPECT_EQ(result.interface_address.value(), "192.168.5.1");
+
+    ASSERT_EQ(received_count(), 1);
+    const auto request = received_request(0);
+    EXPECT_GT(request.at("request_id").get<std::int32_t>(), 0);
+    EXPECT_EQ(request.at("interface").get<std::string>(), "Any");
+}
+
+TEST_F(ConfigureNetworkTester, callConfigureNetworkFailedAndRejected) {
+    // Failed and Rejected both resolve the future as unsuccessful, without an interface address
+
+    for (const auto* status : {R"({"status":"Failed"})", R"({"status":"Rejected"})"}) {
+        interfaces->add_cmd_result(json::parse(status));
+
+        auto future =
+            ocpp->cb_configure_network_connection_profile(1, network_profile(ocpp::v2::OCPPInterfaceEnum::Wired0));
+
+        ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready) << status;
+        const auto result = future.get();
+        EXPECT_FALSE(result.success) << status;
+        EXPECT_FALSE(result.interface_address.has_value()) << status;
+    }
+}
+
+TEST_F(ConfigureNetworkTester, callConfigureNetworkNotSupportedStillSucceeds) {
+    // NotSupported (the stub default when no cmd result is queued) keeps legacy parity: success, no address
+
+    auto future =
+        ocpp->cb_configure_network_connection_profile(1, network_profile(ocpp::v2::OCPPInterfaceEnum::Wired0));
+
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    const auto result = future.get();
+    EXPECT_TRUE(result.success);
+    EXPECT_FALSE(result.interface_address.has_value());
+}
+
+TEST_F(ConfigureNetworkTester, callConfigureNetworkProcessingThenStatusVar) {
+    // Processing keeps the future pending; a status var with a foreign request_id is ignored (late/orphaned
+    // no-op); the matching request_id resolves it
+
+    interfaces->add_cmd_result(R"({"status":"Processing"})"_json);
+
+    auto future =
+        ocpp->cb_configure_network_connection_profile(1, network_profile(ocpp::v2::OCPPInterfaceEnum::Wired0));
+
+    ASSERT_TRUE(wait_for_condition([this] { return received_count() >= 1; }));
+    const auto request_id = received_request(0).at("request_id").get<std::int32_t>();
+
+    EXPECT_EQ(future.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+
+    interfaces->publish(0, "configure_network_status", json{{"request_id", request_id + 1000}, {"status", "Ready"}});
+    EXPECT_EQ(future.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+
+    interfaces->publish(0, "configure_network_status",
+                        json{{"request_id", request_id}, {"status", "Ready"}, {"interface_address", "10.1.2.3"}});
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    const auto result = future.get();
+    EXPECT_TRUE(result.success);
+    ASSERT_TRUE(result.interface_address.has_value());
+    EXPECT_EQ(result.interface_address.value(), "10.1.2.3");
+}
+
+TEST_F(ConfigureNetworkTester, callConfigureNetworkSameSlotDropsStaleRequest) {
+    // A re-request for the same slot resolves the still-pending previous attempt as failed (not a broken
+    // promise) and registers a fresh request_id; the new attempt is the only one a status var can fulfill
+
+    interfaces->add_cmd_result(R"({"status":"Processing"})"_json);
+    interfaces->add_cmd_result(R"({"status":"Processing"})"_json);
+
+    constexpr std::int32_t SLOT = 7;
+    auto first =
+        ocpp->cb_configure_network_connection_profile(SLOT, network_profile(ocpp::v2::OCPPInterfaceEnum::Wired0));
+    auto second =
+        ocpp->cb_configure_network_connection_profile(SLOT, network_profile(ocpp::v2::OCPPInterfaceEnum::Wired0));
+
+    // the dedup happens synchronously in the second invocation
+    ASSERT_EQ(first.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+    const auto stale = first.get();
+    EXPECT_FALSE(stale.success);
+
+    ASSERT_TRUE(wait_for_condition([this] { return received_count() >= 2; }));
+    const auto id_a = received_request(0).at("request_id").get<std::int32_t>();
+    const auto id_b = received_request(1).at("request_id").get<std::int32_t>();
+    ASSERT_NE(id_a, id_b);
+    // ids increase monotonically; the pending attempt is the later (higher) one.
+    const auto pending_id = std::max(id_a, id_b);
+
+    interfaces->publish(0, "configure_network_status", json{{"request_id", pending_id}, {"status", "Ready"}});
+    ASSERT_EQ(second.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    EXPECT_TRUE(second.get().success);
+}
+
+TEST_F(ConfigureNetworkTester, callConfigureNetworkInvalidStatusYieldsFailure) {
+    // An unparseable command result throws inside the callback; the catch path resolves the future
+    // as failed instead of leaking a broken promise
+
+    interfaces->add_cmd_result(R"({"status":"Bogus"})"_json);
+
+    auto future =
+        ocpp->cb_configure_network_connection_profile(1, network_profile(ocpp::v2::OCPPInterfaceEnum::Wired0));
+
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    const auto result = future.get();
+    EXPECT_FALSE(result.success);
+    EXPECT_FALSE(result.interface_address.has_value());
 }
 
 } // namespace

--- a/modules/EVSE/OCPPmulti/tests/v2_chargepoint_tests.cpp
+++ b/modules/EVSE/OCPPmulti/tests/v2_chargepoint_tests.cpp
@@ -9,6 +9,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <future>
+
 namespace {
 
 using namespace ocpp_multi;
@@ -187,6 +190,30 @@ TEST_F(ChargePointV2Test, remoteStartForwardsGroupIdToken) {
     EXPECT_EQ(provided.group_id_token->idToken.get(), "PARENT456");
     EXPECT_EQ(provided.evse_id, EVSE_ID);
     EXPECT_EQ(provided.request_id, 42);
+}
+
+// The configure_network callback forwards slot and profile to the module callback sink and returns its future
+TEST_F(ChargePointV2Test, configureNetworkCallbackForwardsToModuleCallbacks) {
+    auto callbacks = m_chargepoint.configure_callbacks();
+    ASSERT_TRUE(callbacks.configure_network_connection_profile_callback.has_value());
+
+    std::promise<ocpp::ConfigNetworkResult> promise;
+    ocpp::ConfigNetworkResult expected{};
+    expected.success = true;
+    expected.interface_address = "192.168.5.1";
+    promise.set_value(expected);
+    EXPECT_CALL(m_callbacks, cb_configure_network_connection_profile(5, _))
+        .WillOnce(Return(testing::ByMove(promise.get_future())));
+
+    ocpp::v2::NetworkConnectionProfile profile{};
+    profile.ocppInterface = ocpp::v2::OCPPInterfaceEnum::Wired0;
+    auto future = callbacks.configure_network_connection_profile_callback.value()(5, profile);
+
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+    const auto result = future.get();
+    EXPECT_TRUE(result.success);
+    ASSERT_TRUE(result.interface_address.has_value());
+    EXPECT_EQ(result.interface_address.value(), "192.168.5.1");
 }
 
 // SessionStarted(Authorized) creates transaction data with token, group token, reservation and remote start id

--- a/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
+++ b/modules/EVSE/OCPPmulti/v2_chargepoint.cpp
@@ -401,9 +401,8 @@ ocpp::v2::Callbacks ChargePointV2::configure_callbacks() {
                                                          const auto& network_connection_profile) {
         return m_callbacks_ptr->cb_validate_network_profile(network_connection_profile);
     };
-    callbacks.configure_network_connection_profile_callback = [this](auto /* configuration_slot */,
-                                                                     const auto& /* network_connection_profile */) {
-        return m_callbacks_ptr->cb_configure_network_connection_profile();
+    callbacks.configure_network_connection_profile_callback = [this](auto&&... args) {
+        return m_callbacks_ptr->cb_configure_network_connection_profile(args...);
     };
     callbacks.all_connectors_unavailable_callback = [this]() { m_callbacks_ptr->cb_all_connectors_unavailable(); };
     callbacks.transaction_event_callback = [this](const ocpp::v2::TransactionEventRequest& transaction_event) {

--- a/tests/ocpp_tests/conftest.py
+++ b/tests/ocpp_tests/conftest.py
@@ -445,6 +445,13 @@ def probe_module(
     implement_command(
         module,
         skip_implementation,
+        "ProbeModuleSystem",
+        "configure_network",
+        lambda arg: {"status": "NotSupported"},
+    )
+    implement_command(
+        module,
+        skip_implementation,
         "ProbeModuleSecurity",
         "get_leaf_expiry_days_count",
         lambda arg: 42,

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_generic_interface_integration_tests.py
@@ -202,6 +202,8 @@ async def _env(
     _add_pm_command_mock("system", "reset", None, skip_implementation)
     _add_pm_command_mock("system", "set_system_time",
                          True, skip_implementation)
+    _add_pm_command_mock("system", "configure_network",
+                         {"status": "NotSupported"}, skip_implementation)
 
     probe_module.start()
     await probe_module.wait_to_be_ready()

--- a/tests/ocpp_tests/test_sets/ocpp201/configure_network.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/configure_network.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Pionix GmbH and Contributors to EVerest
+
+"""Integration tests for OCPPmulti -> system provider `configure_network` delegation.
+
+Covers the NotSupported / Ready direct answers and the deferred Processing variant
+(completed via the configure_network_status var). The active profile is libocpp's
+default (ocppInterface Wired0); request_id is a module-generated opaque id.
+
+Only the combined OCPPmulti module implements the delegation (legacy OCPP201 keeps
+the unconditional-success stub), so the tests are pinned via ocpp_multi_only; the
+config rewrite swaps the OCPP201 module in the probe config for OCPPmulti.
+"""
+
+import asyncio
+import logging
+import threading
+
+import pytest
+
+from everest.testing.ocpp_utils.central_system import CentralSystem
+
+log = logging.getLogger("OCPPmultiConfigureNetwork")
+
+# Active network-connection-profile of this config (libocpp default single profile):
+# ocppInterface = "Wired0". request_id is a module-generated unique id, not the slot.
+EXPECTED_INTERFACE = "Wired0"
+
+# Valid InterfaceClass enum values (types/network.yaml InterfaceClass).
+_VALID_INTERFACE_CLASSES = {
+    "Wired0", "Wired1", "Wired2", "Wired3",
+    "Wireless0", "Wireless1", "Wireless2", "Wireless3",
+    "Any",
+}
+
+
+async def _connect(probe_module):
+    """Standard probe-module bring-up: start, ready, publish connector readiness."""
+    probe_module.start()
+    await probe_module.wait_to_be_ready()
+    probe_module.publish_variable("ProbeModuleConnectorA", "ready", True)
+    probe_module.publish_variable("ProbeModuleConnectorB", "ready", True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.ocpp_version("ocpp2.0.1")
+@pytest.mark.ocpp_multi_only
+@pytest.mark.everest_core_config("everest-config-ocpp201-probe-module.yaml")
+@pytest.mark.probe_module
+class TestConfigureNetwork:
+
+    async def test_configure_network_not_supported_fallback(
+        self, probe_module, central_system: CentralSystem
+    ):
+        """Case 1: NotSupported (conftest default) -> connects as before."""
+        await _connect(probe_module)
+        chargepoint = await central_system.wait_for_chargepoint()
+        assert chargepoint is not None
+
+    @pytest.mark.parametrize(
+        "skip_implementation",
+        [{"ProbeModuleSystem": ["configure_network"]}],
+    )
+    async def test_configure_network_ready_direct(
+        self, skip_implementation, probe_module, central_system: CentralSystem
+    ):
+        """Case 2: Ready direct (no interface_address, so no fake-iface bind)."""
+        captured = []
+        capture_lock = threading.Lock()
+
+        def handler(arg):
+            # Runs in the ProbeModule worker thread.
+            with capture_lock:
+                captured.append(arg["request"])
+            return {"status": "Ready"}
+
+        probe_module.implement_command(
+            "ProbeModuleSystem", "configure_network", handler
+        )
+
+        await _connect(probe_module)
+        chargepoint = await central_system.wait_for_chargepoint()
+        assert chargepoint is not None
+
+        with capture_lock:
+            assert len(captured) >= 1, "configure_network was never called"
+            request = captured[0]
+
+        # request_id is an opaque module-generated id; interface derives from the profile.
+        assert isinstance(request["request_id"], int)
+        assert request["request_id"] > 0
+        assert request["interface"] in _VALID_INTERFACE_CLASSES
+        assert request["interface"] == EXPECTED_INTERFACE
+
+    @pytest.mark.parametrize(
+        "skip_implementation",
+        [{"ProbeModuleSystem": ["configure_network"]}],
+    )
+    async def test_configure_network_processing_then_status(
+        self, skip_implementation, probe_module, central_system: CentralSystem
+    ):
+        """Case 3: Processing -> connects only after configure_network_status is published."""
+        captured_request_ids = []
+        capture_lock = threading.Lock()
+
+        def handler(arg):
+            with capture_lock:
+                captured_request_ids.append(arg["request"]["request_id"])
+            return {"status": "Processing"}
+
+        probe_module.implement_command(
+            "ProbeModuleSystem", "configure_network", handler
+        )
+
+        await _connect(probe_module)
+
+        # bounded poll until configure_network was invoked (avoids a flaky fixed sleep)
+        request_id = None
+        for _ in range(50):  # up to ~10s
+            with capture_lock:
+                if captured_request_ids:
+                    request_id = captured_request_ids[0]
+                    break
+            await asyncio.sleep(0.2)
+        assert request_id is not None, "configure_network was never called"
+        assert isinstance(request_id, int) and request_id > 0
+
+        # while Processing the websocket must not open yet (bootnotification=False:
+        # assert on the socket, not on a slow boot, and don't consume the connect event)
+        with pytest.raises(asyncio.TimeoutError):
+            await central_system.wait_for_chargepoint(
+                timeout=5, wait_for_bootnotification=False
+            )
+
+        # Publish the deferred outcome; libocpp should now proceed to connect.
+        probe_module.publish_variable(
+            "ProbeModuleSystem",
+            "configure_network_status",
+            {"request_id": request_id, "status": "Ready"},
+        )
+
+        chargepoint = await central_system.wait_for_chargepoint()
+        assert chargepoint is not None

--- a/tests/ocpp_tests/test_sets/ocpp201/configure_network.py
+++ b/tests/ocpp_tests/test_sets/ocpp201/configure_network.py
@@ -89,7 +89,6 @@ class TestConfigureNetwork:
         # request_id is an opaque module-generated id; interface derives from the profile.
         assert isinstance(request["request_id"], int)
         assert request["request_id"] > 0
-        assert request["interface"] in _VALID_INTERFACE_CLASSES
         assert request["interface"] == EXPECTED_INTERFACE
 
     @pytest.mark.parametrize(


### PR DESCRIPTION

## Describe your changes

Replace the unconditional-success stub for libocpp's configure_network_connection_profile_callback with real delegation to the `system` provider's configure_network cmd.

- conversions: ocpp::v2 NetworkConnectionProfile/APN/VPN/OCPPInterfaceEnum ->
  types::network::* (+ unit tests)
- callback dispatches to the provider on a detached thread and returns the future immediately; a per-attempt unique request_id correlates the async configure_network_status var back to the pending promise. Ready/Failed/Rejected/NotSupported resolve directly; Processing defers to the status var. NotSupported stays identical to the old stub so a non-supporting provider connects as before
- conftest probe defaults configure_network to NotSupported so existing probe-based 201 tests don't wait out libocpp's 60s timeout
- integration tests (probe module): NotSupported fallback, direct Ready, Processing then status

## Issue ticket number and link

This is part 2 of 3 from a stack:

1) https://github.com/EVerest/EVerest/pull/2409 
2) https://github.com/EVerest/EVerest/pull/2411 👈
3) https://github.com/EVerest/EVerest/pull/2413

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

