### PR TITLE
Fix devcontainer build failure on macOS from host GID collision

### DIFF
--- a/.devcontainer/general-devcontainer/Dockerfile
+++ b/.devcontainer/general-devcontainer/Dockerfile
@@ -56,7 +56,13 @@ RUN ls -al /tmp/everest_dev_tool \
 ##################################################################
 
 # Modify the existing docker user and group to match the host's USER_UID and USER_GID
-RUN groupmod --gid ${USER_GID} ${USERNAME} && \
+# If the target GID is already in use by another group (e.g. host GID 20 collides with
+# Debian's "dialout" group), move that group out of the way first so groupmod can proceed.
+RUN existing_group="$(getent group ${USER_GID} | cut -d: -f1)"; \
+    if [ -n "${existing_group}" ] && [ "${existing_group}" != "${USERNAME}" ]; then \
+        groupmod --gid $(($(getent group | cut -d: -f3 | sort -n | tail -1) + 1)) "${existing_group}"; \
+    fi && \
+    groupmod --gid ${USER_GID} ${USERNAME} && \
     usermod --uid ${USER_UID} --gid ${USER_GID} ${USERNAME} && \
     usermod -aG dialout ${USERNAME}
 


### PR DESCRIPTION
Fix for creating the devcontainer on osx. 

On macOS the host user's primary group is staff (GID 20), which collides with Debian's built-in dialout group in the container image. groupmod then fails with 'GID already in use', breaking the build for macOS users.

Before aligning the docker group to the host GID, relocate any group that already claims that GID to a free one, then proceed as before. No-op on Linux hosts where the target GID is unused.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

