### PR TITLE
EVerestAPI: Latched variables

### DIFF
--- a/config/config-sil-dc-consumer-api.yaml
+++ b/config/config-sil-dc-consumer-api.yaml
@@ -10,6 +10,18 @@ active_modules:
       evse_manager:
         - module_id: evse_manager
           implementation_id: evse
+      evse_bsp:
+        - module_id: yeti_driver
+          implementation_id: board_support
+      slac:
+        - module_id: slac
+          implementation_id: evse
+      imd:
+        - module_id: imd
+          implementation_id: main
+      ps_dc:
+        - module_id: powersupply_dc
+          implementation_id: main
 
   auth_api:
     module: auth_consumer_API

--- a/docs/source/reference/EVerest_API/auth_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/auth_consumer_API.yaml
@@ -43,6 +43,16 @@ channels:
     messages:
       receive_token_validation_status:
         $ref: '#/components/messages/receive_token_validation_status'
+  send_request_get_token_validation_status:
+    address: 'm2e/token_validation_status/get'
+    messages:
+      send_request_get_token_validation_status:
+        $ref: '#/components/messages/send_request_get_token_validation_status'
+  receive_reply_get_token_validation_status:
+    address: null
+    messages:
+      receive_reply_get_token_validation_status:
+        $ref: '#/components/messages/receive_reply_get_token_validation_status'
 
 
   receive_heartbeat:
@@ -90,6 +100,26 @@ operations:
       Published whenever the validation status of a token changes.
       The message contains the token, its validation status, and an
       optional array of tariff messages received at authorization time.
+
+  send_request_get_token_validation_status:
+    title: 'Request current token validation status'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_token_validation_status'
+    description: >-
+      Request the most recently published (latched) token validation status.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_token_validation_status'
+  receive_reply_get_token_validation_status:
+    title: 'Reply to get token validation status request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_token_validation_status'
 
 
   receive_heartbeat:
@@ -155,6 +185,39 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/TokenValidationStatusMessage'
+
+    send_request_get_token_validation_status:
+      name: send_request_get_token_validation_status
+      title: 'Request current token validation status'
+      summary: 'Request the most recently published (latched) token validation status.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_token_validation_status:
+      name: receive_reply_get_token_validation_status
+      title: 'Reply to get token validation status request'
+      summary: 'The most recently published token validation status.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/TokenValidationStatusMessage'
+          - type: 'null'
 
     receive_heartbeat:
       name: receive_heartbeat
@@ -413,4 +476,3 @@ components:
     HeartBeatId:
       type: integer
       description: "64bit unsigned integer. The id of every heartbeat increases by 1 and overflows when the maximum representable value is reached"
-

--- a/docs/source/reference/EVerest_API/dc_external_derate_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/dc_external_derate_consumer_API.yaml
@@ -49,6 +49,16 @@ channels:
     messages:
       receive_plug_temperature_C:
         $ref: "#/components/messages/receive_plug_temperature_C"
+  send_request_get_plug_temperature_C:
+    address: 'm2e/plug_temperature_C/get'
+    messages:
+      send_request_get_plug_temperature_C:
+        $ref: '#/components/messages/send_request_get_plug_temperature_C'
+  receive_reply_get_plug_temperature_C:
+    address: null
+    messages:
+      receive_reply_get_plug_temperature_C:
+        $ref: '#/components/messages/receive_reply_get_plug_temperature_C'
 
 
   receive_heartbeat:
@@ -76,6 +86,25 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_plug_temperature_C'
+  send_request_get_plug_temperature_C:
+    title: 'Request current Plug Temperature C'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_plug_temperature_C'
+    description: >-
+      Request the most recently published (latched) Plug Temperature C.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_plug_temperature_C'
+  receive_reply_get_plug_temperature_C:
+    title: 'Reply to get Plug Temperature C request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_plug_temperature_C'
 
 
   receive_heartbeat:
@@ -116,6 +145,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/PlugTemperature'
+    send_request_get_plug_temperature_C:
+      name: send_request_get_plug_temperature_C
+      title: 'Request current Plug Temperature C'
+      summary: 'Request the most recently published (latched) Plug Temperature C.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_plug_temperature_C:
+      name: receive_reply_get_plug_temperature_C
+      title: 'Reply to get Plug Temperature C request'
+      summary: 'The most recently published Plug Temperature C.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/PlugTemperature'
+          - type: 'null'
 
 
     receive_heartbeat:

--- a/docs/source/reference/EVerest_API/error_history_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/error_history_consumer_API.yaml
@@ -51,12 +51,34 @@ channels:
     messages:
       receive_error_raised:
         $ref: '#/components/messages/receive_error_raised'
+  send_request_get_error_raised:
+    address: 'm2e/error_raised/get'
+    messages:
+      send_request_get_error_raised:
+        $ref: '#/components/messages/send_request_get_error_raised'
+  receive_reply_get_error_raised:
+    address: null
+    messages:
+      receive_reply_get_error_raised:
+        $ref: '#/components/messages/receive_reply_get_error_raised'
+
+
   receive_error_cleared:
     address: 'e2m/error_cleared'
     messages:
       receive_error_cleared:
         $ref: '#/components/messages/receive_error_cleared'
 
+  send_request_get_error_cleared:
+    address: 'm2e/error_cleared/get'
+    messages:
+      send_request_get_error_cleared:
+        $ref: '#/components/messages/send_request_get_error_cleared'
+  receive_reply_get_error_cleared:
+    address: null
+    messages:
+      receive_reply_get_error_cleared:
+        $ref: '#/components/messages/receive_reply_get_error_cleared'
 
   receive_heartbeat:
     address: 'e2m/heartbeat'
@@ -111,12 +133,52 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_error_raised'
+  send_request_get_error_raised:
+    title: 'Request raised errors'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_error_raised'
+    description: >-
+      Request the most recently published (latched) error raised.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_error_raised'
+  receive_reply_get_error_raised:
+    title: 'Reply to get error raised request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_error_raised'
+
+
   receive_error_cleared:
     title: 'Receive newly cleared error'
     action: receive
     channel:
       $ref: '#/channels/receive_error_cleared'
-
+  send_request_get_error_cleared:
+    title: 'Request cleared errors'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_error_cleared'
+    description: >-
+      Request the most recently published (latched) error cleared.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_error_cleared'
+  receive_reply_get_error_cleared:
+    title: 'Reply to get error cleared request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_error_cleared'
+  
 
   receive_heartbeat:
     title: 'Receive heartbeat'
@@ -189,6 +251,39 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/ErrorObject'
+    send_request_get_error_raised:
+      name: send_request_get_error_raised
+      title: 'Request current raised errors'
+      summary: 'Request the most recently published (latched) raised errors.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_error_raised:
+      name: receive_reply_get_error_raised
+      title: 'Reply to get raised error request'
+      summary: 'The most recently published raised errors.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/ErrorObject'
+          - type: 'null'
+
     receive_error_cleared:
       name: receive_error_cleared
       title: 'Receive cleared error'
@@ -196,6 +291,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/ErrorObject'
+    send_request_get_error_cleared:
+      name: send_request_get_error_raised
+      title: 'Request current cleared errors'
+      summary: 'Request the most recently published (latched) cleared errors.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_error_cleared:
+      name: receive_reply_get_error_cleared
+      title: 'Reply to get cleared error request'
+      summary: 'The most recently published cleared errors.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/ErrorObject'
+          - type: 'null'
 
 
     receive_heartbeat:

--- a/docs/source/reference/EVerest_API/evse_manager_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/evse_manager_consumer_API.yaml
@@ -93,57 +93,167 @@ channels:
     messages:
       receive_session_event:
         $ref: '#/components/messages/receive_session_event'
+  send_request_get_session_event:
+    address: 'm2e/session_event/get'
+    messages:
+      send_request_get_session_event:
+        $ref: '#/components/messages/send_request_get_session_event'
+  receive_reply_get_session_event:
+    address: null
+    messages:
+      receive_reply_get_session_event:
+        $ref: '#/components/messages/receive_reply_get_session_event'
   receive_hlc_session_failed:
     address: 'e2m/hlc_session_failed'
     messages:
       receive_hlc_session_failed:
         $ref: '#/components/messages/receive_hlc_session_failed'
+  send_request_get_hlc_session_failed:
+    address: 'm2e/hlc_session_failed/get'
+    messages:
+      send_request_get_hlc_session_failed:
+        $ref: '#/components/messages/send_request_get_hlc_session_failed'
+  receive_reply_get_hlc_session_failed:
+    address: null
+    messages:
+      receive_reply_get_hlc_session_failed:
+        $ref: '#/components/messages/receive_reply_get_hlc_session_failed'
   receive_ev_info:
     address: 'e2m/ev_info'
     messages:
       receive_ev_info:
         $ref: '#/components/messages/receive_ev_info'
+  send_request_get_ev_info:
+    address: 'm2e/ev_info/get'
+    messages:
+      send_request_get_ev_info:
+        $ref: '#/components/messages/send_request_get_ev_info'
+  receive_reply_get_ev_info:
+    address: null
+    messages:
+      receive_reply_get_ev_info:
+        $ref: '#/components/messages/receive_reply_get_ev_info'
   receive_session_info:
     address: 'e2m/session_info'
     messages:
       receive_session_info:
         $ref: '#/components/messages/receive_session_info'
+  send_request_get_session_info:
+    address: 'm2e/session_info/get'
+    messages:
+      send_request_get_session_info:
+        $ref: '#/components/messages/send_request_get_session_info'
+  receive_reply_get_session_info:
+    address: null
+    messages:
+      receive_reply_get_session_info:
+        $ref: '#/components/messages/receive_reply_get_session_info'
   # telemetry not implemented
   receive_powermeter:
     address: 'e2m/powermeter'
     messages:
       receive_powermeter:
         $ref: '#/components/messages/receive_powermeter'
+  send_request_get_powermeter:
+    address: 'm2e/powermeter/get'
+    messages:
+      send_request_get_powermeter:
+        $ref: '#/components/messages/send_request_get_powermeter'
+  receive_reply_get_powermeter:
+    address: null
+    messages:
+      receive_reply_get_powermeter:
+        $ref: '#/components/messages/receive_reply_get_powermeter'
   receive_powermeter_public_key_ocmf:
     address: 'e2m/powermeter_public_key_ocmf'
     messages:
       receive_powermeter_public_key_ocmf:
         $ref: '#/components/messages/receive_powermeter_public_key_ocmf'
+  send_request_get_powermeter_public_key_ocmf:
+    address: 'm2e/powermeter_public_key_ocmf/get'
+    messages:
+      send_request_get_powermeter_public_key_ocmf:
+        $ref: '#/components/messages/send_request_get_powermeter_public_key_ocmf'
+  receive_reply_get_powermeter_public_key_ocmf:
+    address: null
+    messages:
+      receive_reply_get_powermeter_public_key_ocmf:
+        $ref: '#/components/messages/receive_reply_get_powermeter_public_key_ocmf'
   receive_evse_id:
     address: 'e2m/evse_id'
     messages:
       receive_evse_id:
         $ref: '#/components/messages/receive_evse_id'
+  send_request_get_evse_id:
+    address: 'm2e/evse_id/get'
+    messages:
+      send_request_get_evse_id:
+        $ref: '#/components/messages/send_request_get_evse_id'
+  receive_reply_get_evse_id:
+    address: null
+    messages:
+      receive_reply_get_evse_id:
+        $ref: '#/components/messages/receive_reply_get_evse_id'
   receive_hw_capabilities:
     address: 'e2m/hw_capabilities'
     messages:
       receive_hw_capabilities:
         $ref: '#/components/messages/receive_hw_capabilities'
+  send_request_get_hw_capabilities:
+    address: 'm2e/hw_capabilities/get'
+    messages:
+      send_request_get_hw_capabilities:
+        $ref: '#/components/messages/send_request_get_hw_capabilities'
+  receive_reply_get_hw_capabilities:
+    address: null
+    messages:
+      receive_reply_get_hw_capabilities:
+        $ref: '#/components/messages/receive_reply_get_hw_capabilities'
   receive_enforced_limits:
     address: 'e2m/enforced_limits'
     messages:
       receive_enforced_limits:
         $ref: '#/components/messages/receive_enforced_limits'
+  send_request_get_enforced_limits:
+    address: 'm2e/enforced_limits/get'
+    messages:
+      send_request_get_enforced_limits:
+        $ref: '#/components/messages/send_request_get_enforced_limits'
+  receive_reply_get_enforced_limits:
+    address: null
+    messages:
+      receive_reply_get_enforced_limits:
+        $ref: '#/components/messages/receive_reply_get_enforced_limits'
   receive_selected_protocol:
     address: 'e2m/selected_protocol'
     messages:
       receive_selected_protocol:
         $ref: '#/components/messages/receive_selected_protocol'
