### PR TITLE
fix(cmake): use SQLite3::SQLite3 instead of deprecated SQLite::SQLite3

### DIFF
--- a/lib/everest/ocpp/CMakeLists.txt
+++ b/lib/everest/ocpp/CMakeLists.txt
@@ -46,6 +46,10 @@ endif()
 # dependencies
 find_package(Boost COMPONENTS program_options thread REQUIRED)
 find_package(SQLite3 REQUIRED)
+if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+  set_target_properties(SQLite::SQLite3 PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
 find_package(OpenSSL 3 REQUIRED)
 
 if(NOT DISABLE_EDM)

--- a/lib/everest/ocpp/lib/CMakeLists.txt
+++ b/lib/everest/ocpp/lib/CMakeLists.txt
@@ -228,7 +228,7 @@ target_link_libraries(ocpp
     PRIVATE
         OpenSSL::SSL
         OpenSSL::Crypto
-        SQLite::SQLite3
+        SQLite3::SQLite3
         Threads::Threads
         nlohmann_json::nlohmann_json
         ryml::ryml

--- a/lib/everest/ocpp/src/CMakeLists.txt
+++ b/lib/everest/ocpp/src/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(charge_point
         ocpp
         OpenSSL::SSL
         OpenSSL::Crypto
-        SQLite::SQLite3
+        SQLite3::SQLite3
 )
 
 install(TARGETS charge_point

--- a/lib/everest/ocpp/tests/libocpp-unittests.cmake
+++ b/lib/everest/ocpp/tests/libocpp-unittests.cmake
@@ -52,7 +52,7 @@ set(TEST_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}
 )
 # If the test is not linked against the ocpp library, most probably those libraries are needed to link against.
 set(LIBOCPP_TEST_DEFAULT_LINK_LIBRARIES
-        SQLite::SQLite3
+        SQLite3::SQLite3
         nlohmann_json::nlohmann_json
         nlohmann_json_schema_validator
         date::date-tz

--- a/lib/everest/sqlite/CMakeLists.txt
+++ b/lib/everest/sqlite/CMakeLists.txt
@@ -20,6 +20,10 @@ if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TEST
 endif()
 
 find_package(SQLite3 REQUIRED)
+if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+  set_target_properties(SQLite::SQLite3 PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
 
 if (NOT DISABLE_EDM)
     evc_setup_edm()

--- a/lib/everest/sqlite/lib/CMakeLists.txt
+++ b/lib/everest/sqlite/lib/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(everest_sqlite
 
 target_link_libraries(everest_sqlite
     PRIVATE
-        SQLite::SQLite3
+        SQLite3::SQLite3
 )
 
 if (EVEREST_SQLITE_USE_BOOST_FILESYSTEM)

--- a/modules/Misc/ErrorHistory/CMakeLists.txt
+++ b/modules/Misc/ErrorHistory/CMakeLists.txt
@@ -12,10 +12,14 @@ option(BUILD_TESTING "Run unit tests" OFF)
 set(CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu" ${CMAKE_PREFIX_PATH})
 
 find_package(SQLite3 REQUIRED)
+if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+  set_target_properties(SQLite::SQLite3 PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
 
 target_link_libraries(${MODULE_NAME}
     PRIVATE
-        SQLite::SQLite3
+        SQLite3::SQLite3
         everest::sqlite
 )
 target_sources(${MODULE_NAME}

--- a/modules/Misc/ErrorHistory/tests/CMakeLists.txt
+++ b/modules/Misc/ErrorHistory/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(${TARGET_NAME}
         everest::framework
         everest::log
         everest::sqlite
-        SQLite::SQLite3
+        SQLite3::SQLite3
         Catch2::Catch2WithMain
 )
 if(NOT DISABLE_EDM)

--- a/modules/Misc/PersistentStore/CMakeLists.txt
+++ b/modules/Misc/PersistentStore/CMakeLists.txt
@@ -10,10 +10,14 @@ ev_setup_cpp_module()
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 # insert your custom targets and additional config variables here
 find_package(SQLite3 REQUIRED)
+if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+  set_target_properties(SQLite::SQLite3 PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
 
 target_link_libraries(${MODULE_NAME}
     PRIVATE
-        SQLite::SQLite3
+        SQLite3::SQLite3
 )
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 


### PR DESCRIPTION
CMake 4.3 deprecates the FindSQLite3 target `SQLite::SQLite3` in favor of `SQLite3::SQLite3`, which produces developer warnings at configure time. Switch all link sites to the new target and add the documented CMake < 4.3 alias workaround after each `find_package(SQLite3)`.

### Describe your changes
- Replace `SQLite::SQLite3` with `SQLite3::SQLite3` in everest-sqlite, libocpp, ErrorHistory, and PersistentStore
- After each `find_package(SQLite3 REQUIRED)`, add an alias for CMake < 4.3 (with `IMPORTED_GLOBAL` so the alias works below CMake 3.18)

### Issue ticket number and link
Closes #2516 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements