### PR TITLE
fix(CarloGavazzi_EM580): sync time only if meter support transactions

### DIFF
--- a/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/main/powermeterImpl.cpp
+++ b/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/main/powermeterImpl.cpp
@@ -1113,6 +1113,10 @@ void powermeterImpl::time_sync_thread() {
         if (stop_requested_.load()) {
             break;
         }
+        if (!m_transaction_support) {
+            EVLOG_debug << "Time synchronization skipped: meter model does not support transactions";
+            break;
+        }
 
         if (!is_transaction_active()) {
             // No active transaction, perform time sync immediately


### PR DESCRIPTION
## Describe your changes
Since time sync is only possible for meters with transaction support, skip this step and avoid communication timeouts.

## Issue ticket number and link
#2500

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

