### PR TITLE
feat(EvseManagerSimulator): Add new EvseManagerSimulator module

### DIFF
--- a/modules/Simulation/CMakeLists.txt
+++ b/modules/Simulation/CMakeLists.txt
@@ -1,4 +1,5 @@
 ev_add_module(DCSupplySimulator)
+ev_add_module(EvseManagerSimulator)
 ev_add_module(ManagerLifecycleSimulator)
 ev_add_module(IMDSimulator)
 ev_add_module(OVMSimulator)

--- a/modules/Simulation/EvseManagerSimulator/BUILD.bazel
+++ b/modules/Simulation/EvseManagerSimulator/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//modules:module.bzl", "cc_everest_module")
+
+cc_everest_module(
+    name = "EvseManagerSimulator",
+    impls = [
+        "energy_grid",
+        "evse",
+    ],
+)

--- a/modules/Simulation/EvseManagerSimulator/CMakeLists.txt
+++ b/modules/Simulation/EvseManagerSimulator/CMakeLists.txt
@@ -1,0 +1,22 @@
+#
+# AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+# template version 3
+#
+
+# module setup:
+#   - ${MODULE_NAME}: module name
+ev_setup_cpp_module()
+
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+# insert your custom targets and additional config variables here
+# ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
+
+target_sources(${MODULE_NAME}
+    PRIVATE
+        "evse/evse_managerImpl.cpp"
+        "energy_grid/energyImpl.cpp"
+)
+
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1
+# insert other things like install cmds etc here
+# ev@c55432ab-152c-45a9-9d2e-7281d50c69c3:v1

--- a/modules/Simulation/EvseManagerSimulator/EvseManagerSimulator.cpp
+++ b/modules/Simulation/EvseManagerSimulator/EvseManagerSimulator.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#include "EvseManagerSimulator.hpp"
+
+namespace module {
+
+void EvseManagerSimulator::init() {
+    invoke_init(*p_evse);
+    invoke_init(*p_energy_grid);
+}
+
+void EvseManagerSimulator::ready() {
+    invoke_ready(*p_evse);
+    invoke_ready(*p_energy_grid);
+}
+
+} // namespace module

--- a/modules/Simulation/EvseManagerSimulator/EvseManagerSimulator.hpp
+++ b/modules/Simulation/EvseManagerSimulator/EvseManagerSimulator.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef EVSE_MANAGER_SIMULATOR_HPP
+#define EVSE_MANAGER_SIMULATOR_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 2
+//
+
+#include "ld-ev.hpp"
+
+// headers for provided interface implementations
+#include <generated/interfaces/energy/Implementation.hpp>
+#include <generated/interfaces/evse_manager/Implementation.hpp>
+
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+// insert your custom include headers here
+// ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
+
+namespace module {
+
+struct Conf {};
+
+class EvseManagerSimulator : public Everest::ModuleBase {
+public:
+    EvseManagerSimulator() = delete;
+    EvseManagerSimulator(const ModuleInfo& info, std::unique_ptr<evse_managerImplBase> p_evse,
+                         std::unique_ptr<energyImplBase> p_energy_grid, Conf& config) :
+        ModuleBase(info), p_evse(std::move(p_evse)), p_energy_grid(std::move(p_energy_grid)), config(config){};
+
+    const std::unique_ptr<evse_managerImplBase> p_evse;
+    const std::unique_ptr<energyImplBase> p_energy_grid;
+    const Conf& config;
+
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+    // insert your public definitions here
+    // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
+
+protected:
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+    // insert your protected definitions here
+    // ev@4714b2ab-a24f-4b95-ab81-36439e1478de:v1
+
+private:
+    friend class LdEverest;
+    void init();
+    void ready();
+
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+    // insert your private definitions here
+    // ev@211cfdbe-f69a-4cd6-a4ec-f8aaa3d1b6c8:v1
+};
+
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+// insert other definitions here
+// ev@087e516b-124c-48df-94fb-109508c7cda9:v1
+
+} // namespace module
+
+#endif // EVSE_MANAGER_SIMULATOR_HPP

