### PR TITLE
MCS isolation resistance increased to 125k

### DIFF
--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -2015,7 +2015,12 @@ bool EvseManager::check_voltage_to_protective_earth_in_range(types::isolation_mo
 }
 
 bool EvseManager::check_isolation_resistance_in_range(double resistance) {
-    if (resistance < CABLECHECK_INSULATION_FAULT_RESISTANCE_OHM) {
+    const double insulation_fault_resistance_ohm =
+        (connector_type.has_value() and connector_type.value() == types::evse_manager::ConnectorTypeEnum::cMCS)
+            ? CABLECHECK_MCS_INSULATION_FAULT_RESISTANCE_OHM
+            : CABLECHECK_INSULATION_FAULT_RESISTANCE_OHM;
+
+    if (resistance < insulation_fault_resistance_ohm) {
         session_log.evse(false, fmt::format("Isolation measurement FAULT R_F {}.", resistance));
         r_hlc[0]->call_update_isolation_status(types::iso15118::IsolationStatus::Fault);
         return false;

--- a/modules/EVSE/EvseManager/EvseManager.hpp
+++ b/modules/EVSE/EvseManager/EvseManager.hpp
@@ -406,6 +406,7 @@ private:
 
     static constexpr double CABLECHECK_CURRENT_LIMIT{2};
     static constexpr double CABLECHECK_INSULATION_FAULT_RESISTANCE_OHM{100000.};
+    static constexpr double CABLECHECK_MCS_INSULATION_FAULT_RESISTANCE_OHM{125000.};
     static constexpr double CABLECHECK_SAFE_VOLTAGE{60.};
     static constexpr int CABLECHECK_SELFTEST_TIMEOUT{30};
 


### PR DESCRIPTION
For MCS, in standard ISO61851-23-3 CC.4.1.4 c the isolation resistance threshold was increased to 125k.

For normal DC charging, the isolation resistance threshold for valid isolation tests is 100k. (ISO61851-23 CC.5.1 )
This commit will introduce the new value.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

