### PR TITLE
Chore: Only install tls if TLS_INSTALL is set (non-EDM-build)

### DIFF
--- a/lib/everest/tls/CMakeLists.txt
+++ b/lib/everest/tls/CMakeLists.txt
@@ -41,7 +41,7 @@ if(EVEREST_CORE_BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
-if(DISABLE_EDM)
+if(DISABLE_EDM AND TLS_INSTALL)
     install(
         TARGETS
             tls


### PR DESCRIPTION
## Describe your changes

Unconditional CMake install declarations in the tls-lib prevented successfull non-EDM-builds for some libs.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