--- a/modules/Simulation/EvseManagerSimulator/docs/index.rst
+++ b/modules/Simulation/EvseManagerSimulator/docs/index.rst
@@ -1,0 +1,24 @@
+.. _everest_modules_handwritten_EvseManagerSimulator:
+
+..  This file is a placeholder for optional multiple files
+    handwritten documentation for the EvseManagerSimulator module.
+    
+..  This handwritten documentation is optional. In case
+    you do not want to write it, you can delete the doc/ directory.
+
+..  The documentation can be written in reStructuredText,
+    and will be converted to HTML and PDF by Sphinx.
+    This index.rst file is the entry point for the module documentation.
+
+..  Use underlined-only headlines inside this document (highest-level
+    sub-section headline should use "=" characters)
+
+..  The content of this file will be included in the auto-generated HTML
+    page for the module. You can link to it using the following
+    reference: everest_modules_EvseManagerSimulator.
+
+.. *******************************************
+.. EvseManagerSimulator
+.. *******************************************
+
+EvseManager Simulator

--- a/modules/Simulation/EvseManagerSimulator/energy_grid/energyImpl.cpp
+++ b/modules/Simulation/EvseManagerSimulator/energy_grid/energyImpl.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "energyImpl.hpp"
+
+namespace module {
+namespace energy_grid {
+
+void energyImpl::init() {
+}
+
+void energyImpl::ready() {
+}
+
+void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
+    // your code for cmd enforce_limits goes here
+}
+
+} // namespace energy_grid
+} // namespace module

--- a/modules/Simulation/EvseManagerSimulator/energy_grid/energyImpl.hpp
+++ b/modules/Simulation/EvseManagerSimulator/energy_grid/energyImpl.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef ENERGY_GRID_ENERGY_IMPL_HPP
+#define ENERGY_GRID_ENERGY_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/energy/Implementation.hpp>
+
+#include "../EvseManagerSimulator.hpp"
+
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+// insert your custom include headers here
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+
+namespace module {
+namespace energy_grid {
+
+struct Conf {};
+
+class energyImpl : public energyImplBase {
+public:
+    energyImpl() = delete;
+    energyImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<EvseManagerSimulator>& mod, Conf& config) :
+        energyImplBase(ev, "energy_grid"), mod(mod), config(config){};
+
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+    // insert your public definitions here
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+
+protected:
+    // command handler functions (virtual)
+    virtual void handle_enforce_limits(types::energy::EnforcedLimits& value) override;
+
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+    // insert your protected definitions here
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+
+private:
+    const Everest::PtrContainer<EvseManagerSimulator>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+    // insert your private definitions here
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+};
+
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+// insert other definitions here
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+
+} // namespace energy_grid
+} // namespace module
+
+#endif // ENERGY_GRID_ENERGY_IMPL_HPP

