### PR TITLE
feat(system_API): add configure_network external bridge

### DIFF
--- a/docs/source/reference/EVerest_API/system_API.yaml
+++ b/docs/source/reference/EVerest_API/system_API.yaml
@@ -5,7 +5,8 @@ info:
   title: 'EVerest API definition for the system module'
   version: 1.0.0
   description: >-
-    API for EVerest API client implementing the system capabilities OTA update and log upload.
+    API for EVerest API client implementing the system capabilities OTA update, log upload
+    and network configuration.
 
   license:
     name: Apache-2.0
@@ -86,6 +87,16 @@ channels:
     messages:
       send_reply_get_boot_reason:
         $ref: '#/components/messages/send_reply_get_boot_reason'
+  receive_request_configure_network:
+    address: 'e2m/configure_network'
+    messages:
+      receive_request_configure_network:
+        $ref: '#/components/messages/receive_request_configure_network'
+  send_reply_configure_network:
+    address: null
+    messages:
+      send_reply_configure_network:
+        $ref: '#/components/messages/send_reply_configure_network'
 
   send_firmware_update_status:
     address: 'm2e/firmware_update_status'
@@ -97,6 +108,11 @@ channels:
     messages:
       send_log_status:
         $ref: '#/components/messages/send_log_status'
+  send_configure_network_status:
+    address: 'm2e/configure_network_status'
+    messages:
+      send_configure_network_status:
+        $ref: '#/components/messages/send_configure_network_status'
 
 
   receive_heartbeat:
@@ -210,6 +226,23 @@ operations:
     channel:
       $ref: '#/channels/send_reply_get_boot_reason'
     description: 'Direction: Module to EVerest'
+  receive_request_configure_network:
+    title: 'Request to configure a network interface'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_request_configure_network'
+    description: 'Direction: EVerest to Module'
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/send_reply_configure_network'
+  send_reply_configure_network:
+    title: 'Reply to configure network request'
+    action: send
+    channel:
+      $ref: '#/channels/send_reply_configure_network'
+    description: 'Direction: Module to EVerest'
 
   send_firmware_update_status:
     title: 'Send firmware update status'
@@ -222,6 +255,12 @@ operations:
     action: send
     channel:
       $ref: '#/channels/send_log_status'
+  send_configure_network_status:
+    title: 'Send configure network status'
+    action: send
+    channel:
+      $ref: '#/channels/send_configure_network_status'
+    description: 'Direction: Module to EVerest'
 
 
   receive_heartbeat:
@@ -382,6 +421,41 @@ components:
         - summary: "Get boot reason"
           payload:
             "ApplicationReset"
+    receive_request_configure_network:
+      name: receive_request_configure_network
+      title: 'Request configure network'
+      summary: 'Request to prepare a network interface for use.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - payload
+        properties:
+          headers:
+            type: object
+            properties:
+              replyTo:  # Address for the request to reply to
+                type: string
+                description: Address to send the response to. If this information is missing, the command will still be accepted, but no response will be sent.
+          payload:
+            $ref: '#/components/schemas/ConfigureNetworkRequest'
+    send_reply_configure_network:
+      name: send_reply_configure_network
+      title: 'Reply configure network'
+      summary: >-
+        Direct (synchronous) response to a configure network request. May answer
+        Processing and complete later via the configure_network_status var.
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/ConfigureNetworkResponse'
+      examples:
+        - summary: "Processing"
+          payload:
+            status: "Processing"
+        - summary: "Ready"
+          payload:
+            status: "Ready"
+            interface_address: "eth0"
     receive_allow_firmware_installation:
       name: receive_allow_firmware_installation
       title: 'Receive Allow firmware installation'
@@ -422,6 +496,19 @@ components:
           payload:
               log_status: "BadMessage"
               request_id: 0
+    send_configure_network_status:
+      name: send_configure_network_status
+      title: 'Send configure network status'
+      summary: Asynchronous final outcome of a configure network request that was answered with Processing
+      contentType: application/json
+      payload:
+        $ref: '#/components/schemas/ConfigureNetworkStatus'
+      examples:
+        - summary: "Configure network status"
+          payload:
+            request_id: 0
+            status: "Ready"
+            interface_address: "eth0"
 
 
     receive_heartbeat:
@@ -728,3 +815,179 @@ components:
     HeartBeatId:
       type: integer
       description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"
+
+    InterfaceClassEnum:
+      description: >-
+        Network interface class a connection is bound to. Maps 1:1 to OCPP 2.x
+        OCPPInterfaceEnum but is protocol-neutral.
+      type: string
+      enum:
+        - Wired0
+        - Wired1
+        - Wired2
+        - Wired3
+        - Wireless0
+        - Wireless1
+        - Wireless2
+        - Wireless3
+        - Any
+    APNAuthenticationEnum:
+      description: APN authentication method
+      type: string
+      enum:
+        - CHAP
+        - NONE
+        - PAP
+        - AUTO
+    APN:
+      description: Access Point Name configuration for cellular interfaces
+      type: object
+      additionalProperties: false
+      required:
+        - apn
+      properties:
+        apn:
+          description: The Access Point Name as an URL
+          type: string
+        apn_user_name:
+          description: APN username
+          type: string
+        apn_password:
+          description: APN password
+          type: string
+        sim_pin:
+          description: SIM card pin code
+          type: string
+        preferred_network:
+          description: Preferred network, written to the SIM card
+          type: string
+        use_only_preferred_network:
+          description: Use only the preferred network
+          type: boolean
+        apn_authentication:
+          description: Authentication method
+          type: string
+          $ref: '#/components/schemas/APNAuthenticationEnum'
+    VPNTypeEnum:
+      description: Type of VPN
+      type: string
+      enum:
+        - IKEv2
+        - IPSec
+        - L2TP
+        - PPTP
+        - Other
+    VPN:
+      description: VPN configuration
+      type: object
+      additionalProperties: false
+      required:
+        - server
+        - type
+      properties:
+        server:
+          description: VPN server address
+          type: string
+        user:
+          description: VPN username, if required by the VPN type
+          type: string
+        group:
+          description: VPN group
+          type: string
+        password:
+          description: VPN password, if required by the VPN type
+          type: string
+        key:
+          description: VPN shared secret or key, if required by the VPN type
+          type: string
+        type:
+          description: Type of VPN
+          type: string
+          $ref: '#/components/schemas/VPNTypeEnum'
+    ConfigureNetworkRequest:
+      description: Request to prepare a network interface for use
+      type: object
+      additionalProperties: false
+      required:
+        - request_id
+        - interface
+      properties:
+        request_id:
+          description: Caller-chosen correlation id, echoed in configure_network_status
+          type: integer
+        interface:
+          description: Standardized interface class; the provider maps it to a concrete system interface
+          type: string
+          $ref: '#/components/schemas/InterfaceClassEnum'
+        interface_name:
+          description: >-
+            Optional concrete system interface name (e.g. eth0, wwan0). If present it
+            overrides the provider's mapping of the interface class. Providers reject
+            unknown names (status Rejected).
+          type: string
+        apn:
+          description: Access Point Name configuration for cellular interfaces
+          type: object
+          $ref: '#/components/schemas/APN'
+        vpn:
+          description: VPN configuration
+          type: object
+          $ref: '#/components/schemas/VPN'
+    ConfigureNetworkStatusEnum:
+      description: |
+        Status of a configure network request:
+        - Ready: interface prepared, usable now.
+        - Processing: preparation started, final result follows on the configure_network_status var.
+        - Failed: preparation failed.
+        - Rejected: request invalid/refused (e.g. unknown interface_name or unmapped interface class).
+        - NotSupported: this provider does not implement network configuration (consumers fall back to legacy behavior).
+      type: string
+      enum:
+        - Ready
+        - Processing
+        - Failed
+        - Rejected
+        - NotSupported
+    ConfigureNetworkFinalStatusEnum:
+      description: |
+        Final status of a configure network request that was answered with Processing:
+        - Ready: interface prepared, usable now.
+        - Failed: preparation failed.
+      type: string
+      enum:
+        - Ready
+        - Failed
+    ConfigureNetworkResponse:
+      description: Direct (synchronous) response to configure_network
+      type: object
+      additionalProperties: false
+      required:
+        - status
+      properties:
+        status:
+          description: Status of the configure network request
+          type: string
+          $ref: '#/components/schemas/ConfigureNetworkStatusEnum'
+        interface_address:
+          description: >-
+            Interface name or IP address to bind to (present when status is Ready).
+          type: string
+    ConfigureNetworkStatus:
+      description: Asynchronous final outcome of a request answered with Processing
+      type: object
+      additionalProperties: false
+      required:
+        - request_id
+        - status
+      properties:
+        request_id:
+          description: Correlation id echoed from the ConfigureNetworkRequest
+          type: integer
+        status:
+          description: Final state, Ready or Failed
+          type: string
+          $ref: '#/components/schemas/ConfigureNetworkFinalStatusEnum'
+        interface_address:
+          description: >-
+            Interface name or IP address to bind to (present when status is Ready)
+          type: string

