### PR TITLE
fix(EvseManager): stop pushing stale DC HLC limits after session stop

### DIFF
--- a/modules/EVSE/EvseManager/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/CMakeLists.txt
@@ -12,6 +12,7 @@ ev_setup_cpp_module()
 target_sources(${MODULE_NAME}
     PRIVATE
         Charger.cpp
+        dc_hlc_limits.cpp
         energy_transfer_modes.cpp
         SessionLog.cpp
         v2gMessage.cpp

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -2085,6 +2085,11 @@ void Charger::set_hlc_charging_active() {
     shared_context.hlc_charging_active = true;
 }
 
+Charger::HlcTerminatePause Charger::get_hlc_terminate_pause() {
+    Everest::scoped_lock_timeout lock(state_machine_mutex, Everest::MutexDescription::Charger_get_hlc_terminate_pause);
+    return shared_context.hlc_charging_terminate_pause;
+}
+
 void Charger::set_hlc_allow_close_contactor(bool on) {
     Everest::scoped_lock_timeout lock(state_machine_mutex,
                                       Everest::MutexDescription::Charger_set_hlc_allow_close_contactor);

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -639,6 +639,9 @@ void Charger::run_state_machine() {
             if (initialize_state) {
                 signal_simple_event(types::evse_manager::SessionEventEnum::PrepareCharging);
                 bcb_toggle_reset();
+                // A new HLC session may start here without passing through Idle (e.g. EV wake-up from
+                // ChargingPausedEV after D-LINK_TERMINATE), so allow limit updates to the HLC stack again
+                shared_context.hlc_charging_terminate_pause = HlcTerminatePause::Unknown;
                 internal_context.hlc_charge_loop_no_energy_timeout_running = false;
 
                 if (config_context.charge_mode == ChargeMode::DC) {

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -191,6 +191,7 @@ public:
     void dlink_terminate();
 
     void set_hlc_charging_active();
+    HlcTerminatePause get_hlc_terminate_pause();
     void set_hlc_allow_close_contactor(bool on);
 
     void set_hlc_d20_active();
@@ -314,7 +315,7 @@ private:
         bool iec_allow_close_contactor{false};
         bool contactor_open{true};
         bool hlc_charging_active{false};
-        HlcTerminatePause hlc_charging_terminate_pause;
+        HlcTerminatePause hlc_charging_terminate_pause{HlcTerminatePause::Unknown};
         types::iso15118::DcEvseMaximumLimits current_evse_max_limits;
         types::iso15118::DcEvseMinimumLimits current_evse_min_limits;
         bool pwm_running{false};

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -1273,6 +1273,16 @@ void EvseManager::ready() {
             p_evse->publish_ev_info(ev_info);
         }
 
+        if (s == types::evse_manager::SessionEventEnum::PrepareCharging) {
+            // An HLC session may restart here without crossing a session boundary (e.g. EV wake-up
+            // from ChargingPausedEV after D-LINK_TERMINATE). Drop the previous HLC session's targets,
+            // the EV communicates new ones in PreCharge/CurrentDemand.
+            Everest::scoped_lock_timeout lock(ev_info_mutex, Everest::MutexDescription::EVSE_set_ev_info);
+            ev_info.target_voltage.reset();
+            ev_info.target_current.reset();
+            p_evse->publish_ev_info(ev_info);
+        }
+
         if (not hlc_enabled) {
             return;
         }

--- a/modules/EVSE/EvseManager/dc_hlc_limits.cpp
+++ b/modules/EVSE/EvseManager/dc_hlc_limits.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "dc_hlc_limits.hpp"
+
+namespace module {
+
+bool should_update_dc_hlc_limits(Charger::EvseState charger_state, Charger::HlcTerminatePause hlc_link_status) {
+    // Once the HLC link was terminated (D-LINK_TERMINATE), no limit update can reach the EV
+    // anymore until a new session starts, even if the car is still plugged in.
+    if (hlc_link_status == Charger::HlcTerminatePause::Terminate) {
+        return false;
+    }
+
+    switch (charger_state) {
+    case Charger::EvseState::WaitingForAuthentication:
+    case Charger::EvseState::PrepareCharging:
+    case Charger::EvseState::Charging:
+    case Charger::EvseState::ChargingPausedEV:
+    case Charger::EvseState::ChargingPausedEVSE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace module

--- a/modules/EVSE/EvseManager/dc_hlc_limits.hpp
+++ b/modules/EVSE/EvseManager/dc_hlc_limits.hpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include "Charger.hpp"
+
+namespace module {
+
+/// \brief Decide whether DC HLC limits and targets may still be pushed to the ISO 15118 stack.
+/// Once the HLC link was terminated (D-LINK_TERMINATE) or the charger left the active charging
+/// states, ev_info only contains stale values from the previous session and must not be applied.
+/// \param[in] charger_state - current state of the charger state machine
+/// \param[in] hlc_link_status - latched terminate/pause status of the HLC link
+/// \returns true while limit updates may be forwarded to the HLC stack
+bool should_update_dc_hlc_limits(Charger::EvseState charger_state, Charger::HlcTerminatePause hlc_link_status);
+
+} // namespace module

--- a/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
+++ b/modules/EVSE/EvseManager/energy_grid/energyImpl.cpp
@@ -2,6 +2,7 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 
 #include "energyImpl.hpp"
+#include "../dc_hlc_limits.hpp"
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -530,6 +531,11 @@ void energyImpl::handle_enforce_limits(types::energy::EnforcedLimits& value) {
         mod->signalNrOfPhasesAvailable(mod->ac_nr_phases_active);
 
         if (mod->config.charge_mode == "DC") {
+            // Once the HLC session is gone (link terminated or charger no longer in a charging state),
+            // ev_info only contains stale values from the previous session, so stop updating the limits.
+            if (not should_update_dc_hlc_limits(charger_state, mod->charger->get_hlc_terminate_pause())) {
+                return;
+            }
             // DC mode apply limit at the leave side, we get root side limits here from EnergyManager on ACDC!
             // FIXME: multiply by conversion_efficiency here!
             if (value.limits_root_side.total_power_W.has_value() and

--- a/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
+++ b/modules/EVSE/EvseManager/scoped_lock_timeout.hpp
@@ -48,6 +48,7 @@ enum class MutexDescription {
     Charger_dlink_terminate,
     Charger_dlink_error,
     Charger_set_hlc_charging_active,
+    Charger_get_hlc_terminate_pause,
     Charger_set_hlc_allow_close_contactor,
     Charger_errors_prevent_charging,
     Charger_set_max_current,
@@ -155,6 +156,8 @@ static std::string to_string(MutexDescription d) {
         return "Charger.cpp: dlink_error";
     case MutexDescription::Charger_set_hlc_charging_active:
         return "Charger.cpp: set_hlc_charging_active";
+    case MutexDescription::Charger_get_hlc_terminate_pause:
+        return "Charger.cpp: get_hlc_terminate_pause";
     case MutexDescription::Charger_set_hlc_allow_close_contactor:
         return "Charger.cpp: set_hlc_allow_close_contactor";
     case MutexDescription::Charger_errors_prevent_charging:

--- a/modules/EVSE/EvseManager/tests/CMakeLists.txt
+++ b/modules/EVSE/EvseManager/tests/CMakeLists.txt
@@ -63,7 +63,9 @@ target_include_directories(${CHARGER_TEST_TARGET_NAME} PRIVATE
 
 target_sources(${CHARGER_TEST_TARGET_NAME} PRIVATE
     ChargerTest.cpp
+    DcHlcLimitsTest.cpp
     ../Charger.cpp
+    ../dc_hlc_limits.cpp
 )
 
 target_compile_definitions(${CHARGER_TEST_TARGET_NAME} PRIVATE

--- a/modules/EVSE/EvseManager/tests/ChargerTest.cpp
+++ b/modules/EVSE/EvseManager/tests/ChargerTest.cpp
@@ -761,6 +761,29 @@ TEST_F(ChargerTest, DisableDuringIdle) {
     EXPECT_EQ(last_event, SessionEventEnum::Disabled);
 }
 
+// Regression test: an HLC session may restart without unplugging (EV wake-up from
+// ChargingPausedEV after D-LINK_TERMINATE goes straight to PrepareCharging, never
+// passing through Idle). Entering PrepareCharging must reset the Terminate latch so
+// that DC HLC limit updates resume for the new session.
+TEST_F(ChargerTest, HlcTerminateLatchIsResetOnPrepareCharging) {
+    auto& ctx = charger->get_shared_context();
+
+    // Simulate a plugged-in EV whose previous session ended with D-LINK_TERMINATE
+    ctx.hlc_charging_terminate_pause = Charger::HlcTerminatePause::Terminate;
+    ctx.flag_ev_plugged_in = true;
+    ctx.flag_transaction_active = true;
+    ctx.session_active = true;
+    ctx.flag_authorized = true;
+
+    EXPECT_EQ(charger->get_hlc_terminate_pause(), Charger::HlcTerminatePause::Terminate);
+
+    // EV wakes up and a new session enters PrepareCharging
+    ctx.current_state = Charger::EvseState::PrepareCharging;
+    charger->run_state_machine();
+
+    EXPECT_EQ(charger->get_hlc_terminate_pause(), Charger::HlcTerminatePause::Unknown);
+}
+
 } // namespace
 
 // ----------------------------------------------------------------------------

--- a/modules/EVSE/EvseManager/tests/DcHlcLimitsTest.cpp
+++ b/modules/EVSE/EvseManager/tests/DcHlcLimitsTest.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <gtest/gtest.h>
+
+#include <dc_hlc_limits.hpp>
+
+namespace module {
+
+using EvseState = Charger::EvseState;
+using HlcTerminatePause = Charger::HlcTerminatePause;
+
+TEST(DcHlcLimitsTest, update_allowed_during_active_session) {
+    for (const auto state : {EvseState::WaitingForAuthentication, EvseState::PrepareCharging, EvseState::Charging,
+                             EvseState::ChargingPausedEV, EvseState::ChargingPausedEVSE}) {
+        EXPECT_TRUE(should_update_dc_hlc_limits(state, HlcTerminatePause::Unknown));
+        EXPECT_TRUE(should_update_dc_hlc_limits(state, HlcTerminatePause::Pause));
+    }
+}
+
+// Regression test: after SessionStop the HLC stack sends D-LINK_TERMINATE while the car may stay
+// plugged in for a long time with the charger in ChargingPausedEV. Stale limits (e.g. an old
+// target_voltage) must not be pushed to the HLC stack anymore in this phase.
+TEST(DcHlcLimitsTest, no_update_after_dlink_terminate) {
+    for (const auto state : {EvseState::WaitingForAuthentication, EvseState::PrepareCharging, EvseState::Charging,
+                             EvseState::ChargingPausedEV, EvseState::ChargingPausedEVSE, EvseState::StoppingCharging,
+                             EvseState::Finished, EvseState::Idle}) {
+        EXPECT_FALSE(should_update_dc_hlc_limits(state, HlcTerminatePause::Terminate));
+    }
+}
+
+TEST(DcHlcLimitsTest, no_update_outside_of_session) {
+    for (const auto state : {EvseState::Disabled, EvseState::Idle, EvseState::StoppingCharging, EvseState::Finished,
+                             EvseState::T_step_EF, EvseState::T_step_X1, EvseState::SwitchPhases}) {
+        EXPECT_FALSE(should_update_dc_hlc_limits(state, HlcTerminatePause::Unknown));
+    }
+}
+
+} // namespace module


### PR DESCRIPTION
## Describe your changes

After SessionStop the HLC stack sends D-LINK_TERMINATE while the car may stay plugged in for a long time (charger in `ChargingPausedEV`). In this phase `ev_info` still contains values from the previous session (e.g. an old `target_voltage`), which were pushed to the ISO 15118 stack and the power supply on every `enforce_limits` update.

This PR gates the DC branch of `energyImpl::handle_enforce_limits` on a new free helper `should_update_dc_hlc_limits(charger_state, hlc_link_status)`:

- returns `false` once the HLC link was terminated (`HlcTerminatePause::Terminate` latch, read under `state_machine_mutex` via a new `Charger::get_hlc_terminate_pause()`), since no limit update can reach the EV anymore until a new session starts
- returns `true` only in active-session states (`WaitingForAuthentication`, `PrepareCharging`, `Charging`, `ChargingPausedEV`, `ChargingPausedEVSE`)

The `Terminate` latch is reset to `Unknown` in the Idle init block and on entering `Charging`, so a new session is not blocked by a stale value.

Also fixes `SharedContext::hlc_charging_terminate_pause` being read uninitialized if `enforce_limits` arrives before the state machine's first Idle init.

The helper lives in its own `dc_hlc_limits.cpp/.hpp` (same pattern as `energy_transfer_modes.*`) so it can be unit tested; `energyImpl.cpp` is not part of any test target. Optionally, we could merge them in one charger_helpers.* if this is wanted.

## Issue ticket number and link

n/a

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

## Tests

New unit test `DcHlcLimitsTest.cpp` (added to the Charger test target) covers:
- updates allowed in all active-session states while the link is not terminated
- regression: no updates in any state once D-LINK_TERMINATE was received
- no updates outside of a session (`Idle`, `Finished`, `StoppingCharging`, `Disabled`, `T_step_*`, `SwitchPhases`)