### PR TITLE
yocto: Add missing TLS_INSTALL=ON to scarthgap and kirkstone recipes

### DIFF
--- a/yocto/kirkstone/meta-everest/recipes-core/everest/everest-core_git.bb
+++ b/yocto/kirkstone/meta-everest/recipes-core/everest/everest-core_git.bb
@@ -57,6 +57,7 @@ EXTRA_OECMAKE += " \
     -DTIMER_INSTALL=ON \
     -DEVSE_SECURITY_INSTALL=ON \
     -DOCPP_INSTALL=ON \
+    -DTLS_INSTALL=ON \
 "
 
 # there are issues with pybind11 and the sstate cache

--- a/yocto/scarthgap/meta-everest/recipes-core/everest/everest-core_git.bb
+++ b/yocto/scarthgap/meta-everest/recipes-core/everest/everest-core_git.bb
@@ -70,6 +70,7 @@ EXTRA_OECMAKE += " \
     -DTIMER_INSTALL=ON \
     -DEVSE_SECURITY_INSTALL=ON \
     -DOCPP_INSTALL=ON \
+    -DTLS_INSTALL=ON \
 "
 
 # there are issues with pybind11 and the sstate cache


### PR DESCRIPTION
If this is omitted the Yocto builds fail [due to recent changes in dependencies](https://github.com/EVerest/EVerest/pull/2478)

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