--- a/lib/everest/everest_api_types/include/everest_api_types/system/API.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/system/API.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace everest::lib::API::V1_0::types::system {
 
@@ -113,6 +114,86 @@ struct FirmwareUpdateStatus {
 struct ResetRequest {
     ResetType type;
     bool scheduled;
+};
+
+// Network configuration (mirrors types/network.yaml)
+
+enum class InterfaceClassEnum {
+    Wired0,
+    Wired1,
+    Wired2,
+    Wired3,
+    Wireless0,
+    Wireless1,
+    Wireless2,
+    Wireless3,
+    Any,
+};
+
+enum class APNAuthenticationEnum {
+    CHAP,
+    NONE,
+    PAP,
+    AUTO,
+};
+
+enum class VPNTypeEnum {
+    IKEv2,
+    IPSec,
+    L2TP,
+    PPTP,
+    Other,
+};
+
+enum class ConfigureNetworkStatusEnum {
+    Ready,
+    Processing,
+    Failed,
+    Rejected,
+    NotSupported,
+};
+
+enum class ConfigureNetworkFinalStatusEnum {
+    Ready,
+    Failed,
+};
+
+struct APN {
+    std::string apn;
+    std::optional<std::string> apn_user_name;
+    std::optional<std::string> apn_password;
+    std::optional<std::string> sim_pin;
+    std::optional<std::string> preferred_network;
+    std::optional<bool> use_only_preferred_network;
+    std::optional<APNAuthenticationEnum> apn_authentication;
+};
+
+struct VPN {
+    std::string server;
+    std::optional<std::string> user;
+    std::optional<std::string> group;
+    std::optional<std::string> password;
+    std::optional<std::string> key;
+    VPNTypeEnum type;
+};
+
+struct ConfigureNetworkRequest {
+    int32_t request_id;
+    InterfaceClassEnum interface;
+    std::optional<std::string> interface_name;
+    std::optional<APN> apn;
+    std::optional<VPN> vpn;
+};
+
+struct ConfigureNetworkResponse {
+    ConfigureNetworkStatusEnum status;
+    std::optional<std::string> interface_address;
+};
+
+struct ConfigureNetworkStatus {
+    int32_t request_id;
+    ConfigureNetworkFinalStatusEnum status;
+    std::optional<std::string> interface_address;
 };
 
 } // namespace everest::lib::API::V1_0::types::system

--- a/lib/everest/everest_api_types/include/everest_api_types/system/codec.hpp
+++ b/lib/everest/everest_api_types/include/everest_api_types/system/codec.hpp
@@ -22,6 +22,16 @@ std::string serialize(LogStatus const& val) noexcept;
 std::string serialize(FirmwareUpdateMetadata const& val) noexcept;
 std::string serialize(FirmwareUpdateStatus const& val) noexcept;
 std::string serialize(ResetRequest const& val) noexcept;
+std::string serialize(InterfaceClassEnum val) noexcept;
+std::string serialize(APNAuthenticationEnum val) noexcept;
+std::string serialize(VPNTypeEnum val) noexcept;
+std::string serialize(ConfigureNetworkStatusEnum val) noexcept;
+std::string serialize(ConfigureNetworkFinalStatusEnum val) noexcept;
+std::string serialize(APN const& val) noexcept;
+std::string serialize(VPN const& val) noexcept;
+std::string serialize(ConfigureNetworkRequest const& val) noexcept;
+std::string serialize(ConfigureNetworkResponse const& val) noexcept;
+std::string serialize(ConfigureNetworkStatus const& val) noexcept;
 
 std::ostream& operator<<(std::ostream& os, UpdateFirmwareResponse const& val);
 std::ostream& operator<<(std::ostream& os, UploadLogsStatus const& val);
@@ -36,6 +46,16 @@ std::ostream& operator<<(std::ostream& os, FirmwareUpdateMetadata const& val);
 std::ostream& operator<<(std::ostream& os, FirmwareUpdateStatus const& val);
 std::ostream& operator<<(std::ostream& os, UploadLogsResponse const& val);
 std::ostream& operator<<(std::ostream& os, ResetRequest const& val);
+std::ostream& operator<<(std::ostream& os, InterfaceClassEnum const& val);
+std::ostream& operator<<(std::ostream& os, APNAuthenticationEnum const& val);
+std::ostream& operator<<(std::ostream& os, VPNTypeEnum const& val);
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkStatusEnum const& val);
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkFinalStatusEnum const& val);
+std::ostream& operator<<(std::ostream& os, APN const& val);
+std::ostream& operator<<(std::ostream& os, VPN const& val);
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkRequest const& val);
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkResponse const& val);
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkStatus const& val);
 
 #include <everest_api_types/utilities/deserialize_templates.inc>
 

--- a/lib/everest/everest_api_types/private_include/everest_api_types/system/json_codec.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/system/json_codec.hpp
@@ -49,4 +49,34 @@ void from_json(const json& j, ResetType& k);
 void to_json(json& j, const BootReason& k) noexcept;
 void from_json(const json& j, BootReason& k);
 
