### PR TITLE
Fix cmake include path to refer to PROJECT_SOURCE_DIR instead of CMAK…

### DIFF
--- a/modules/EnergyManagement/CMakeLists.txt
+++ b/modules/EnergyManagement/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT EEBUS_BUILD_MODE MATCHES "^(AUTO|ON|OFF)$")
 endif()
 
 if (NOT EEBUS_BUILD_MODE STREQUAL "OFF")
-    include(${CMAKE_SOURCE_DIR}/cmake/eebus-dependency-check.cmake)
+    include(${PROJECT_SOURCE_DIR}/cmake/eebus-dependency-check.cmake)
     eebus_check_dependencies(
         RESULT_VAR EEBUS_DEPENDENCIES_AVAILABLE
         REASON_VAR EEBUS_MISSING_DEPENDENCIES


### PR DESCRIPTION
Fix cmake include path to refer to PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR, this is required in cvase of including everest as sub project into another cmake project.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