--- a/modules/Simulation/EvseManagerSimulator/evse/evse_managerImpl.cpp
+++ b/modules/Simulation/EvseManagerSimulator/evse/evse_managerImpl.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "evse_managerImpl.hpp"
+
+namespace module {
+namespace evse {
+
+void evse_managerImpl::init() {
+}
+
+void evse_managerImpl::ready() {
+    types::evse_manager::SessionEvent se;
+    se.event = types::evse_manager::SessionEventEnum::Enabled;
+    se.timestamp = Everest::Date::to_rfc3339(date::utc_clock::now());
+    publish_session_event(se);
+    publish_waiting_for_external_ready(true);
+}
+
+types::evse_manager::Evse evse_managerImpl::handle_get_evse() {
+    types::evse_manager::Evse evse;
+    evse.id = 1;
+
+    types::evse_manager::Connector connector;
+    connector.id = 1;
+
+    if (const auto& mapping = get_mapping(); mapping.has_value()) {
+        evse.id = mapping->evse;
+        if (mapping->connector.has_value()) {
+            connector.id = mapping->connector.value();
+        }
+    }
+
+    evse.connectors = {connector};
+    return evse;
+}
+
+bool evse_managerImpl::handle_enable_disable(int& connector_id, types::evse_manager::EnableDisableSource& cmd_source) {
+    // your code for cmd enable_disable goes here
+    return true;
+}
+
+void evse_managerImpl::handle_authorize_response(types::authorization::ProvidedIdToken& provided_token,
+                                                 types::authorization::ValidationResult& validation_result) {
+    // your code for cmd authorize_response goes here
+}
+
+void evse_managerImpl::handle_withdraw_authorization() {
+    // your code for cmd withdraw_authorization goes here
+}
+
+bool evse_managerImpl::handle_reserve(int& reservation_id) {
+    // your code for cmd reserve goes here
+    return true;
+}
+
+void evse_managerImpl::handle_cancel_reservation() {
+    // your code for cmd cancel_reservation goes here
+}
+
+bool evse_managerImpl::handle_pause_charging() {
+    // your code for cmd pause_charging goes here
+    return true;
+}
+
+bool evse_managerImpl::handle_resume_charging() {
+    // your code for cmd resume_charging goes here
+    return true;
+}
+
+bool evse_managerImpl::handle_stop_transaction(types::evse_manager::StopTransactionRequest& request) {
+    // your code for cmd stop_transaction goes here
+    return true;
+}
+
+bool evse_managerImpl::handle_force_unlock(int& connector_id) {
+    // your code for cmd force_unlock goes here
+    return true;
+}
+
+bool evse_managerImpl::handle_external_ready_to_start_charging() {
+    publish_ready(true);
+    return true;
+}
+
+void evse_managerImpl::handle_set_plug_and_charge_configuration(
+    types::evse_manager::PlugAndChargeConfiguration& plug_and_charge_configuration) {
+    // your code for cmd set_plug_and_charge_configuration goes here
+}
+
+types::evse_manager::UpdateAllowedEnergyTransferModesResult
+evse_managerImpl::handle_update_allowed_energy_transfer_modes(
+    std::vector<types::iso15118::EnergyTransferMode>& allowed_energy_transfer_modes) {
+    // your code for cmd update_allowed_energy_transfer_modes goes here
+    return types::evse_manager::UpdateAllowedEnergyTransferModesResult::NoHlc;
+
+    types::evse_manager::SetDerAvailableResult evse_managerImpl::handle_set_der_available(bool& available) {
+        // your code for cmd set_der_available goes here
+        return types::evse_manager::SetDerAvailableResult::Accepted;
+    }
+
+} // namespace evse
+} // namespace module

--- a/modules/Simulation/EvseManagerSimulator/evse/evse_managerImpl.cpp
+++ b/modules/Simulation/EvseManagerSimulator/evse/evse_managerImpl.cpp
@@ -93,11 +93,12 @@ evse_managerImpl::handle_update_allowed_energy_transfer_modes(
     std::vector<types::iso15118::EnergyTransferMode>& allowed_energy_transfer_modes) {
     // your code for cmd update_allowed_energy_transfer_modes goes here
     return types::evse_manager::UpdateAllowedEnergyTransferModesResult::NoHlc;
+}
 
-    types::evse_manager::SetDerAvailableResult evse_managerImpl::handle_set_der_available(bool& available) {
-        // your code for cmd set_der_available goes here
-        return types::evse_manager::SetDerAvailableResult::Accepted;
-    }
+types::evse_manager::SetDerAvailableResult evse_managerImpl::handle_set_der_available(bool& available) {
+    // your code for cmd set_der_available goes here
+    return types::evse_manager::SetDerAvailableResult::Accepted;
+}
 
 } // namespace evse
 } // namespace module

