### PR TITLE
feat(YetiSimulator): make simulated AC nominal voltage configurable

### DIFF
--- a/modules/Simulation/YetiSimulator/YetiSimulator.hpp
+++ b/modules/Simulation/YetiSimulator/YetiSimulator.hpp
@@ -31,6 +31,7 @@ struct Conf {
     bool dummy_meter_value_send_on_transaction_start;
     std::string dummy_meter_value_blob_start;
     std::string dummy_meter_value_blob_stop;
+    double ac_nominal_voltage;
 };
 
 class YetiSimulator : public Everest::ModuleBase {
@@ -67,7 +68,18 @@ public:
     std::unique_ptr<state::ModuleState> module_state;
 
     void reset_module_state() {
-        module_state = std::make_unique<state::ModuleState>();
+        auto new_state = std::make_unique<state::ModuleState>();
+        const auto nominal_voltage = config.ac_nominal_voltage;
+        new_state->simdata_setting.voltages.L1 = nominal_voltage;
+        new_state->simdata_setting.voltages.L2 = nominal_voltage;
+        new_state->simdata_setting.voltages.L3 = nominal_voltage;
+        new_state->simulation_data.voltages.L1 = nominal_voltage;
+        new_state->simulation_data.voltages.L2 = nominal_voltage;
+        new_state->simulation_data.voltages.L3 = nominal_voltage;
+        new_state->powermeter_data.vrmsL1 = nominal_voltage;
+        new_state->powermeter_data.vrmsL2 = nominal_voltage;
+        new_state->powermeter_data.vrmsL3 = nominal_voltage;
+        module_state = std::move(new_state);
     }
 
     void pwm_on(const double dutycycle);

--- a/modules/Simulation/YetiSimulator/manifest.yaml
+++ b/modules/Simulation/YetiSimulator/manifest.yaml
@@ -19,6 +19,11 @@ config:
     description: Dummy meter value blob sent on transaction stop to be used for testing
     type: string
     default: "test stop value"
+  ac_nominal_voltage:
+    description: Nominal AC voltage between phase and neutral in Volt, reported per phase by the simulated power meter
+    type: number
+    default: 230.0
+    minimum: 99.0
 provides:
   powermeter:
     interface: powermeter


### PR DESCRIPTION
## Describe your changes

### Motivation

The YetiSimulator module hardcodes the simulated AC nominal voltage to 230 V per phase
(struct defaults in `util/state.hpp`). This matches European grids, but makes SIL
simulation unrealistic for other regions (e.g. Japan, where AC charging circuits are
200 V).

When using the SIL setup to test CSMS integrations (OCPP `MeterValues`, energy
accounting, smart-charging behavior), the reported voltage and the resulting power
values (`P = V * I` per phase in `simulate_powermeter()`) should reflect the target
grid. The companion simulator module `EvManager` already exposes `ac_nominal_voltage`
on the EV side; this PR adds the matching option on the simulated EVSE
board-support/power-meter side.

### What changed

- `modules/Simulation/YetiSimulator/manifest.yaml`: new config option `ac_nominal_voltage`
  (type `number`, default `230.0`, minimum `0`), named consistently with the existing
  `EvManager` option.
- `modules/Simulation/YetiSimulator/YetiSimulator.hpp`:
  - `Conf` struct extended with `double ac_nominal_voltage;` (matching the generated code
    from `ev-cli` for the updated manifest).
  - `reset_module_state()` now applies the configured value to
    `simdata_setting.voltages`, `simulation_data.voltages` and
    `powermeter_data.vrmsL1/L2/L3` right after the `ModuleState` is reconstructed.
    Initializing all three keeps the reported voltage correct even while the
    simulation loop is idle (`publish_powermeter()` publishes unconditionally, also
    before the EV simulation is enabled). The hook covers both module `init()` and
    the runtime state reset triggered via `ev_board_supportImpl::handle_enable()`,
    so the configured voltage survives a simulation restart instead of falling back
    to the 230 V struct defaults.

Note: open PR #2511 appends config options at the same anchors in the same two files.
The content is unrelated, but whichever PR merges second will need a trivial rebase.

### Backward compatibility

The default remains 230 V and the struct defaults in `util/state.hpp` are unchanged, so
existing configurations behave exactly as before. The new option is optional (has a
default), so no config migration is needed.

### How to test

1. In a SIL configuration (e.g. `config/config-sil-ocpp.yaml`), set the option on a
   YetiSimulator module instance:

   ```yaml
   yeti_driver_1:
     module: YetiSimulator
     config_module:
       connector_id: 1
       ac_nominal_voltage: 200
   ```

2. Start the SIL simulation. Already before a charging session starts, the published
   powermeter values (`powermeter` interface var, or the OCPP `MeterValues` on the
   connected CSMS) report `voltage_V.L1/L2/L3` at ~200 V instead of ~230 V.
3. Begin a charging session (e.g. via the node-red UI or the `ev_manager_1` module):
   `voltage_V.L1/L2/L3` now hovers around 200 V (with the usual +/-1 % simulation noise
   and impedance drop), and `power_W` scales accordingly (`~200 V * I` instead of
   `~230 V * I`).
4. Without the option set, values stay at ~230 V as before.

For consistent energy-management calculations in such a setup, `EvseManager`'s own
`ac_nominal_voltage` option (also defaulting to 230 V) should be set to the same value.

## Issue ticket number and link

N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (config option description in the manifest)
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements
