### PR TITLE
feat(Evse15118D20): wire AC_DER_IEC grid_support

### DIFF
--- a/modules/EVSE/Evse15118D20/CMakeLists.txt
+++ b/modules/EVSE/Evse15118D20/CMakeLists.txt
@@ -10,6 +10,8 @@ ev_setup_cpp_module()
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 target_sources(${MODULE_NAME}
     PRIVATE
+        charger/der_setup.cpp
+        charger/grid_event.cpp
         charger/session_logger.cpp
         charger/utils.cpp
 )
@@ -24,8 +26,12 @@ target_sources(${MODULE_NAME}
     PRIVATE
         "charger/ISO15118_chargerImpl.cpp"
         "extensions/iso15118_extensionsImpl.cpp"
+        "grid_support/grid_supportImpl.cpp"
 )
 
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
 # insert other things like install cmds etc here
+if(EVEREST_CORE_BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 # ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/EVSE/Evse15118D20/Evse15118D20.cpp
+++ b/modules/EVSE/Evse15118D20/Evse15118D20.cpp
@@ -7,11 +7,22 @@ namespace module {
 void Evse15118D20::init() {
     invoke_init(*p_charger);
     invoke_init(*p_extensions);
+    invoke_init(*p_grid_support);
 }
 
 void Evse15118D20::ready() {
-    invoke_ready(*p_charger);
+    invoke_ready(*p_grid_support);
     invoke_ready(*p_extensions);
+    // Invoked last: the charger ready blocks on the libiso15118 controller event loop.
+    invoke_ready(*p_charger);
+}
+
+void Evse15118D20::set_active_der_directives(const types::grid_support::ActiveDirectiveSet& directives) {
+    *active_der_directives.handle() = directives;
+}
+
+std::optional<types::grid_support::ActiveDirectiveSet> Evse15118D20::get_active_der_directives() const {
+    return *active_der_directives.handle();
 }
 
 } // namespace module

--- a/modules/EVSE/Evse15118D20/Evse15118D20.hpp
+++ b/modules/EVSE/Evse15118D20/Evse15118D20.hpp
@@ -12,6 +12,7 @@
 
 // headers for provided interface implementations
 #include <generated/interfaces/ISO15118_charger/Implementation.hpp>
+#include <generated/interfaces/grid_support/Implementation.hpp>
 #include <generated/interfaces/iso15118_extensions/Implementation.hpp>
 
 // headers for required interface implementations
@@ -20,6 +21,11 @@
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
+#include <optional>
+
+#include <everest/util/async/monitor.hpp>
+
+#include <generated/types/grid_support.hpp>
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {
@@ -46,23 +52,27 @@ public:
     Evse15118D20() = delete;
     Evse15118D20(const ModuleInfo& info, std::unique_ptr<ISO15118_chargerImplBase> p_charger,
                  std::unique_ptr<iso15118_extensionsImplBase> p_extensions,
-                 std::unique_ptr<evse_securityIntf> r_security,
+                 std::unique_ptr<grid_supportImplBase> p_grid_support, std::unique_ptr<evse_securityIntf> r_security,
                  std::vector<std::unique_ptr<ISO15118_vasIntf>> r_iso15118_vas, Conf& config) :
         ModuleBase(info),
         p_charger(std::move(p_charger)),
         p_extensions(std::move(p_extensions)),
+        p_grid_support(std::move(p_grid_support)),
         r_security(std::move(r_security)),
         r_iso15118_vas(std::move(r_iso15118_vas)),
         config(config){};
 
     const std::unique_ptr<ISO15118_chargerImplBase> p_charger;
     const std::unique_ptr<iso15118_extensionsImplBase> p_extensions;
+    const std::unique_ptr<grid_supportImplBase> p_grid_support;
     const std::unique_ptr<evse_securityIntf> r_security;
     const std::vector<std::unique_ptr<ISO15118_vasIntf>> r_iso15118_vas;
     const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     // insert your public definitions here
+    void set_active_der_directives(const types::grid_support::ActiveDirectiveSet& directives);
+    std::optional<types::grid_support::ActiveDirectiveSet> get_active_der_directives() const;
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:
@@ -77,6 +87,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
+    mutable everest::lib::util::monitor<std::optional<types::grid_support::ActiveDirectiveSet>> active_der_directives;
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
 };
 

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.cpp
@@ -4,8 +4,12 @@
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 
+#include "der_setup.hpp"
+#include "grid_event.hpp"
 #include "session_logger.hpp"
 #include "utils.hpp"
+
+#include <utils/date.hpp>
 
 #include <iso15118/io/logging.hpp>
 #include <iso15118/session/logger.hpp>
@@ -239,16 +243,12 @@ void ISO15118_chargerImpl::ready() {
 
     setup_config.selecting_sap_based_on_energy_service = mod->config.selecting_sap_based_on_energy_service;
 
-    // TODO(ml): hardcoded safe DER limits; populate real limits from the grid_support interface once available.
-    // der_setup_config is intentionally left unset: libiso15118 defaults it to {GridFollowing, GridConnected},
-    // which is exactly the minimal IEC setup we want.
+    // IEC DER limits pass through from ac_limits. Applying DER control directives to the EV is handled
+    // separately by the DER control-function relay.
     {
         const auto& services = setup_config.supported_energy_services;
         if (std::find(services.begin(), services.end(), dt::ServiceCategory::AC_DER_IEC) != services.end()) {
-            auto& der_limits = setup_config.der_limits.emplace();
-            der_limits.nominal_charge_power = dt::from_float(11000);
-            der_limits.nominal_discharge_power = dt::from_float(11000);
-            der_limits.max_discharge_power = dt::from_float(11000);
+            setup_config.der_limits = build_iec_der_transfer_limits(setup_config.ac_limits);
         }
     }
 
@@ -306,6 +306,40 @@ std::optional<size_t> ISO15118_chargerImpl::get_vas_provider_index(uint16_t serv
     return std::nullopt; // Service ID not found in any provider's list
 }
 
+void ISO15118_chargerImpl::publish_grid_event(uint8_t condition) {
+    const auto edge = grid_event_detector.peek(condition);
+
+    if (edge.transition == Transition::None) {
+        grid_event_detector.commit(condition);
+        return;
+    }
+
+    // A grid fault must never throw out of the V2G session thread; commit only after publish succeeds.
+    try {
+        types::grid_support::GridAlarm alarm{};
+        alarm.fault = edge.fault.value();
+        alarm.alarm_ended = (edge.transition == Transition::Falling);
+        alarm.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
+        // TODO: set alarm.directive_type from a grid_event_condition to directive_type mapping once defined.
+
+        if (edge.transition == Transition::Rising) {
+            EVLOG_warning << "EV reported grid-event fault (condition " << static_cast<unsigned>(condition) << ")";
+        } else {
+            EVLOG_info << "EV grid-event fault cleared (condition " << static_cast<unsigned>(condition) << ")";
+        }
+
+        mod->p_grid_support->publish_alarm(alarm);
+
+        // Publish succeeded: advance the fault state.
+        grid_event_detector.commit(condition);
+    } catch (const std::exception& e) {
+        const auto direction = (edge.transition == Transition::Rising) ? "rising" : "falling";
+        EVLOG_error << "grid-event alarm publish failed (condition " << static_cast<unsigned>(condition) << ", "
+                    << direction << "): " << e.what();
+        // Not committed: a persisting condition is re-peeked and retried next iteration.
+    }
+}
+
 iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() {
 
     using ScheduleControlModeDC = dt::Scheduled_DC_CLReqControlMode;
@@ -326,77 +360,83 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
         publish_dc_ev_target_voltage_current({target_voltage, 0});
     };
 
-    callbacks.notify_ev_charging_needs =
-        [this](const dt::ServiceCategory& service_category, const std::optional<dt::AcConnector>& ac_connector,
-               const dt::ControlMode& control_mode, const dt::MobilityNeedsMode& mobility_needs_mode,
-               const feedback::EvseTransferLimits& evse_limits, const feedback::EvTransferLimits& ev_limits,
-               const feedback::EvSEControlMode& ev_control_mode,
-               const std::vector<dt::ServiceCategory>& ev_energy_services) {
-            // Everest types sent to OCPP
+    callbacks.notify_ev_charging_needs = [this](const dt::ServiceCategory& service_category,
+                                                const std::optional<dt::AcConnector>& ac_connector,
+                                                const dt::ControlMode& control_mode,
+                                                const dt::MobilityNeedsMode& mobility_needs_mode,
+                                                const feedback::EvseTransferLimits& evse_limits,
+                                                const feedback::EvTransferLimits& ev_limits,
+                                                const feedback::EvSEControlMode& ev_control_mode,
+                                                const std::vector<dt::ServiceCategory>& ev_energy_services) {
+        types::iso15118::ChargingNeeds charging_needs;
 
-            types::iso15118::ChargingNeeds charging_needs;
-
-            charging_needs.requested_energy_transfer = get_energy_transfer_mode(service_category, ac_connector);
-            if (!ev_energy_services.empty()) {
-                charging_needs.available_energy_transfer = std::vector<types::iso15118::EnergyTransferMode>{};
-                charging_needs.available_energy_transfer->reserve(ev_energy_services.size());
-                for (const auto& energy_transfer : ev_energy_services) {
-                    charging_needs.available_energy_transfer->emplace_back(
-                        get_energy_transfer_mode(energy_transfer, std::nullopt));
-                }
+        charging_needs.requested_energy_transfer = get_energy_transfer_mode(service_category, ac_connector);
+        if (!ev_energy_services.empty()) {
+            charging_needs.available_energy_transfer = std::vector<types::iso15118::EnergyTransferMode>{};
+            charging_needs.available_energy_transfer->reserve(ev_energy_services.size());
+            for (const auto& energy_transfer : ev_energy_services) {
+                charging_needs.available_energy_transfer->emplace_back(
+                    get_energy_transfer_mode(energy_transfer, std::nullopt));
             }
+        }
 
-            if (control_mode == dt::ControlMode::Scheduled) {
-                charging_needs.control_mode = types::iso15118::ControlMode::ScheduledControl;
-            } else if (control_mode == dt::ControlMode::Dynamic) {
-                charging_needs.control_mode = types::iso15118::ControlMode::DynamicControl;
-            } else {
-                EVLOG_error << "Invalid value received for control mode! Not sending 'ChargingNeeds'.";
-                return;
+        if (control_mode == dt::ControlMode::Scheduled) {
+            charging_needs.control_mode = types::iso15118::ControlMode::ScheduledControl;
+        } else if (control_mode == dt::ControlMode::Dynamic) {
+            charging_needs.control_mode = types::iso15118::ControlMode::DynamicControl;
+        } else {
+            EVLOG_error << "Invalid value received for control mode! Not sending 'ChargingNeeds'.";
+            return;
+        }
+
+        if (mobility_needs_mode == dt::MobilityNeedsMode::ProvidedByEvcc) {
+            charging_needs.mobility_needs_mode = types::iso15118::MobilityNeedsMode::EVCC;
+        } else if (mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
+            charging_needs.mobility_needs_mode = types::iso15118::MobilityNeedsMode::EVCC_SECC;
+        } else {
+            EVLOG_error << "Invalid value received for mobility needs mode! Not sending 'ChargingNeeds'.";
+            return;
+        }
+
+        types::iso15118::V2XChargingParameters& v2x_charging_parameters =
+            charging_needs.v2x_charging_parameters.emplace();
+
+        if (const auto* dc_evse_limits = std::get_if<iso15118::d20::DcTransferLimits>(&evse_limits)) {
+            if (const auto* dc_ev_limits = std::get_if<dt::DC_CPDReqEnergyTransferMode>(&ev_limits)) {
+                fill_v2x_charging_parameters(v2x_charging_parameters, *dc_evse_limits, *dc_ev_limits);
+            } else if (const auto* dc_ev_limits = std::get_if<dt::BPT_DC_CPDReqEnergyTransferMode>(&ev_limits)) {
+                fill_v2x_charging_parameters(v2x_charging_parameters, *dc_evse_limits, *dc_ev_limits);
             }
-
-            if (mobility_needs_mode == dt::MobilityNeedsMode::ProvidedByEvcc) {
-                charging_needs.mobility_needs_mode = types::iso15118::MobilityNeedsMode::EVCC;
-            } else if (mobility_needs_mode == dt::MobilityNeedsMode::ProvidedBySecc) {
-                charging_needs.mobility_needs_mode = types::iso15118::MobilityNeedsMode::EVCC_SECC;
-            } else {
-                EVLOG_error << "Invalid value received for mobility needs mode! Not sending 'ChargingNeeds'.";
-                return;
+        } else if (const auto* ac_evse_limits = std::get_if<iso15118::d20::AcTransferLimits>(&evse_limits)) {
+            if (const auto* ac_ev_limits = std::get_if<dt::AC_CPDReqEnergyTransferMode>(&ev_limits)) {
+                fill_v2x_charging_parameters(v2x_charging_parameters, *ac_evse_limits, *ac_ev_limits);
+            } else if (const auto* ac_ev_limits = std::get_if<dt::BPT_AC_CPDReqEnergyTransferMode>(&ev_limits)) {
+                fill_v2x_charging_parameters(v2x_charging_parameters, *ac_evse_limits, *ac_ev_limits);
+            } else if (const auto* der_ac_ev_limits = std::get_if<dt::DER_AC_CPDReqEnergyTransferMode>(&ev_limits)) {
+                // AC_DER_IEC: reuse the AC base-class slice for v2x params; DER limits go to der_charging_parameters.
+                fill_v2x_charging_parameters(v2x_charging_parameters, *ac_evse_limits,
+                                             static_cast<const dt::AC_CPDReqEnergyTransferMode&>(*der_ac_ev_limits));
+                charging_needs.der_charging_parameters = to_der_charging_parameters(*der_ac_ev_limits);
+                charging_needs.der_charging_parameters->ev_supported_dercontrol =
+                    map_ev_supported_der_controls(ev_selected_der_control_functions);
             }
+        } else {
+            EVLOG_error << "Invalid type received for EVSE limits! Not sending 'ChargingNeeds'.";
+            return;
+        }
 
-            // For dash20 the data we will publish will be the v2xChargingParameters
-            types::iso15118::V2XChargingParameters& v2x_charging_parameters =
-                charging_needs.v2x_charging_parameters.emplace();
+        if (const auto* ev_se_control_mode = std::get_if<dt::Scheduled_SEReqControlMode>(&ev_control_mode)) {
+            fill_v2x_charging_parameters(v2x_charging_parameters, *ev_se_control_mode);
+        } else if (const auto* ev_se_control_mode = std::get_if<dt::Dynamic_SEReqControlMode>(&ev_control_mode)) {
+            fill_v2x_charging_parameters(v2x_charging_parameters, *ev_se_control_mode);
+        } else {
+            EVLOG_error << "Invalid type received for EV Control Mode! Not sending 'ChargingNeeds'.";
+            return;
+        }
 
-            if (const auto* dc_evse_limits = std::get_if<iso15118::d20::DcTransferLimits>(&evse_limits)) {
-                if (const auto* dc_ev_limits = std::get_if<dt::DC_CPDReqEnergyTransferMode>(&ev_limits)) {
-                    fill_v2x_charging_parameters(v2x_charging_parameters, *dc_evse_limits, *dc_ev_limits);
-                } else if (const auto* dc_ev_limits = std::get_if<dt::BPT_DC_CPDReqEnergyTransferMode>(&ev_limits)) {
-                    fill_v2x_charging_parameters(v2x_charging_parameters, *dc_evse_limits, *dc_ev_limits);
-                }
-            } else if (const auto* ac_evse_limits = std::get_if<iso15118::d20::AcTransferLimits>(&evse_limits)) {
-                if (const auto* ac_ev_limits = std::get_if<dt::AC_CPDReqEnergyTransferMode>(&ev_limits)) {
-                    fill_v2x_charging_parameters(v2x_charging_parameters, *ac_evse_limits, *ac_ev_limits);
-                } else if (const auto* ac_ev_limits = std::get_if<dt::BPT_AC_CPDReqEnergyTransferMode>(&ev_limits)) {
-                    fill_v2x_charging_parameters(v2x_charging_parameters, *ac_evse_limits, *ac_ev_limits);
-                }
-            } else {
-                EVLOG_error << "Invalid type received for EVSE limits! Not sending 'ChargingNeeds'.";
-                return;
-            }
-
-            if (const auto* ev_se_control_mode = std::get_if<dt::Scheduled_SEReqControlMode>(&ev_control_mode)) {
-                fill_v2x_charging_parameters(v2x_charging_parameters, *ev_se_control_mode);
-            } else if (const auto* ev_se_control_mode = std::get_if<dt::Dynamic_SEReqControlMode>(&ev_control_mode)) {
-                fill_v2x_charging_parameters(v2x_charging_parameters, *ev_se_control_mode);
-            } else {
-                EVLOG_error << "Invalid type received for EV Control Mode! Not sending 'ChargingNeeds'.";
-                return;
-            }
-
-            // Publish charging needs through the extensions
-            this->mod->p_extensions->publish_charging_needs(charging_needs);
-        };
+        // Publish charging needs through the extensions
+        this->mod->p_extensions->publish_charging_needs(charging_needs);
+    };
 
     callbacks.dc_charge_loop_req = [this](const feedback::DcChargeLoopReq& dc_charge_loop_req) {
         if (const auto* dc_control_mode = std::get_if<feedback::DcReqControlMode>(&dc_charge_loop_req)) {
@@ -498,7 +538,8 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
                            std::get_if<dt::DER_Scheduled_AC_CLReqControlMode>(ac_control_mode)) {
                 publish_ac_ev_power_limits(fill_ac_ev_power_limits(*der_scheduled_mode));
                 publish_ac_ev_present_powers(fill_ac_ev_present_power_values(*der_scheduled_mode));
-                // TODO(ml): reactive-power fields and grid_event_condition are not yet surfaced.
+                publish_grid_event(der_scheduled_mode->grid_event_condition);
+                // TODO(ml): reactive-power fields are not yet surfaced.
             } else if (const auto* der_dynamic_mode =
                            std::get_if<dt::DER_Dynamic_AC_CLReqControlMode>(ac_control_mode)) {
                 publish_ac_ev_power_limits(fill_ac_ev_power_limits(*der_dynamic_mode));
@@ -509,8 +550,9 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
                 ev_dynamic_values.min_v2x_energy_request =
                     convert_from_optional(der_dynamic_mode->min_v2x_energy_request);
                 publish_ac_ev_dynamic_control_mode(ev_dynamic_values);
-                // TODO(ml): reactive-power fields, grid_event_condition and
-                // session_total_discharge_energy_available are not yet surfaced.
+                publish_grid_event(der_dynamic_mode->grid_event_condition);
+                // TODO(ml): reactive-power fields and session_total_discharge_energy_available are
+                // not yet surfaced.
             }
         } else if (const auto* display_parameters = std::get_if<dt::DisplayParameters>(&ac_charge_loop_req)) {
             publish_display_parameters(convert_display_parameters(*display_parameters));
@@ -532,6 +574,10 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
             publish_current_demand_started(nullptr);
             break;
         case Signal::SETUP_FINISHED:
+            // Reset so a fault held from a prior session does not dedup a genuine new one.
+            grid_event_detector.reset();
+            // Clear the prior session's negotiated DER controls; the next session renegotiates them.
+            ev_selected_der_control_functions.reset();
             publish_v2g_setup_finished(nullptr);
             break;
         case Signal::START_CABLE_CHECK:
@@ -574,6 +620,9 @@ iso15118::session::feedback::Callbacks ISO15118_chargerImpl::create_callbacks() 
     callbacks.selected_protocol = [this](const std::string& protocol) { publish_selected_protocol(protocol); };
 
     callbacks.selected_service_parameters = [this](const iso15118::d20::SelectedServiceParameters& parameters) {
+        // Captured for ChargeParameterDiscovery to surface DERChargingParameters.ev_supported_dercontrol.
+        ev_selected_der_control_functions = parameters.selected_der_control_functions;
+
         types::iso15118::SelectedServiceParameters selected_parameters{};
 
         if (parameters.selected_energy_service == dt::ServiceCategory::AC) {

--- a/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
+++ b/modules/EVSE/Evse15118D20/charger/ISO15118_chargerImpl.hpp
@@ -16,6 +16,7 @@
 #include <bitset>
 #include <mutex>
 
+#include "grid_event.hpp"
 #include "utils.hpp"
 
 #include <iso15118/d20/config.hpp>
@@ -100,6 +101,14 @@ private:
 
     void update_supported_vas_services();
     std::optional<size_t> get_vas_provider_index(uint16_t service_id);
+
+    // EV grid-event fault detector; outlives sessions (reset at SETUP_FINISHED), touched only by the charger thread.
+    GridEventEdgeDetector grid_event_detector;
+    void publish_grid_event(uint8_t condition);
+
+    // EV-negotiated DER control functions from ServiceSelection; read at ChargeParameterDiscovery to
+    // surface ev_supported_dercontrol. Reset at SETUP_FINISHED; touched only by the charger thread.
+    std::bitset<12> ev_selected_der_control_functions;
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/EVSE/Evse15118D20/charger/conversions.hpp
+++ b/modules/EVSE/Evse15118D20/charger/conversions.hpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include <iso15118/message/common_types.hpp>
+
+namespace module::charger {
+
+inline std::optional<float>
+convert_from_optional(const std::optional<iso15118::message_20::datatypes::RationalNumber>& in) {
+    return (in.has_value()) ? std::make_optional(iso15118::message_20::datatypes::from_RationalNumber(in.value()))
+                            : std::nullopt;
+}
+
+inline std::optional<iso15118::message_20::datatypes::RationalNumber>
+convert_from_optional(const std::optional<float>& in) {
+    return (in.has_value()) ? std::make_optional(iso15118::message_20::datatypes::from_float(in.value()))
+                            : std::nullopt;
+}
+
+inline std::optional<float> convert_from_optional(const std::optional<uint32_t>& in) {
+    return (in.has_value()) ? std::make_optional(static_cast<float>(in.value())) : std::nullopt;
+}
+
+} // namespace module::charger

--- a/modules/EVSE/Evse15118D20/charger/der_setup.cpp
+++ b/modules/EVSE/Evse15118D20/charger/der_setup.cpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "der_setup.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include <iso15118/d20/der_functions.hpp>
+#include <iso15118/message/common_types.hpp>
+
+#include "conversions.hpp"
+
+namespace module {
+
+namespace {
+namespace dt = iso15118::message_20::datatypes;
+} // namespace
+
+iso15118::d20::IecDerTransferLimits build_iec_der_transfer_limits(const iso15118::d20::AcTransferLimits& ac_limits) {
+    iso15118::d20::IecDerTransferLimits limits{};
+    limits.nominal_charge_power = ac_limits.charge_power.max;
+    if (ac_limits.discharge_power.has_value()) {
+        limits.nominal_discharge_power = ac_limits.discharge_power.value().max;
+        limits.max_discharge_power = ac_limits.discharge_power.value().max;
+    } else {
+        limits.nominal_discharge_power = dt::from_float(0.0f);
+        limits.max_discharge_power = dt::from_float(0.0f);
+    }
+    return limits;
+}
+
+types::iso15118::DERChargingParameters to_der_charging_parameters(const dt::DER_AC_CPDReqEnergyTransferMode& ev) {
+    types::iso15118::DERChargingParameters params{};
+
+    // The EV's active charge/discharge power (max/min_charge_power, max/min_discharge_power) has no
+    // 1:1 DERChargingParameters counterpart.
+    params.ev_session_total_discharge_energy_available =
+        charger::convert_from_optional(ev.session_total_discharge_energy_available);
+
+    if (ev.reactive_power_limits.has_value()) {
+        const auto& reactive = ev.reactive_power_limits.value();
+
+        params.max_charge_reactive_power = dt::from_RationalNumber(reactive.max_charge_reactive_power);
+        params.max_charge_reactive_power_l2 = charger::convert_from_optional(reactive.max_charge_reactive_power_L2);
+        params.max_charge_reactive_power_l3 = charger::convert_from_optional(reactive.max_charge_reactive_power_L3);
+
+        params.min_charge_reactive_power = dt::from_RationalNumber(reactive.min_charge_reactive_power);
+        params.min_charge_reactive_power_l2 = charger::convert_from_optional(reactive.min_charge_reactive_power_L2);
+        params.min_charge_reactive_power_l3 = charger::convert_from_optional(reactive.min_charge_reactive_power_L3);
+
+        params.max_discharge_reactive_power = dt::from_RationalNumber(reactive.max_discharge_reactive_power);
+        params.max_discharge_reactive_power_l2 =
+            charger::convert_from_optional(reactive.max_discharge_reactive_power_L2);
+        params.max_discharge_reactive_power_l3 =
+            charger::convert_from_optional(reactive.max_discharge_reactive_power_L3);
+
+        params.min_discharge_reactive_power = charger::convert_from_optional(reactive.min_discharge_reactive_power);
+        params.min_discharge_reactive_power_l2 =
+            charger::convert_from_optional(reactive.min_discharge_reactive_power_L2);
+        params.min_discharge_reactive_power_l3 =
+            charger::convert_from_optional(reactive.min_discharge_reactive_power_L3);
+    }
+
+    // supported-DER-control bitmap is in ServiceDetail, not CPDReq; the caller fills
+    // ev_supported_dercontrol via map_ev_supported_der_controls, so it is left unset here.
+
+    return params;
+}
+
+std::optional<std::vector<types::grid_support::DirectiveType>>
+map_ev_supported_der_controls(const std::bitset<12>& selected) {
+    using DT = types::grid_support::DirectiveType;
+    using iso15118::iec::DERControlName;
+
+    // Bit position (DERControlName) -> grid_support DirectiveType. Over/UnderFrequencyWattMode both
+    // surface as FreqWatt; the dedup below keeps the list distinct.
+    static constexpr std::pair<DERControlName, DT> table[] = {
+        {DERControlName::OverFrequencyWattMode, DT::FreqWatt},
+        {DERControlName::UnderFrequencyWattMode, DT::FreqWatt},
+        {DERControlName::VoltWattMode, DT::VoltWatt},
+        {DERControlName::VoltVarMode, DT::VoltVar},
+        {DERControlName::WattVarMode, DT::WattVar},
+        {DERControlName::WattCosPhiMode, DT::WattPF},
+        {DERControlName::DSOQSetpointProvision, DT::DSOQSetpoint},
+        {DERControlName::DSOCosPhiSetpointProvision, DT::DSOCosPhiSetpoint},
+        {DERControlName::DCInjectionRestriction, DT::MaximumLevelDCInjection},
+        {DERControlName::ZeroCurrentMode, DT::ZeroCurrent},
+        {DERControlName::OverVoltageFaultRideThroughMode, DT::OvervoltageFaultRideThrough},
+        {DERControlName::UnderVoltageFaultRideThroughMode, DT::UndervoltageFaultRideThrough},
+    };
+
+    std::vector<DT> supported;
+    for (const auto& [name, directive] : table) {
+        if (selected.test(static_cast<size_t>(name)) and
+            std::find(supported.begin(), supported.end(), directive) == supported.end()) {
+            supported.push_back(directive);
+        }
+    }
+
+    if (supported.empty()) {
+        return std::nullopt;
+    }
+    return supported;
+}
+
+} // namespace module

--- a/modules/EVSE/Evse15118D20/charger/der_setup.hpp
+++ b/modules/EVSE/Evse15118D20/charger/der_setup.hpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <bitset>
+#include <optional>
+#include <vector>
+
+#include <generated/types/grid_support.hpp>
+#include <generated/types/iso15118.hpp>
+#include <iso15118/d20/limits.hpp>
+#include <iso15118/message/ac_der_iec_charge_parameter_discovery.hpp>
+
+namespace module {
+
+/// \brief Build the IEC DER transfer limits from the module's AC transfer limits.
+///
+/// Charge and discharge pass through from ac_limits (the discharge sign is already applied upstream).
+/// nominal and max discharge are set equal, so the advertised pair satisfies V2G20-3229. When no
+/// discharge limit is present the DER discharge limits are zero. Applying DER control directives to
+/// the EV is handled separately by the DER control-function relay, not here.
+iso15118::d20::IecDerTransferLimits build_iec_der_transfer_limits(const iso15118::d20::AcTransferLimits& ac_limits);
+
+/// \brief Map an AC_DER_IEC EV's reported DER limits onto the OCPP-bound DERChargingParameters.
+///
+/// Surfaces the EV's reactive-power limits and session total discharge energy available. Active
+/// charge/discharge power has no DERChargingParameters counterpart and is omitted; the EV's
+/// supported-DER-control-functions bitmap is not present at ChargeParameterDiscovery (it lives in
+/// ServiceDetail) and is left unset. Pure and session-free.
+types::iso15118::DERChargingParameters
+to_der_charging_parameters(const iso15118::message_20::datatypes::DER_AC_CPDReqEnergyTransferMode& ev);
+
+/// \brief Map the EV's negotiated DER control-function bitset onto the grid_support DirectiveTypes it
+/// supports, for DERChargingParameters.ev_supported_dercontrol.
+///
+/// The bitset is indexed by iso15118::iec::DERControlName. Over- and UnderFrequencyWattMode both map
+/// to FreqWatt and are deduplicated. Returns nullopt when no control function is selected
+/// (ev_supported_dercontrol has minItems:1, so the empty case must be unset, not an empty list).
+std::optional<std::vector<types::grid_support::DirectiveType>>
+map_ev_supported_der_controls(const std::bitset<12>& selected);
+
+} // namespace module

--- a/modules/EVSE/Evse15118D20/charger/grid_event.cpp
+++ b/modules/EVSE/Evse15118D20/charger/grid_event.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "grid_event.hpp"
+
+namespace module {
+
+std::optional<types::grid_support::GridEventFault> map_grid_event_condition(uint8_t condition) {
+    if (condition == 0) {
+        return std::nullopt;
+    }
+    return types::grid_support::GridEventFault::LocalEmergency;
+}
+
+EdgeResult GridEventEdgeDetector::peek(uint8_t condition) const {
+    const auto incoming = map_grid_event_condition(condition);
+
+    if (incoming.has_value()) {
+        if (active_fault.has_value()) {
+            // Already in fault. A repeated or differing nonzero code is treated as
+            // still-in-fault: deduplicate and keep the original active fault.
+            return EdgeResult::none();
+        }
+        return EdgeResult::rising(incoming.value());
+    }
+
+    if (active_fault.has_value()) {
+        return EdgeResult::falling(active_fault.value());
+    }
+
+    return EdgeResult::none();
+}
+
+void GridEventEdgeDetector::commit(uint8_t condition) {
+    const auto incoming = map_grid_event_condition(condition);
+
+    if (incoming.has_value()) {
+        if (not active_fault.has_value()) {
+            active_fault = incoming;
+        }
+    } else {
+        active_fault.reset();
+    }
+}
+
+void GridEventEdgeDetector::reset() {
+    active_fault.reset();
+}
+
+} // namespace module

--- a/modules/EVSE/Evse15118D20/charger/grid_event.hpp
+++ b/modules/EVSE/Evse15118D20/charger/grid_event.hpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include <generated/types/grid_support.hpp>
+
+namespace module {
+
+/// \brief Map an EV-reported grid_event_condition code (from the DER AC charge-loop request) to a
+/// GridEventFault. 0 = no event; any nonzero code maps to a single generic fault (LocalEmergency)
+/// until the IEC 61851-1 code table is wired in.
+std::optional<types::grid_support::GridEventFault> map_grid_event_condition(uint8_t condition);
+
+/// \brief The kind of fault-state transition produced by GridEventEdgeDetector.
+enum class Transition {
+    None,    ///< No state change; nothing to publish.
+    Rising,  ///< no-fault -> fault; publish a new alarm (alarm_ended=false).
+    Falling, ///< fault -> no-fault; publish a clearing alarm (alarm_ended=true).
+};
+
+/// \brief The result of inspecting one condition sample against the edge detector.
+///
+/// Constructed only through the factories so illegal states (e.g. a Rising with
+/// no fault) cannot be expressed: None always carries no fault, Rising/Falling
+/// always carry one. The caller can therefore dereference \c fault unguarded
+/// whenever \c transition is not None.
+class EdgeResult {
+public:
+    const Transition transition;
+    const std::optional<types::grid_support::GridEventFault> fault;
+
+    static EdgeResult none() {
+        return EdgeResult{Transition::None, std::nullopt};
+    }
+    static EdgeResult rising(types::grid_support::GridEventFault fault) {
+        return EdgeResult{Transition::Rising, fault};
+    }
+    static EdgeResult falling(types::grid_support::GridEventFault fault) {
+        return EdgeResult{Transition::Falling, fault};
+    }
+
+private:
+    EdgeResult(Transition transition, std::optional<types::grid_support::GridEventFault> fault) :
+        transition(transition), fault(fault) {
+    }
+};
+
+/// \brief Rising/falling edge detector for EV grid-event faults.
+///
+/// Reports exactly one transition per edge; repeated or changed nonzero
+/// conditions while already in fault are deduplicated. peek() reports the
+/// transition without mutating, commit() advances state, so a caller can commit
+/// only after a successful publish and retry otherwise. Not thread-safe (single
+/// charger thread); call reset() at session start, as the detector outlives
+/// individual sessions.
+class GridEventEdgeDetector {
+public:
+    /// \brief Report the transition \p condition would cause, without mutating state.
+    EdgeResult peek(uint8_t condition) const;
+    /// \brief Advance the held fault state to reflect \p condition.
+    void commit(uint8_t condition);
+    /// \brief Clear to the no-fault baseline; call at session start.
+    void reset();
+
+private:
+    std::optional<types::grid_support::GridEventFault> active_fault{std::nullopt};
+};
+
+} // namespace module

--- a/modules/EVSE/Evse15118D20/charger/utils.cpp
+++ b/modules/EVSE/Evse15118D20/charger/utils.cpp
@@ -56,18 +56,6 @@ dt::ParameterSet convert_parameter_set(const types::iso15118_vas::ParameterSet& 
 }
 } // namespace
 
-std::optional<float> convert_from_optional(const std::optional<dt::RationalNumber>& in) {
-    return (in.has_value()) ? std::make_optional(dt::from_RationalNumber(*in)) : std::nullopt;
-}
-
-std::optional<dt::RationalNumber> convert_from_optional(const std::optional<float>& in) {
-    return (in.has_value()) ? std::make_optional(dt::from_float(*in)) : std::nullopt;
-}
-
-std::optional<float> convert_from_optional(const std::optional<uint32_t>& in) {
-    return (in.has_value()) ? std::make_optional(static_cast<float>(*in)) : std::nullopt;
-}
-
 types::iso15118::AppProtocol convert_app_protocol(const iso15118::message_20::SupportedAppProtocol& app_protocol) {
     types::iso15118::AppProtocol result;
     result.protocol_namespace = app_protocol.protocol_namespace;

--- a/modules/EVSE/Evse15118D20/charger/utils.hpp
+++ b/modules/EVSE/Evse15118D20/charger/utils.hpp
@@ -20,6 +20,8 @@
 
 #include <everest/util/vector/fixed_vector.hpp>
 
+#include "conversions.hpp"
+
 static constexpr auto NUMBER_OF_SETUP_STEPS = 5;
 
 namespace module::charger {
@@ -137,10 +139,6 @@ constexpr types::iso15118::V2gMessageId convert_v2g_message_type(iso15118::messa
 
     return Id::UnknownMessage;
 }
-
-std::optional<float> convert_from_optional(const std::optional<dt::RationalNumber>& in);
-std::optional<dt::RationalNumber> convert_from_optional(const std::optional<float>& in);
-std::optional<float> convert_from_optional(const std::optional<uint32_t>& in);
 
 types::iso15118::AppProtocol convert_app_protocol(const iso15118::message_20::SupportedAppProtocol& app_protocol);
 types::iso15118::EvInformation convert_ev_info(const iso15118::d20::EVInformation& ev_info);

--- a/modules/EVSE/Evse15118D20/docs/index.rst
+++ b/modules/EVSE/Evse15118D20/docs/index.rst
@@ -1,0 +1,37 @@
+.. _everest_modules_handwritten_Evse15118D20:
+
+.. ===================
+.. Evse15118D20 Module
+.. ===================
+
+This module implements the SECC side of ISO 15118-20 charging, including the
+AC_DER_IEC service and a ``grid_support`` provider that accepts active DER
+directives and raises grid alarms from EV-reported grid-event conditions.
+
+DER grid support
+================
+
+Active DER directives received via ``grid_support::set_active_directives`` are
+accepted and stored, but are not yet applied to the EV: the DER control-function
+relay that would push a directive into the session is not implemented. The DER
+transfer limits advertised at each session's charge parameter discovery derive
+from the module's AC transfer limits (``ac_limits``), not from the directives.
+Applying directives (including via an in-session service renegotiation) is
+planned but not yet implemented.
+
+This module does not publish DER ``capability``; for the AC_DER_IEC service an
+empty capability is expected.
+
+The DER control functions the EV negotiates during service selection are
+surfaced upward in ``ChargingNeeds.der_charging_parameters.ev_supported_dercontrol``
+so the backend can learn what the EV supports without the EVSE advertising a
+guess. Relaying grid directives back down onto those control functions is a
+planned follow-up: it depends on this EV-supported set plus a source for the
+nominal-voltage and reactive-power bases needed to encode the ISO 15118-20
+absolute-unit control curves, neither of which this module currently holds.
+
+Discharge power limits advertised to the EV follow ISO 15118-20 8.3.5.2.1: they
+are emitted as negative values when the ``negative_bidirectional_limits`` config
+key is set, and the nominal discharge power is never advertised above the
+maximum discharge power (V2G20-3229), including under a ``LimitMaxDischarge``
+curtailment directive.

--- a/modules/EVSE/Evse15118D20/grid_support/grid_supportImpl.cpp
+++ b/modules/EVSE/Evse15118D20/grid_support/grid_supportImpl.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "grid_supportImpl.hpp"
+
+namespace module {
+namespace grid_support {
+
+void grid_supportImpl::init() {
+}
+
+void grid_supportImpl::ready() {
+}
+
+types::grid_support::SetDirectivesResponse
+grid_supportImpl::handle_set_active_directives(types::grid_support::ActiveDirectiveSet& directives) {
+    if (not directives.directives.empty()) {
+        std::call_once(directive_seam_log_flag, [] {
+            EVLOG_info << "grid_support directives accepted but not yet applied to the EV: the DER "
+                          "control-function relay is not implemented; session limits derive from ac_limits.";
+        });
+    }
+    mod->set_active_der_directives(directives);
+    types::grid_support::SetDirectivesResponse response;
+    response.accepted = true;
+    return response;
+}
+
+} // namespace grid_support
+} // namespace module

--- a/modules/EVSE/Evse15118D20/grid_support/grid_supportImpl.hpp
+++ b/modules/EVSE/Evse15118D20/grid_support/grid_supportImpl.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef GRID_SUPPORT_GRID_SUPPORT_IMPL_HPP
+#define GRID_SUPPORT_GRID_SUPPORT_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/grid_support/Implementation.hpp>
+
+#include "../Evse15118D20.hpp"
+
+// ev@9d65c5b8-78c2-4208-95b5-ed872434a08d:v1
+// insert your custom include headers here
+#include <mutex>
+// ev@9d65c5b8-78c2-4208-95b5-ed872434a08d:v1
+
+namespace module {
+namespace grid_support {
+
+struct Conf {};
+
+class grid_supportImpl : public grid_supportImplBase {
+public:
+    grid_supportImpl() = delete;
+    grid_supportImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<Evse15118D20>& mod, Conf& config) :
+        grid_supportImplBase(ev, "grid_support"), mod(mod), config(config){};
+
+    // ev@ce703c19-c14d-4f4b-8056-2ad0f5dd0070:v1
+    // insert your public definitions here
+    // ev@ce703c19-c14d-4f4b-8056-2ad0f5dd0070:v1
+
+protected:
+    // command handler functions (virtual)
+    virtual types::grid_support::SetDirectivesResponse
+    handle_set_active_directives(types::grid_support::ActiveDirectiveSet& directives) override;
+
+    // ev@d37d73a2-baca-45a7-9089-521171267dd9:v1
+    // insert your protected definitions here
+    // ev@d37d73a2-baca-45a7-9089-521171267dd9:v1
+
+private:
+    const Everest::PtrContainer<Evse15118D20>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@d014281f-feb6-4c48-8134-117ade18f2ba:v1
+    // insert your private definitions here
+    // Logged the first time a non-empty directive set arrives: applying directives to the EV
+    // (the DER control-function relay) is not yet wired, so accepting them has no effect yet.
+    std::once_flag directive_seam_log_flag;
+    // ev@d014281f-feb6-4c48-8134-117ade18f2ba:v1
+};
+
+// ev@e05d7d33-4bca-4f9f-bc15-b2d61d72b99f:v1
+// insert other definitions here
+// ev@e05d7d33-4bca-4f9f-bc15-b2d61d72b99f:v1
+
+} // namespace grid_support
+} // namespace module
+
+#endif // GRID_SUPPORT_GRID_SUPPORT_IMPL_HPP

--- a/modules/EVSE/Evse15118D20/manifest.yaml
+++ b/modules/EVSE/Evse15118D20/manifest.yaml
@@ -88,6 +88,12 @@ provides:
     description: >-
       This interface is used to share data between ISO15118 and OCPP modules
       to support the requirements of the OCPP protocol
+  grid_support:
+    interface: grid_support
+    description: >-
+      Raises grid alarms from EV grid-event conditions and accepts active DER
+      directives. Directive application to the EV is not yet wired; DER
+      capability is not published by this module.
 requires:
   security:
     interface: evse_security

--- a/modules/EVSE/Evse15118D20/tests/CMakeLists.txt
+++ b/modules/EVSE/Evse15118D20/tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+set(TEST_TARGET_NAME ${PROJECT_NAME}_Evse15118D20_tests)
+
+add_executable(${TEST_TARGET_NAME})
+
+add_dependencies(${TEST_TARGET_NAME} ${MODULE_NAME})
+
+get_target_property(GENERATED_INCLUDE_DIR generate_cpp_files EVEREST_GENERATED_INCLUDE_DIR)
+
+target_include_directories(${TEST_TARGET_NAME} PRIVATE
+    ../charger
+    ${GENERATED_INCLUDE_DIR}
+    ${CMAKE_BINARY_DIR}/generated/modules/${MODULE_NAME}
+)
+
+target_sources(${TEST_TARGET_NAME} PRIVATE
+    DerSetupTest.cpp
+    DerChargingParametersTest.cpp
+    DerControlsTest.cpp
+    GridEventTest.cpp
+    ../charger/der_setup.cpp
+    ../charger/grid_event.cpp
+)
+
+target_link_libraries(${TEST_TARGET_NAME} PRIVATE
+    GTest::gmock
+    GTest::gtest_main
+    everest::log
+    everest::framework
+    iso15118::iso15118
+)
+
+add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})
+ev_register_test_target(${TEST_TARGET_NAME})

--- a/modules/EVSE/Evse15118D20/tests/DerChargingParametersTest.cpp
+++ b/modules/EVSE/Evse15118D20/tests/DerChargingParametersTest.cpp
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include <iso15118/message/ac_der_iec_charge_parameter_discovery.hpp>
+#include <iso15118/message/common_types.hpp>
+
+#include "der_setup.hpp"
+
+namespace dt = iso15118::message_20::datatypes;
+
+namespace {
+
+dt::DER_AC_CPDReqEnergyTransferMode make_ev_limits_with_reactive() {
+    dt::DER_AC_CPDReqEnergyTransferMode ev{};
+    // Active-power fields are required by the wire type but are not surfaced into
+    // DERChargingParameters.
+    ev.max_charge_power = dt::from_float(11000.0f);
+    ev.min_charge_power = dt::from_float(0.0f);
+    ev.max_discharge_power = dt::from_float(11000.0f);
+    ev.min_discharge_power = dt::from_float(0.0f);
+
+    ev.session_total_discharge_energy_available = dt::from_float(20000.0f);
+
+    dt::ReactivePowerLimits reactive{};
+    reactive.max_charge_reactive_power = dt::from_float(3000.0f);
+    reactive.min_charge_reactive_power = dt::from_float(100.0f);
+    reactive.max_discharge_reactive_power = dt::from_float(4000.0f);
+    reactive.min_discharge_reactive_power = dt::from_float(200.0f);
+    ev.reactive_power_limits = reactive;
+
+    return ev;
+}
+
+} // namespace
+
+TEST(DerChargingParametersTest, reactive_limits_and_session_energy_are_mapped) {
+    const auto ev = make_ev_limits_with_reactive();
+
+    const auto params = module::to_der_charging_parameters(ev);
+
+    ASSERT_TRUE(params.max_charge_reactive_power.has_value());
+    EXPECT_FLOAT_EQ(params.max_charge_reactive_power.value(), 3000.0f);
+
+    ASSERT_TRUE(params.min_charge_reactive_power.has_value());
+    EXPECT_FLOAT_EQ(params.min_charge_reactive_power.value(), 100.0f);
+
+    ASSERT_TRUE(params.max_discharge_reactive_power.has_value());
+    EXPECT_FLOAT_EQ(params.max_discharge_reactive_power.value(), 4000.0f);
+
+    ASSERT_TRUE(params.min_discharge_reactive_power.has_value());
+    EXPECT_FLOAT_EQ(params.min_discharge_reactive_power.value(), 200.0f);
+
+    ASSERT_TRUE(params.ev_session_total_discharge_energy_available.has_value());
+    EXPECT_FLOAT_EQ(params.ev_session_total_discharge_energy_available.value(), 20000.0f);
+}
+
+TEST(DerChargingParametersTest, per_phase_reactive_limits_are_mapped) {
+    auto ev = make_ev_limits_with_reactive();
+    ev.reactive_power_limits->max_charge_reactive_power_L2 = dt::from_float(1500.0f);
+    ev.reactive_power_limits->max_charge_reactive_power_L3 = dt::from_float(1600.0f);
+    ev.reactive_power_limits->max_discharge_reactive_power_L2 = dt::from_float(2500.0f);
+
+    const auto params = module::to_der_charging_parameters(ev);
+
+    ASSERT_TRUE(params.max_charge_reactive_power_l2.has_value());
+    EXPECT_FLOAT_EQ(params.max_charge_reactive_power_l2.value(), 1500.0f);
+    ASSERT_TRUE(params.max_charge_reactive_power_l3.has_value());
+    EXPECT_FLOAT_EQ(params.max_charge_reactive_power_l3.value(), 1600.0f);
+    ASSERT_TRUE(params.max_discharge_reactive_power_l2.has_value());
+    EXPECT_FLOAT_EQ(params.max_discharge_reactive_power_l2.value(), 2500.0f);
+
+    // Absent per-phase optionals must stay unset, not default to zero.
+    EXPECT_FALSE(params.max_discharge_reactive_power_l3.has_value());
+}
+
+TEST(DerChargingParametersTest, absent_reactive_limits_leave_target_fields_unset) {
+    dt::DER_AC_CPDReqEnergyTransferMode ev{};
+    ev.max_charge_power = dt::from_float(11000.0f);
+    ev.min_charge_power = dt::from_float(0.0f);
+    ev.max_discharge_power = dt::from_float(11000.0f);
+    ev.min_discharge_power = dt::from_float(0.0f);
+    // No reactive_power_limits and no session_total_discharge_energy_available.
+
+    const auto params = module::to_der_charging_parameters(ev);
+
+    EXPECT_FALSE(params.max_charge_reactive_power.has_value());
+    EXPECT_FALSE(params.min_charge_reactive_power.has_value());
+    EXPECT_FALSE(params.max_discharge_reactive_power.has_value());
+    EXPECT_FALSE(params.min_discharge_reactive_power.has_value());
+    EXPECT_FALSE(params.ev_session_total_discharge_energy_available.has_value());
+}
+
+TEST(DerChargingParametersTest, ev_supported_dercontrol_is_left_unset) {
+    const auto ev = make_ev_limits_with_reactive();
+
+    const auto params = module::to_der_charging_parameters(ev);
+
+    // The supported-DER-control-functions bitmap is not available at ChargeParameterDiscovery in
+    // IEC (it lives in ServiceDetail); it must remain unset.
+    EXPECT_FALSE(params.ev_supported_dercontrol.has_value());
+}
+
+TEST(DerChargingParametersTest, each_reactive_field_maps_to_its_own_target) {
+    // Distinct sentinels per source field catch any L2/L3 transposition or charge/discharge swap in
+    // the near-identical mapping lines.
+    dt::DER_AC_CPDReqEnergyTransferMode ev{};
+    ev.max_charge_power = dt::from_float(11000.0f);
+    ev.min_charge_power = dt::from_float(0.0f);
+    ev.max_discharge_power = dt::from_float(11000.0f);
+    ev.min_discharge_power = dt::from_float(0.0f);
+
+    ev.session_total_discharge_energy_available = dt::from_float(1300.0f);
+
+    dt::ReactivePowerLimits reactive{};
+    reactive.max_charge_reactive_power = dt::from_float(101.0f);
+    reactive.max_charge_reactive_power_L2 = dt::from_float(102.0f);
+    reactive.max_charge_reactive_power_L3 = dt::from_float(103.0f);
+    reactive.min_charge_reactive_power = dt::from_float(201.0f);
+    reactive.min_charge_reactive_power_L2 = dt::from_float(202.0f);
+    reactive.min_charge_reactive_power_L3 = dt::from_float(203.0f);
+    reactive.max_discharge_reactive_power = dt::from_float(301.0f);
+    reactive.max_discharge_reactive_power_L2 = dt::from_float(302.0f);
+    reactive.max_discharge_reactive_power_L3 = dt::from_float(303.0f);
+    reactive.min_discharge_reactive_power = dt::from_float(401.0f);
+    reactive.min_discharge_reactive_power_L2 = dt::from_float(402.0f);
+    reactive.min_discharge_reactive_power_L3 = dt::from_float(403.0f);
+    ev.reactive_power_limits = reactive;
+
+    const auto params = module::to_der_charging_parameters(ev);
+
+    ASSERT_TRUE(params.max_charge_reactive_power.has_value());
+    EXPECT_FLOAT_EQ(params.max_charge_reactive_power.value(), 101.0f);
+    ASSERT_TRUE(params.max_charge_reactive_power_l2.has_value());
+    EXPECT_FLOAT_EQ(params.max_charge_reactive_power_l2.value(), 102.0f);
+    ASSERT_TRUE(params.max_charge_reactive_power_l3.has_value());
+    EXPECT_FLOAT_EQ(params.max_charge_reactive_power_l3.value(), 103.0f);
+
+    ASSERT_TRUE(params.min_charge_reactive_power.has_value());
+    EXPECT_FLOAT_EQ(params.min_charge_reactive_power.value(), 201.0f);
+    ASSERT_TRUE(params.min_charge_reactive_power_l2.has_value());
+    EXPECT_FLOAT_EQ(params.min_charge_reactive_power_l2.value(), 202.0f);
+    ASSERT_TRUE(params.min_charge_reactive_power_l3.has_value());
+    EXPECT_FLOAT_EQ(params.min_charge_reactive_power_l3.value(), 203.0f);
+
+    ASSERT_TRUE(params.max_discharge_reactive_power.has_value());
+    EXPECT_FLOAT_EQ(params.max_discharge_reactive_power.value(), 301.0f);
+    ASSERT_TRUE(params.max_discharge_reactive_power_l2.has_value());
+    EXPECT_FLOAT_EQ(params.max_discharge_reactive_power_l2.value(), 302.0f);
+    ASSERT_TRUE(params.max_discharge_reactive_power_l3.has_value());
+    EXPECT_FLOAT_EQ(params.max_discharge_reactive_power_l3.value(), 303.0f);
+
+    ASSERT_TRUE(params.min_discharge_reactive_power.has_value());
+    EXPECT_FLOAT_EQ(params.min_discharge_reactive_power.value(), 401.0f);
+    ASSERT_TRUE(params.min_discharge_reactive_power_l2.has_value());
+    EXPECT_FLOAT_EQ(params.min_discharge_reactive_power_l2.value(), 402.0f);
+    ASSERT_TRUE(params.min_discharge_reactive_power_l3.has_value());
+    EXPECT_FLOAT_EQ(params.min_discharge_reactive_power_l3.value(), 403.0f);
+
+    ASSERT_TRUE(params.ev_session_total_discharge_energy_available.has_value());
+    EXPECT_FLOAT_EQ(params.ev_session_total_discharge_energy_available.value(), 1300.0f);
+}
+
+TEST(DerChargingParametersTest, session_energy_maps_independently_of_reactive_limits) {
+    dt::DER_AC_CPDReqEnergyTransferMode ev{};
+    ev.max_charge_power = dt::from_float(11000.0f);
+    ev.min_charge_power = dt::from_float(0.0f);
+    ev.max_discharge_power = dt::from_float(11000.0f);
+    ev.min_discharge_power = dt::from_float(0.0f);
+
+    // Session energy present, reactive limits absent.
+    ev.session_total_discharge_energy_available = dt::from_float(5000.0f);
+
+    const auto params = module::to_der_charging_parameters(ev);
+
+    ASSERT_TRUE(params.ev_session_total_discharge_energy_available.has_value());
+    EXPECT_FLOAT_EQ(params.ev_session_total_discharge_energy_available.value(), 5000.0f);
+
+    EXPECT_FALSE(params.max_charge_reactive_power.has_value());
+    EXPECT_FALSE(params.min_charge_reactive_power.has_value());
+    EXPECT_FALSE(params.max_discharge_reactive_power.has_value());
+    EXPECT_FALSE(params.min_discharge_reactive_power.has_value());
+}

--- a/modules/EVSE/Evse15118D20/tests/DerControlsTest.cpp
+++ b/modules/EVSE/Evse15118D20/tests/DerControlsTest.cpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <bitset>
+#include <initializer_list>
+
+#include <iso15118/d20/der_functions.hpp>
+
+#include "der_setup.hpp"
+
+namespace {
+
+using module::map_ev_supported_der_controls;
+using DT = types::grid_support::DirectiveType;
+using iso15118::iec::DERControlName;
+
+std::bitset<12> bits_for(std::initializer_list<DERControlName> names) {
+    std::bitset<12> b{};
+    for (const auto name : names) {
+        b.set(static_cast<size_t>(name));
+    }
+    return b;
+}
+
+} // namespace
+
+TEST(DerControlsTest, empty_selection_yields_nullopt) {
+    // ev_supported_dercontrol has minItems:1, so an empty selection must be unset, not [].
+    EXPECT_FALSE(map_ev_supported_der_controls(std::bitset<12>{}).has_value());
+}
+
+TEST(DerControlsTest, single_bit_maps_to_its_directive_type) {
+    const auto out = map_ev_supported_der_controls(bits_for({DERControlName::VoltVarMode}));
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->size(), 1u);
+    EXPECT_EQ(out->front(), DT::VoltVar);
+}
+
+TEST(DerControlsTest, over_and_under_frequency_watt_dedupe_to_single_freqwatt) {
+    const auto out = map_ev_supported_der_controls(
+        bits_for({DERControlName::OverFrequencyWattMode, DERControlName::UnderFrequencyWattMode}));
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->size(), 1u);
+    EXPECT_EQ(out->front(), DT::FreqWatt);
+}
+
+TEST(DerControlsTest, each_remaining_name_maps_to_its_directive_type) {
+    struct Case {
+        DERControlName name;
+        DT expected;
+    };
+    const Case cases[] = {
+        {DERControlName::VoltWattMode, DT::VoltWatt},
+        {DERControlName::VoltVarMode, DT::VoltVar},
+        {DERControlName::WattVarMode, DT::WattVar},
+        {DERControlName::WattCosPhiMode, DT::WattPF},
+        {DERControlName::DSOQSetpointProvision, DT::DSOQSetpoint},
+        {DERControlName::DSOCosPhiSetpointProvision, DT::DSOCosPhiSetpoint},
+        {DERControlName::DCInjectionRestriction, DT::MaximumLevelDCInjection},
+        {DERControlName::ZeroCurrentMode, DT::ZeroCurrent},
+        {DERControlName::OverVoltageFaultRideThroughMode, DT::OvervoltageFaultRideThrough},
+        {DERControlName::UnderVoltageFaultRideThroughMode, DT::UndervoltageFaultRideThrough},
+    };
+    for (const auto& c : cases) {
+        const auto out = map_ev_supported_der_controls(bits_for({c.name}));
+        ASSERT_TRUE(out.has_value());
+        ASSERT_EQ(out->size(), 1u);
+        EXPECT_EQ(out->front(), c.expected);
+    }
+}
+
+TEST(DerControlsTest, all_bits_set_yields_eleven_distinct_types) {
+    // 12 control names, but Over/UnderFrequencyWatt collapse to one FreqWatt -> 11 distinct.
+    std::bitset<12> all{};
+    all.set();
+    const auto out = map_ev_supported_der_controls(all);
+    ASSERT_TRUE(out.has_value());
+    EXPECT_EQ(out->size(), 11u);
+    // No duplicates.
+    for (auto it = out->begin(); it != out->end(); ++it) {
+        EXPECT_EQ(std::count(out->begin(), out->end(), *it), 1);
+    }
+}

--- a/modules/EVSE/Evse15118D20/tests/DerSetupTest.cpp
+++ b/modules/EVSE/Evse15118D20/tests/DerSetupTest.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include <iso15118/d20/limits.hpp>
+#include <iso15118/message/common_types.hpp>
+
+#include "der_setup.hpp"
+
+namespace dt = iso15118::message_20::datatypes;
+
+namespace {
+
+bool equal(const dt::RationalNumber& a, const dt::RationalNumber& b) {
+    return a.value == b.value and a.exponent == b.exponent;
+}
+
+iso15118::d20::AcTransferLimits make_ac_limits(float charge_max, std::optional<float> discharge_max) {
+    iso15118::d20::AcTransferLimits ac{};
+    ac.charge_power.max = dt::from_float(charge_max);
+    ac.charge_power.min = dt::from_float(0.0f);
+    ac.nominal_frequency = dt::from_float(50.0f);
+    if (discharge_max.has_value()) {
+        iso15118::d20::Limit<dt::RationalNumber> discharge{};
+        discharge.max = dt::from_float(discharge_max.value());
+        discharge.min = dt::from_float(0.0f);
+        ac.discharge_power = discharge;
+    }
+    return ac;
+}
+
+} // namespace
+
+TEST(DerSetupTest, nominal_charge_equals_ac_charge_max) {
+    const auto ac = make_ac_limits(7400.0f, 11000.0f);
+
+    const auto limits = module::build_iec_der_transfer_limits(ac);
+
+    EXPECT_TRUE(equal(limits.nominal_charge_power, ac.charge_power.max));
+}
+
+TEST(DerSetupTest, discharge_present_passes_through_to_both_fields) {
+    const auto ac = make_ac_limits(11000.0f, 11000.0f);
+
+    const auto limits = module::build_iec_der_transfer_limits(ac);
+
+    EXPECT_TRUE(equal(limits.nominal_discharge_power, ac.discharge_power->max));
+    EXPECT_TRUE(equal(limits.max_discharge_power, ac.discharge_power->max));
+}
+
+TEST(DerSetupTest, discharge_absent_yields_zero_discharge) {
+    const auto ac = make_ac_limits(11000.0f, std::nullopt);
+
+    const auto limits = module::build_iec_der_transfer_limits(ac);
+
+    EXPECT_TRUE(equal(limits.nominal_charge_power, ac.charge_power.max));
+    EXPECT_TRUE(equal(limits.nominal_discharge_power, dt::from_float(0.0f)));
+    EXPECT_TRUE(equal(limits.max_discharge_power, dt::from_float(0.0f)));
+}
+
+TEST(DerSetupTest, negative_ac_discharge_yields_negative_outputs) {
+    const auto ac = make_ac_limits(11000.0f, -11000.0f);
+
+    const auto limits = module::build_iec_der_transfer_limits(ac);
+
+    EXPECT_TRUE(equal(limits.nominal_discharge_power, ac.discharge_power->max));
+    EXPECT_TRUE(equal(limits.max_discharge_power, ac.discharge_power->max));
+    EXPECT_LT(dt::from_RationalNumber(limits.max_discharge_power), 0.0f);
+    // Charge stays positive.
+    EXPECT_TRUE(equal(limits.nominal_charge_power, ac.charge_power.max));
+    EXPECT_GT(dt::from_RationalNumber(limits.nominal_charge_power), 0.0f);
+}
+
+TEST(DerSetupTest, positive_ac_discharge_yields_positive_outputs) {
+    const auto ac = make_ac_limits(11000.0f, 11000.0f);
+
+    const auto limits = module::build_iec_der_transfer_limits(ac);
+
+    EXPECT_GT(dt::from_RationalNumber(limits.max_discharge_power), 0.0f);
+    EXPECT_GT(dt::from_RationalNumber(limits.nominal_discharge_power), 0.0f);
+}

--- a/modules/EVSE/Evse15118D20/tests/GridEventTest.cpp
+++ b/modules/EVSE/Evse15118D20/tests/GridEventTest.cpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include <generated/types/grid_support.hpp>
+
+#include "grid_event.hpp"
+
+namespace {
+
+using module::GridEventEdgeDetector;
+using module::Transition;
+
+module::EdgeResult step(module::GridEventEdgeDetector& detector, uint8_t condition) {
+    const auto result = detector.peek(condition);
+    detector.commit(condition);
+    return result;
+}
+
+TEST(GridEventMapTest, zero_condition_is_no_event) {
+    EXPECT_FALSE(module::map_grid_event_condition(0).has_value());
+}
+
+TEST(GridEventMapTest, nonzero_condition_maps_to_a_fault) {
+    const auto fault = module::map_grid_event_condition(1);
+    ASSERT_TRUE(fault.has_value());
+    // A concrete enum value is produced; the exact value is the documented default.
+    EXPECT_EQ(*fault, types::grid_support::GridEventFault::LocalEmergency);
+}
+
+TEST(GridEventMapTest, max_condition_maps_to_a_fault) {
+    // Every nonzero code, up to the full uint8_t range, is a fault.
+    EXPECT_TRUE(module::map_grid_event_condition(255).has_value());
+}
+
+TEST(GridEventEdgeTest, no_event_with_no_prior_fault_yields_none) {
+    GridEventEdgeDetector detector;
+    const auto result = step(detector, 0);
+    EXPECT_EQ(result.transition, Transition::None);
+    EXPECT_FALSE(result.fault.has_value());
+}
+
+TEST(GridEventEdgeTest, rising_edge_emitted_once_then_deduped) {
+    GridEventEdgeDetector detector;
+
+    const auto first = step(detector, 1);
+    EXPECT_EQ(first.transition, Transition::Rising);
+    ASSERT_TRUE(first.fault.has_value());
+
+    // Same condition asserted again must not re-emit.
+    const auto second = step(detector, 1);
+    EXPECT_EQ(second.transition, Transition::None);
+}
+
+TEST(GridEventEdgeTest, falling_edge_emitted_once_carrying_prior_fault) {
+    GridEventEdgeDetector detector;
+
+    const auto rising = step(detector, 1);
+    ASSERT_EQ(rising.transition, Transition::Rising);
+    const auto prior_fault = rising.fault;
+
+    const auto falling = step(detector, 0);
+    EXPECT_EQ(falling.transition, Transition::Falling);
+    ASSERT_TRUE(falling.fault.has_value());
+    EXPECT_EQ(falling.fault, prior_fault);
+
+    // Clearing again with no active fault must not re-emit.
+    const auto again = step(detector, 0);
+    EXPECT_EQ(again.transition, Transition::None);
+}
+
+TEST(GridEventEdgeTest, asserted_twice_then_cleared_is_one_rising_one_falling) {
+    GridEventEdgeDetector detector;
+
+    EXPECT_EQ(step(detector, 1).transition, Transition::Rising);
+    EXPECT_EQ(step(detector, 1).transition, Transition::None);
+    EXPECT_EQ(step(detector, 0).transition, Transition::Falling);
+}
+
+TEST(GridEventEdgeTest, change_to_a_different_nonzero_code_stays_in_fault) {
+    GridEventEdgeDetector detector;
+
+    EXPECT_EQ(step(detector, 1).transition, Transition::Rising);
+    // A different nonzero code while already in fault is treated as still-in-fault:
+    // no falling+rising churn for this milestone.
+    EXPECT_EQ(step(detector, 2).transition, Transition::None);
+    // Clearing still produces exactly one falling edge.
+    EXPECT_EQ(step(detector, 0).transition, Transition::Falling);
+}
+
+TEST(GridEventEdgeTest, fault_cleared_then_reasserted_re_arms_rising) {
+    // The detector's whole purpose: a fault that clears must be able to fire again.
+    GridEventEdgeDetector detector;
+
+    EXPECT_EQ(step(detector, 1).transition, Transition::Rising);
+    EXPECT_EQ(step(detector, 0).transition, Transition::Falling);
+    // Re-arm: the same nonzero condition must produce a fresh Rising.
+    EXPECT_EQ(step(detector, 1).transition, Transition::Rising);
+}
+
+TEST(GridEventEdgeTest, reset_clears_a_held_fault_so_next_session_re_arms) {
+    // Mirrors a session that ends with a fault still held (EV unplugged, loop
+    // stops sending condition==0). The next session must start clean and be able
+    // to emit Rising again for the same fault.
+    GridEventEdgeDetector detector;
+
+    EXPECT_EQ(step(detector, 1).transition, Transition::Rising);
+    // Fault never cleared; session ends abruptly.
+    detector.reset();
+    // Fresh session: the same nonzero condition is a genuinely new fault.
+    EXPECT_EQ(step(detector, 1).transition, Transition::Rising);
+}
+
+TEST(GridEventEdgeTest, peek_does_not_mutate_state) {
+    // A peeked Rising that is never committed (publish failed) must still be Rising
+    // on the next peek, so a dropped publish is retried rather than lost.
+    GridEventEdgeDetector detector;
+
+    const auto first = detector.peek(1);
+    EXPECT_EQ(first.transition, Transition::Rising);
+    ASSERT_TRUE(first.fault.has_value());
+
+    // No commit happened: peeking again must report the same Rising.
+    const auto retry = detector.peek(1);
+    EXPECT_EQ(retry.transition, Transition::Rising);
+}
+
+TEST(GridEventEdgeTest, commit_advances_state_so_peek_then_dedupes) {
+    GridEventEdgeDetector detector;
+
+    EXPECT_EQ(detector.peek(1).transition, Transition::Rising);
+    detector.commit(1);
+    // After commit the fault is active: peeking the same condition dedupes.
+    EXPECT_EQ(detector.peek(1).transition, Transition::None);
+}
+
+} // namespace


### PR DESCRIPTION
## Describe your changes

Adds the device/producer side of DER grid support to Evse15118D20 for the AC_DER_IEC service.

- Provides the `grid_support` interface: accepts active DER directives and raises grid alarms from
  EV-reported grid-event conditions. A rising/falling edge detector emits exactly one `GridAlarm`
  per fault edge (deduplicating repeated conditions) and only advances its state after a successful
  publish, so a dropped alarm is retried rather than lost.
- Routes real AC_DER_IEC transfer limits to the EV instead of the previous hardcoded values. The IEC
  DER limits pass through from the module's AC transfer limits; nominal and max discharge are set
  equal so the advertised pair satisfies V2G20-3229, and the discharge sign convention
  (ISO 15118-20 8.3.5.2.1) is carried through from the AC limits.
- Surfaces the EV's DER charging parameters (reactive-power limits, session discharge energy) into
  `ChargingNeeds`.
- Surfaces the DER control functions the EV negotiates at service selection into
  `ev_supported_dercontrol`, so the backend can learn what the EV supports without the EVSE having
  to advertise a capability it cannot know up front in the AC_DER_IEC case.

This is the device/producer half; it pairs with the OCPP-consumer side on
`feature/grid-support-der-dynamic`.

Out of scope, tracked as a follow-up: relaying grid directives back down onto the EV's DER control
functions. That requires the EV-supported set (added here) plus a source for the nominal-voltage and
reactive-power bases needed to encode ISO 15118-20's absolute-unit control curves, which this module
does not currently hold. This module does not publish a DER capability; that is sourced elsewhere.

### Testing

- New module unit tests (`everest-core_Evse15118D20_tests`): DER transfer-limit sign, clamp and
  pass-through; DER charging-parameter mapping (reactive power, per-phase, session energy);
  grid-event edge detection (rising/falling/dedup/reset/retry); and the EV-supported-control-function
  mapping. `ctest -R Evse15118D20` passes.

### Config / migration impact

- None for existing setups. Adds a provided `grid_support` interface to the module manifest.

## Issue ticket number and link

_n/a_

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
