### PR TITLE
feat(ocpp): add start_connecting flag to v16 ChargePoint::start

### DIFF
--- a/lib/everest/ocpp/config/common/component_config/standardized/NetworkConfiguration_1.json
+++ b/lib/everest/ocpp/config/common/component_config/standardized/NetworkConfiguration_1.json
@@ -370,7 +370,7 @@
       "characteristics": {
         "supportsMonitoring": false,
         "dataType": "OptionList",
-        "valuesList": "OCPP20,OCPP201,OCPP21"
+        "valuesList": "OCPP16,OCPP20,OCPP201,OCPP21"
       },
       "attributes": [
         {

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point.hpp
@@ -138,9 +138,11 @@ public:
     /// not stop transactions with this session_id even in case it has an internal database entry for this session and
     /// it hasnt been stopped yet. Its ignored if this vector contains session_ids that are unknown to libocpp.
     ///  \return
+    /// \param start_connecting if true (default) the websocket connection is initiated as part of start(). If false
+    /// connecting is deferred until an explicit connect_websocket() call.
     bool start(const std::map<int, ChargePointStatus>& connector_status_map = {},
                BootReasonEnum bootreason = BootReasonEnum::PowerUp,
-               const std::set<std::string>& resuming_session_ids = {});
+               const std::set<std::string>& resuming_session_ids = {}, bool start_connecting = true);
 
     /// \brief Restarts the ChargePoint if it has been stopped before. The ChargePoint is reinitialized, connects to the
     /// websocket and starts to communicate OCPP messages again

--- a/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
+++ b/lib/everest/ocpp/include/ocpp/v16/charge_point_impl.hpp
@@ -493,9 +493,11 @@ public:
     /// initiate a StopTransaction.req for those transactions. If this vector contains session_ids this function will
     /// not stop transactions with this session_id even in case it has an internal database entry for this session and
     /// it hasnt been stopped yet. Its ignored if this vector contains session_ids that are unknown to libocpp.
+    /// \param start_connecting if true (default) the websocket connection is initiated as part of start(). If false
+    /// connecting is deferred until an explicit connect_websocket() call.
     ///  \return
     bool start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason,
-               const std::set<std::string>& resuming_session_ids);
+               const std::set<std::string>& resuming_session_ids, bool start_connecting = true);
 
     /// \brief Restarts the ChargePoint if it has been stopped before. The ChargePoint is reinitialized, connects to the
     /// websocket and starts to communicate OCPP messages again

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point.cpp
@@ -56,8 +56,8 @@ bool ChargePoint::init(const std::map<int, ChargePointStatus>& connector_status_
 }
 
 bool ChargePoint::start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason,
-                        const std::set<std::string>& resuming_session_ids) {
-    return this->charge_point->start(connector_status_map, bootreason, resuming_session_ids);
+                        const std::set<std::string>& resuming_session_ids, bool start_connecting) {
+    return this->charge_point->start(connector_status_map, bootreason, resuming_session_ids, start_connecting);
 }
 
 bool ChargePoint::restart(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason) {

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -1140,7 +1140,7 @@ bool ChargePointImpl::init(const std::map<int, ChargePointStatus>& connector_sta
 }
 
 bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason,
-                            const std::set<std::string>& resuming_session_ids) {
+                            const std::set<std::string>& resuming_session_ids, bool start_connecting) {
     if (!this->initialized) {
         init(connector_status_map, resuming_session_ids);
     }
@@ -1149,7 +1149,9 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     this->publish_default_price(true);
     this->connectivity_manager->set_message_callback(
         [this](const std::string& message) { this->message_callback(message); });
-    this->connectivity_manager->connect();
+    if (start_connecting && !this->connectivity_manager->is_websocket_connected()) {
+        this->connectivity_manager->connect();
+    }
     this->boot_notification();
     this->call_set_connection_timeout();
 


### PR DESCRIPTION

## Describe your changes

When false, the websocket connect is deferred to an explicit connect_websocket() call. Also skip connecting when the websocket is already connected.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