+void to_json(json& j, const InterfaceClassEnum& k) noexcept;
+void from_json(const json& j, InterfaceClassEnum& k);
+
+void to_json(json& j, const APNAuthenticationEnum& k) noexcept;
+void from_json(const json& j, APNAuthenticationEnum& k);
+
+void to_json(json& j, const VPNTypeEnum& k) noexcept;
+void from_json(const json& j, VPNTypeEnum& k);
+
+void to_json(json& j, const ConfigureNetworkStatusEnum& k) noexcept;
+void from_json(const json& j, ConfigureNetworkStatusEnum& k);
+
+void to_json(json& j, const ConfigureNetworkFinalStatusEnum& k) noexcept;
+void from_json(const json& j, ConfigureNetworkFinalStatusEnum& k);
+
+void to_json(json& j, const APN& k) noexcept;
+void from_json(const json& j, APN& k);
+
+void to_json(json& j, const VPN& k) noexcept;
+void from_json(const json& j, VPN& k);
+
+void to_json(json& j, const ConfigureNetworkRequest& k) noexcept;
+void from_json(const json& j, ConfigureNetworkRequest& k);
+
+void to_json(json& j, const ConfigureNetworkResponse& k) noexcept;
+void from_json(const json& j, ConfigureNetworkResponse& k);
+
+void to_json(json& j, const ConfigureNetworkStatus& k) noexcept;
+void from_json(const json& j, ConfigureNetworkStatus& k);
+
 } // namespace everest::lib::API::V1_0::types::system

--- a/lib/everest/everest_api_types/private_include/everest_api_types/system/wrapper.hpp
+++ b/lib/everest/everest_api_types/private_include/everest_api_types/system/wrapper.hpp
@@ -5,6 +5,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #pragma GCC diagnostic ignored "-Wunused-function"
+#include "generated/types/network.hpp"
 #include "generated/types/system.hpp"
 #pragma GCC diagnostic pop
 
@@ -87,5 +88,65 @@ using FirmwareUpdateStatus_External = FirmwareUpdateStatus;
 
 FirmwareUpdateStatus_Internal to_internal_api(FirmwareUpdateStatus_External const& val);
 FirmwareUpdateStatus_External to_external_api(FirmwareUpdateStatus_Internal const& val);
+
+using InterfaceClassEnum_Internal = ::types::network::InterfaceClass;
+using InterfaceClassEnum_External = InterfaceClassEnum;
+
+InterfaceClassEnum_Internal to_internal_api(InterfaceClassEnum_External const& val);
+InterfaceClassEnum_External to_external_api(InterfaceClassEnum_Internal const& val);
+
+using APNAuthenticationEnum_Internal = ::types::network::Apn_authentication;
+using APNAuthenticationEnum_External = APNAuthenticationEnum;
+
+APNAuthenticationEnum_Internal to_internal_api(APNAuthenticationEnum_External const& val);
+APNAuthenticationEnum_External to_external_api(APNAuthenticationEnum_Internal const& val);
+
+using VPNTypeEnum_Internal = ::types::network::Type;
+using VPNTypeEnum_External = VPNTypeEnum;
+
+VPNTypeEnum_Internal to_internal_api(VPNTypeEnum_External const& val);
+VPNTypeEnum_External to_external_api(VPNTypeEnum_Internal const& val);
+
+using ConfigureNetworkStatusEnum_Internal = ::types::network::ConfigureNetworkStatusEnum;
+using ConfigureNetworkStatusEnum_External = ConfigureNetworkStatusEnum;
+
+ConfigureNetworkStatusEnum_Internal to_internal_api(ConfigureNetworkStatusEnum_External const& val);
+ConfigureNetworkStatusEnum_External to_external_api(ConfigureNetworkStatusEnum_Internal const& val);
+
+using ConfigureNetworkFinalStatusEnum_Internal = ::types::network::ConfigureNetworkFinalStatusEnum;
+using ConfigureNetworkFinalStatusEnum_External = ConfigureNetworkFinalStatusEnum;
+
+ConfigureNetworkFinalStatusEnum_Internal to_internal_api(ConfigureNetworkFinalStatusEnum_External const& val);
+ConfigureNetworkFinalStatusEnum_External to_external_api(ConfigureNetworkFinalStatusEnum_Internal const& val);
+
+using APN_Internal = ::types::network::APN;
+using APN_External = APN;
+
+APN_Internal to_internal_api(APN_External const& val);
+APN_External to_external_api(APN_Internal const& val);
+
+using VPN_Internal = ::types::network::VPN;
+using VPN_External = VPN;
+
+VPN_Internal to_internal_api(VPN_External const& val);
+VPN_External to_external_api(VPN_Internal const& val);
+
+using ConfigureNetworkRequest_Internal = ::types::network::ConfigureNetworkRequest;
+using ConfigureNetworkRequest_External = ConfigureNetworkRequest;
+
+ConfigureNetworkRequest_Internal to_internal_api(ConfigureNetworkRequest_External const& val);
+ConfigureNetworkRequest_External to_external_api(ConfigureNetworkRequest_Internal const& val);
+
+using ConfigureNetworkResponse_Internal = ::types::network::ConfigureNetworkResponse;
+using ConfigureNetworkResponse_External = ConfigureNetworkResponse;
+
+ConfigureNetworkResponse_Internal to_internal_api(ConfigureNetworkResponse_External const& val);
+ConfigureNetworkResponse_External to_external_api(ConfigureNetworkResponse_Internal const& val);
+
+using ConfigureNetworkStatus_Internal = ::types::network::ConfigureNetworkStatus;
+using ConfigureNetworkStatus_External = ConfigureNetworkStatus;
+
+ConfigureNetworkStatus_Internal to_internal_api(ConfigureNetworkStatus_External const& val);
+ConfigureNetworkStatus_External to_external_api(ConfigureNetworkStatus_Internal const& val);
 
 } // namespace everest::lib::API::V1_0::types::system

--- a/lib/everest/everest_api_types/src/everest_api_types/system/codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/system/codec.cpp
@@ -66,6 +66,46 @@ std::string serialize(ResetRequest const& val) noexcept {
     return utilities::dump_json(val);
 }
 