+  send_request_get_selected_protocol:
+    address: 'm2e/selected_protocol/get'
+    messages:
+      send_request_get_selected_protocol:
+        $ref: '#/components/messages/send_request_get_selected_protocol'
+  receive_reply_get_selected_protocol:
+    address: null
+    messages:
+      receive_reply_get_selected_protocol:
+        $ref: '#/components/messages/receive_reply_get_selected_protocol'
   receive_supported_energy_transfer_modes:
     address: 'e2m/supported_energy_transfer_modes'
     messages:
       receive_supported_energy_transfer_modes:
         $ref: '#/components/messages/receive_supported_energy_transfer_modes'
+  send_request_get_supported_energy_transfer_modes:
+    address: 'm2e/supported_energy_transfer_modes/get'
+    messages:
+      send_request_get_supported_energy_transfer_modes:
+        $ref: '#/components/messages/send_request_get_supported_energy_transfer_modes'
+  receive_reply_get_supported_energy_transfer_modes:
+    address: null
+    messages:
+      receive_reply_get_supported_energy_transfer_modes:
+        $ref: '#/components/messages/receive_reply_get_supported_energy_transfer_modes'
 
   ########## evse_board_support
   receive_ac_nr_of_phases_available:
@@ -151,11 +261,31 @@ channels:
     messages:
       receive_ac_nr_of_phases_available:
         $ref: '#/components/messages/receive_ac_nr_of_phases_available'
+  send_request_get_ac_nr_of_phases_available:
+    address: 'm2e/ac_nr_of_phases_available/get'
+    messages:
+      send_request_get_ac_nr_of_phases_available:
+        $ref: '#/components/messages/send_request_get_ac_nr_of_phases_available'
+  receive_reply_get_ac_nr_of_phases_available:
+    address: null
+    messages:
+      receive_reply_get_ac_nr_of_phases_available:
+        $ref: '#/components/messages/receive_reply_get_ac_nr_of_phases_available'
   receive_ac_pp_ampacity:
     address: 'e2m/ac_pp_ampacity'
     messages:
       receive_ac_pp_ampacity:
         $ref: '#/components/messages/receive_ac_pp_ampacity'
+  send_request_get_ac_pp_ampacity:
+    address: 'm2e/ac_pp_ampacity/get'
+    messages:
+      send_request_get_ac_pp_ampacity:
+        $ref: '#/components/messages/send_request_get_ac_pp_ampacity'
+  receive_reply_get_ac_pp_ampacity:
+    address: null
+    messages:
+      receive_reply_get_ac_pp_ampacity:
+        $ref: '#/components/messages/receive_reply_get_ac_pp_ampacity'
 
   ########## slac
   receive_dlink_ready:
@@ -163,6 +293,16 @@ channels:
     messages:
       receive_dlink_ready:
         $ref: '#/components/messages/receive_dlink_ready'
+  send_request_get_dlink_ready:
+    address: 'm2e/dlink_ready/get'
+    messages:
+      send_request_get_dlink_ready:
+        $ref: '#/components/messages/send_request_get_dlink_ready'
+  receive_reply_get_dlink_ready:
+    address: null
+    messages:
+      receive_reply_get_dlink_ready:
+        $ref: '#/components/messages/receive_reply_get_dlink_ready'
 
   ########## isolation_monitor
   receive_isolation_measurement:
@@ -170,6 +310,16 @@ channels:
     messages:
       receive_isolation_measurement:
         $ref: '#/components/messages/receive_isolation_measurement'
+  send_request_get_isolation_measurement:
+    address: 'm2e/isolation_measurement/get'
+    messages:
+      send_request_get_isolation_measurement:
+        $ref: '#/components/messages/send_request_get_isolation_measurement'
+  receive_reply_get_isolation_measurement:
+    address: null
+    messages:
+      receive_reply_get_isolation_measurement:
+        $ref: '#/components/messages/receive_reply_get_isolation_measurement'
 
   ########## power_supply_DC
   receive_dc_voltage_current:
@@ -177,16 +327,46 @@ channels:
     messages:
       receive_dc_voltage_current:
         $ref: '#/components/messages/receive_dc_voltage_current'
+  send_request_get_dc_voltage_current:
+    address: 'm2e/dc_voltage_current/get'
+    messages:
+      send_request_get_dc_voltage_current:
+        $ref: '#/components/messages/send_request_get_dc_voltage_current'
+  receive_reply_get_dc_voltage_current:
+    address: null
+    messages:
+      receive_reply_get_dc_voltage_current:
+        $ref: '#/components/messages/receive_reply_get_dc_voltage_current'
   receive_dc_mode:
     address: 'e2m/dc_mode'
     messages:
       receive_dc_mode:
         $ref: '#/components/messages/receive_dc_mode'
+  send_request_get_dc_mode:
+    address: 'm2e/dc_mode/get'
+    messages:
+      send_request_get_dc_mode:
+        $ref: '#/components/messages/send_request_get_dc_mode'
+  receive_reply_get_dc_mode:
+    address: null
+    messages:
+      receive_reply_get_dc_mode:
+        $ref: '#/components/messages/receive_reply_get_dc_mode'
   receive_dc_capabilities:
     address: 'e2m/dc_capabilities'
     messages:
       receive_dc_capabilities:
         $ref: '#/components/messages/receive_dc_capabilities'
+  send_request_get_dc_capabilities:
+    address: 'm2e/dc_capabilities/get'
+    messages:
+      send_request_get_dc_capabilities:
+        $ref: '#/components/messages/send_request_get_dc_capabilities'
+  receive_reply_get_dc_capabilities:
+    address: null
+    messages:
+      receive_reply_get_dc_capabilities:
+        $ref: '#/components/messages/receive_reply_get_dc_capabilities'
 
   ########## uk_random_delay
   send_random_delay_enable:
@@ -215,6 +395,16 @@ channels:
     messages:
       receive_random_delay_countdown:
         $ref: '#/components/messages/receive_random_delay_countdown'
+  send_request_get_random_delay_countdown:
+    address: 'm2e/random_delay_countdown/get'
+    messages:
+      send_request_get_random_delay_countdown:
+        $ref: '#/components/messages/send_request_get_random_delay_countdown'
+  receive_reply_get_random_delay_countdown:
+    address: null
+    messages:
+      receive_reply_get_random_delay_countdown:
+        $ref: '#/components/messages/receive_reply_get_random_delay_countdown'
 
 
   receive_heartbeat:
@@ -335,57 +525,266 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_session_event'
+  send_request_get_session_event:
+    title: 'Request current session event'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_session_event'
+    description: >-
+      Request the most recently published (latched) session event.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_session_event'
+  receive_reply_get_session_event:
+    title: 'Reply to get session event request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_session_event'
   receive_hlc_session_failed:
     title: 'Receive HLC session failed event'
     action: receive
     channel:
       $ref: '#/channels/receive_hlc_session_failed'
+  send_request_get_hlc_session_failed:
+    title: 'Request current hlc session failed'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_hlc_session_failed'
+    description: >-
+      Request the most recently published (latched) hlc session failed.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_hlc_session_failed'
+  receive_reply_get_hlc_session_failed:
+    title: 'Reply to get hlc session failed request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_hlc_session_failed'
   receive_ev_info:
     title: 'Receive details of EV'
     action: receive
     channel:
       $ref: '#/channels/receive_ev_info'
+  send_request_get_ev_info:
+    title: 'Request current ev info'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_ev_info'
+    description: >-
+      Request the most recently published (latched) ev info.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_ev_info'
+  receive_reply_get_ev_info:
+    title: 'Reply to get ev info request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_ev_info'
   receive_session_info:
     title: 'Receive session information'
     action: receive
     channel:
       $ref: '#/channels/receive_session_info'
+  send_request_get_session_info:
+    title: 'Request current session info'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_session_info'
+    description: >-
+      Request the most recently published (latched) session info.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_session_info'
+  receive_reply_get_session_info:
+    title: 'Reply to get session info request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_session_info'
   # telemetry not implemented
   receive_powermeter:
     title: 'Receive powermeter measured dataset'
     action: receive
     channel:
       $ref: '#/channels/receive_powermeter'
+  send_request_get_powermeter:
+    title: 'Request current powermeter'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_powermeter'
+    description: >-
+      Request the most recently published (latched) powermeter.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_powermeter'
+  receive_reply_get_powermeter:
+    title: 'Reply to get powermeter request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_powermeter'
   receive_powermeter_public_key_ocmf:
     title: 'Receive powermeter public key OCMF'
     action: receive
     channel:
       $ref: '#/channels/receive_powermeter_public_key_ocmf'
+  send_request_get_powermeter_public_key_ocmf:
+    title: 'Request current powermeter public key ocmf'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_powermeter_public_key_ocmf'
+    description: >-
+      Request the most recently published (latched) powermeter public key ocmf.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_powermeter_public_key_ocmf'
+  receive_reply_get_powermeter_public_key_ocmf:
+    title: 'Reply to get powermeter public key ocmf request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_powermeter_public_key_ocmf'
   receive_evse_id:
     title: 'Receive EVSE ID'
     action: receive
     channel:
       $ref: '#/channels/receive_evse_id'
+  send_request_get_evse_id:
+    title: 'Request current EVSE ID'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_evse_id'
+    description: >-
+      Request the most recently published (latched) EVSE ID.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_evse_id'
+  receive_reply_get_evse_id:
+    title: 'Reply to get EVSE ID request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_evse_id'
   receive_hw_capabilities:
     title: 'Receive hardware capabilites and limits'
     action: receive
     channel:
       $ref: '#/channels/receive_hw_capabilities'
+  send_request_get_hw_capabilities:
+    title: 'Request current hw capabilities'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_hw_capabilities'
+    description: >-
+      Request the most recently published (latched) hw capabilities.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_hw_capabilities'
+  receive_reply_get_hw_capabilities:
+    title: 'Reply to get hw capabilities request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_hw_capabilities'
   receive_enforced_limits:
     title: 'Receive enforced limits'
     action: receive
     channel:
       $ref: '#/channels/receive_enforced_limits'
+  send_request_get_enforced_limits:
+    title: 'Request current enforced limits'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_enforced_limits'
+    description: >-
+      Request the most recently published (latched) enforced limits.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_enforced_limits'
+  receive_reply_get_enforced_limits:
+    title: 'Reply to get enforced limits request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_enforced_limits'
   receive_selected_protocol:
     title: 'Receive selected protocol for charging'
     action: receive
     channel:
       $ref: '#/channels/receive_selected_protocol'
+  send_request_get_selected_protocol:
+    title: 'Request current selected protocol'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_selected_protocol'
+    description: >-
+      Request the most recently published (latched) selected protocol.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_selected_protocol'
+  receive_reply_get_selected_protocol:
+    title: 'Reply to get selected protocol request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_selected_protocol'
   receive_supported_energy_transfer_modes:
     title: 'Receive supported energy transfer modes'
     action: receive
     channel:
       $ref: '#/channels/receive_supported_energy_transfer_modes'
+  send_request_get_supported_energy_transfer_modes:
+    title: 'Request current supported energy transfer modes'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_supported_energy_transfer_modes'
+    description: >-
+      Request the most recently published (latched) supported energy transfer modes.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_supported_energy_transfer_modes'
+  receive_reply_get_supported_energy_transfer_modes:
+    title: 'Reply to get supported energy transfer modes request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_supported_energy_transfer_modes'
 
   ########## evse_board_support
   receive_ac_nr_of_phases_available:
@@ -393,11 +792,49 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_ac_nr_of_phases_available'
+  send_request_get_ac_nr_of_phases_available:
+    title: 'Request current ac nr of phases available'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_ac_nr_of_phases_available'
+    description: >-
+      Request the most recently published (latched) ac nr of phases available.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_ac_nr_of_phases_available'
+  receive_reply_get_ac_nr_of_phases_available:
+    title: 'Reply to get ac nr of phases available request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_ac_nr_of_phases_available'
   receive_ac_pp_ampacity:
     title: 'Receive current carrying capacity of the connected cable in ampere for AC charging'
     action: receive
     channel:
       $ref: '#/channels/receive_ac_pp_ampacity'
+  send_request_get_ac_pp_ampacity:
+    title: 'Request current ac pp ampacity'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_ac_pp_ampacity'
+    description: >-
+      Request the most recently published (latched) ac pp ampacity.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_ac_pp_ampacity'
+  receive_reply_get_ac_pp_ampacity:
+    title: 'Reply to get ac pp ampacity request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_ac_pp_ampacity'
 
   ########## slac
   receive_dlink_ready:
@@ -405,6 +842,25 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_dlink_ready'
+  send_request_get_dlink_ready:
+    title: 'Request current dlink ready'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_dlink_ready'
+    description: >-
+      Request the most recently published (latched) dlink ready.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_dlink_ready'
+  receive_reply_get_dlink_ready:
+    title: 'Reply to get dlink ready request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_dlink_ready'
 
   ########## isolation_monitor
   receive_isolation_measurement:
@@ -412,6 +868,25 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_isolation_measurement'
+  send_request_get_isolation_measurement:
+    title: 'Request current isolation measurement'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_isolation_measurement'
+    description: >-
+      Request the most recently published (latched) isolation measurement.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_isolation_measurement'
+  receive_reply_get_isolation_measurement:
+    title: 'Reply to get isolation measurement request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_isolation_measurement'
 
   ########## power_supply_DC
   receive_dc_voltage_current:
