### PR TITLE
InfyPower: FIXED_ADDRESS unknown-source filtering and communication-failure recovery

### DIFF
--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.cpp
@@ -116,6 +116,7 @@ void InfyCanDevice::rx_handler(uint32_t can_id, const std::vector<uint8_t>& payl
         telemetry.status = status;
         // using status message to set the last_update time
         telemetry.last_update = std::chrono::steady_clock::now();
+        mark_module_active(source_address); // keep active set in sync with the liveness heartbeat
     } break;
     case can_packet_acdc::ReadModuleVIAfterDiode::CMD_ID: {
         handle_simple_telemetry_update(source_address, payload, command_number);
@@ -339,19 +340,23 @@ void InfyCanDevice::handle_simple_telemetry_update(uint8_t source_address, const
         EVLOG_info << format_module_id(source_address) << ": capabilities: " << caps.max_voltage << "V / "
                    << caps.min_voltage << "V, " << caps.max_current << "A, power " << caps.rated_power << "W";
         signalCapabilitiesUpdate(telemetries);
-
-        // Consider the module active again if we previously lost it due to communication timeout.
-        // This is only relevant in FIXED_ADDRESS mode, GROUP_DISCOVERY uses `ReadModuleCount` responses instead.
-        if (operating_mode == OperatingMode::FIXED_ADDRESS) {
-            std::lock_guard<std::mutex> lock(active_modules_mutex);
-            if (std::find(active_module_addresses.begin(), active_module_addresses.end(), source_address) ==
-                active_module_addresses.end()) {
-                active_module_addresses.push_back(source_address);
-                EVLOG_info << format_module_id(source_address)
-                           << ": Module added to active modules based on capabilities response.";
-            }
-        }
+        mark_module_active(source_address);
     } break;
+    }
+}
+
+void InfyCanDevice::mark_module_active(uint8_t source_address) {
+    // In FIXED_ADDRESS mode the active set is driven purely by received telemetry: any message from a
+    // configured module means it is alive, so (re-)add it if it had been dropped after a comm timeout.
+    // GROUP_DISCOVERY derives the active set from ReadModuleCount responses instead.
+    if (operating_mode != OperatingMode::FIXED_ADDRESS) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(active_modules_mutex);
+    if (std::find(active_module_addresses.begin(), active_module_addresses.end(), source_address) ==
+        active_module_addresses.end()) {
+        active_module_addresses.push_back(source_address);
+        EVLOG_info << format_module_id(source_address) << ": module re-activated after receiving telemetry.";
     }
 }
 

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.cpp
@@ -91,6 +91,15 @@ void InfyCanDevice::rx_handler(uint32_t can_id, const std::vector<uint8_t>& payl
     const uint8_t source_address = can_packet_acdc::source_address_from_can_id(can_id);
     const uint8_t command_number = can_packet_acdc::command_number_from_can_id(can_id);
 
+    // Ignore messages from unknown sources in FIXED_ADDRESS mode, only consider those that are explicitly configured.
+    // This prevents interference with other Infy devices on the same CAN bus that are not part of this system.
+    if (operating_mode == OperatingMode::FIXED_ADDRESS &&
+        std::find(module_addresses.begin(), module_addresses.end(), source_address) == module_addresses.end()) {
+        EVLOG_debug << "Infy: Received message from unknown module address 0x" << std::hex << std::uppercase
+                    << static_cast<int>(source_address) << ". Ignoring.";
+        return;
+    }
+
     switch (command_number) {
     case can_packet_acdc::ReadModuleCount::CMD_ID: {
         handle_module_count_packet(payload);

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.cpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.cpp
@@ -60,8 +60,9 @@ void InfyCanDevice::set_config_values(const std::string& addrs, int group_addr, 
     EVLOG_info << "Infy: Operating with controller address: 0x" << std::hex << controller_address;
     if (!addrs.empty()) {
         operating_mode = OperatingMode::FIXED_ADDRESS;
-        active_module_addresses = parse_module_addresses(addrs);
-        expected_module_count = active_module_addresses.size();
+        module_addresses = parse_module_addresses(addrs);
+        expected_module_count = module_addresses.size();
+        active_module_addresses = module_addresses; // Initially assume all configured addresses are active
         EVLOG_info << "Infy: Operating in FIXED_ADDRESS mode with " << expected_module_count << " addresses: " << addrs;
     } else {
         operating_mode = OperatingMode::GROUP_DISCOVERY;
@@ -182,14 +183,18 @@ void InfyCanDevice::poll_status_handler() {
 
     clear_paced_tx_queue();
 
-    if (operating_mode == OperatingMode::GROUP_DISCOVERY) {
-        enqueue_poll_command(group_address, can_packet_acdc::ReadModuleCount::CMD_ID, empty_read_payload, true);
-    }
-
     std::vector<uint8_t> poll_addresses;
-    {
+    if (operating_mode == OperatingMode::GROUP_DISCOVERY) {
+        // Request a list of active modules in the group, this updates `active_module_addresses` based on responses.
+        enqueue_poll_command(group_address, can_packet_acdc::ReadModuleCount::CMD_ID, empty_read_payload, true);
+
+        // Only poll addresses that are currently active based on received telemetry.
         std::lock_guard<std::mutex> lock(active_modules_mutex);
         poll_addresses = active_module_addresses;
+    } else if (operating_mode == OperatingMode::FIXED_ADDRESS) {
+        // Poll all configured module addresses in FIXED_ADDRESS mode, even if they are not currently active.
+        // This allows the system to detect modules that have come back online after a temporary communication loss.
+        poll_addresses = module_addresses;
     }
 
     for (const auto& addr : poll_addresses) {
@@ -325,6 +330,18 @@ void InfyCanDevice::handle_simple_telemetry_update(uint8_t source_address, const
         EVLOG_info << format_module_id(source_address) << ": capabilities: " << caps.max_voltage << "V / "
                    << caps.min_voltage << "V, " << caps.max_current << "A, power " << caps.rated_power << "W";
         signalCapabilitiesUpdate(telemetries);
+
+        // Consider the module active again if we previously lost it due to communication timeout.
+        // This is only relevant in FIXED_ADDRESS mode, GROUP_DISCOVERY uses `ReadModuleCount` responses instead.
+        if (operating_mode == OperatingMode::FIXED_ADDRESS) {
+            std::lock_guard<std::mutex> lock(active_modules_mutex);
+            if (std::find(active_module_addresses.begin(), active_module_addresses.end(), source_address) ==
+                active_module_addresses.end()) {
+                active_module_addresses.push_back(source_address);
+                EVLOG_info << format_module_id(source_address)
+                           << ": Module added to active modules based on capabilities response.";
+            }
+        }
     } break;
     }
 }

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.hpp
@@ -107,6 +107,9 @@ private:
     void handle_module_count_packet(const std::vector<uint8_t>& payload);
     void handle_simple_telemetry_update(uint8_t source_address, const std::vector<uint8_t>& payload,
                                         uint8_t command_number);
+
+    /// (Re-)add a configured module to the active set in FIXED_ADDRESS mode after receiving telemetry from it.
+    void mark_module_active(uint8_t source_address);
     void check_and_signal_error_status_change(uint8_t source_address,
                                               const can_packet_acdc::PowerModuleStatus& new_status,
                                               const can_packet_acdc::PowerModuleStatus& old_status);

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.hpp
@@ -95,7 +95,8 @@ private:
     /// In OperatingMode::FIXED_ADDRESS, this contains the configured module addresses.
     std::vector<uint8_t> module_addresses;
 
-    /// List of currently active module addresses based on received telemetry. Updated dynamically as modules go offline/online.
+    /// List of currently active module addresses based on received telemetry. Updated dynamically as modules go
+    /// offline/online.
     std::vector<uint8_t> active_module_addresses;
     std::mutex active_modules_mutex;
 

--- a/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.hpp
+++ b/modules/HardwareDrivers/PowerSupplies/InfyPower/can_driver_acdc/InfyCanDevice.hpp
@@ -92,6 +92,10 @@ private:
     int device_connection_timeout_s{0};
     OperatingMode operating_mode{OperatingMode::FIXED_ADDRESS};
 
+    /// In OperatingMode::FIXED_ADDRESS, this contains the configured module addresses.
+    std::vector<uint8_t> module_addresses;
+
+    /// List of currently active module addresses based on received telemetry. Updated dynamically as modules go offline/online.
     std::vector<uint8_t> active_module_addresses;
     std::mutex active_modules_mutex;
 


### PR DESCRIPTION
## Describe your changes
Recreates the changes from #2315 (originally by @IvarScholten,
from a fork) on a branch in this repo, plus a follow-up fix.

Ivar Scholten's commits (unchanged):
- Fix communication failure recovery in FIXED_ADDRESS mode (poll all
  configured modules, not just active ones)
- Ignore messages from unknown sources in FIXED_ADDRESS mode
- Formatting

Follow-up (this PR):
- Re-activate a timed-out module on **any** received telemetry, not only on
  the `ReadModuleCapabilities` reply. Previously, if a recovering module's
  capabilities reply was lost while its barcode reply arrived (so the serial
  became known and capabilities was no longer polled), the module could keep
  answering VI/status polls yet stay permanently excluded from `switch_on_off`
  / `setExportVoltageCurrent`. Recovery is now anchored to the
  `PowerModuleStatus` heartbeat via a shared `mark_module_active()` helper.

Co-authored work preserved via original commit authorship.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