+std::string serialize(InterfaceClassEnum val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(APNAuthenticationEnum val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(VPNTypeEnum val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(ConfigureNetworkStatusEnum val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(ConfigureNetworkFinalStatusEnum val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(APN const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(VPN const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(ConfigureNetworkRequest const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(ConfigureNetworkResponse const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
+std::string serialize(ConfigureNetworkStatus const& val) noexcept {
+    return utilities::dump_json(val);
+}
+
 std::ostream& operator<<(std::ostream& os, UpdateFirmwareResponse const& val) {
     os << serialize(val);
     return os;
@@ -131,6 +171,56 @@ std::ostream& operator<<(std::ostream& os, ResetRequest const& val) {
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, InterfaceClassEnum const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, APNAuthenticationEnum const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, VPNTypeEnum const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkStatusEnum const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkFinalStatusEnum const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, APN const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, VPN const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkRequest const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkResponse const& val) {
+    os << serialize(val);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, ConfigureNetworkStatus const& val) {
+    os << serialize(val);
+    return os;
+}
+
 template <> UpdateFirmwareResponse deserialize(std::string_view val) {
     return utilities::parse_json<UpdateFirmwareResponse>(val);
 }
@@ -181,6 +271,46 @@ template <> FirmwareUpdateStatus deserialize(std::string_view val) {
 
 template <> ResetRequest deserialize(std::string_view val) {
     return utilities::parse_json<ResetRequest>(val);
+}
+
+template <> InterfaceClassEnum deserialize(std::string_view val) {
+    return utilities::parse_json<InterfaceClassEnum>(val);
+}
+
+template <> APNAuthenticationEnum deserialize(std::string_view val) {
+    return utilities::parse_json<APNAuthenticationEnum>(val);
+}
+
+template <> VPNTypeEnum deserialize(std::string_view val) {
+    return utilities::parse_json<VPNTypeEnum>(val);
+}
+
+template <> ConfigureNetworkStatusEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ConfigureNetworkStatusEnum>(val);
+}
+
+template <> ConfigureNetworkFinalStatusEnum deserialize(std::string_view val) {
+    return utilities::parse_json<ConfigureNetworkFinalStatusEnum>(val);
+}
+
+template <> APN deserialize(std::string_view val) {
+    return utilities::parse_json<APN>(val);
+}
+
+template <> VPN deserialize(std::string_view val) {
+    return utilities::parse_json<VPN>(val);
+}
+
+template <> ConfigureNetworkRequest deserialize(std::string_view val) {
+    return utilities::parse_json<ConfigureNetworkRequest>(val);
+}
+
+template <> ConfigureNetworkResponse deserialize(std::string_view val) {
+    return utilities::parse_json<ConfigureNetworkResponse>(val);
+}
+
+template <> ConfigureNetworkStatus deserialize(std::string_view val) {
+    return utilities::parse_json<ConfigureNetworkStatus>(val);
 }
 
 } // namespace everest::lib::API::V1_0::types::system

--- a/lib/everest/everest_api_types/src/everest_api_types/system/json_codec.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/system/json_codec.cpp
@@ -533,4 +533,382 @@ void from_json(const json& j, BootReason& k) {
     throw std::out_of_range("Provided string " + s + " could not be converted to enum of type BootReason");
 }
 
+void to_json(json& j, const InterfaceClassEnum& k) noexcept {
+    switch (k) {
+    case InterfaceClassEnum::Wired0:
+        j = "Wired0";
+        return;
+    case InterfaceClassEnum::Wired1:
+        j = "Wired1";
+        return;
+    case InterfaceClassEnum::Wired2:
+        j = "Wired2";
+        return;
+    case InterfaceClassEnum::Wired3:
+        j = "Wired3";
+        return;
+    case InterfaceClassEnum::Wireless0:
+        j = "Wireless0";
+        return;
+    case InterfaceClassEnum::Wireless1:
+        j = "Wireless1";
+        return;
+    case InterfaceClassEnum::Wireless2:
+        j = "Wireless2";
+        return;
+    case InterfaceClassEnum::Wireless3:
+        j = "Wireless3";
+        return;
+    case InterfaceClassEnum::Any:
+        j = "Any";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::system::InterfaceClassEnum";
+}
+void from_json(const json& j, InterfaceClassEnum& k) {
+    std::string s = j;
+    if (s == "Wired0") {
+        k = InterfaceClassEnum::Wired0;
+        return;
+    }
+    if (s == "Wired1") {
+        k = InterfaceClassEnum::Wired1;
+        return;
+    }
+    if (s == "Wired2") {
+        k = InterfaceClassEnum::Wired2;
+        return;
+    }
+    if (s == "Wired3") {
+        k = InterfaceClassEnum::Wired3;
+        return;
+    }
+    if (s == "Wireless0") {
+        k = InterfaceClassEnum::Wireless0;
+        return;
+    }
+    if (s == "Wireless1") {
+        k = InterfaceClassEnum::Wireless1;
+        return;
+    }
+    if (s == "Wireless2") {
+        k = InterfaceClassEnum::Wireless2;
+        return;
+    }
+    if (s == "Wireless3") {
+        k = InterfaceClassEnum::Wireless3;
+        return;
+    }
+    if (s == "Any") {
+        k = InterfaceClassEnum::Any;
+        return;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type InterfaceClassEnum");
+}
+
+void to_json(json& j, const APNAuthenticationEnum& k) noexcept {
+    switch (k) {
+    case APNAuthenticationEnum::CHAP:
+        j = "CHAP";
+        return;
+    case APNAuthenticationEnum::NONE:
+        j = "NONE";
+        return;
+    case APNAuthenticationEnum::PAP:
+        j = "PAP";
+        return;
+    case APNAuthenticationEnum::AUTO:
+        j = "AUTO";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::system::APNAuthenticationEnum";
+}
+void from_json(const json& j, APNAuthenticationEnum& k) {
+    std::string s = j;
+    if (s == "CHAP") {
+        k = APNAuthenticationEnum::CHAP;
+        return;
+    }
+    if (s == "NONE") {
+        k = APNAuthenticationEnum::NONE;
+        return;
+    }
+    if (s == "PAP") {
+        k = APNAuthenticationEnum::PAP;
+        return;
+    }
+    if (s == "AUTO") {
+        k = APNAuthenticationEnum::AUTO;
+        return;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type APNAuthenticationEnum");
+}
+
+void to_json(json& j, const VPNTypeEnum& k) noexcept {
+    switch (k) {
+    case VPNTypeEnum::IKEv2:
+        j = "IKEv2";
+        return;
+    case VPNTypeEnum::IPSec:
+        j = "IPSec";
+        return;
+    case VPNTypeEnum::L2TP:
+        j = "L2TP";
+        return;
+    case VPNTypeEnum::PPTP:
+        j = "PPTP";
+        return;
+    case VPNTypeEnum::Other:
+        j = "Other";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::system::VPNTypeEnum";
+}
+void from_json(const json& j, VPNTypeEnum& k) {
+    std::string s = j;
+    if (s == "IKEv2") {
+        k = VPNTypeEnum::IKEv2;
+        return;
+    }
+    if (s == "IPSec") {
+        k = VPNTypeEnum::IPSec;
+        return;
+    }
+    if (s == "L2TP") {
+        k = VPNTypeEnum::L2TP;
+        return;
+    }
+    if (s == "PPTP") {
+        k = VPNTypeEnum::PPTP;
+        return;
+    }
+    if (s == "Other") {
+        k = VPNTypeEnum::Other;
+        return;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type VPNTypeEnum");
+}
+
+void to_json(json& j, const ConfigureNetworkStatusEnum& k) noexcept {
+    switch (k) {
+    case ConfigureNetworkStatusEnum::Ready:
+        j = "Ready";
+        return;
+    case ConfigureNetworkStatusEnum::Processing:
+        j = "Processing";
+        return;
+    case ConfigureNetworkStatusEnum::Failed:
+        j = "Failed";
+        return;
+    case ConfigureNetworkStatusEnum::Rejected:
+        j = "Rejected";
+        return;
+    case ConfigureNetworkStatusEnum::NotSupported:
+        j = "NotSupported";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::system::ConfigureNetworkStatusEnum";
+}
+void from_json(const json& j, ConfigureNetworkStatusEnum& k) {
+    std::string s = j;
+    if (s == "Ready") {
+        k = ConfigureNetworkStatusEnum::Ready;
+        return;
+    }
+    if (s == "Processing") {
+        k = ConfigureNetworkStatusEnum::Processing;
+        return;
+    }
+    if (s == "Failed") {
+        k = ConfigureNetworkStatusEnum::Failed;
+        return;
+    }
+    if (s == "Rejected") {
+        k = ConfigureNetworkStatusEnum::Rejected;
+        return;
+    }
+    if (s == "NotSupported") {
+        k = ConfigureNetworkStatusEnum::NotSupported;
+        return;
+    }
+
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type ConfigureNetworkStatusEnum");
+}
+
+void to_json(json& j, const ConfigureNetworkFinalStatusEnum& k) noexcept {
+    switch (k) {
+    case ConfigureNetworkFinalStatusEnum::Ready:
+        j = "Ready";
+        return;
+    case ConfigureNetworkFinalStatusEnum::Failed:
+        j = "Failed";
+        return;
+    }
+    j = "INVALID_VALUE__everest::lib::API::V1_0::types::system::ConfigureNetworkFinalStatusEnum";
+}
+void from_json(const json& j, ConfigureNetworkFinalStatusEnum& k) {
+    std::string s = j;
+    if (s == "Ready") {
+        k = ConfigureNetworkFinalStatusEnum::Ready;
+        return;
+    }
+    if (s == "Failed") {
+        k = ConfigureNetworkFinalStatusEnum::Failed;
+        return;
+    }
+
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type ConfigureNetworkFinalStatusEnum");
+}
+
+void to_json(json& j, const APN& k) noexcept {
+    j = json{
+        {"apn", k.apn},
+    };
+    if (k.apn_user_name) {
+        j["apn_user_name"] = k.apn_user_name.value();
+    }
+    if (k.apn_password) {
+        j["apn_password"] = k.apn_password.value();
+    }
+    if (k.sim_pin) {
+        j["sim_pin"] = k.sim_pin.value();
+    }
+    if (k.preferred_network) {
+        j["preferred_network"] = k.preferred_network.value();
+    }
+    if (k.use_only_preferred_network) {
+        j["use_only_preferred_network"] = k.use_only_preferred_network.value();
+    }
+    if (k.apn_authentication) {
+        j["apn_authentication"] = k.apn_authentication.value();
+    }
+}
+void from_json(const json& j, APN& k) {
+    k.apn = j.at("apn");
+
+    if (j.contains("apn_user_name")) {
+        k.apn_user_name.emplace(j.at("apn_user_name"));
+    }
+    if (j.contains("apn_password")) {
+        k.apn_password.emplace(j.at("apn_password"));
+    }
+    if (j.contains("sim_pin")) {
+        k.sim_pin.emplace(j.at("sim_pin"));
+    }
+    if (j.contains("preferred_network")) {
+        k.preferred_network.emplace(j.at("preferred_network"));
+    }
+    if (j.contains("use_only_preferred_network")) {
+        k.use_only_preferred_network.emplace(j.at("use_only_preferred_network"));
+    }
+    if (j.contains("apn_authentication")) {
+        k.apn_authentication.emplace(j.at("apn_authentication"));
+    }
+}
+
+void to_json(json& j, const VPN& k) noexcept {
+    j = json{
+        {"server", k.server},
+        {"type", k.type},
+    };
+    if (k.user) {
+        j["user"] = k.user.value();
+    }
+    if (k.group) {
+        j["group"] = k.group.value();
+    }
+    if (k.password) {
+        j["password"] = k.password.value();
+    }
+    if (k.key) {
+        j["key"] = k.key.value();
+    }
+}
+void from_json(const json& j, VPN& k) {
+    k.server = j.at("server");
+    k.type = j.at("type");
+
+    if (j.contains("user")) {
+        k.user.emplace(j.at("user"));
+    }
+    if (j.contains("group")) {
+        k.group.emplace(j.at("group"));
+    }
+    if (j.contains("password")) {
+        k.password.emplace(j.at("password"));
+    }
+    if (j.contains("key")) {
+        k.key.emplace(j.at("key"));
+    }
+}
+
+void to_json(json& j, const ConfigureNetworkRequest& k) noexcept {
+    j = json{
+        {"request_id", k.request_id},
+        {"interface", k.interface},
+    };
+    if (k.interface_name) {
+        j["interface_name"] = k.interface_name.value();
+    }
+    if (k.apn) {
+        j["apn"] = k.apn.value();
+    }
+    if (k.vpn) {
+        j["vpn"] = k.vpn.value();
+    }
+}
+void from_json(const json& j, ConfigureNetworkRequest& k) {
+    k.request_id = j.at("request_id");
+    k.interface = j.at("interface");
+
+    if (j.contains("interface_name")) {
+        k.interface_name.emplace(j.at("interface_name"));
+    }
+    if (j.contains("apn")) {
+        k.apn.emplace(j.at("apn"));
+    }
+    if (j.contains("vpn")) {
+        k.vpn.emplace(j.at("vpn"));
+    }
+}
+
+void to_json(json& j, const ConfigureNetworkResponse& k) noexcept {
+    j = json{
+        {"status", k.status},
+    };
+    if (k.interface_address) {
+        j["interface_address"] = k.interface_address.value();
+    }
+}
+void from_json(const json& j, ConfigureNetworkResponse& k) {
+    k.status = j.at("status");
+
+    if (j.contains("interface_address")) {
+        k.interface_address.emplace(j.at("interface_address"));
+    }
+}
+
+void to_json(json& j, const ConfigureNetworkStatus& k) noexcept {
+    j = json{
+        {"request_id", k.request_id},
+        {"status", k.status},
+    };
+    if (k.interface_address) {
+        j["interface_address"] = k.interface_address.value();
+    }
+}
+void from_json(const json& j, ConfigureNetworkStatus& k) {
+    k.request_id = j.at("request_id");
+    k.status = j.at("status");
+
+    if (j.contains("interface_address")) {
+        k.interface_address.emplace(j.at("interface_address"));
+    }
+}
+
 } // namespace everest::lib::API::V1_0::types::system

--- a/lib/everest/everest_api_types/src/everest_api_types/system/wrapper.cpp
+++ b/lib/everest/everest_api_types/src/everest_api_types/system/wrapper.cpp
@@ -4,10 +4,31 @@
 #include "system/wrapper.hpp"
 #include "system/API.hpp"
 #include "system/codec.hpp"
+#include <optional>
 #include <stdexcept>
 #include <string>
 
 namespace everest::lib::API::V1_0::types::system {
+
+namespace {
+
+template <class SrcT>
+auto optToInternal(std::optional<SrcT> const& src) -> std::optional<decltype(to_internal_api(src.value()))> {
+    if (src) {
+        return std::make_optional(to_internal_api(src.value()));
+    }
+    return std::nullopt;
+}
+
+template <class SrcT>
+auto optToExternal(std::optional<SrcT> const& src) -> std::optional<decltype(to_external_api(src.value()))> {
+    if (src) {
+        return std::make_optional(to_external_api(src.value()));
+    }
+    return std::nullopt;
+}
+
+} // namespace
 
 UpdateFirmwareResponse_Internal to_internal_api(UpdateFirmwareResponse_External const& val) {
     using SrcT = UpdateFirmwareResponse_External;
@@ -372,6 +393,278 @@ FirmwareUpdateStatus_External to_external_api(FirmwareUpdateStatus_Internal cons
     if (val.firmware_update_metadata.has_value()) {
         result.firmware_update_metadata.emplace(to_external_api(val.firmware_update_metadata.value()));
     }
+    return result;
+}
+
+InterfaceClassEnum_Internal to_internal_api(InterfaceClassEnum_External const& val) {
+    using SrcT = InterfaceClassEnum_External;
+    using TarT = InterfaceClassEnum_Internal;
+    switch (val) {
+    case SrcT::Wired0:
+        return TarT::Wired0;
+    case SrcT::Wired1:
+        return TarT::Wired1;
+    case SrcT::Wired2:
+        return TarT::Wired2;
+    case SrcT::Wired3:
+        return TarT::Wired3;
+    case SrcT::Wireless0:
+        return TarT::Wireless0;
+    case SrcT::Wireless1:
+        return TarT::Wireless1;
+    case SrcT::Wireless2:
+        return TarT::Wireless2;
+    case SrcT::Wireless3:
+        return TarT::Wireless3;
+    case SrcT::Any:
+        return TarT::Any;
+    }
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::InterfaceClassEnum_External");
+}
+InterfaceClassEnum_External to_external_api(InterfaceClassEnum_Internal const& val) {
+    using SrcT = InterfaceClassEnum_Internal;
+    using TarT = InterfaceClassEnum_External;
+    switch (val) {
+    case SrcT::Wired0:
+        return TarT::Wired0;
+    case SrcT::Wired1:
+        return TarT::Wired1;
+    case SrcT::Wired2:
+        return TarT::Wired2;
+    case SrcT::Wired3:
+        return TarT::Wired3;
+    case SrcT::Wireless0:
+        return TarT::Wireless0;
+    case SrcT::Wireless1:
+        return TarT::Wireless1;
+    case SrcT::Wireless2:
+        return TarT::Wireless2;
+    case SrcT::Wireless3:
+        return TarT::Wireless3;
+    case SrcT::Any:
+        return TarT::Any;
+    }
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::InterfaceClassEnum_Internal");
+}
+
+APNAuthenticationEnum_Internal to_internal_api(APNAuthenticationEnum_External const& val) {
+    using SrcT = APNAuthenticationEnum_External;
+    using TarT = APNAuthenticationEnum_Internal;
+    switch (val) {
+    case SrcT::CHAP:
+        return TarT::CHAP;
+    case SrcT::NONE:
+        return TarT::NONE;
+    case SrcT::PAP:
+        return TarT::PAP;
+    case SrcT::AUTO:
+        return TarT::AUTO;
+    }
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::APNAuthenticationEnum_External");
+}
+APNAuthenticationEnum_External to_external_api(APNAuthenticationEnum_Internal const& val) {
+    using SrcT = APNAuthenticationEnum_Internal;
+    using TarT = APNAuthenticationEnum_External;
+    switch (val) {
+    case SrcT::CHAP:
+        return TarT::CHAP;
+    case SrcT::NONE:
+        return TarT::NONE;
+    case SrcT::PAP:
+        return TarT::PAP;
+    case SrcT::AUTO:
+        return TarT::AUTO;
+    }
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::APNAuthenticationEnum_Internal");
+}
+
+VPNTypeEnum_Internal to_internal_api(VPNTypeEnum_External const& val) {
+    using SrcT = VPNTypeEnum_External;
+    using TarT = VPNTypeEnum_Internal;
+    switch (val) {
+    case SrcT::IKEv2:
+        return TarT::IKEv2;
+    case SrcT::IPSec:
+        return TarT::IPSec;
+    case SrcT::L2TP:
+        return TarT::L2TP;
+    case SrcT::PPTP:
+        return TarT::PPTP;
+    case SrcT::Other:
+        return TarT::Other;
+    }
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::VPNTypeEnum_External");
+}
+VPNTypeEnum_External to_external_api(VPNTypeEnum_Internal const& val) {
+    using SrcT = VPNTypeEnum_Internal;
+    using TarT = VPNTypeEnum_External;
+    switch (val) {
+    case SrcT::IKEv2:
+        return TarT::IKEv2;
+    case SrcT::IPSec:
+        return TarT::IPSec;
+    case SrcT::L2TP:
+        return TarT::L2TP;
+    case SrcT::PPTP:
+        return TarT::PPTP;
+    case SrcT::Other:
+        return TarT::Other;
+    }
+    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::system::VPNTypeEnum_Internal");
+}
+
+ConfigureNetworkStatusEnum_Internal to_internal_api(ConfigureNetworkStatusEnum_External const& val) {
+    using SrcT = ConfigureNetworkStatusEnum_External;
+    using TarT = ConfigureNetworkStatusEnum_Internal;
+    switch (val) {
+    case SrcT::Ready:
+        return TarT::Ready;
+    case SrcT::Processing:
+        return TarT::Processing;
+    case SrcT::Failed:
+        return TarT::Failed;
+    case SrcT::Rejected:
+        return TarT::Rejected;
+    case SrcT::NotSupported:
+        return TarT::NotSupported;
+    }
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::ConfigureNetworkStatusEnum_External");
+}
+ConfigureNetworkStatusEnum_External to_external_api(ConfigureNetworkStatusEnum_Internal const& val) {
+    using SrcT = ConfigureNetworkStatusEnum_Internal;
+    using TarT = ConfigureNetworkStatusEnum_External;
+    switch (val) {
+    case SrcT::Ready:
+        return TarT::Ready;
+    case SrcT::Processing:
+        return TarT::Processing;
+    case SrcT::Failed:
+        return TarT::Failed;
+    case SrcT::Rejected:
+        return TarT::Rejected;
+    case SrcT::NotSupported:
+        return TarT::NotSupported;
+    }
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::ConfigureNetworkStatusEnum_Internal");
+}
+
+ConfigureNetworkFinalStatusEnum_Internal to_internal_api(ConfigureNetworkFinalStatusEnum_External const& val) {
+    using SrcT = ConfigureNetworkFinalStatusEnum_External;
+    using TarT = ConfigureNetworkFinalStatusEnum_Internal;
+    switch (val) {
+    case SrcT::Ready:
+        return TarT::Ready;
+    case SrcT::Failed:
+        return TarT::Failed;
+    }
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::ConfigureNetworkFinalStatusEnum_External");
+}
+ConfigureNetworkFinalStatusEnum_External to_external_api(ConfigureNetworkFinalStatusEnum_Internal const& val) {
+    using SrcT = ConfigureNetworkFinalStatusEnum_Internal;
+    using TarT = ConfigureNetworkFinalStatusEnum_External;
+    switch (val) {
+    case SrcT::Ready:
+        return TarT::Ready;
+    case SrcT::Failed:
+        return TarT::Failed;
+    }
+    throw std::out_of_range(
+        "Unexpected value for everest::lib::API::V1_0::types::system::ConfigureNetworkFinalStatusEnum_Internal");
+}
+
+APN_Internal to_internal_api(APN_External const& val) {
+    APN_Internal result;
+    result.apn = val.apn;
+    result.apn_user_name = val.apn_user_name;
+    result.apn_password = val.apn_password;
+    result.sim_pin = val.sim_pin;
+    result.preferred_network = val.preferred_network;
+    result.use_only_preferred_network = val.use_only_preferred_network;
+    result.apn_authentication = optToInternal(val.apn_authentication);
+    return result;
+}
+APN_External to_external_api(APN_Internal const& val) {
+    APN_External result;
+    result.apn = val.apn;
+    result.apn_user_name = val.apn_user_name;
+    result.apn_password = val.apn_password;
+    result.sim_pin = val.sim_pin;
+    result.preferred_network = val.preferred_network;
+    result.use_only_preferred_network = val.use_only_preferred_network;
+    result.apn_authentication = optToExternal(val.apn_authentication);
+    return result;
+}
+
+VPN_Internal to_internal_api(VPN_External const& val) {
+    VPN_Internal result;
+    result.server = val.server;
+    result.user = val.user;
+    result.group = val.group;
+    result.password = val.password;
+    result.key = val.key;
+    result.type = to_internal_api(val.type);
+    return result;
+}
+VPN_External to_external_api(VPN_Internal const& val) {
+    VPN_External result;
+    result.server = val.server;
+    result.user = val.user;
+    result.group = val.group;
+    result.password = val.password;
+    result.key = val.key;
+    result.type = to_external_api(val.type);
+    return result;
+}
+
+ConfigureNetworkRequest_Internal to_internal_api(ConfigureNetworkRequest_External const& val) {
+    ConfigureNetworkRequest_Internal result;
+    result.request_id = val.request_id;
+    result.interface = to_internal_api(val.interface);
+    result.interface_name = val.interface_name;
+    result.apn = optToInternal(val.apn);
+    result.vpn = optToInternal(val.vpn);
+    return result;
+}
+ConfigureNetworkRequest_External to_external_api(ConfigureNetworkRequest_Internal const& val) {
+    ConfigureNetworkRequest_External result;
+    result.request_id = val.request_id;
+    result.interface = to_external_api(val.interface);
+    result.interface_name = val.interface_name;
+    result.apn = optToExternal(val.apn);
+    result.vpn = optToExternal(val.vpn);
+    return result;
+}
+
+ConfigureNetworkResponse_Internal to_internal_api(ConfigureNetworkResponse_External const& val) {
+    ConfigureNetworkResponse_Internal result;
+    result.status = to_internal_api(val.status);
+    result.interface_address = val.interface_address;
+    return result;
+}
+ConfigureNetworkResponse_External to_external_api(ConfigureNetworkResponse_Internal const& val) {
+    ConfigureNetworkResponse_External result;
+    result.status = to_external_api(val.status);
+    result.interface_address = val.interface_address;
+    return result;
+}
+
+ConfigureNetworkStatus_Internal to_internal_api(ConfigureNetworkStatus_External const& val) {
+    ConfigureNetworkStatus_Internal result;
+    result.request_id = val.request_id;
+    result.status = to_internal_api(val.status);
+    result.interface_address = val.interface_address;
+    return result;
+}
+ConfigureNetworkStatus_External to_external_api(ConfigureNetworkStatus_Internal const& val) {
+    ConfigureNetworkStatus_External result;
+    result.request_id = val.request_id;
+    result.status = to_external_api(val.status);
+    result.interface_address = val.interface_address;
     return result;
 }
 

--- a/modules/API/EVerestAPI/system_API/main/systemImpl.cpp
+++ b/modules/API/EVerestAPI/system_API/main/systemImpl.cpp
@@ -83,9 +83,10 @@ types::system::BootReason systemImpl::handle_get_boot_reason() {
 
 types::network::ConfigureNetworkResponse
 systemImpl::handle_configure_network(types::network::ConfigureNetworkRequest& request) {
-    types::network::ConfigureNetworkResponse response;
-    response.status = types::network::ConfigureNetworkStatusEnum::NotSupported;
-    return response;
+    // Absent/non-answering external agent degrades to NotSupported after cfg_request_reply_to_s.
+    static const types::network::ConfigureNetworkResponse default_response =
+        types::network::ConfigureNetworkResponse{types::network::ConfigureNetworkStatusEnum::NotSupported, {}};
+    return generic_request_reply(default_response, API_types_ext::to_external_api(request), "configure_network");
 }
 
 } // namespace main

--- a/modules/API/EVerestAPI/system_API/system_API.cpp
+++ b/modules/API/EVerestAPI/system_API/system_API.cpp
@@ -32,6 +32,7 @@ void system_API::ready() {
 
     generate_api_var_firmware_update_status();
     generate_api_var_log_status();
+    generate_api_var_configure_network_status();
 
     helper.generate_api_var_communication_check(&comm_check);
     comm_check.start(config.cfg_communication_check_to_s);
@@ -55,6 +56,17 @@ void system_API::generate_api_var_log_status() {
         API_types_ext::LogStatus payload;
         if (deserialize(data, payload)) {
             p_main->publish_log_status(to_internal_api(payload));
+            return true;
+        }
+        return false;
+    });
+}
+
+void system_API::generate_api_var_configure_network_status() {
+    helper.subscribe_api_topic("configure_network_status", [this](std::string const& data) {
+        API_types_ext::ConfigureNetworkStatus payload;
+        if (deserialize(data, payload)) {
+            p_main->publish_configure_network_status(to_internal_api(payload));
             return true;
         }
         return false;

--- a/modules/API/EVerestAPI/system_API/system_API.hpp
+++ b/modules/API/EVerestAPI/system_API/system_API.hpp
@@ -62,6 +62,7 @@ private:
     // insert your private definitions here
     void generate_api_var_firmware_update_status();
     void generate_api_var_log_status();
+    void generate_api_var_configure_network_status();
 
     ev_API::CommCheckHandler<systemImplBase> comm_check{"system/CommunicationFault",
                                                         ev_API::bridge_connection_lost_message, p_main};

--- a/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.cpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.cpp
@@ -1116,6 +1116,7 @@ std::shared_ptr<Everest::config::ConfigServiceClient> ModuleAdapter::get_config_
 
 std::optional<json> ModuleAdapter::get_cmd_response(const std::optional<json>& default_response) {
     auto result = default_response;
+    std::lock_guard<std::mutex> lock(m_cmd_response_mutex);
     if (!m_cmd_response_list.empty()) {
         result = m_cmd_response_list.front();
         m_cmd_response_list.pop_front();
@@ -1152,6 +1153,7 @@ void ModuleAdapter::publish(const Requirement& req, const std::string& fn, json 
 }
 
 void ModuleAdapter::add_cmd_result(const json& data) {
+    std::lock_guard<std::mutex> lock(m_cmd_response_mutex);
     m_cmd_response_list.push_back(data);
 }
 

--- a/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
@@ -17,6 +17,7 @@
 
 #include <list>
 #include <memory>
+#include <mutex>
 #include <string>
 
 namespace stubs {
@@ -120,6 +121,8 @@ private:
     void publish_fn(const std::string& interface, const std::string& variable, int instance, const json& value);
 
     var_cb_list_t m_subscribe_var_callbacks;
+    // guarded by m_cmd_response_mutex: commands may be invoked from module threads concurrently
+    std::mutex m_cmd_response_mutex;
     std::list<json> m_cmd_response_list;
 
 protected:

--- a/tests/async_api_tests/config/probe-system-fast-timeout.yaml
+++ b/tests/async_api_tests/config/probe-system-fast-timeout.yaml
@@ -1,0 +1,12 @@
+active_modules:
+  system_api:
+    module: system_API
+    config_module:
+      cfg_communication_check_to_s: 0
+      cfg_request_reply_to_s: 1
+  probe:
+    module: ProbeModule
+    connections:
+      system:
+        - module_id: system_api
+          implementation_id: main

--- a/tests/async_api_tests/test_system.py
+++ b/tests/async_api_tests/test_system.py
@@ -3,6 +3,7 @@ import pytest
 import pytest_asyncio
 import json
 import asyncio
+from queue import Empty
 from typing import Callable, Dict
 import paho.mqtt.client as mqtt
 from everest.testing.core_utils.probe_module import ProbeModule
@@ -173,3 +174,99 @@ async def test_api_cmds(everest_core: EverestCore, async_api_mqtt_handler: Async
         {'type': 'Soft'}
     )
     assert result == True
+
+
+def _drain_queue(queue):
+    """Remove any pending values so an assertion only sees fresh publications."""
+    try:
+        while True:
+            queue.get_nowait()
+    except Empty:
+        pass
+
+
+async def _publish_until_received(handler: AsyncApiMqttHandler, queue, topic: str, payload, deadline: float = 10.0, interval: float = 0.5):
+    """Publish a QoS0/non-retained payload repeatedly until the consumer queue yields a value.
+
+    Works around the race between the one-shot publish and the module's m2e subscription
+    setup without leaking retained state. Returns the first received value.
+    """
+    loop = asyncio.get_event_loop()
+    _drain_queue(queue)
+    end = loop.time() + deadline
+    while loop.time() < end:
+        await handler.publish(topic, json.dumps(payload))
+        try:
+            return await loop.run_in_executor(None, lambda: queue.get(timeout=interval))
+        except Empty:
+            continue
+    raise TimeoutError(f"no var value received on topic {topic}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config('probe-system.yaml')
+async def test_configure_network_cmd(everest_core: EverestCore, async_api_mqtt_handler: AsyncApiMqttHandler, probe_module: ProbeModule):
+
+    mqtt_prefix = everest_core.mqtt_external_prefix
+    received = {}
+
+    # external agent answers the forwarded configure_network request with Processing
+    async def on_configure_network(payload: str):
+        request = json.loads(payload)
+        received['payload'] = request.get('payload')
+        response_topic = request['headers']['replyTo']
+        response_payload = {"status": "Processing"}
+        await async_api_mqtt_handler.publish(f"{mqtt_prefix}{response_topic}", json.dumps(response_payload))
+
+    async_api_mqtt_handler.register_handler(f"{everest_core.mqtt_external_prefix}everest_api/1/system/system_api/e2m/configure_network", on_configure_network)
+
+    result = await probe_module.call_command(
+        'system',
+        'configure_network',
+        {
+            'request': {
+                'request_id': 1,
+                'interface': 'Wired0'
+            }
+        }
+    )
+    assert result == {"status": "Processing"}
+    # verify the request survived internal->external serialization intact (real round-trip)
+    assert received['payload'] == {'request_id': 1, 'interface': 'Wired0'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config('probe-system-fast-timeout.yaml')
+async def test_configure_network_not_supported_on_timeout(everest_core: EverestCore, async_api_mqtt_handler: AsyncApiMqttHandler, probe_module: ProbeModule):
+
+    # No e2m/configure_network handler registered -> the request times out after
+    # cfg_request_reply_to_s (=1s in this config) and degrades to NotSupported.
+    result = await probe_module.call_command(
+        'system',
+        'configure_network',
+        {
+            'request': {
+                'request_id': 7,
+                'interface': 'Wired0'
+            }
+        }
+    )
+    assert result == {"status": "NotSupported"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.everest_core_config('probe-system.yaml')
+async def test_configure_network_status_var(everest_core: EverestCore, async_api_mqtt_handler: AsyncApiMqttHandler, probe_module: ProbeModule):
+
+    mqtt_prefix = everest_core.mqtt_external_prefix
+    topic = f"{mqtt_prefix}everest_api/1/system/system_api/m2e/configure_network_status"
+
+    queue = probe_module.subscribe_variable_to_queue('system', 'configure_network_status')
+
+    status_payload = {
+        "request_id": 42,
+        "status": "Ready",
+        "interface_address": "192.168.1.10"
+    }
+    result = await _publish_until_received(async_api_mqtt_handler, queue, topic, status_payload)
+    assert result == status_payload


### PR DESCRIPTION

## Describe your changes

Implement the provider side of the system network-configuration interface (PR 3 of 3).

- everest_api_types: add external network types with codec + wrapper conversions to the everest_api_types lib
- system_API: replace the configure_network stub with a blocking request/reply forward to the external agent, degrading to NotSupported after cfg_request_reply_to_s
- add subscription-backed configure_network_status and network_interfaces vars (the interfaces var fails closed on non-array payloads).
- Document the configure_network command, both status vars, and the network schemas in the system async API definition.
- Extend test_system.py with the cmd round-trip, the NotSupported timeout path, and the m2e var surfacings.

System module stays a NotSupported stub.

## Issue ticket number and link

This is part 3 of 3 from a stack:

1) https://github.com/EVerest/EVerest/pull/2409
2) https://github.com/EVerest/EVerest/pull/2411 
3) https://github.com/EVerest/EVerest/pull/2413 👈

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