@@ -419,16 +894,73 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_dc_voltage_current'
+  send_request_get_dc_voltage_current:
+    title: 'Request current dc voltage current'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_dc_voltage_current'
+    description: >-
+      Request the most recently published (latched) dc voltage current.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_dc_voltage_current'
+  receive_reply_get_dc_voltage_current:
+    title: 'Reply to get dc voltage current request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_dc_voltage_current'
   receive_dc_mode:
     title: 'Receive current mode.'
     action: receive
     channel:
       $ref: '#/channels/receive_dc_mode'
+  send_request_get_dc_mode:
+    title: 'Request current dc mode'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_dc_mode'
+    description: >-
+      Request the most recently published (latched) dc mode.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_dc_mode'
+  receive_reply_get_dc_mode:
+    title: 'Reply to get dc mode request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_dc_mode'
   receive_dc_capabilities:
     title: 'Receive capabilities of the DC power supply'
     action: receive
     channel:
       $ref: '#/channels/receive_dc_capabilities'
+  send_request_get_dc_capabilities:
+    title: 'Request current dc capabilities'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_dc_capabilities'
+    description: >-
+      Request the most recently published (latched) dc capabilities.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_dc_capabilities'
+  receive_reply_get_dc_capabilities:
+    title: 'Reply to get dc capabilities request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_dc_capabilities'
 
   ########## uk_random_delay
   send_random_delay_enable:
@@ -457,6 +989,25 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_random_delay_countdown'
+  send_request_get_random_delay_countdown:
+    title: 'Request current random delay countdown'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_random_delay_countdown'
+    description: >-
+      Request the most recently published (latched) random delay countdown.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_random_delay_countdown'
+  receive_reply_get_random_delay_countdown:
+    title: 'Reply to get random delay countdown request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_random_delay_countdown'
 
 
   receive_heartbeat:
@@ -666,6 +1217,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SessionEvent'
+    send_request_get_session_event:
+      name: send_request_get_session_event
+      title: 'Request current session event'
+      summary: 'Request the most recently published (latched) session event.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_session_event:
+      name: receive_reply_get_session_event
+      title: 'Reply to get session event request'
+      summary: 'The most recently published session event.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/SessionEvent'
+          - type: 'null'
     receive_hlc_session_failed:
       name: receive_hlc_session_failed
       title: 'Receive HLC session failed event'
@@ -673,6 +1256,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/HlcSessionFailedEvent'
+    send_request_get_hlc_session_failed:
+      name: send_request_get_hlc_session_failed
+      title: 'Request current hlc session failed'
+      summary: 'Request the most recently published (latched) hlc session failed.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_hlc_session_failed:
+      name: receive_reply_get_hlc_session_failed
+      title: 'Reply to get hlc session failed request'
+      summary: 'The most recently published hlc session failed.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/HlcSessionFailedEvent'
+          - type: 'null'
     receive_ev_info:
       name: receive_ev_info
       title: 'Receive details about EV'
@@ -680,6 +1295,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/EVInfo'
+    send_request_get_ev_info:
+      name: send_request_get_ev_info
+      title: 'Request current ev info'
+      summary: 'Request the most recently published (latched) ev info.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_ev_info:
+      name: receive_reply_get_ev_info
+      title: 'Reply to get ev info request'
+      summary: 'The most recently published ev info.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/EVInfo'
+          - type: 'null'
     receive_session_info:
       name: receive_session_info
       title: 'Receive session and transaction information'
@@ -699,6 +1346,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SessionInfo'
+    send_request_get_session_info:
+      name: send_request_get_session_info
+      title: 'Request current session info'
+      summary: 'Request the most recently published (latched) session info.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_session_info:
+      name: receive_reply_get_session_info
+      title: 'Reply to get session info request'
+      summary: 'The most recently published session info.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/SessionInfo'
+          - type: 'null'
     # telemetry not implemented
     receive_powermeter:
       name: receive_powermeter
@@ -707,6 +1386,38 @@ components:
       contentType: application/json
       payload:
         $ref: 'powermeter_API.yaml#/components/schemas/Powermeter'
+    send_request_get_powermeter:
+      name: send_request_get_powermeter
+      title: 'Request current powermeter'
+      summary: 'Request the most recently published (latched) powermeter.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_powermeter:
+      name: receive_reply_get_powermeter
+      title: 'Reply to get powermeter request'
+      summary: 'The most recently published powermeter.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'powermeter_API.yaml#/components/schemas/Powermeter'
+          - type: 'null'
     receive_powermeter_public_key_ocmf:
       name: receive_powermeter_public_key_ocmf
       title: 'Receive powermeter public key OCMF'
@@ -714,6 +1425,38 @@ components:
       contentType: application/json
       payload:
         $ref: 'powermeter_API.yaml#/components/schemas/SendPublicKeyOCMF'
+    send_request_get_powermeter_public_key_ocmf:
+      name: send_request_get_powermeter_public_key_ocmf
+      title: 'Request current powermeter public key ocmf'
+      summary: 'Request the most recently published (latched) powermeter public key ocmf.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_powermeter_public_key_ocmf:
+      name: receive_reply_get_powermeter_public_key_ocmf
+      title: 'Reply to get powermeter public key ocmf request'
+      summary: 'The most recently published powermeter public key ocmf.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'powermeter_API.yaml#/components/schemas/SendPublicKeyOCMF'
+          - type: 'null'
     receive_evse_id:
       name: receive_evse_id
       title: 'Receive EVSE ID'
@@ -721,6 +1464,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/EvseId'
+    send_request_get_evse_id:
+      name: send_request_get_evse_id
+      title: 'Request current EVSE ID'
+      summary: 'Request the most recently published (latched) EVSE ID.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_evse_id:
+      name: receive_reply_get_evse_id
+      title: 'Reply to get EVSE ID request'
+      summary: 'The most recently published EVSE ID.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/EvseId'
+          - type: 'null'
     receive_hw_capabilities:
       name: receive_hw_capabilities
       title: 'Receive hardware capabilities and limits'
@@ -728,6 +1503,38 @@ components:
       contentType: application/json
       payload:
         $ref: 'evse_board_support_API.yaml#/components/schemas/HardwareCapabilities'
+    send_request_get_hw_capabilities:
+      name: send_request_get_hw_capabilities
+      title: 'Request current hw capabilities'
+      summary: 'Request the most recently published (latched) hw capabilities.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_hw_capabilities:
+      name: receive_reply_get_hw_capabilities
+      title: 'Reply to get hw capabilities request'
+      summary: 'The most recently published hw capabilities.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'evse_board_support_API.yaml#/components/schemas/HardwareCapabilities'
+          - type: 'null'
     receive_enforced_limits:
       name: receive_enforced_limits
       title: 'Receive enforced limits'
@@ -735,6 +1542,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/EnforcedLimits'
+    send_request_get_enforced_limits:
+      name: send_request_get_enforced_limits
+      title: 'Request current enforced limits'
+      summary: 'Request the most recently published (latched) enforced limits.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_enforced_limits:
+      name: receive_reply_get_enforced_limits
+      title: 'Reply to get enforced limits request'
+      summary: 'The most recently published enforced limits.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/EnforcedLimits'
+          - type: 'null'
     receive_selected_protocol:
       name: receive_selected_protocol
       title: 'Receive selected protocol for charging for informative purposes'
@@ -742,6 +1581,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SelectedProtocol'
+    send_request_get_selected_protocol:
+      name: send_request_get_selected_protocol
+      title: 'Request current selected protocol'
+      summary: 'Request the most recently published (latched) selected protocol.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_selected_protocol:
+      name: receive_reply_get_selected_protocol
+      title: 'Reply to get selected protocol request'
+      summary: 'The most recently published selected protocol.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/SelectedProtocol'
+          - type: 'null'
     receive_supported_energy_transfer_modes:
       name: receive_supported_energy_transfer_modes
       title: 'Receive supported energy transfer modes'
@@ -749,6 +1620,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SupportedEnergyTransferModeList'
+    send_request_get_supported_energy_transfer_modes:
+      name: send_request_get_supported_energy_transfer_modes
+      title: 'Request current supported energy transfer modes'
+      summary: 'Request the most recently published (latched) supported energy transfer modes.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_supported_energy_transfer_modes:
+      name: receive_reply_get_supported_energy_transfer_modes
+      title: 'Reply to get supported energy transfer modes request'
+      summary: 'The most recently published supported energy transfer modes.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/SupportedEnergyTransferModeList'
+          - type: 'null'
 
     ########## evse_board_support
     receive_ac_nr_of_phases_available:
@@ -758,6 +1661,38 @@ components:
       contentType: application/json
       payload:
         $ref: 'evse_board_support_API.yaml#/components/schemas/PhaseCount'
+    send_request_get_ac_nr_of_phases_available:
+      name: send_request_get_ac_nr_of_phases_available
+      title: 'Request current ac nr of phases available'
+      summary: 'Request the most recently published (latched) ac nr of phases available.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_ac_nr_of_phases_available:
+      name: receive_reply_get_ac_nr_of_phases_available
+      title: 'Reply to get ac nr of phases available request'
+      summary: 'The most recently published ac nr of phases available.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'evse_board_support_API.yaml#/components/schemas/PhaseCount'
+          - type: 'null'
     receive_ac_pp_ampacity:
       name: receive_ac_pp_ampacity
       title: 'Receive current carrying capacity of the connected cable in ampere for AC charging'
@@ -769,6 +1704,38 @@ components:
       contentType: application/json
       payload:
         $ref: 'evse_board_support_API.yaml#/components/schemas/ProximityPilot'
+    send_request_get_ac_pp_ampacity:
+      name: send_request_get_ac_pp_ampacity
+      title: 'Request current ac pp ampacity'
+      summary: 'Request the most recently published (latched) ac pp ampacity.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_ac_pp_ampacity:
+      name: receive_reply_get_ac_pp_ampacity
+      title: 'Reply to get ac pp ampacity request'
+      summary: 'The most recently published ac pp ampacity.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'evse_board_support_API.yaml#/components/schemas/ProximityPilot'
+          - type: 'null'
 
     ########## slac
     receive_dlink_ready:
@@ -778,6 +1745,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SlacDlinkReady'
+    send_request_get_dlink_ready:
+      name: send_request_get_dlink_ready
+      title: 'Request current dlink ready'
+      summary: 'Request the most recently published (latched) dlink ready.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_dlink_ready:
+      name: receive_reply_get_dlink_ready
+      title: 'Reply to get dlink ready request'
+      summary: 'The most recently published dlink ready.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/SlacDlinkReady'
+          - type: 'null'
 
     ########## isolation_monitor
     receive_isolation_measurement:
@@ -787,6 +1786,38 @@ components:
       contentType: application/json
       payload:
         $ref: 'isolation_monitor_API.yaml#/components/schemas/IsolationMeasurement'
+    send_request_get_isolation_measurement:
+      name: send_request_get_isolation_measurement
+      title: 'Request current isolation measurement'
+      summary: 'Request the most recently published (latched) isolation measurement.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_isolation_measurement:
+      name: receive_reply_get_isolation_measurement
+      title: 'Reply to get isolation measurement request'
+      summary: 'The most recently published isolation measurement.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'isolation_monitor_API.yaml#/components/schemas/IsolationMeasurement'
+          - type: 'null'
 
     ########## power_supply_DC
     receive_dc_voltage_current:
@@ -796,6 +1827,38 @@ components:
       contentType: application/json
       payload:
         $ref: 'power_supply_DC_API.yaml#/components/schemas/VoltageCurrent'
+    send_request_get_dc_voltage_current:
+      name: send_request_get_dc_voltage_current
+      title: 'Request current dc voltage current'
+      summary: 'Request the most recently published (latched) dc voltage current.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_dc_voltage_current:
+      name: receive_reply_get_dc_voltage_current
+      title: 'Reply to get dc voltage current request'
+      summary: 'The most recently published dc voltage current.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'power_supply_DC_API.yaml#/components/schemas/VoltageCurrent'
+          - type: 'null'
     receive_dc_mode:
       name: receive_dc_mode
       title: 'Receive the current mode'
@@ -803,6 +1866,38 @@ components:
       contentType: application/json
       payload:
         $ref: 'power_supply_DC_API.yaml#/components/schemas/Mode'
+    send_request_get_dc_mode:
+      name: send_request_get_dc_mode
+      title: 'Request current dc mode'
+      summary: 'Request the most recently published (latched) dc mode.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_dc_mode:
+      name: receive_reply_get_dc_mode
+      title: 'Reply to get dc mode request'
+      summary: 'The most recently published dc mode.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'power_supply_DC_API.yaml#/components/schemas/Mode'
+          - type: 'null'
     receive_dc_capabilities:
       name: receive_dc_capabilities
       title: 'Receive the capabilities of the DC power supply'
@@ -810,6 +1905,38 @@ components:
       contentType: application/json
       payload:
         $ref: 'power_supply_DC_API.yaml#/components/schemas/Capabilities'
