### PR TITLE
[OCPP1.6] AuthorizationCacheEnabled: check the value, not just presence

### DIFF
--- a/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/everest/ocpp/lib/ocpp/v16/charge_point_impl.cpp
@@ -2066,7 +2066,7 @@ void ChargePointImpl::handleClearCacheRequest(ocpp::Call<ClearCacheRequest> call
 
     ClearCacheResponse response;
 
-    if (this->configuration.getAuthorizationCacheEnabled()) {
+    if (this->configuration.getAuthorizationCacheEnabled().value_or(false)) {
         try {
             this->database_handler->clear_authorization_cache();
             response.status = ClearCacheStatus::Accepted;
@@ -3539,7 +3539,7 @@ EnhancedIdTagInfo ChargePointImpl::authorize_id_token(CiString<20> id_token, con
             }
         }
 
-        if (this->configuration.getAuthorizationCacheEnabled()) {
+        if (this->configuration.getAuthorizationCacheEnabled().value_or(false)) {
             if (this->validate_against_cache_entries(id_token)) {
                 try {
                     const auto auth_cache_entry = this->database_handler->get_authorization_cache_entry(id_token);


### PR DESCRIPTION
## Problem

`ChargePointConfiguration::getAuthorizationCacheEnabled()` (OCPP 1.6) returns `std::optional<bool>`, modelling the spec's three states: key absent = cache unsupported, key present = supported, and the bool value = enabled/disabled.

Two call sites in `lib/ocpp/v16/charge_point_impl.cpp` (`handleClearCacheRequest` and `authorize_id_token`) evaluate the optional directly in a boolean context — i.e. they test `has_value()` (presence), not the contained value. As a result, a configuration with `AuthorizationCacheEnabled` **present and set to `false`** still enables the Authorization Cache (ClearCache is accepted, cache lookups run). Only an *absent* key disables it, which contradicts the schema's own description ("If it is set to true the feature is enabled").

## Fix

Use `.value_or(false)` at both call sites, so an explicit `false` disables the cache and an absent key stays off.

## How it was found

Contributed by the **Enteligent team**. Surfaced while implementing a host-side toggle of `AuthorizationCacheEnabled`: publishing `false` did not disable the cache because presence alone re-enabled it.
