### PR TITLE
fix(ocpp): make DER device model components opt-in

### DIFF
--- a/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/everest_device_model_storage.hpp
+++ b/lib/everest/ocpp_module_common/include/everest/ocpp_module_common/device_model/everest_device_model_storage.hpp
@@ -50,13 +50,16 @@ void disable_der_ctrlr(ocpp::v2::DeviceModelStorageInterface& storage, int32_t e
 
 class EverestDeviceModelStorage : public ocpp::v2::DeviceModelStorageInterface {
 public:
+    /// \param with_der_components When true, DER-capable EVSEs get a DCDERCtrlr/ACDERCtrlr component. Pass true
+    ///        only if the module implements der_active_directives_callback: a present DER component makes that
+    ///        callback mandatory in ocpp::v2::Callbacks::all_callbacks_valid.
     EverestDeviceModelStorage(
         const std::vector<std::unique_ptr<evse_managerIntf>>& r_evse_manager,
         const std::vector<std::unique_ptr<iso15118_extensionsIntf>>& r_extensions_15118,
         const std::map<int32_t, types::evse_board_support::HardwareCapabilities>& evse_hardware_capabilities_map,
         const std::map<int32_t, std::vector<types::iso15118::EnergyTransferMode>>& evse_supported_energy_transfers,
-        const std::map<int32_t, bool>& evse_service_renegotiation_supported, const std::filesystem::path& db_path,
-        const std::filesystem::path& migration_files_path,
+        const std::map<int32_t, bool>& evse_service_renegotiation_supported, const bool with_der_components,
+        const std::filesystem::path& db_path, const std::filesystem::path& migration_files_path,
         std::shared_ptr<Everest::config::ConfigServiceClient> config_service_client);
     virtual ~EverestDeviceModelStorage() override = default;
     virtual ocpp::v2::DeviceModelMap get_device_model() override;

--- a/lib/everest/ocpp_module_common/src/device_model/everest_device_model_storage.cpp
+++ b/lib/everest/ocpp_module_common/src/device_model/everest_device_model_storage.cpp
@@ -544,8 +544,8 @@ EverestDeviceModelStorage::EverestDeviceModelStorage(
     const std::vector<std::unique_ptr<iso15118_extensionsIntf>>& r_extensions_15118,
     const std::map<int32_t, types::evse_board_support::HardwareCapabilities>& evse_hardware_capabilities_map,
     const std::map<int32_t, std::vector<types::iso15118::EnergyTransferMode>>& evse_supported_energy_transfers,
-    const std::map<int32_t, bool>& evse_service_renegotiation_supported, const std::filesystem::path& db_path,
-    const std::filesystem::path& migration_files_path,
+    const std::map<int32_t, bool>& evse_service_renegotiation_supported, const bool with_der_components,
+    const std::filesystem::path& db_path, const std::filesystem::path& migration_files_path,
     std::shared_ptr<Everest::config::ConfigServiceClient> config_service_client) :
     r_evse_manager(r_evse_manager),
     r_extensions_15118(r_extensions_15118),
@@ -586,9 +586,11 @@ EverestDeviceModelStorage::EverestDeviceModelStorage(
         const auto connected_ev_component_key = get_connected_ev_component_key(evse_info.id);
         component_configs[connected_ev_component_key] = build_connected_ev_variables();
 
-        auto der_ctrlr_config = build_der_ctrlr_component_config(evse_info.id, supported_energy_transfer_modes);
-        if (der_ctrlr_config.has_value()) {
-            component_configs[der_ctrlr_config->first] = std::move(der_ctrlr_config->second);
+        if (with_der_components) {
+            auto der_ctrlr_config = build_der_ctrlr_component_config(evse_info.id, supported_energy_transfer_modes);
+            if (der_ctrlr_config.has_value()) {
+                component_configs[der_ctrlr_config->first] = std::move(der_ctrlr_config->second);
+            }
         }
     }
     for (const auto& extension : r_extensions_15118) {

--- a/modules/EVSE/OCPP201/OCPP201.cpp
+++ b/modules/EVSE/OCPP201/OCPP201.cpp
@@ -1012,10 +1012,12 @@ void OCPP201::ready() {
         device_model_database_path, device_model_database_migration_path, device_model_config_path);
 
     // initialize everest device model
+    // no DER components: this module does not implement der_active_directives_callback (DER is OCPPmulti-only)
     this->everest_device_model_storage = std::make_shared<device_model::EverestDeviceModelStorage>(
         r_evse_manager, r_extensions_15118, this->evse_hardware_capabilities_map,
         this->evse_supported_energy_transfer_modes, this->evse_service_renegotiation_supported,
-        everest_device_model_database_path, device_model_database_migration_path, get_config_service_client());
+        /*with_der_components=*/false, everest_device_model_database_path, device_model_database_migration_path,
+        get_config_service_client());
 
     // initialize composed device model, this will be provided to the ChargePoint constructor
     auto composed_device_model_storage = std::make_unique<module::device_model::ComposedDeviceModelStorage>();

--- a/modules/EVSE/OCPPmulti/generic_ocpp.cpp
+++ b/modules/EVSE/OCPPmulti/generic_ocpp.cpp
@@ -413,7 +413,8 @@ void GenericOcpp::ready(const ConfigServiceClient& client) {
         m_everest_device_model_storage = std::make_shared<module::device_model::EverestDeviceModelStorage>(
             mv_requires.evse_manager, mv_requires.extensions_15118, m_evse_hardware_capabilities_map,
             m_evse_supported_energy_transfer_modes, m_evse_service_renegotiation_supported,
-            everest_device_model_database_path, device_model_database_migration_path, client);
+            /*with_der_components=*/true, everest_device_model_database_path, device_model_database_migration_path,
+            client);
     }
 
     // clang-format off


### PR DESCRIPTION

## Describe your changes

EverestDeviceModelStorage injects a DCDERCtrlr/ACDERCtrlr component for every DER-capable EVSE, and a present DER component makes der_active_directives_callback mandatory in Callbacks:: all_callbacks_valid. The legacy OCPP201 module does not implement that callback, so on any DC_BPT-capable config (SIL DC simulators default to bidirectional) the ChargePoint constructor threw and the charge point never connected, failing the PnC and ocpp21 bidirectional test sets on the legacy variant.

Gate the injection behind a with_der_components constructor flag: OCPPmulti passes true (behavior unchanged), OCPP201 passes false, restoring its pre-DER device model.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