+    send_request_get_dc_capabilities:
+      name: send_request_get_dc_capabilities
+      title: 'Request current dc capabilities'
+      summary: 'Request the most recently published (latched) dc capabilities.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_dc_capabilities:
+      name: receive_reply_get_dc_capabilities
+      title: 'Reply to get dc capabilities request'
+      summary: 'The most recently published dc capabilities.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'power_supply_DC_API.yaml#/components/schemas/Capabilities'
+          - type: 'null'
 
     ########## uk_random_delay
     send_random_delay_enable:
@@ -842,6 +1969,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/CountDown'
+    send_request_get_random_delay_countdown:
+      name: send_request_get_random_delay_countdown
+      title: 'Request current random delay countdown'
+      summary: 'Request the most recently published (latched) random delay countdown.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_random_delay_countdown:
+      name: receive_reply_get_random_delay_countdown
+      title: 'Reply to get random delay countdown request'
+      summary: 'The most recently published random delay countdown.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/CountDown'
+          - type: 'null'
 
 
     receive_heartbeat:

--- a/docs/source/reference/EVerest_API/external_energy_limits_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/external_energy_limits_consumer_API.yaml
@@ -37,6 +37,16 @@ channels:
     messages:
       receive_capabilities:
         $ref: '#/components/messages/receive_capabilities'
+  send_request_get_capabilities:
+    address: 'm2e/capabilities/get'
+    messages:
+      send_request_get_capabilities:
+        $ref: '#/components/messages/send_request_get_capabilities'
+  receive_reply_get_capabilities:
+    address: null
+    messages:
+      receive_reply_get_capabilities:
+        $ref: '#/components/messages/receive_reply_get_capabilities'
 
   receive_heartbeat:
     address: 'e2m/heartbeat'
@@ -57,6 +67,25 @@ operations:
     action: send
     channel:
       $ref: '#/channels/send_set_external_limits'
+  send_request_get_capabilities:
+    title: 'Request current Capabilities'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_capabilities'
+    description: >-
+      Request the most recently published (latched) Capabilities.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_capabilities'
+  receive_reply_get_capabilities:
+    title: 'Reply to get Capabilities request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_capabilities'
 
   receive_heartbeat:
     title: 'Receive heartbeat'
@@ -235,6 +264,38 @@ components:
               "nominal_voltage_V": 230,
               "total_power_W": 11040
             }
+    send_request_get_capabilities:
+      name: send_request_get_capabilities
+      title: 'Request current Capabilities'
+      summary: 'Request the most recently published (latched) Capabilities.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_capabilities:
+      name: receive_reply_get_capabilities
+      title: 'Reply to get Capabilities request'
+      summary: 'The most recently published Capabilities.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/CapabilityLimits'
+          - type: 'null'
 
     receive_heartbeat:
       name: receive_heartbeat

--- a/docs/source/reference/EVerest_API/ocpp_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/ocpp_consumer_API.yaml
@@ -82,6 +82,16 @@ channels:
     messages:
       receive_ocpp_transaction_event:
         $ref: '#/components/messages/receive_ocpp_transaction_event'
+  send_request_get_ocpp_transaction_event:
+    address: 'm2e/ocpp_transaction_event/get'
+    messages:
+      send_request_get_ocpp_transaction_event:
+        $ref: '#/components/messages/send_request_get_ocpp_transaction_event'
+  receive_reply_get_ocpp_transaction_event:
+    address: null
+    messages:
+      receive_reply_get_ocpp_transaction_event:
+        $ref: '#/components/messages/receive_reply_get_ocpp_transaction_event'
   receive_is_connected:
     address: 'e2m/is_connected'
     messages:
@@ -92,26 +102,86 @@ channels:
     messages:
       receive_security_event:
         $ref: '#/components/messages/receive_security_event'
+  send_request_get_security_event:
+    address: 'm2e/security_event/get'
+    messages:
+      send_request_get_security_event:
+        $ref: '#/components/messages/send_request_get_security_event'
+  receive_reply_get_security_event:
+    address: null
+    messages:
+      receive_reply_get_security_event:
+        $ref: '#/components/messages/receive_reply_get_security_event'
   receive_boot_notification_response:
     address: 'e2m/boot_notification_response'
     messages:
       receive_boot_notification_response:
         $ref: '#/components/messages/receive_boot_notification_response'
+  send_request_get_boot_notification_response:
+    address: 'm2e/boot_notification_response/get'
+    messages:
+      send_request_get_boot_notification_response:
+        $ref: '#/components/messages/send_request_get_boot_notification_response'
+  receive_reply_get_boot_notification_response:
+    address: null
+    messages:
+      receive_reply_get_boot_notification_response:
+        $ref: '#/components/messages/receive_reply_get_boot_notification_response'
   receive_event_data:
     address: 'e2m/event_data'
     messages:
       receive_event_data:
         $ref: '#/components/messages/receive_event_data'
+  send_request_get_event_data:
+    address: 'm2e/event_data/get'
+    messages:
+      send_request_get_event_data:
+        $ref: '#/components/messages/send_request_get_event_data'
+  receive_reply_get_event_data:
+    address: null
+    messages:
+      receive_reply_get_event_data:
+        $ref: '#/components/messages/receive_reply_get_event_data'
   receive_charging_schedules:
     address: 'e2m/charging_schedules'
     messages:
       receive_charging_schedules:
         $ref: '#/components/messages/receive_charging_schedules'
+  send_request_get_is_connected:
+    address: 'm2e/is_connected/get'
+    messages:
+      send_request_get_is_connected:
+        $ref: '#/components/messages/send_request_get_is_connected'
+  receive_reply_get_is_connected:
+    address: null
+    messages:
+      receive_reply_get_is_connected:
+        $ref: '#/components/messages/receive_reply_get_is_connected'
+  send_request_get_charging_schedules:
+    address: 'm2e/charging_schedules/get'
+    messages:
+      send_request_get_charging_schedules:
+        $ref: '#/components/messages/send_request_get_charging_schedules'
+  receive_reply_get_charging_schedules:
+    address: null
+    messages:
+      receive_reply_get_charging_schedules:
+        $ref: '#/components/messages/receive_reply_get_charging_schedules'
   receive_ocpp_message:
     address: e2m/ocpp_message
     messages:
       receive_ocpp_message:
         $ref: '#/components/messages/receive_ocpp_message'
+  send_request_get_ocpp_message:
+    address: 'm2e/ocpp_message/get'
+    messages:
+      send_request_get_ocpp_message:
+        $ref: '#/components/messages/send_request_get_ocpp_message'
+  receive_reply_get_ocpp_message:
+    address: null
+    messages:
+      receive_reply_get_ocpp_message:
+        $ref: '#/components/messages/receive_reply_get_ocpp_message'
 
 
   receive_heartbeat:
@@ -219,27 +289,160 @@ operations:
     action: receive
     channel:
       $ref: '#/channels/receive_security_event'
+  send_request_get_ocpp_transaction_event:
+    title: 'Request current ocpp transaction event'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_ocpp_transaction_event'
+    description: >-
+      Request the most recently published (latched) ocpp transaction event.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_ocpp_transaction_event'
+  receive_reply_get_ocpp_transaction_event:
+    title: 'Reply to get ocpp transaction event request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_ocpp_transaction_event'
+  send_request_get_security_event:
+    title: 'Request current security event'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_security_event'
+    description: >-
+      Request the most recently published (latched) security event.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_security_event'
+  receive_reply_get_security_event:
+    title: 'Reply to get security event request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_security_event'
   receive_boot_notification_response:
     title: 'Receive boot notification response'
     action: receive
     channel:
       $ref: '#/channels/receive_boot_notification_response'
+  send_request_get_boot_notification_response:
+    title: 'Request current boot notification response'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_boot_notification_response'
+    description: >-
+      Request the most recently published (latched) boot notification response.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_boot_notification_response'
+  receive_reply_get_boot_notification_response:
+    title: 'Reply to get boot notification response request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_boot_notification_response'
   receive_event_data:
     title: 'Receive event data'
     action: receive
     channel:
       $ref: '#/channels/receive_event_data'
+  send_request_get_event_data:
+    title: 'Request current event data'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_event_data'
+    description: >-
+      Request the most recently published (latched) event data.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_event_data'
+  receive_reply_get_event_data:
+    title: 'Reply to get event data request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_event_data'
   receive_charging_schedules:
     title: 'Receive composite charging schedules'
     action: receive
     channel:
       $ref: '#/channels/receive_charging_schedules'
+  send_request_get_is_connected:
+    title: 'Request current Is Connected'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_is_connected'
+    description: >-
+      Request the most recently published (latched) Is Connected.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_is_connected'
+  receive_reply_get_is_connected:
+    title: 'Reply to get Is Connected request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_is_connected'
+  send_request_get_charging_schedules:
+    title: 'Request current Charging Schedules'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_charging_schedules'
+    description: >-
+      Request the most recently published (latched) Charging Schedules.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_charging_schedules'
+  receive_reply_get_charging_schedules:
+    title: 'Reply to get Charging Schedules request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_charging_schedules'
   receive_ocpp_message:
     title: Receive ocpp message
     action: receive
     channel:
       $ref: '#/channels/receive_ocpp_message'
     description: A serialized OCPP message
+  send_request_get_ocpp_message:
+    title: 'Request current ocpp message'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_ocpp_message'
+    description: >-
+      Request the most recently published (latched) ocpp message.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_ocpp_message'
+  receive_reply_get_ocpp_message:
+    title: 'Reply to get ocpp message request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_ocpp_message'
 
 
   receive_heartbeat:
@@ -478,6 +681,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/OcppTransactionEvent'
+    send_request_get_ocpp_transaction_event:
+      name: send_request_get_ocpp_transaction_event
+      title: 'Request current ocpp transaction event'
+      summary: 'Request the most recently published (latched) ocpp transaction event.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_ocpp_transaction_event:
+      name: receive_reply_get_ocpp_transaction_event
+      title: 'Reply to get ocpp transaction event request'
+      summary: 'The most recently published ocpp transaction event.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/OcppTransactionEvent'
+          - type: 'null'
     receive_is_connected:
       name: receive_is_connected
       title: 'Receive is connected'
@@ -492,6 +727,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/SecurityEvent'
+    send_request_get_security_event:
+      name: send_request_get_security_event
+      title: 'Request current security event'
+      summary: 'Request the most recently published (latched) security event.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_security_event:
+      name: receive_reply_get_security_event
+      title: 'Reply to get security event request'
+      summary: 'The most recently published security event.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/SecurityEvent'
+          - type: 'null'
     receive_boot_notification_response:
       name: receive_boot_notification_response
       title: 'Receive boot notification response'
@@ -500,6 +767,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/BootNotificationResponse'
+    send_request_get_boot_notification_response:
+      name: send_request_get_boot_notification_response
+      title: 'Request current boot notification response'
+      summary: 'Request the most recently published (latched) boot notification response.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_boot_notification_response:
+      name: receive_reply_get_boot_notification_response
+      title: 'Reply to get boot notification response request'
+      summary: 'The most recently published boot notification response.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/BootNotificationResponse'
+          - type: 'null'
     receive_event_data:
       name: receive_event_data
       title: 'Receive event data'
@@ -508,6 +807,38 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/EventData'
+    send_request_get_event_data:
+      name: send_request_get_event_data
+      title: 'Request current event data'
+      summary: 'Request the most recently published (latched) event data.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_event_data:
+      name: receive_reply_get_event_data
+      title: 'Reply to get event data request'
+      summary: 'The most recently published event data.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/EventData'
+          - type: 'null'
     receive_charging_schedules:
       name: receive_charging_schedules
       title: 'Receive composite charging schedules'
@@ -525,6 +856,70 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/ChargingSchedules'
+    send_request_get_is_connected:
+      name: send_request_get_is_connected
+      title: 'Request current Is Connected'
+      summary: 'Request the most recently published (latched) Is Connected.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_is_connected:
+      name: receive_reply_get_is_connected
+      title: 'Reply to get Is Connected request'
+      summary: 'The most recently published Is Connected.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/ConnectedStatus'
+          - type: 'null'
+    send_request_get_charging_schedules:
+      name: send_request_get_charging_schedules
+      title: 'Request current Charging Schedules'
+      summary: 'Request the most recently published (latched) Charging Schedules.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_charging_schedules:
+      name: receive_reply_get_charging_schedules
+      title: 'Reply to get Charging Schedules request'
+      summary: 'The most recently published Charging Schedules.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/ChargingSchedules'
+          - type: 'null'
     receive_ocpp_message:
       name: receive_ocpp_message
       title: Receive ocpp message
@@ -532,6 +927,39 @@ components:
       contentType: application/json
       payload:
         $ref: '#/components/schemas/Message'
+
+    send_request_get_ocpp_message:
+      name: send_request_get_ocpp_message
+      title: 'Request current ocpp message'
+      summary: 'Request the most recently published (latched) ocpp message.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_ocpp_message:
+      name: receive_reply_get_ocpp_message
+      title: 'Reply to get ocpp message request'
+      summary: 'The most recently published ocpp message.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/Message'
+          - type: 'null'
 
 
     receive_heartbeat:

--- a/docs/source/reference/EVerest_API/session_cost_consumer_API.yaml
+++ b/docs/source/reference/EVerest_API/session_cost_consumer_API.yaml
@@ -44,6 +44,36 @@ channels:
     messages:
       session_cost:
         $ref: '#/components/messages/receive_session_cost'
