### PR TITLE
EvseManager: skip calculation of limits if no. of phases is unknown

### DIFF
--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -387,8 +387,19 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
         // EVLOG_info << "Incoming enforce limits" << value;
 
         //   set hardware limit
+        const int active_phasecount = mod->ac_nr_phases_active;
+
+        static bool warning_shown{false};
+        if (active_phasecount == 0) {
+            if (not warning_shown) {
+                EVLOG_warning << "Number of active phases is still uninitialized, skipping limits calculation "
+                                 "while waiting for BSP";
+                warning_shown = true;
+            }
+            return;
+        }
+
         float limit = 0.;
-        int active_phasecount = mod->ac_nr_phases_active;
 
         // apply enforced limits
 


### PR DESCRIPTION
The number of phases needs to be set via the `evse_board_support` interface before using them.

Fixes a potential division by zero.

Fixes https://github.com/EVerest/EVerest/issues/2469 .

## Describe your changes

Exit hander early if no. of phases is not valid.

Tested with SIL and YetiSimulator, the latter with an additional forced delay before publishing its capabilities.

## Issue ticket number and link
Fixes:
https://github.com/EVerest/EVerest/issues/2469

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

