### PR TITLE
fix(libiso15118): Correct size handling in CB2CPP_BYTES macro

### DIFF
--- a/lib/everest/iso15118/include/iso15118/detail/cb_exi.hpp
+++ b/lib/everest/iso15118/include/iso15118/detail/cb_exi.hpp
@@ -2,6 +2,7 @@
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include <algorithm>
 #include <stdexcept>
 
 #include <cbv2g/common/exi_bitstream.h>
@@ -28,7 +29,7 @@
     if (in.bytesLen > out.size()) {                                                                                    \
         throw std::runtime_error("Byte array too long");                                                               \
     }                                                                                                                  \
-    std::copy(std::begin(in.bytes), std::end(in.bytes), out.begin());
+    std::copy_n(std::begin(in.bytes), in.bytesLen, std::begin(out));
 
 #define CB_SET_USED(property) (property##_isUsed = 1)
 #define CB2CPP_ASSIGN_IF_USED(in, out)                                                                                 \

--- a/lib/everest/iso15118/include/iso15118/message/common_types.hpp
+++ b/lib/everest/iso15118/include/iso15118/message/common_types.hpp
@@ -29,8 +29,9 @@ using Description = std::string; // MaxLength: 160
 static constexpr auto SESSION_ID_LENGTH = 8;
 using SessionId = std::array<uint8_t, SESSION_ID_LENGTH>;
 
-using MeterId = std::string;        // MaxLength: 32
-using MeterSignature = std::string; // Base64 encoded, MaxLength: 64
+using MeterId = std::string; // MaxLength: 32
+static constexpr auto METER_SIGNATURE_LENGTH = 64;
+using MeterSignature = std::array<uint8_t, METER_SIGNATURE_LENGTH>; // Base64 encoded, MaxLength: 64
 
 static constexpr auto GEN_CHALLENGE_LENGTH = 16;
 using GenChallenge = std::array<uint8_t, GEN_CHALLENGE_LENGTH>; // Base64 encoded, MaxLength: 16


### PR DESCRIPTION
## Describe your changes
- CB2CPP_BYTES macro should now use the correct size of the input buffer.
- Changed MeterSignature type to std::array

## Issue ticket number and link
When copying cb buffer into cpp buffer then it could happen that the input size were not correct.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