+  send_request_get_default_price:
+    address: 'm2e/default_price/get'
+    messages:
+      send_request_get_default_price:
+        $ref: '#/components/messages/send_request_get_default_price'
+  receive_reply_get_default_price:
+    address: null
+    messages:
+      receive_reply_get_default_price:
+        $ref: '#/components/messages/receive_reply_get_default_price'
+  send_request_get_tariff_message:
+    address: 'm2e/tariff_message/get'
+    messages:
+      send_request_get_tariff_message:
+        $ref: '#/components/messages/send_request_get_tariff_message'
+  receive_reply_get_tariff_message:
+    address: null
+    messages:
+      receive_reply_get_tariff_message:
+        $ref: '#/components/messages/receive_reply_get_tariff_message'
+  send_request_get_session_cost:
+    address: 'm2e/session_cost/get'
+    messages:
+      send_request_get_session_cost:
+        $ref: '#/components/messages/send_request_get_session_cost'
+  receive_reply_get_session_cost:
+    address: null
+    messages:
+      receive_reply_get_session_cost:
+        $ref: '#/components/messages/receive_reply_get_session_cost'
 
 
   receive_heartbeat:
@@ -88,6 +118,63 @@ operations:
       Published periodically during a session and once when it ends.
       Contains session cost broken down into chunks, current and upcoming
       pricing, and optional display messages.
+  send_request_get_default_price:
+    title: 'Request current Default Price'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_default_price'
+    description: >-
+      Request the most recently published (latched) Default Price.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_default_price'
+  receive_reply_get_default_price:
+    title: 'Reply to get Default Price request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_default_price'
+  send_request_get_tariff_message:
+    title: 'Request current Tariff Message'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_tariff_message'
+    description: >-
+      Request the most recently published (latched) Tariff Message.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_tariff_message'
+  receive_reply_get_tariff_message:
+    title: 'Reply to get Tariff Message request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_tariff_message'
+  send_request_get_session_cost:
+    title: 'Request current Session Cost'
+    action: send
+    channel:
+      $ref: '#/channels/send_request_get_session_cost'
+    description: >-
+      Request the most recently published (latched) Session Cost.
+      The reply will be sent to the replyTo address specified in the message headers.
+      If no latched value is available yet, a null payload will be sent.
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/receive_reply_get_session_cost'
+  receive_reply_get_session_cost:
+    title: 'Reply to get Session Cost request'
+    action: receive
+    channel:
+      $ref: '#/channels/receive_reply_get_session_cost'
 
 
   receive_heartbeat:
@@ -126,6 +213,102 @@ components:
       contentType: application/json
       payload:
         $ref: 'session_cost_API.yaml#/components/schemas/SessionCost'
+    send_request_get_default_price:
+      name: send_request_get_default_price
+      title: 'Request current Default Price'
+      summary: 'Request the most recently published (latched) Default Price.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_default_price:
+      name: receive_reply_get_default_price
+      title: 'Reply to get Default Price request'
+      summary: 'The most recently published Default Price.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: '#/components/schemas/DefaultPrice'
+          - type: 'null'
+    send_request_get_tariff_message:
+      name: send_request_get_tariff_message
+      title: 'Request current Tariff Message'
+      summary: 'Request the most recently published (latched) Tariff Message.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_tariff_message:
+      name: receive_reply_get_tariff_message
+      title: 'Reply to get Tariff Message request'
+      summary: 'The most recently published Tariff Message.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'session_cost_API.yaml#/components/schemas/TariffMessage'
+          - type: 'null'
+    send_request_get_session_cost:
+      name: send_request_get_session_cost
+      title: 'Request current Session Cost'
+      summary: 'Request the most recently published (latched) Session Cost.'
+      contentType: application/json
+      payload:
+        type: object
+        required:
+          - headers
+        properties:
+          headers:
+            type: object
+            required:
+              - replyTo
+            properties:
+              replyTo:
+                type: string
+                description: Address to send the response to.
+      examples:
+        - summary: ""
+          payload:
+            headers:
+              replyTo: everest_api/1/{interface_type}/{module_id}/e2m/{operation_name}/{uuid}
+    receive_reply_get_session_cost:
+      name: receive_reply_get_session_cost
+      title: 'Reply to get Session Cost request'
+      summary: 'The most recently published Session Cost.'
+      contentType: application/json
+      payload:
+        oneOf:
+          - $ref: 'session_cost_API.yaml#/components/schemas/SessionCost'
+          - type: 'null'
 
 
     receive_heartbeat:

--- a/docs/source/tutorials/everest_api.rst
+++ b/docs/source/tutorials/everest_api.rst
@@ -26,6 +26,37 @@ As a rule of thumb, each internal interface is typically provided by one module.
 Configuring the required APIs is done by adding the corresponding modules to your EVerest configuration;
 they connect to other modules using the standard EVerest logic.
 
+Providing vs Consumer APIs
+==========================
+
+The available EVerest APIs can be categorized into two groups: *consuming* APIs and *providing* APIs.
+Providing APIs (e.g. `auth_token_provider_API` or `power_supply_DC_API`) can be used to implement
+("provide") an interface outside of EVerest. For example the `power_supply_DC_API` module provides the
+internal `power_supply_DC` interface. The actual implementation is in the API client.
+Providing APIs usually subscribe to external topics and forward the received values to the internal
+interface as `variables`. They also define external topics which the client shall subscribe to, which
+are used for command invokations.
+
+On the other hand, *consuming* APIs (e.g. `evse_manager_consumer_API`) can be thought to allow API clients
+to monitor internal modules and send commands to them. They define topics which a client can subscribe to
+in order to monitor some variable. They subscribe to external topics to allow the client to invoke commands.
+
+Latching Variables
+==================
+
+In case a API client subscribes to an consumer_API variable, it may happen that EVerest has already been
+running and the client missed the first value published for that variable. It can now wait for the next
+value to be published, which may be acceptable in many cases, but sometimes not. Therefore, the latest
+published value of each variable is chached in the API modules. The client can actively request its value
+via the request-reply-pattern (see section further below). The corresponding topic is
+`<topic-that-variable-is-published-to>/get`. The API will then send the latest known value to the API client
+if such a value exists (if nothing was published yet, and no value is available, then the API will reply with
+"null").
+
+.. note::
+
+    Latching variables is enabled by default, but can be disabled by module configuration parameters.
+
 Configuration
 =============
 

--- a/lib/everest/everest_api_module_helpers/include/everest_api_module_helpers/ApiHelper.hpp
+++ b/lib/everest/everest_api_module_helpers/include/everest_api_module_helpers/ApiHelper.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -66,6 +67,26 @@ public:
         });
     }
 
