### PR TITLE
EVerest::tls does not need framework as dependency

### DIFF
--- a/cmake/ev-lib-dependencies.cmake
+++ b/cmake/ev-lib-dependencies.cmake
@@ -63,14 +63,14 @@ set(EVEREST_LIB_DEPS_evse_security "log;timer")
 set(EVEREST_LIB_DEPS_ocpp "log;timer;evse_security;sqlite;util")
 set(EVEREST_LIB_DEPS_iso15118 "cbv2g;util;tls")
 set(EVEREST_LIB_DEPS_ieee2030_1_1 "util")
+set(EVEREST_LIB_DEPS_tls "util;evse_security")
+set(EVEREST_LIB_DEPS_slac "tls;fsm")
 # Tier 3 (framework-coupled)
-set(EVEREST_LIB_DEPS_tls "util;evse_security;framework")
 set(EVEREST_LIB_DEPS_helpers "tls;framework")
 set(EVEREST_LIB_DEPS_external_energy_limits "framework")
 set(EVEREST_LIB_DEPS_everest_api_types "")
 set(EVEREST_LIB_DEPS_conversions "framework;evse_security")
 set(EVEREST_LIB_DEPS_ocpp_module_common "ocpp;conversions;framework")
-set(EVEREST_LIB_DEPS_slac "tls")
 
 # --- Transitive dependency resolver ---
 # Given a list of library names, computes the full transitive closure


### PR DESCRIPTION
## Describe your changes
Removing framework dependency when building only tls or other libraries that depend on tls

## Issue ticket number and link
See title

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

