### PR TITLE
fix (ocpp) : OCSP_REQUEST_TIMER_INTERVAL hardcoded value

### DIFF
--- a/lib/everest/ocpp/config/v16/config-full.json
+++ b/lib/everest/ocpp/config/v16/config-full.json
@@ -138,20 +138,16 @@
     "CostAndPrice": {
         "CustomDisplayCostAndPrice": true,
         "NumberOfDecimalsForCostValues": 4,
-        "DefaultPrice":
-        {
+        "DefaultPrice": {
             "priceText": "This is the price",
             "priceTextOffline": "Show this price text when offline!",
-            "chargingPrice":
-            {
+            "chargingPrice": {
                 "kWhPrice": 3.14,
                 "hourPrice": 0.42
             }
         },
-        "DefaultPriceText":
-        {
-            "priceTexts":
-            [
+        "DefaultPriceText": {
+            "priceTexts": [
                 {
                     "priceText": "This is the price",
                     "priceTextOffline": "Show this price text when offline!",

--- a/lib/everest/ocpp/config/v16/profile_schemas/Internal.json
+++ b/lib/everest/ocpp/config/v16/profile_schemas/Internal.json
@@ -341,7 +341,7 @@
         "MessageTypesDiscardForQueueing": {
             "$comment": "Comma seperated list of message types that shall not be queued (when offline) even in case QueueAllMessages is true. If QueueAllMessages is false, the configuration of this paramater has no effect.",
             "type": "string",
-            "readOnly": true   
+            "readOnly": true
         },
         "MessageQueueSizeThreshold": {
             "$comment": "Threshold for the size of in-memory message queues used to buffer messages (and store e.g. while offline). If threshold is exceeded, messages  will be dropped according to OCPP specification to avoid memory issues.",

--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -29,7 +29,6 @@ const auto ISO15118_PNC_VENDOR_ID = "org.openchargealliance.iso15118pnc";
 const auto CALIFORNIA_PRICING_VENDOR_ID = "org.openchargealliance.costmsg";
 const auto CLIENT_CERTIFICATE_TIMER_INTERVAL = std::chrono::hours(12);
 const auto V2G_CERTIFICATE_TIMER_INTERVAL = std::chrono::hours(12);
-const auto OCSP_REQUEST_TIMER_INTERVAL = std::chrono::hours(12);
 const auto INITIAL_CERTIFICATE_REQUESTS_DELAY = std::chrono::seconds(60);
 const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 1000;
 const auto DEFAULT_BOOT_NOTIFICATION_INTERVAL_S = 60; // fallback interval if BootNotification returns interval of 0.
@@ -214,7 +213,13 @@ ChargePointImpl::ChargePointImpl(
             };
         this->ocsp_request_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() {
             this->update_ocsp_cache();
-            this->ocsp_request_timer->interval(OCSP_REQUEST_TIMER_INTERVAL);
+            int32_t ocsp_request_interval = 604800; // default to 12 hours if not configured
+            try {
+                ocsp_request_interval = this->configuration.getOcspRequestInterval();
+            } catch (const std::runtime_error& e) {
+                EVLOG_error << "OCSP request interval could not be loaded (Using default 168 hours): " << e.what();
+            }
+            this->ocsp_request_timer->interval(std::chrono::seconds(ocsp_request_interval));
         });
     }
 


### PR DESCRIPTION
Hi,

i saw that rishabhvaish began to fix it in https://github.com/EVerest/EVerest/pull/2002 but since he didn't answered since a few month, i thought i could do it by myself.

## Describe your changes
Removed the hardcoded value and use the already existing config value.

## Issue ticket number and link
https://github.com/EVerest/EVerest/issues/1991

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