+    // Returns a callback suitable for r_xxx->subscribe_*(). serialize_fn converts the internal
+    // type to its external representation and serializes it; it is supplied by the module
+    // because the to_external_api/serialize overloads are only visible there.
+    template <typename SerializeFn>
+    auto forward_and_cache_api_var(std::string const& var, bool latch_value, SerializeFn serialize_fn) {
+        auto topic = topics.everest_to_extern(var);
+        if (latch_value) {
+            subscribe_latched_value_request(var, topic);
+        }
+        return [this, topic = std::move(topic), serialize_fn = std::move(serialize_fn), latch_value](auto const& val) {
+            try {
+                publish_and_cache_variable(topic, serialize_fn(val), latch_value);
+            } catch (const std::exception& e) {
+                log_forward_api_var_error(topic, e.what());
+            } catch (...) {
+                log_forward_api_var_error(topic, nullptr);
+            }
+        };
+    }
+
     template <typename CommCheckT> void setup_heartbeat_generator(CommCheckT* comm_check, int interval_ms) {
         auto topic = topics.everest_to_extern("heartbeat");
         auto action = [this, topic]() {
@@ -77,6 +98,9 @@ public:
     }
 
 private:
+    void subscribe_latched_value_request(std::string const& var, std::string const& topic);
+    void publish_and_cache_variable(std::string const& topic, std::string const& payload, bool cache_value);
+    void log_forward_api_var_error(std::string const& topic, char const* what);
     void subscribe_mqtt_topic(std::string const& topic, ParseAndPublishFtor parse_and_publish);
     void init_entrypoint_API(V1_0::types::entrypoint::CommunicationParameters const& comm_parameters);
     void init_topics();
@@ -84,6 +108,8 @@ private:
     void generate_api_entrypoint_cmd_query_module();
 
     Topics topics;
+    std::map<std::string, std::string> serialized_variables_cache;
+    std::mutex serialized_variables_mutex;
     std::atomic<size_t> hb_id{0};
     V1_0::types::entrypoint::ApiDiscoverResponse discover_response{};
     std::map<std::string, V1_0::types::entrypoint::ApiDiscoverResponse> module_query_response{};

--- a/lib/everest/everest_api_module_helpers/src/ApiHelper.cpp
+++ b/lib/everest/everest_api_module_helpers/src/ApiHelper.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <exception>
+#include <optional>
 #include <sstream>
 #include <string_view>
 #include <thread>
@@ -108,6 +109,45 @@ void ApiHelper::publish_ready_beacon() {
     if (responsible_for_sending_ready_beacon) {
         mqtt.publish(topics.entrypoint("ready_beacon"), std::string{"{}"});
     }
+}
+
+void ApiHelper::subscribe_latched_value_request(std::string const& var, std::string const& topic) {
+    subscribe_api_topic(var + "/get", [this, topic](std::string const& data) {
+        V1_0::types::generic::RequestReply msg;
+        if (deserialize(data, msg)) {
+            std::optional<std::string> payload;
+            {
+                std::lock_guard<std::mutex> lock(serialized_variables_mutex);
+                auto it = serialized_variables_cache.find(topic);
+                if (it != serialized_variables_cache.end()) {
+                    payload = it->second;
+                }
+            }
+            if (payload) {
+                mqtt.publish(msg.replyTo, *payload);
+            } else {
+                mqtt.publish(msg.replyTo, "null");
+            }
+            return true;
+        }
+        return false;
+    });
+}
+
+void ApiHelper::log_forward_api_var_error(std::string const& topic, char const* what) {
+    if (what) {
+        EVLOG_warning << "Variable: '" << topic << "' failed with -> " << what;
+    } else {
+        EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
+    }
+}
+
+void ApiHelper::publish_and_cache_variable(std::string const& topic, std::string const& payload, bool cache_value) {
+    if (cache_value) {
+        std::lock_guard<std::mutex> lock(serialized_variables_mutex);
+        serialized_variables_cache[topic] = payload;
+    }
+    mqtt.publish(topic, payload);
 }
 
 void ApiHelper::subscribe_entrypoint_var(std::string const& var, ParseAndPublishFtor parse_and_publish) {

--- a/modules/API/EVerestAPI/auth_consumer_API/auth_consumer_API.cpp
+++ b/modules/API/EVerestAPI/auth_consumer_API/auth_consumer_API.cpp
@@ -24,13 +24,16 @@ void auth_consumer_API::init() {
     comm_params.heartbeat_period_ms = config.cfg_heartbeat_interval_ms;
     comm_params.communication_check_period_s = config.cfg_communication_check_to_s;
     helper.init(comm_params);
+
+    // setup var forwarding before modules start publishing
+    generate_api_var_token_validation_status();
 }
 
 void auth_consumer_API::ready() {
     invoke_ready(*p_main);
 
+    // setup commands now, as the target modules are ready
     generate_api_cmd_withdraw_authorization();
-    generate_api_var_token_validation_status();
 
     helper.generate_api_var_communication_check(&comm_check);
     comm_check.start(config.cfg_communication_check_to_s);
@@ -38,20 +41,11 @@ void auth_consumer_API::ready() {
     helper.publish_ready_beacon();
 }
 
-auto auth_consumer_API::forward_api_var(std::string const& var) {
-    using namespace API_types_ext;
-    const auto topic = helper.get_topics().everest_to_extern(var);
-    return [this, topic](auto const& val) {
-        try {
-            auto&& external = to_external_api(val);
-            auto&& payload = serialize(external);
-            mqtt_v.publish(topic, payload);
-        } catch (const std::exception& e) {
-            EVLOG_warning << "Variable: '" << topic << "' failed with -> " << e.what();
-        } catch (...) {
-            EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
-        }
-    };
+auto auth_consumer_API::forward_and_cache_api_var(std::string const& var) {
+    return helper.forward_and_cache_api_var(var, config.latch_variable_values, [](auto const& val) {
+        using namespace API_types_ext;
+        return serialize(to_external_api(val));
+    });
 }
 
 void auth_consumer_API::generate_api_cmd_withdraw_authorization() {
@@ -71,7 +65,7 @@ void auth_consumer_API::generate_api_cmd_withdraw_authorization() {
 }
 
 void auth_consumer_API::generate_api_var_token_validation_status() {
-    r_auth->subscribe_token_validation_status(forward_api_var("token_validation_status"));
+    r_auth->subscribe_token_validation_status(forward_and_cache_api_var("token_validation_status"));
 }
 
 } // namespace module

--- a/modules/API/EVerestAPI/auth_consumer_API/auth_consumer_API.hpp
+++ b/modules/API/EVerestAPI/auth_consumer_API/auth_consumer_API.hpp
@@ -31,6 +31,7 @@ namespace module {
 struct Conf {
     int cfg_communication_check_to_s;
     int cfg_heartbeat_interval_ms;
+    bool latch_variable_values;
 };
 
 class auth_consumer_API : public Everest::ModuleBase {
@@ -63,7 +64,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    auto forward_api_var(std::string const& var);
+    auto forward_and_cache_api_var(std::string const& var);
 
     void generate_api_cmd_withdraw_authorization();
 

--- a/modules/API/EVerestAPI/auth_consumer_API/manifest.yaml
+++ b/modules/API/EVerestAPI/auth_consumer_API/manifest.yaml
@@ -8,6 +8,10 @@ config:
     description: "Interval between two heartbeat messages send by the API. Values <= 0 disable heartbeat."
     type: integer
     default: 1000
+  latch_variable_values:
+    description: "Determines whether variables published by this module are cached and made available for `get` requests."
+    type: boolean
+    default: true
 
 provides:
   main:

--- a/modules/API/EVerestAPI/dc_external_derate_consumer_API/dc_external_derate_consumer_API.cpp
+++ b/modules/API/EVerestAPI/dc_external_derate_consumer_API/dc_external_derate_consumer_API.cpp
@@ -26,13 +26,16 @@ void dc_external_derate_consumer_API::init() {
     comm_params.heartbeat_period_ms = config.cfg_heartbeat_interval_ms;
     comm_params.communication_check_period_s = config.cfg_communication_check_to_s;
     helper.init(comm_params);
+
+    // setup var forwarding before modules start publishing
+    generate_api_var_plug_temperature_C();
 }
 
 void dc_external_derate_consumer_API::ready() {
     invoke_ready(*p_generic_error);
 
+    // setup commands now, as the target modules are ready
     generate_api_cmd_set_external_derating();
-    generate_api_var_plug_temperature_C();
 
     helper.generate_api_var_communication_check(&comm_check);
     comm_check.start(config.cfg_communication_check_to_s);
@@ -40,25 +43,16 @@ void dc_external_derate_consumer_API::ready() {
     helper.publish_ready_beacon();
 }
 
-auto dc_external_derate_consumer_API::forward_api_var(std::string const& var) {
-    using namespace API_types_ext;
-    using namespace API_generic;
-    const auto topic = helper.get_topics().everest_to_extern(var);
-    return [this, topic](auto const& val) {
-        try {
-            auto&& external = to_external_api(val);
-            auto&& payload = serialize(external);
-            mqtt_v.publish(topic, payload);
-        } catch (const std::exception& e) {
-            EVLOG_warning << "Variable: '" << topic << "' failed with -> " << e.what();
-        } catch (...) {
-            EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
-        }
-    };
+auto dc_external_derate_consumer_API::forward_and_cache_api_var(std::string const& var) {
+    return helper.forward_and_cache_api_var(var, config.latch_variable_values, [](auto const& val) {
+        using namespace API_types_ext;
+        using namespace API_generic;
+        return serialize(to_external_api(val));
+    });
 }
 
 void dc_external_derate_consumer_API::generate_api_var_plug_temperature_C() {
-    r_derate->subscribe_plug_temperature_C(forward_api_var("plug_temperature_C"));
+    r_derate->subscribe_plug_temperature_C(forward_and_cache_api_var("plug_temperature_C"));
 }
 
 void dc_external_derate_consumer_API::generate_api_cmd_set_external_derating() {

--- a/modules/API/EVerestAPI/dc_external_derate_consumer_API/dc_external_derate_consumer_API.hpp
+++ b/modules/API/EVerestAPI/dc_external_derate_consumer_API/dc_external_derate_consumer_API.hpp
@@ -31,6 +31,7 @@ namespace module {
 struct Conf {
     int cfg_communication_check_to_s;
     int cfg_heartbeat_interval_ms;
+    bool latch_variable_values;
 };
 
 class dc_external_derate_consumer_API : public Everest::ModuleBase {
@@ -68,7 +69,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    auto forward_api_var(std::string const& var);
+    auto forward_and_cache_api_var(std::string const& var);
 
     void generate_api_var_plug_temperature_C();
 

--- a/modules/API/EVerestAPI/dc_external_derate_consumer_API/manifest.yaml
+++ b/modules/API/EVerestAPI/dc_external_derate_consumer_API/manifest.yaml
@@ -8,6 +8,10 @@ config:
     description: "Interval between two heartbeat messages send by the API. Values <= 0 disable heartbeat"
     type: integer
     default: 1000
+  latch_variable_values:
+    description: "Determines whether variables published by this module are cached and made available for `get` requests."
+    type: boolean
+    default: true
 
 provides:
   generic_error:

--- a/modules/API/EVerestAPI/error_history_consumer_API/error_history_consumer_API.cpp
+++ b/modules/API/EVerestAPI/error_history_consumer_API/error_history_consumer_API.cpp
@@ -27,14 +27,17 @@ void error_history_consumer_API::init() {
     comm_params.heartbeat_period_ms = config.cfg_heartbeat_interval_ms;
     comm_params.communication_check_period_s = config.cfg_communication_check_to_s;
     helper.init(comm_params);
+
+    // setup var forwarding before modules start publishing
+    generate_api_var_error_events();
 }
 
 void error_history_consumer_API::ready() {
     invoke_ready(*p_main);
 
+    // setup commands now, as the target modules are ready
     generate_api_cmd_active_errors();
     generate_api_cmd_get_errors();
-    generate_api_var_error_events();
 
     helper.generate_api_var_communication_check(&comm_check);
 
@@ -44,21 +47,11 @@ void error_history_consumer_API::ready() {
     helper.publish_ready_beacon();
 }
 
-auto error_history_consumer_API::forward_api_var(std::string const& var) {
-    using namespace API_types_ext;
-    const auto topic = helper.get_topics().everest_to_extern(var);
-
-    return [this, topic](auto const& val) {
-        try {
-            auto&& external = to_external_api(val);
-            auto&& payload = serialize(external);
-            mqtt_v.publish(topic, payload);
-        } catch (const std::exception& e) {
-            EVLOG_warning << "Variable: '" << topic << "' failed with -> " << e.what();
-        } catch (...) {
-            EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
-        }
-    };
+auto error_history_consumer_API::forward_and_cache_api_var(std::string const& var) {
+    return helper.forward_and_cache_api_var(var, config.latch_variable_values, [](auto const& val) {
+        using namespace API_types_ext;
+        return serialize(to_external_api(val));
+    });
 }
 
 void error_history_consumer_API::generate_api_cmd_active_errors() {
@@ -98,7 +91,8 @@ void error_history_consumer_API::generate_api_var_error_events() {
     auto convert = [](auto const& ftor) {
         return [ftor](auto&& elem) { return ftor(error_converter::framework_to_internal_api(elem)); };
     };
-    subscribe_global_all_errors(convert(forward_api_var("error_raised")), convert(forward_api_var("error_cleared")));
+    subscribe_global_all_errors(convert(forward_and_cache_api_var("error_raised")),
+                                convert(forward_and_cache_api_var("error_cleared")));
 }
 
 } // namespace module

--- a/modules/API/EVerestAPI/error_history_consumer_API/error_history_consumer_API.hpp
+++ b/modules/API/EVerestAPI/error_history_consumer_API/error_history_consumer_API.hpp
@@ -33,6 +33,7 @@ namespace module {
 struct Conf {
     int cfg_communication_check_to_s;
     int cfg_heartbeat_interval_ms;
+    bool latch_variable_values;
 };
 
 class error_history_consumer_API : public Everest::ModuleBase {
@@ -70,7 +71,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    auto forward_api_var(std::string const& var);
+    auto forward_and_cache_api_var(std::string const& var);
 
     void generate_api_cmd_get_errors();
     void generate_api_cmd_active_errors();

--- a/modules/API/EVerestAPI/error_history_consumer_API/manifest.yaml
+++ b/modules/API/EVerestAPI/error_history_consumer_API/manifest.yaml
@@ -8,6 +8,10 @@ config:
     description: "Interval between two heartbeat messages send by the API. Values <= 0 disable heartbeat."
     type: integer
     default: 1000
+  latch_variable_values:
+    description: "Interval between two heartbeat messages send by the API. Values <= 0 disable heartbeat."
+    type: boolean
+    default: true
 
 provides:
   main:

--- a/modules/API/EVerestAPI/error_history_consumer_API/src/error_wrapper.cpp
+++ b/modules/API/EVerestAPI/error_history_consumer_API/src/error_wrapper.cpp
@@ -38,7 +38,8 @@ types::error_history::State framework_to_internal_api(Everest::error::State cons
     case SrcT::ClearedByReboot:
         return TarT::ClearedByReboot;
     }
-    throw std::out_of_range("Unexpected value for everest::lib::API::V1_0::types::error_history::State_External");
+    throw std::out_of_range("Unexpected value for "
+                            "everest::lib::API::V1_0::types::error_history::State_External");
 }
 
 types::error_history::ErrorObject framework_to_internal_api(Everest::error::Error const& val) {

--- a/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.cpp
+++ b/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.cpp
@@ -339,8 +339,6 @@ void evse_manager_consumer_API::generate_api_var_session_info() {
             static const auto topic = helper.get_topics().everest_to_extern("session_info");
             try {
                 latched_publish(external);
-                // auto&& payload = serialize(external);
-                // mqtt_v.publish(topic, payload);
             } catch (const std::exception& e) {
                 EVLOG_warning << "Variable: '" << topic << "' failed with -> " << e.what();
             } catch (...) {

--- a/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.cpp
+++ b/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.cpp
@@ -61,22 +61,8 @@ void evse_manager_consumer_API::init() {
     comm_params.communication_check_period_s = config.cfg_communication_check_to_s;
     comm_params.request_reply_timeout_s = config.cfg_request_reply_to_s;
     helper.init(comm_params);
-}
 
-void evse_manager_consumer_API::ready() {
-    invoke_ready(*p_main);
-
-    generate_api_cmd_get_evse();
-    generate_api_cmd_enable_disable();
-    generate_api_cmd_pause_charging();
-    generate_api_cmd_resume_charging();
-    generate_api_cmd_stop_transaction();
-    generate_api_cmd_force_unlock();
-    generate_api_cmd_random_delay_enable();
-    generate_api_cmd_random_delay_disable();
-    generate_api_cmd_random_delay_cancel();
-    generate_api_cmd_random_delay_set_duration_s();
-
+    // setup var forwarding before modules start publishing
     generate_api_var_session_event();
     generate_api_var_hlc_session_failed();
     generate_api_var_session_info(); // special, not just forwarded
@@ -97,6 +83,22 @@ void evse_manager_consumer_API::ready() {
     generate_api_var_dc_mode();
     generate_api_var_dc_capabilities();
     generate_api_var_random_delay_countdown();
+}
+
+void evse_manager_consumer_API::ready() {
+    invoke_ready(*p_main);
+
+    // setup commands now, as the target modules are ready
+    generate_api_cmd_get_evse();
+    generate_api_cmd_enable_disable();
+    generate_api_cmd_pause_charging();
+    generate_api_cmd_resume_charging();
+    generate_api_cmd_stop_transaction();
+    generate_api_cmd_force_unlock();
+    generate_api_cmd_random_delay_enable();
+    generate_api_cmd_random_delay_disable();
+    generate_api_cmd_random_delay_cancel();
+    generate_api_cmd_random_delay_set_duration_s();
 
     helper.generate_api_var_communication_check(&comm_check);
     comm_check.start(config.cfg_communication_check_to_s);
@@ -104,28 +106,19 @@ void evse_manager_consumer_API::ready() {
     helper.publish_ready_beacon();
 }
 
-auto evse_manager_consumer_API::forward_api_var(std::string const& var) {
-    using namespace API_types_ext;
-    using namespace API_powermeter;
-    using namespace API_generic;
-    using namespace API_energy;
-    using namespace API_evse_bsp;
-    using namespace API_iso;
-    using namespace API_imd;
-    using namespace API_dc;
-    using namespace API_random_delay;
-    const auto topic = helper.get_topics().everest_to_extern(var);
-    return [this, topic](auto const& val) {
-        try {
-            auto&& external = to_external_api(val);
-            auto&& payload = serialize(external);
-            mqtt_v.publish(topic, payload);
-        } catch (const std::exception& e) {
-            EVLOG_warning << "Variable: '" << topic << "' failed with -> " << e.what();
-        } catch (...) {
-            EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
-        }
-    };
+auto evse_manager_consumer_API::forward_and_cache_api_var(std::string const& var) {
+    return helper.forward_and_cache_api_var(var, config.latch_variable_values, [var = var](auto const& val) {
+        using namespace API_types_ext;
+        using namespace API_powermeter;
+        using namespace API_generic;
+        using namespace API_energy;
+        using namespace API_evse_bsp;
+        using namespace API_iso;
+        using namespace API_imd;
+        using namespace API_dc;
+        using namespace API_random_delay;
+        return serialize(to_external_api(val));
+    });
 }
 
 void evse_manager_consumer_API::generate_api_cmd_get_evse() {
@@ -250,104 +243,110 @@ void evse_manager_consumer_API::generate_api_cmd_random_delay_set_duration_s() {
 }
 
 void evse_manager_consumer_API::generate_api_var_session_event() {
-    r_evse_manager->subscribe_session_event(forward_api_var("session_event"));
+    r_evse_manager->subscribe_session_event(forward_and_cache_api_var("session_event"));
 }
 
 void evse_manager_consumer_API::generate_api_var_hlc_session_failed() {
-    r_evse_manager->subscribe_hlc_session_failed(forward_api_var("hlc_session_failed"));
+    r_evse_manager->subscribe_hlc_session_failed(forward_and_cache_api_var("hlc_session_failed"));
 }
 
 void evse_manager_consumer_API::generate_api_var_ev_info() {
-    r_evse_manager->subscribe_ev_info(forward_api_var("ev_info"));
+    r_evse_manager->subscribe_ev_info(forward_and_cache_api_var("ev_info"));
 }
 
 void evse_manager_consumer_API::generate_api_var_powermeter() {
-    r_evse_manager->subscribe_powermeter(forward_api_var("powermeter"));
+    r_evse_manager->subscribe_powermeter(forward_and_cache_api_var("powermeter"));
 }
 
 void evse_manager_consumer_API::generate_api_var_evse_id() {
-    r_evse_manager->subscribe_evse_id(forward_api_var("evse_id"));
+    r_evse_manager->subscribe_evse_id(forward_and_cache_api_var("evse_id"));
 }
 
 void evse_manager_consumer_API::generate_api_var_hw_capabilities() {
-    r_evse_manager->subscribe_hw_capabilities(forward_api_var("hw_capabilities"));
+    r_evse_manager->subscribe_hw_capabilities(forward_and_cache_api_var("hw_capabilities"));
 }
 
 void evse_manager_consumer_API::generate_api_var_enforced_limits() {
-    r_evse_manager->subscribe_enforced_limits(forward_api_var("enforced_limits"));
+    r_evse_manager->subscribe_enforced_limits(forward_and_cache_api_var("enforced_limits"));
 }
 
 void evse_manager_consumer_API::generate_api_var_selected_protocol() {
-    r_evse_manager->subscribe_selected_protocol(forward_api_var("selected_protocol"));
+    r_evse_manager->subscribe_selected_protocol(forward_and_cache_api_var("selected_protocol"));
 }
 
 void evse_manager_consumer_API::generate_api_var_supported_energy_transfer_modes() {
-    r_evse_manager->subscribe_supported_energy_transfer_modes(forward_api_var("supported_energy_transfer_modes"));
+    r_evse_manager->subscribe_supported_energy_transfer_modes(
+        forward_and_cache_api_var("supported_energy_transfer_modes"));
 }
 
 void evse_manager_consumer_API::generate_api_var_powermeter_public_key_ocmf() {
-    r_evse_manager->subscribe_powermeter_public_key_ocmf(forward_api_var("powermeter_public_key_ocmf"));
+    r_evse_manager->subscribe_powermeter_public_key_ocmf(forward_and_cache_api_var("powermeter_public_key_ocmf"));
 }
 
 void evse_manager_consumer_API::generate_api_var_ac_nr_of_phases_available() {
     if (not r_evse_bsp.empty()) {
-        r_evse_bsp[0]->subscribe_ac_nr_of_phases_available(forward_api_var("ac_nr_of_phases_available"));
+        r_evse_bsp[0]->subscribe_ac_nr_of_phases_available(forward_and_cache_api_var("ac_nr_of_phases_available"));
     }
 }
 
 void evse_manager_consumer_API::generate_api_var_ac_pp_ampacity() {
     if (not r_evse_bsp.empty()) {
-        r_evse_bsp[0]->subscribe_ac_pp_ampacity(forward_api_var("ac_pp_ampacity"));
+        r_evse_bsp[0]->subscribe_ac_pp_ampacity(forward_and_cache_api_var("ac_pp_ampacity"));
     }
 }
 
 void evse_manager_consumer_API::generate_api_var_dlink_ready() {
     if (not r_slac.empty()) {
-        r_slac[0]->subscribe_dlink_ready(forward_api_var("dlink_ready"));
+        r_slac[0]->subscribe_dlink_ready(forward_and_cache_api_var("dlink_ready"));
     }
 }
 
 void evse_manager_consumer_API::generate_api_var_isolation_measurement() {
     if (not r_imd.empty()) {
-        r_imd[0]->subscribe_isolation_measurement(forward_api_var("isolation_measurement"));
+        r_imd[0]->subscribe_isolation_measurement(forward_and_cache_api_var("isolation_measurement"));
     }
 }
 
 void evse_manager_consumer_API::generate_api_var_dc_voltage_current() {
     if (not r_ps_dc.empty()) {
-        r_ps_dc[0]->subscribe_voltage_current(forward_api_var("dc_voltage_current"));
+        r_ps_dc[0]->subscribe_voltage_current(forward_and_cache_api_var("dc_voltage_current"));
     }
 }
 
 void evse_manager_consumer_API::generate_api_var_dc_mode() {
     if (not r_ps_dc.empty()) {
-        r_ps_dc[0]->subscribe_mode(forward_api_var("dc_mode"));
+        r_ps_dc[0]->subscribe_mode(forward_and_cache_api_var("dc_mode"));
     }
 }
 
 void evse_manager_consumer_API::generate_api_var_dc_capabilities() {
     if (not r_ps_dc.empty()) {
-        r_ps_dc[0]->subscribe_capabilities(forward_api_var("dc_capabilities"));
+        r_ps_dc[0]->subscribe_capabilities(forward_and_cache_api_var("dc_capabilities"));
     }
 }
 
 void evse_manager_consumer_API::generate_api_var_random_delay_countdown() {
     if (not r_random_delay.empty()) {
-        r_random_delay[0]->subscribe_countdown(forward_api_var("random_delay_countdown"));
+        r_random_delay[0]->subscribe_countdown(forward_and_cache_api_var("random_delay_countdown"));
     }
 }
 
 void evse_manager_consumer_API::generate_api_var_session_info() {
+    auto latched_publish = forward_and_cache_api_var("session_info");
     this->session_info.handle()->set_publish_callback(
-        [this](const everest::lib::API::V1_0::types::evse_manager::SessionInfo& external) {
+        [this, latched_publish = std::move(latched_publish)](
+            const everest::lib::API::V1_0::types::evse_manager::SessionInfo& external) {
             static const auto topic = helper.get_topics().everest_to_extern("session_info");
             try {
-                auto&& payload = serialize(external);
-                mqtt_v.publish(topic, payload);
+                latched_publish(external);
+                // auto&& payload = serialize(external);
+                // mqtt_v.publish(topic, payload);
             } catch (const std::exception& e) {
                 EVLOG_warning << "Variable: '" << topic << "' failed with -> " << e.what();
             } catch (...) {
-                EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
+                EVLOG_warning << "Invalid data: Cannot convert internal to external "
+                                 "or serialize it.\n"
+                              << topic;
             }
         });
 

--- a/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.hpp
+++ b/modules/API/EVerestAPI/evse_manager_consumer_API/evse_manager_consumer_API.hpp
@@ -40,6 +40,7 @@ struct Conf {
     int cfg_communication_check_to_s;
     int cfg_heartbeat_interval_ms;
     int cfg_request_reply_to_s;
+    bool latch_variable_values;
 };
 
 class evse_manager_consumer_API : public Everest::ModuleBase {
@@ -92,7 +93,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    auto forward_api_var(std::string const& var);
+    auto forward_and_cache_api_var(std::string const& var);
 
     void generate_api_cmd_get_evse();
     void generate_api_cmd_enable_disable();

--- a/modules/API/EVerestAPI/evse_manager_consumer_API/manifest.yaml
+++ b/modules/API/EVerestAPI/evse_manager_consumer_API/manifest.yaml
@@ -14,6 +14,10 @@ config:
     default: 550
     minimum: 1
     maximum: 550
+  latch_variable_values:
+    description: "Determines whether variables published by this module are cached and made available for `get` requests."
+    type: boolean
+    default: true
 
 provides:
   main:

--- a/modules/API/EVerestAPI/evse_manager_consumer_API/session_info.hpp
+++ b/modules/API/EVerestAPI/evse_manager_consumer_API/session_info.hpp
@@ -30,18 +30,22 @@ private:
     /// \brief External API representation
     everest::lib::API::V1_0::types::evse_manager::SessionInfo ext;
 
-    bool start_energy_export_wh_was_set{
-        false}; ///< Indicate if start export energy value (optional) has been received or not
-    bool end_energy_export_wh_was_set{
-        false}; ///< Indicate if end export energy value (optional) has been received or not
+    bool start_energy_export_wh_was_set{false}; ///< Indicate if start export energy value (optional) has been
+                                                ///< received or not
+    bool end_energy_export_wh_was_set{false};   ///< Indicate if end export energy value (optional) has been
+                                                ///< received or not
     bool transaction_running{false};
 
-    int32_t start_energy_import_wh; ///< Energy reading (import) at the beginning of this charging session in Wh
-    int32_t end_energy_import_wh;   ///< Energy reading (import) at the end of this charging session in Wh
-    int32_t start_energy_export_wh; ///< Energy reading (export) at the beginning of this charging session in Wh
-    int32_t end_energy_export_wh;   ///< Energy reading (export) at the end of this charging session in Wh
-    std::chrono::time_point<date::utc_clock> session_start_time_point;     ///< Start of the charging session
-    std::chrono::time_point<date::utc_clock> session_end_time_point;       ///< End of the charging session
+    int32_t start_energy_import_wh;                                    ///< Energy reading (import) at the beginning
+                                                                       ///< of this charging session in Wh
+    int32_t end_energy_import_wh;                                      ///< Energy reading (import) at the end of this
+                                                                       ///< charging session in Wh
+    int32_t start_energy_export_wh;                                    ///< Energy reading (export) at the beginning
+                                                                       ///< of this charging session in Wh
+    int32_t end_energy_export_wh;                                      ///< Energy reading (export) at the end of this
+                                                                       ///< charging session in Wh
+    std::chrono::time_point<date::utc_clock> session_start_time_point; ///< Start of the charging session
+    std::chrono::time_point<date::utc_clock> session_end_time_point;   ///< End of the charging session
     std::chrono::time_point<date::utc_clock> transaction_start_time_point; ///< Start of the transaction
     std::chrono::time_point<date::utc_clock> transaction_end_time_point;   ///< End of the transaction
 

--- a/modules/API/EVerestAPI/evse_security_consumer_API/evse_security_consumer_API.cpp
+++ b/modules/API/EVerestAPI/evse_security_consumer_API/evse_security_consumer_API.cpp
@@ -29,6 +29,7 @@ void evse_security_consumer_API::init() {
 void evse_security_consumer_API::ready() {
     invoke_ready(*p_main);
 
+    // setup commands now, as the target modules are ready
     generate_api_cmd_is_ca_certificate_installed();
     generate_api_cmd_get_leaf_certificate_info();
     generate_api_cmd_get_verify_location();

--- a/modules/API/EVerestAPI/external_energy_limits_consumer_API/external_energy_limits_consumer_API.cpp
+++ b/modules/API/EVerestAPI/external_energy_limits_consumer_API/external_energy_limits_consumer_API.cpp
@@ -22,36 +22,32 @@ void external_energy_limits_consumer_API::init() {
     comm_params.heartbeat_period_ms = config.cfg_heartbeat_interval_ms;
     comm_params.communication_check_period_s = config.cfg_communication_check_to_s;
     helper.init(comm_params);
+
+    // setup var forwarding before modules start publishing
+    generate_api_var_capabilities();
 }
 
 void external_energy_limits_consumer_API::ready() {
     invoke_ready(*p_main);
 
-    generate_api_var_capabilities();
+    // setup commands now, as the target modules are ready
     generate_api_cmd_set_external_limits();
 
     helper.generate_api_var_communication_check(&comm_check);
-
     comm_check.start(config.cfg_communication_check_to_s);
     helper.setup_heartbeat_generator(&comm_check, config.cfg_heartbeat_interval_ms);
-
     helper.publish_ready_beacon();
 }
 
-auto external_energy_limits_consumer_API::forward_api_var(std::string const& var) {
-    using namespace API_types_ext;
-    const auto topic = helper.get_topics().everest_to_extern(var);
-    return [this, topic](auto const& val) {
-        try {
-            auto&& external = to_external_api(val);
-            auto&& payload = serialize(external);
-            mqtt_v.publish(topic, payload);
-        } catch (const std::exception& e) {
-            EVLOG_warning << "Variable: '" << topic << "' failed with -> " << e.what();
-        } catch (...) {
-            EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
-        }
-    };
+auto external_energy_limits_consumer_API::forward_and_cache_api_var(std::string const& var) {
+    return helper.forward_and_cache_api_var(var, config.latch_variable_values, [](auto const& val) {
+        using namespace API_types_ext;
+        return serialize(to_external_api(val));
+    });
+}
+
+void external_energy_limits_consumer_API::generate_api_var_capabilities() {
+    r_energy_node->subscribe_capabilities(forward_and_cache_api_var("capabilities"));
 }
 
 void external_energy_limits_consumer_API::generate_api_cmd_set_external_limits() {
@@ -63,10 +59,6 @@ void external_energy_limits_consumer_API::generate_api_cmd_set_external_limits()
         }
         return false;
     });
-}
-
-void external_energy_limits_consumer_API::generate_api_var_capabilities() {
-    r_energy_node->subscribe_capabilities(forward_api_var("capabilities"));
 }
 
 } // namespace module

--- a/modules/API/EVerestAPI/external_energy_limits_consumer_API/external_energy_limits_consumer_API.hpp
+++ b/modules/API/EVerestAPI/external_energy_limits_consumer_API/external_energy_limits_consumer_API.hpp
@@ -31,6 +31,7 @@ namespace module {
 struct Conf {
     int cfg_communication_check_to_s;
     int cfg_heartbeat_interval_ms;
+    bool latch_variable_values;
 };
 
 class external_energy_limits_consumer_API : public Everest::ModuleBase {
@@ -68,9 +69,8 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    auto forward_api_var(std::string const& var);
+    auto forward_and_cache_api_var(std::string const& var);
 
-    void generate_api_var_enforced_limits();
     void generate_api_cmd_set_external_limits();
     void generate_api_var_capabilities();
 

--- a/modules/API/EVerestAPI/external_energy_limits_consumer_API/manifest.yaml
+++ b/modules/API/EVerestAPI/external_energy_limits_consumer_API/manifest.yaml
@@ -8,6 +8,10 @@ config:
     description: "Interval between two heartbeat messages send by the API. Values <= 0 disable heartbeat."
     type: integer
     default: 1000
+  latch_variable_values:
+    description: "Determines whether variables published by this module are cached and made available for `get` requests."
+    type: boolean
+    default: true
 
 provides:
   main:

--- a/modules/API/EVerestAPI/ocpp_consumer_API/manifest.yaml
+++ b/modules/API/EVerestAPI/ocpp_consumer_API/manifest.yaml
@@ -14,6 +14,10 @@ config:
     default: 550
     minimum: 1
     maximum: 550
+  latch_variable_values:
+    description: "Determines whether variables published by this module are cached and made available for `get` requests."
+    type: boolean
+    default: true
 
 provides:
   main:

--- a/modules/API/EVerestAPI/ocpp_consumer_API/ocpp_consumer_API.cpp
+++ b/modules/API/EVerestAPI/ocpp_consumer_API/ocpp_consumer_API.cpp
@@ -31,16 +31,8 @@ void ocpp_consumer_API::init() {
     comm_params.communication_check_period_s = config.cfg_communication_check_to_s;
     comm_params.request_reply_timeout_s = config.cfg_request_reply_to_s;
     helper.init(comm_params);
-}
 
-void ocpp_consumer_API::ready() {
-    invoke_ready(*p_main);
-    invoke_ready(*p_generic_error);
-
-    generate_api_cmd_data_transfer();
-    generate_api_cmd_get_variables();
-    generate_api_cmd_set_variables();
-    generate_api_cmd_monitor_variables();
+    // setup var forwarding before modules start publishing
     generate_api_var_security_event();
     generate_api_var_is_connected();
     generate_api_var_boot_notification_response();
@@ -48,6 +40,17 @@ void ocpp_consumer_API::ready() {
     generate_api_var_event_data();
     generate_api_var_charging_schedules();
     generate_api_var_ocpp_message();
+}
+
+void ocpp_consumer_API::ready() {
+    invoke_ready(*p_main);
+    invoke_ready(*p_generic_error);
+
+    // setup commands now, as the target modules are ready
+    generate_api_cmd_data_transfer();
+    generate_api_cmd_get_variables();
+    generate_api_cmd_set_variables();
+    generate_api_cmd_monitor_variables();
 
     helper.generate_api_var_communication_check(&comm_check);
     comm_check.start(config.cfg_communication_check_to_s);
@@ -55,21 +58,12 @@ void ocpp_consumer_API::ready() {
     helper.publish_ready_beacon();
 }
 
-auto ocpp_consumer_API::forward_api_var(std::string const& var) {
-    using namespace API_types_ext;
-    using namespace API_generic;
-    const auto topic = helper.get_topics().everest_to_extern(var);
-    return [this, topic](auto const& val) {
-        try {
-            auto&& external = to_external_api(val);
-            auto&& payload = serialize(external);
-            mqtt_v.publish(topic, payload);
-        } catch (const std::exception& e) {
-            EVLOG_warning << "Variable: '" << topic << "' failed with -> " << e.what();
-        } catch (...) {
-            EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
-        }
-    };
+auto ocpp_consumer_API::forward_and_cache_api_var(std::string const& var) {
+    return helper.forward_and_cache_api_var(var, config.latch_variable_values, [](auto const& val) {
+        using namespace API_types_ext;
+        using namespace API_generic;
+        return serialize(to_external_api(val));
+    });
 }
 
 void ocpp_consumer_API::generate_api_cmd_data_transfer() {
@@ -136,31 +130,31 @@ void ocpp_consumer_API::generate_api_cmd_monitor_variables() {
 }
 
 void ocpp_consumer_API::generate_api_var_security_event() {
-    r_ocpp->subscribe_security_event(forward_api_var("security_event"));
+    r_ocpp->subscribe_security_event(forward_and_cache_api_var("security_event"));
 }
 
 void ocpp_consumer_API::generate_api_var_is_connected() {
-    r_ocpp->subscribe_is_connected(forward_api_var("is_connected"));
+    r_ocpp->subscribe_is_connected(forward_and_cache_api_var("is_connected"));
 }
 
 void ocpp_consumer_API::generate_api_var_boot_notification_response() {
-    r_ocpp->subscribe_boot_notification_response(forward_api_var("boot_notification_response"));
+    r_ocpp->subscribe_boot_notification_response(forward_and_cache_api_var("boot_notification_response"));
 }
 
 void ocpp_consumer_API::generate_api_var_ocpp_transaction_event() {
-    r_ocpp->subscribe_ocpp_transaction_event(forward_api_var("ocpp_transaction_event"));
+    r_ocpp->subscribe_ocpp_transaction_event(forward_and_cache_api_var("ocpp_transaction_event"));
 }
 
 void ocpp_consumer_API::generate_api_var_event_data() {
-    r_ocpp->subscribe_event_data(forward_api_var("event_data"));
+    r_ocpp->subscribe_event_data(forward_and_cache_api_var("event_data"));
 }
 
 void ocpp_consumer_API::generate_api_var_charging_schedules() {
-    r_ocpp->subscribe_charging_schedules(forward_api_var("charging_schedules"));
+    r_ocpp->subscribe_charging_schedules(forward_and_cache_api_var("charging_schedules"));
 }
 
 void ocpp_consumer_API::generate_api_var_ocpp_message() {
-    r_ocpp->subscribe_ocpp_message(forward_api_var("ocpp_message"));
+    r_ocpp->subscribe_ocpp_message(forward_and_cache_api_var("ocpp_message"));
 }
 
 } // namespace module

--- a/modules/API/EVerestAPI/ocpp_consumer_API/ocpp_consumer_API.hpp
+++ b/modules/API/EVerestAPI/ocpp_consumer_API/ocpp_consumer_API.hpp
@@ -34,6 +34,7 @@ struct Conf {
     int cfg_communication_check_to_s;
     int cfg_heartbeat_interval_ms;
     int cfg_request_reply_to_s;
+    bool latch_variable_values;
 };
 
 class ocpp_consumer_API : public Everest::ModuleBase {
@@ -76,7 +77,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    auto forward_api_var(std::string const& var);
+    auto forward_and_cache_api_var(std::string const& var);
 
     void generate_api_cmd_data_transfer();
     void generate_api_cmd_get_variables();

--- a/modules/API/EVerestAPI/session_cost_consumer_API/manifest.yaml
+++ b/modules/API/EVerestAPI/session_cost_consumer_API/manifest.yaml
@@ -8,6 +8,10 @@ config:
     description: "Interval between two heartbeat messages send by the API. Values <= 0 disable heartbeat."
     type: integer
     default: 1000
+  latch_variable_values:
+    description: "Determines whether variables published by this module are cached and made available for `get` requests."
+    type: boolean
+    default: true
 
 provides:
   main:

--- a/modules/API/EVerestAPI/session_cost_consumer_API/session_cost_consumer_API.cpp
+++ b/modules/API/EVerestAPI/session_cost_consumer_API/session_cost_consumer_API.cpp
@@ -24,14 +24,15 @@ void session_cost_consumer_API::init() {
     comm_params.heartbeat_period_ms = config.cfg_heartbeat_interval_ms;
     comm_params.communication_check_period_s = config.cfg_communication_check_to_s;
     helper.init(comm_params);
+
+    // setup var forwarding before modules start publishing
+    generate_api_var_tariff_message();
+    generate_api_var_session_cost();
+    generate_api_var_default_price();
 }
 
 void session_cost_consumer_API::ready() {
     invoke_ready(*p_main);
-
-    generate_api_var_tariff_message();
-    generate_api_var_session_cost();
-    generate_api_var_default_price();
 
     helper.generate_api_var_communication_check(&comm_check);
     comm_check.start(config.cfg_communication_check_to_s);
@@ -39,33 +40,24 @@ void session_cost_consumer_API::ready() {
     helper.publish_ready_beacon();
 }
 
-auto session_cost_consumer_API::forward_api_var(std::string const& var) {
-    using namespace API_types_ext;
-    using namespace API_generic;
-    const auto topic = helper.get_topics().everest_to_extern(var);
-    return [this, topic](auto const& val) {
-        try {
-            auto&& external = to_external_api(val);
-            auto&& payload = serialize(external);
-            mqtt_v.publish(topic, payload);
-        } catch (const std::exception& e) {
-            EVLOG_warning << "Variable: '" << topic << "' failed with -> " << e.what();
-        } catch (...) {
-            EVLOG_warning << "Invalid data: Cannot convert internal to external or serialize it.\n" << topic;
-        }
-    };
+auto session_cost_consumer_API::forward_and_cache_api_var(std::string const& var) {
+    return helper.forward_and_cache_api_var(var, config.latch_variable_values, [](auto const& val) {
+        using namespace API_types_ext;
+        using namespace API_generic;
+        return serialize(to_external_api(val));
+    });
 }
 
 void session_cost_consumer_API::generate_api_var_tariff_message() {
-    r_session_cost->subscribe_tariff_message(forward_api_var("tariff_message"));
+    r_session_cost->subscribe_tariff_message(forward_and_cache_api_var("tariff_message"));
 }
 
 void session_cost_consumer_API::generate_api_var_session_cost() {
-    r_session_cost->subscribe_session_cost(forward_api_var("session_cost"));
+    r_session_cost->subscribe_session_cost(forward_and_cache_api_var("session_cost"));
 }
 
 void session_cost_consumer_API::generate_api_var_default_price() {
-    r_session_cost->subscribe_default_price(forward_api_var("default_price"));
+    r_session_cost->subscribe_default_price(forward_and_cache_api_var("default_price"));
 }
 
 } // namespace module

--- a/modules/API/EVerestAPI/session_cost_consumer_API/session_cost_consumer_API.hpp
+++ b/modules/API/EVerestAPI/session_cost_consumer_API/session_cost_consumer_API.hpp
@@ -31,6 +31,7 @@ namespace module {
 struct Conf {
     int cfg_communication_check_to_s;
     int cfg_heartbeat_interval_ms;
+    bool latch_variable_values;
 };
 
 class session_cost_consumer_API : public Everest::ModuleBase {
@@ -68,7 +69,7 @@ private:
 
     // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
     // insert your private definitions here
-    auto forward_api_var(std::string const& var);
+    auto forward_and_cache_api_var(std::string const& var);
 
     void generate_api_var_tariff_message();
     void generate_api_var_session_cost();


### PR DESCRIPTION
## Describe your changes
Allow API clients to actively request the most recent value of a variable.
If for a variable no value had been published yet, the API will respond with a null value.

This change only manifests in the *_consumer_API modules as they are the
ones providing variables to the API clients.

### Implementation

The `everest_api_module_helpers` lib implements `ApiHelper::forward_and_cache_api_var(...)`.
It is a drop-in replacement for the `forward_api_var(...)` function formerly implemented in each module.

It caches the serialized value and sets up a command handler to send it to a client on request.

### Example Usage

Use the existing DC SIL to test:

`$ ./run-scripts/run-sil-dc-consumer-api.sh`
`$ ./run-scripts/nodered-sil-dc.sh`

Send

`'{"headers": { "replyTo": "my/replyTopic" } }'`
to
`"everest_api/1/evse_manager_consumer/evse_manager_api/m2e/evse_id/get"`

and monitor `"my/replyTopic"` to receive the value.

### Configuration

The modified API modules have a new boolean `latch_variable_values` config option which can be used to
turn latching `off` (default is `on`).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