--- a/modules/Simulation/EvseManagerSimulator/evse/evse_managerImpl.hpp
+++ b/modules/Simulation/EvseManagerSimulator/evse/evse_managerImpl.hpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+#ifndef EVSE_EVSE_MANAGER_IMPL_HPP
+#define EVSE_EVSE_MANAGER_IMPL_HPP
+
+//
+// AUTO GENERATED - MARKED REGIONS WILL BE KEPT
+// template version 3
+//
+
+#include <generated/interfaces/evse_manager/Implementation.hpp>
+
+#include "../EvseManagerSimulator.hpp"
+
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+// insert your custom include headers here
+// ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
+
+namespace module {
+namespace evse {
+
+struct Conf {};
+
+class evse_managerImpl : public evse_managerImplBase {
+public:
+    evse_managerImpl() = delete;
+    evse_managerImpl(Everest::ModuleAdapter* ev, const Everest::PtrContainer<EvseManagerSimulator>& mod, Conf& config) :
+        evse_managerImplBase(ev, "evse"), mod(mod), config(config){};
+
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+    // insert your public definitions here
+    // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
+
+protected:
+    // command handler functions (virtual)
+    virtual types::evse_manager::Evse handle_get_evse() override;
+    virtual bool handle_enable_disable(int& connector_id,
+                                       types::evse_manager::EnableDisableSource& cmd_source) override;
+    virtual void handle_authorize_response(types::authorization::ProvidedIdToken& provided_token,
+                                           types::authorization::ValidationResult& validation_result) override;
+    virtual void handle_withdraw_authorization() override;
+    virtual bool handle_reserve(int& reservation_id) override;
+    virtual void handle_cancel_reservation() override;
+    virtual bool handle_pause_charging() override;
+    virtual bool handle_resume_charging() override;
+    virtual bool handle_stop_transaction(types::evse_manager::StopTransactionRequest& request) override;
+    virtual bool handle_force_unlock(int& connector_id) override;
+    virtual bool handle_external_ready_to_start_charging() override;
+    virtual void handle_set_plug_and_charge_configuration(
+        types::evse_manager::PlugAndChargeConfiguration& plug_and_charge_configuration) override;
+    virtual types::evse_manager::UpdateAllowedEnergyTransferModesResult handle_update_allowed_energy_transfer_modes(
+        std::vector<types::iso15118::EnergyTransferMode>& allowed_energy_transfer_modes) override;
+    virtual types::evse_manager::SetDerAvailableResult handle_set_der_available(bool& available) override;
+
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+    // insert your protected definitions here
+    // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
+
+private:
+    const Everest::PtrContainer<EvseManagerSimulator>& mod;
+    const Conf& config;
+
+    virtual void init() override;
+    virtual void ready() override;
+
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+    // insert your private definitions here
+    // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
+};
+
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+// insert other definitions here
+// ev@3d7da0ad-02c2-493d-9920-0bbbd56b9876:v1
+
+} // namespace evse
+} // namespace module
+
+#endif // EVSE_EVSE_MANAGER_IMPL_HPP

--- a/modules/Simulation/EvseManagerSimulator/manifest.yaml
+++ b/modules/Simulation/EvseManagerSimulator/manifest.yaml
@@ -1,0 +1,12 @@
+description: EvseManager Simulator module
+provides:
+  evse:
+    interface: evse_manager
+    description: This is the main evsemanager interface
+  energy_grid:
+    description: This is the tree leaf interface to build the energy supply tree
+    interface: energy
+metadata:
+  license: https://opensource.org/licenses/Apache-2.0
+  authors:
+    - Piet Gömpel (Pionix GmbH)


### PR DESCRIPTION

## Describe your changes

Add new EvseManagerSimulator module that implements a stub for evse_manager.yaml and energy.yaml interface. This module can potentially be extended in the future to support simulated control of an EvseManager (e.g. for tests) without the overhead of the production EvseManager module.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

