### PR TITLE
fix(Auth): publish Withdrawn for granted authorizations

### DIFF
--- a/modules/EVSE/Auth/lib/AuthHandler.cpp
+++ b/modules/EVSE/Auth/lib/AuthHandler.cpp
@@ -1037,6 +1037,15 @@ WithdrawAuthorizationResult AuthHandler::handle_withdraw_authorization(const Wit
             this->stop_transaction_callback(evse.evse_index, req);
         } else {
             this->withdraw_authorization_callback(evse.evse_index);
+            if (evse.identifier.has_value()) {
+                const auto& identifier = evse.identifier.value();
+                ProvidedIdToken provided_token;
+                provided_token.id_token = identifier.id_token;
+                provided_token.authorization_type = identifier.type;
+                provided_token.parent_id_token = identifier.parent_id_token;
+                provided_token.connectors = std::vector<int32_t>{evse.evse_id};
+                this->publish_token_validation_status(provided_token, TokenValidationStatus::Withdrawn);
+            }
         }
     };
 

--- a/modules/EVSE/Auth/tests/auth_tests.cpp
+++ b/modules/EVSE/Auth/tests/auth_tests.cpp
@@ -1791,6 +1791,8 @@ TEST_F(AuthTest, test_withdraw_authorization) {
                 Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Accepted));
     EXPECT_CALL(mock_publish_token_validation_status_callback,
                 Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::UsedToStart));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Withdrawn));
     EXPECT_CALL(mock_withdraw_authorization_callback_mock, Call(0)).Times(1);
     EXPECT_CALL(mock_stop_transaction_callback, Call(_, _)).Times(0);
 
@@ -2257,6 +2259,8 @@ TEST_F(AuthTest, test_case_insensitive_withdraw_authorization) {
                 Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Accepted));
     EXPECT_CALL(mock_publish_token_validation_status_callback,
                 Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::UsedToStart));
+    EXPECT_CALL(mock_publish_token_validation_status_callback,
+                Call(Field(&ProvidedIdToken::id_token, provided_token.id_token), TokenValidationStatus::Withdrawn));
     EXPECT_CALL(mock_withdraw_authorization_callback_mock, Call(0)).Times(1);
 
     const auto result = this->auth_handler->on_token(provided_token);


### PR DESCRIPTION

## Describe your changes

Withdrawn was only published for tokens still in process. Withdrawing an already granted authorization invoked the withdraw callback without publishing any token validation status. Publish it from the EVSE's stored identifier, mirroring the TimedOut publish on timeout.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

