### PR TITLE
libocpp: fix positional args for unsigned firmware_status_notification, add test for disabled connectors on unsigned updates

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -4648,7 +4648,7 @@ void ChargePointImpl::on_firmware_update_status_notification(std::int32_t reques
                 request_id, false, disable_connectors_during_install);
         } else {
             this->firmware_status_notification(
-                ocpp::conversions::firmware_status_notification_to_firmware_status(firmware_update_status),
+                ocpp::conversions::firmware_status_notification_to_firmware_status(firmware_update_status), false,
                 disable_connectors_during_install);
         }
     } catch (const std::out_of_range& e) {

--- a/modules/Misc/System/main/systemImpl.cpp
+++ b/modules/Misc/System/main/systemImpl.cpp
@@ -51,6 +51,13 @@ fs::path create_temp_file(const fs::path& dir, const std::string& prefix) {
     return fn_template_buffer.data();
 }
 
+bool split_key_value(const std::string& key_value, std::string& key, std::string& value) {
+    std::stringstream line_stream(key_value);
+    bool split_ok = !std::getline(line_stream, key, '=').fail();
+    split_ok = split_ok && !std::getline(line_stream, value, '=').fail();
+    return split_ok;
+}
+
 void systemImpl::init() {
     this->scripts_path = mod->info.paths.libexec;
     this->log_upload_running = false;
@@ -83,8 +90,12 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
     this->update_firmware_thread = std::thread([this, firmware_update_request, firmware_file_path, constants]() {
         const auto firmware_updater = this->scripts_path / FIRMWARE_UPDATER;
 
-        const std::vector<std::string> args = {constants.string(), firmware_update_request.location,
-                                               firmware_file_path.string()};
+        const auto separator = firmware_update_request.location.find('#');
+        const auto location = firmware_update_request.location.substr(0, separator);
+        const auto metadata_fragment =
+            separator == std::string::npos ? std::string() : firmware_update_request.location.substr(separator + 1);
+
+        const std::vector<std::string> args = {constants.string(), location, firmware_file_path.string()};
         int32_t retries = 0;
         const auto total_retries = firmware_update_request.retries.value_or(this->mod->config.DefaultRetries);
         const auto retry_interval =
@@ -94,6 +105,22 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
         types::system::FirmwareUpdateStatus firmware_status;
         firmware_status.request_id = -1;
         firmware_status.firmware_update_status = firmware_status_enum;
+
+        std::map<std::string, std::string> parsed_fragment;
+        std::stringstream fragment_stream(metadata_fragment);
+        std::string fragment_key_value;
+        while (std::getline(fragment_stream, fragment_key_value, '&')) {
+            std::string key;
+            std::string value;
+            if (split_key_value(fragment_key_value, key, value)) {
+                parsed_fragment[key] = value;
+            }
+        }
+        if (parsed_fragment.count("disable_connectors_during_install") != 0) {
+            types::system::FirmwareUpdateMetadata metadata;
+            metadata.disable_connectors_during_install = parsed_fragment["disable_connectors_during_install"] == "true";
+            firmware_status.firmware_update_metadata.emplace(metadata);
+        }
 
         while (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
                retries < total_retries) {
@@ -283,13 +310,9 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
                                 return CmdControl::Continue;
                             }
 
-                            std::stringstream line_stream(output_line);
                             std::string key;
                             std::string value;
-                            bool split_ok = !std::getline(line_stream, key, '=').fail();
-                            split_ok = split_ok && !std::getline(line_stream, value, '=').fail();
-
-                            if (!split_ok) {
+                            if (!split_key_value(output_line, key, value)) {
                                 EVLOG_error << "Firmware metadata parser returned invalid data: " << output_line;
                                 terminated = true;
                                 return CmdControl::Terminate;

--- a/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
+++ b/tests/ocpp_tests/test_sets/ocpp16/ocpp_compliance_tests.py
@@ -4302,6 +4302,15 @@ async def test_firmware_update_download_install(
     assert await wait_for_and_validate(
         test_utility,
         charge_point_v16,
+        "StatusNotification",
+        call.StatusNotification(
+            1, ChargePointErrorCode.no_error, ChargePointStatus.unavailable
+        ),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
         "FirmwareStatusNotification",
         call.DiagnosticsStatusNotification(FirmwareStatus.installing),
     )
@@ -4311,6 +4320,67 @@ async def test_firmware_update_download_install(
         charge_point_v16,
         "FirmwareStatusNotification",
         call.DiagnosticsStatusNotification(FirmwareStatus.installed),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "StatusNotification",
+        call.StatusNotification(
+            1, ChargePointErrorCode.no_error, ChargePointStatus.available
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.xdist_group(name="FTP")
+async def test_firmware_update_download_install_keep_connectors_available(
+    charge_point_v16: ChargePoint16, test_utility: TestUtility, ftp_server, test_config
+):
+    logging.info(
+        "######### test_firmware_update_download_install_keep_connectors_available #########"
+    )
+
+    retrieve_date = datetime.now(timezone.utc)
+    location = f"ftp://{getpass.getuser()}:12345@localhost:{ftp_server.port}/firmware_update.pnx#disable_connectors_during_install=false"
+
+    await charge_point_v16.update_firmware_req(
+        location=location, retrieve_date=retrieve_date.isoformat()
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "FirmwareStatusNotification",
+        call.FirmwareStatusNotification(FirmwareStatus.downloading),
+    )
+
+    # Verify that the connectors are not made unavailable.
+    # Drop the message buffer so that no StatusNotification sent before this point causes a test failure.
+    test_utility.messages.clear()
+    test_utility.forbidden_actions.append("StatusNotification")
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "FirmwareStatusNotification",
+        call.FirmwareStatusNotification(FirmwareStatus.downloaded),
+    )
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "FirmwareStatusNotification",
+        call.FirmwareStatusNotification(FirmwareStatus.installing),
+    )
+
+    test_utility.forbidden_actions.remove("StatusNotification")
+
+    assert await wait_for_and_validate(
+        test_utility,
+        charge_point_v16,
+        "FirmwareStatusNotification",
+        call.FirmwareStatusNotification(FirmwareStatus.installed),
     )
 
 


### PR DESCRIPTION
## Describe your changes

Fixes a missing argument on a call to firmware_status_notification that lead to the second optional argument for disable_connectors_during_install to be passed as initiated_by_trigger_message instead.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

