### PR TITLE
refactor(libiso15118): Refactored message_20::Variant to a std::unique_ptr

### DIFF
--- a/lib/everest/iso15118/include/iso15118/detail/variant_access.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/variant_access.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cassert>
+#include <memory>
 
 #include <iso15118/message/variant.hpp>
 
@@ -15,19 +16,17 @@ struct VariantAccess {
     exi_bitstream_t input_stream;
 
     // output
-    void*& data;
+    std::unique_ptr<void, Variant::CustomDeleter>& data;
     iso15118::message_20::Type& type;
-    iso15118::message_20::Variant::CustomDeleter& custom_deleter;
     std::string& error;
 
     template <typename MessageType, typename CbExiMessageType> void insert_type(const CbExiMessageType& in) {
-        assert(data == nullptr);
-
-        data = new MessageType;
+        assert(data.get() == nullptr);
         type = iso15118::message_20::TypeTrait<MessageType>::type;
-        custom_deleter = [](void* ptr) { delete static_cast<MessageType*>(ptr); };
 
-        convert(in, *static_cast<MessageType*>(data));
+        data = std::unique_ptr<void, Variant::CustomDeleter>(new MessageType,
+                                                             [](void* ptr) { delete static_cast<MessageType*>(ptr); });
+        convert(in, *static_cast<MessageType*>(data.get()));
     };
 };
 

--- a/lib/everest/iso15118/include/iso15118/message/variant.hpp
+++ b/lib/everest/iso15118/include/iso15118/message/variant.hpp
@@ -2,8 +2,7 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
+#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -18,21 +17,18 @@ namespace iso15118::message_20 {
 
 class Variant {
 public:
-    using CustomDeleter = void (*)(void*);
+    using CustomDeleter = std::function<void(void*)>;
     Variant(io::v2gtp::PayloadType, const io::StreamInputView&);
-    template <typename MessageType> Variant(const MessageType& in) {
+    template <typename MessageType>
+    explicit Variant(const MessageType& in_) :
+        data(new MessageType, [](void* ptr) { delete static_cast<MessageType*>(ptr); }),
+        type(message_20::TypeTrait<MessageType>::type) {
         static_assert(TypeTrait<MessageType>::type != Type::None, "Unhandled type!");
-
-        data = new MessageType;
-        *static_cast<MessageType*>(data) = in;
-        custom_deleter = [](void* ptr) { delete static_cast<MessageType*>(ptr); };
-        type = message_20::TypeTrait<MessageType>::type;
+        *static_cast<MessageType*>(data.get()) = in_;
     }
-    ~Variant();
 
-    Type get_type() const;
-
-    const std::string& get_error() const;
+    [[nodiscard]] Type get_type() const;
+    [[nodiscard]] const std::string& get_error() const;
 
     template <typename T> const T& get() const {
         static_assert(TypeTrait<T>::type != Type::None, "Unhandled type!");
@@ -40,7 +36,7 @@ public:
             throw std::runtime_error("Illegal message type access");
         }
 
-        return *static_cast<T*>(data);
+        return *static_cast<T*>(data.get());
     }
 
     template <typename T> T const* get_if() const {
@@ -49,12 +45,11 @@ public:
             return nullptr;
         }
 
-        return static_cast<T*>(data);
+        return static_cast<T*>(data.get());
     }
 
 private:
-    CustomDeleter custom_deleter{nullptr};
-    void* data{nullptr};
+    std::unique_ptr<void, CustomDeleter> data;
     Type type{Type::None};
     std::string error;
 };

--- a/lib/everest/iso15118/src/iso15118/message/variant.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/variant.cpp
@@ -194,7 +194,10 @@ static void handle_ac_sae_der(VariantAccess& va) {
 Variant::Variant(io::v2gtp::PayloadType payload_type, const io::StreamInputView& buffer_view) {
 
     VariantAccess va{
-        get_exi_input_stream(buffer_view), this->data, this->type, this->custom_deleter, this->error,
+        get_exi_input_stream(buffer_view),
+        this->data,
+        this->type,
+        this->error,
     };
 
     if (payload_type == PayloadType::SAP) {
@@ -213,18 +216,11 @@ Variant::Variant(io::v2gtp::PayloadType payload_type, const io::StreamInputView&
         logf_warning("Unknown type");
     }
 
-    if (data) {
-        // in case data was set, make sure the custom deleter and the type were set!
-        assert(custom_deleter != nullptr);
+    if (data != nullptr) {
+        // in case data was set, make sure the type were set!
         assert(type != Type::None);
     } else {
         logf_error("Failed due to: %s\n", error.c_str());
-    }
-}
-
-Variant::~Variant() {
-    if (data) {
-        custom_deleter(data);
     }
 }
 


### PR DESCRIPTION
## Describe your changes
See title.
Changed void pointer and custom_deleter to a `std::unique_ptr<void, CustomDeleter>` in the `Variant` class.

## Issue ticket number and link
The `Variant` class in `libiso15118` used raw pointers with manual memory management, which is error-prone and not exception-safe.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

