### PR TITLE
fix(EvseManager): make SessionLog::output() thread-safe (torn eventlog.csv rows)

### DIFF
--- a/modules/EVSE/EvseManager/SessionLog.cpp
+++ b/modules/EVSE/EvseManager/SessionLog.cpp
@@ -193,6 +193,7 @@ void SessionLog::car(bool iso15118, const std::string& msg, const std::string& x
 
 void SessionLog::output(unsigned int typ, bool iso15118, const std::string& msg, const std::string& xml,
                         const std::string& xml_hex, const std::string& xml_base64, const std::string& json_str) {
+    const std::lock_guard<std::mutex> lock(output_mutex);
     if (enabled && session_active) {
         std::string ts = Everest::Date::to_rfc3339(date::utc_clock::now());
 

--- a/modules/EVSE/EvseManager/SessionLog.hpp
+++ b/modules/EVSE/EvseManager/SessionLog.hpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <mutex>
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 #include <string>
@@ -52,6 +53,9 @@ private:
 
     std::ofstream logfile_csv;
     std::ofstream logfile_html;
+    // Serialises concurrent output() writes from the EVSE/CAR/SYS event
+    // threads; std::ofstream::operator<< is not thread-safe.
+    std::mutex output_mutex;
     mqtt_publish_ftor mqtt;
 };
 


### PR DESCRIPTION
## Describe your changes

`SessionLog::output()` in `EvseManager` appends each event to the per-session `eventlog.csv` / `eventlog.html` via `std::ofstream::operator<<` + `flush()` with no synchronisation, but is reached concurrently from the EVSE, CAR and SYS event threads (through `evse()` / `car()` / `sys()`). `std::ofstream::operator<<` is not thread-safe, so two near-simultaneous calls interleave at the byte level, producing a CSV record cut off mid-value with the next record's bytes on the same line. Such rows lose their canonical four fields and break downstream parsers of `eventlog.csv`. (`flush()` doesn't help — it only pushes the buffer to disk, it doesn't serialise the writes.)

**Fix:** add a `std::mutex` to `SessionLog` and take a `std::lock_guard` at the top of `output()` so each record is emitted atomically. The lock is taken only in `output()`; `startSession()` / `stopSession()` reach the writes via `sys()` → `output()`, so there's no self-recursion. No API or behaviour change.

## Issue ticket number and link

N/A — reported and fixed by the Enteligent team from corrupted session logs seen in the field.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (none required)
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
