### PR TITLE
feat(libiso15118): Run a single session with an external provided connected socket

### DIFF
--- a/lib/everest/iso15118/include/iso15118/io/connection_plain.hpp
+++ b/lib/everest/iso15118/include/iso15118/io/connection_plain.hpp
@@ -12,6 +12,7 @@ namespace iso15118::io {
 class ConnectionPlain : public IConnection {
 public:
     ConnectionPlain(PollManager&, const std::string& interface_name);
+    ConnectionPlain(PollManager&, int connected_fd);
 
     void set_event_callback(const ConnectionEventCallback&) final;
     Ipv6EndPoint get_public_endpoint() const final;
@@ -40,5 +41,6 @@ private:
 
     void handle_connect();
     void handle_data();
+    void handle_bootstrap();
 };
 } // namespace iso15118::io

--- a/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
+++ b/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
@@ -25,6 +25,13 @@
 
 namespace iso15118 {
 
+enum class StartSessionResult : std::uint8_t {
+    KeepFdOpen,
+    FdNotValid,
+    FdClosed,
+    SessionComplete,
+};
+
 struct TbdConfig {
     config::SSLConfig ssl{};
     std::string interface_name;
@@ -32,6 +39,9 @@ struct TbdConfig {
     bool enable_sdp_server{true};
 };
 
+// TbdController is single-threaded. Exactly one driver may run at a time: either loop() or start_session(), driven from
+// a single thread. They must never run concurrently - they share the poll manager and session state, which are not
+// thread-safe. Sequential reuse (one driver returns, then the other is called) is allowed.
 class TbdController {
 public:
     // Creates the connection for sessions when the SDP server is disabled.
@@ -42,7 +52,12 @@ public:
     TbdController(TbdConfig, session::feedback::Callbacks, d20::EvseSetupConfig, ConnectionFactory);
     ~TbdController();
 
+    // Mutually exclusive with the other driver; see the class note. Refuses (logs and returns) if the other driver is
+    // already running.
     void loop();
+    // Mutually exclusive with the other driver; see the class note. Refuses (logs and returns false) if the other
+    // driver is already running.
+    StartSessionResult start_session(int connected_fd);
     void tick();
 
     bool has_active_session() const {
@@ -76,11 +91,23 @@ private:
     std::atomic_bool shutdown_active{false};
     std::atomic_bool terminate_session_requested{false};
 
+    // Guards against loop() and start_session() running concurrently (see class note).
+    std::atomic_bool driver_running{false};
+
     bool shutdown_signaled{false};
     TimePoint next_event{};
 
     // callbacks for sdp server
     void handle_sdp_server_input();
+
+    // Runs one poll_manager.poll() step using next_event; returns false if poll()
+    // threw, so the caller can break out of its loop.
+    bool poll_once();
+
+    // Services the currently active session for one cycle: propagates a pending
+    // shutdown, consumes the terminate request, polls the session and reaps it when
+    // finished. Shared by loop()/tick() and start_session().
+    void service_active_session();
 
     const TbdConfig config;
     const session::feedback::Callbacks callbacks;

--- a/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
@@ -64,6 +64,25 @@ ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& 
     poll_manager.register_fd(fd, [this]() { this->handle_connect(); });
 }
 
+ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, int connected_fd) :
+    poll_manager(poll_manager_), fd(connected_fd) {
+
+    sockaddr_in6 local_adr{};
+    socklen_t length = sizeof(local_adr);
+
+    const auto sock_name_result = getsockname(fd, reinterpret_cast<sockaddr*>(&local_adr), &length);
+    if (sock_name_result == 0 and local_adr.sin6_family == AF_INET6) {
+        std::memcpy(&end_point.address, &local_adr.sin6_addr, sizeof(end_point.address));
+        end_point.port = ntohs(local_adr.sin6_port);
+    } else {
+        logf_warning("getsockname() failed or local adr had no ipv6 address, falling back");
+        end_point.port = 50000;
+        std::memset(&end_point.address, 0x00, sizeof(end_point.address));
+    }
+
+    poll_manager.register_fd(fd, [this]() { this->handle_bootstrap(); });
+}
+
 ConnectionPlain::~ConnectionPlain() = default;
 
 void ConnectionPlain::set_event_callback(const ConnectionEventCallback& callback) {
@@ -152,6 +171,17 @@ void ConnectionPlain::handle_data() {
     assert(connection_open);
 
     call_if_available(event_callback, ConnectionEvent::NEW_DATA);
+}
+
+void ConnectionPlain::handle_bootstrap() {
+    call_if_available(event_callback, ConnectionEvent::ACCEPTED);
+    connection_open = true;
+    call_if_available(event_callback, ConnectionEvent::OPEN);
+
+    poll_manager.unregister_fd(fd);
+
+    // The incoming v2gtp message is handled one poll cycle later
+    poll_manager.register_fd(fd, [this]() { this->handle_data(); });
 }
 
 void ConnectionPlain::close() {

--- a/lib/everest/iso15118/src/iso15118/message/supported_app_protocol.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/supported_app_protocol.cpp
@@ -57,8 +57,20 @@ template <> void convert(const SupportedAppProtocolResponse& in, struct appHand_
     }
 }
 
+template <> void convert(const struct appHand_supportedAppProtocolRes& in, SupportedAppProtocolResponse& out) {
+    cb_convert_enum(in.ResponseCode, out.response_code);
+
+    if (in.SchemaID_isUsed) {
+        out.schema_id.emplace(in.SchemaID);
+    }
+}
+
 template <> void insert_type(VariantAccess& va, const struct appHand_supportedAppProtocolReq& in) {
     va.insert_type<SupportedAppProtocolRequest>(in);
+};
+
+template <> void insert_type(VariantAccess& va, const struct appHand_supportedAppProtocolRes& in) {
+    va.insert_type<SupportedAppProtocolResponse>(in);
 };
 
 template <> int serialize_to_exi(const SupportedAppProtocolResponse& in, exi_bitstream_t& out) {

--- a/lib/everest/iso15118/src/iso15118/message/variant.cpp
+++ b/lib/everest/iso15118/src/iso15118/message/variant.cpp
@@ -31,6 +31,8 @@ static void handle_sap(VariantAccess& va) {
 
     if (doc.supportedAppProtocolReq_isUsed) {
         insert_type(va, doc.supportedAppProtocolReq);
+    } else if (doc.supportedAppProtocolRes_isUsed) {
+        insert_type(va, doc.supportedAppProtocolRes);
     } else {
         va.error = "chosen message type unhandled";
     }

--- a/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
+++ b/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
@@ -4,6 +4,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <fcntl.h>
+#include <unistd.h>
 
 #include <iso15118/io/connection_plain.hpp>
 #include <iso15118/io/connection_ssl.hpp>
@@ -15,6 +17,21 @@
 namespace iso15118 {
 
 static constexpr auto POLL_MANAGER_TIMEOUT_MS = 50;
+
+namespace {
+bool fd_is_open(int fd) {
+    return fd >= 0 and fcntl(fd, F_GETFD) != -1;
+}
+
+// Resets the driver-running flag on scope exit, so it is released even if an exception
+// propagates out of a driver.
+struct DriverRunningGuard {
+    std::atomic_bool& flag;
+    ~DriverRunningGuard() {
+        flag.store(false);
+    }
+};
+} // namespace
 
 TbdController::TbdController(TbdConfig config_, session::feedback::Callbacks callbacks_, d20::EvseSetupConfig setup_) :
     TbdController(std::move(config_), std::move(callbacks_), std::move(setup_),
@@ -51,38 +68,21 @@ TbdController::~TbdController() {
     }
 }
 
-void TbdController::loop() {
-    shutdown_active.store(false);
-    shutdown_signaled = false;
+bool TbdController::poll_once() {
+    const auto poll_timeout_ms = get_timeout_ms_until(next_event, POLL_MANAGER_TIMEOUT_MS);
 
-    next_event = get_current_time_point();
-
-    while (session or not shutdown_active.load()) {
-        const auto poll_timeout_ms = get_timeout_ms_until(next_event, POLL_MANAGER_TIMEOUT_MS);
-
-        try {
-            poll_manager.poll(poll_timeout_ms);
-        } catch (const std::runtime_error& e) {
-            logf_error("Shutdown loop() because of: %s", e.what());
-            break;
-        }
-
-        tick();
+    try {
+        poll_manager.poll(poll_timeout_ms);
+    } catch (const std::runtime_error& e) {
+        logf_error("Shutting down poll loop because of: %s", e.what());
+        return false;
     }
-    logf_info("Exiting TbdController loop gracefully");
+
+    return true;
 }
 
-void TbdController::tick() {
+void TbdController::service_active_session() {
     next_event = offset_time_point_by_ms(get_current_time_point(), POLL_MANAGER_TIMEOUT_MS);
-
-    if (communication_setup_timeout && communication_setup_timeout->is_reached()) {
-        logf_warning("V2G communication setup timeout (18s) expired before session was established");
-        communication_setup_timeout.reset();
-        if (sdp_server) {
-            sdp_server->set_dlink_ready(false);
-        }
-        callbacks.signal(session::feedback::Signal::DLINK_ERROR);
-    }
 
     if (session and shutdown_active.load() and not shutdown_signaled) {
         session->request_shutdown(); // Stopping the session
@@ -111,6 +111,95 @@ void TbdController::tick() {
             session.reset();
         }
     }
+}
+
+void TbdController::loop() {
+    if (driver_running.exchange(true)) {
+        logf_error("Another driver (loop/start_session) is already running; refusing concurrent entry");
+        return;
+    }
+    DriverRunningGuard driver_guard{driver_running};
+
+    shutdown_active.store(false);
+    shutdown_signaled = false;
+
+    next_event = get_current_time_point();
+
+    while (session or not shutdown_active.load()) {
+        if (not poll_once()) {
+            if (session) {
+                session->close();
+                session.reset();
+            }
+            break;
+        }
+
+        tick();
+    }
+    logf_info("Exiting TbdController loop gracefully");
+}
+
+// The caller of this function needs to provide a non-blocking, keepalive fd.
+// ConnectionPlain::read() depends on the socket being non-blocking
+StartSessionResult TbdController::start_session(int connected_fd) {
+    if (driver_running.exchange(true)) {
+        logf_error("Another driver (loop/start_session) is already running; refusing concurrent entry");
+        return StartSessionResult::KeepFdOpen;
+    }
+    DriverRunningGuard driver_guard{driver_running};
+
+    if (not fd_is_open(connected_fd)) {
+        logf_error("Passed fd is not open and valid, returning...");
+        return StartSessionResult::FdNotValid;
+    }
+
+    if (config.enable_sdp_server) {
+        logf_error("SDP server is active; incompatible with externally-provided-fd mode. Not starting a session and "
+                   "keeping fd open");
+        return StartSessionResult::KeepFdOpen;
+    }
+
+    if (session) {
+        logf_error("Session already exists; not overwriting the existing session; keeping fd open");
+        return StartSessionResult::KeepFdOpen;
+    }
+
+    // Reseting because this could cancel service_active_session.
+    terminate_session_requested.store(false);
+
+    auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, connected_fd);
+    session = std::make_unique<Session>(std::move(connection), d20::SessionConfig(*evse_setup.handle()), callbacks,
+                                        pause_ctx);
+    shutdown_active.store(false);
+    shutdown_signaled = false;
+
+    next_event = get_current_time_point();
+
+    while (session) {
+        if (not poll_once()) {
+            session->close();
+            session.reset();
+            return StartSessionResult::FdClosed;
+        }
+
+        service_active_session();
+    }
+
+    logf_info("Session is closed");
+    return StartSessionResult::SessionComplete;
+}
+
+void TbdController::tick() {
+    if (communication_setup_timeout && communication_setup_timeout->is_reached()) {
+        logf_warning("V2G communication setup timeout (18s) expired before session was established");
+        communication_setup_timeout.reset();
+        if (sdp_server) {
+            sdp_server->set_dlink_ready(false);
+        }
+        callbacks.signal(session::feedback::Signal::DLINK_ERROR);
+    }
+
+    service_active_session();
 
     if (not session and not shutdown_active.load() and not config.enable_sdp_server) {
         session = std::make_unique<Session>(connection_factory(poll_manager, interface_name),

--- a/lib/everest/iso15118/test/iso15118/session/CMakeLists.txt
+++ b/lib/everest/iso15118/test/iso15118/session/CMakeLists.txt
@@ -29,3 +29,13 @@ target_link_libraries(test_tbd_controller_teardown
 )
 
 catch_discover_tests(test_tbd_controller_teardown)
+
+add_executable(test_tbd_controller_start_session tbd_controller_start_session.cpp)
+
+target_link_libraries(test_tbd_controller_start_session
+    PRIVATE
+        iso15118
+        Catch2::Catch2WithMain
+)
+
+catch_discover_tests(test_tbd_controller_start_session)

--- a/lib/everest/iso15118/test/iso15118/session/tbd_controller_start_session.cpp
+++ b/lib/everest/iso15118/test/iso15118/session/tbd_controller_start_session.cpp
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Pionix GmbH and Contributors to EVerest
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <iso15118/d20/config.hpp>
+#include <iso15118/io/sdp.hpp>
+#include <iso15118/io/sdp_packet.hpp>
+#include <iso15118/io/stream_view.hpp>
+#include <iso15118/message/supported_app_protocol.hpp>
+#include <iso15118/message/variant.hpp>
+#include <iso15118/session/feedback.hpp>
+#include <iso15118/session/iso.hpp>
+#include <iso15118/tbd_controller.hpp>
+
+namespace {
+
+iso15118::TbdController make_controller(bool enable_sdp_server,
+                                        const iso15118::session::feedback::Callbacks& callbacks) {
+    return iso15118::TbdController{
+        iso15118::TbdConfig{{}, "lo", iso15118::config::TlsNegotiationStrategy::ACCEPT_CLIENT_OFFER, enable_sdp_server},
+        callbacks, iso15118::d20::EvseSetupConfig{}};
+}
+
+std::array<int, 2> make_nonblocking_socketpair() {
+    std::array<int, 2> fds{-1, -1};
+
+    if (socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds.data()) == -1) {
+        throw std::runtime_error(std::string("socketpair() failed: ") + std::strerror(errno));
+    }
+
+    return fds;
+}
+
+bool fd_is_open(int fd) {
+    return fd >= 0 and fcntl(fd, F_GETFD) != -1;
+}
+
+// Captured SupportedAppProtocolReq offering the -20:AC namespace.
+constexpr uint8_t sap_req[] = {0x80, 0x00, 0xf3, 0xab, 0x93, 0x71, 0xd3, 0x4b, 0x9b, 0x79, 0xd3, 0x9b, 0xa3,
+                               0x21, 0xd3, 0x4b, 0x9b, 0x79, 0xd1, 0x89, 0xa9, 0x89, 0x89, 0xc1, 0xd1, 0x69,
+                               0x91, 0x81, 0xd2, 0x0a, 0x18, 0x01, 0x00, 0x00, 0x04, 0x00, 0x40};
+
+// Wraps an EXI payload in a V2GTP frame (8-byte header + payload), mirroring the framing in
+// MockConnection::queue_v2gtp_packet.
+std::vector<uint8_t> make_v2gtp_frame(iso15118::io::v2gtp::PayloadType payload_type, const uint8_t* payload,
+                                      std::size_t payload_len) {
+    std::vector<uint8_t> frame(iso15118::io::SdpPacket::V2GTP_HEADER_SIZE + payload_len);
+    frame[0] = iso15118::io::SDP_PROTOCOL_VERSION;
+    frame[1] = iso15118::io::SDP_INVERSE_PROTOCOL_VERSION;
+
+    const uint16_t type = htons(static_cast<uint16_t>(payload_type));
+    std::memcpy(frame.data() + 2, &type, sizeof(type));
+
+    const uint32_t len = htonl(static_cast<uint32_t>(payload_len));
+    std::memcpy(frame.data() + 4, &len, sizeof(len));
+
+    std::memcpy(frame.data() + iso15118::io::SdpPacket::V2GTP_HEADER_SIZE, payload, payload_len);
+    return frame;
+}
+
+// Reads one full V2GTP frame (8-byte header + declared payload) from a non-blocking fd, retrying
+// until the frame is complete or the timeout elapses. Returns std::nullopt on timeout/peer close.
+std::optional<std::vector<uint8_t>> read_v2gtp_frame(int fd, std::chrono::milliseconds timeout) {
+    using clock = std::chrono::steady_clock;
+    constexpr std::size_t header_size = iso15118::io::SdpPacket::V2GTP_HEADER_SIZE;
+    const auto deadline = clock::now() + timeout;
+
+    std::vector<uint8_t> buffer;
+    std::size_t expected = header_size; // grows once the header is parsed
+
+    while (buffer.size() < expected) {
+        uint8_t chunk[256];
+        const auto n = ::read(fd, chunk, sizeof(chunk));
+
+        if (n > 0) {
+            buffer.insert(buffer.end(), chunk, chunk + n);
+
+            // Parse the declared payload length as soon as the header is complete.
+            if (expected == header_size and buffer.size() >= header_size) {
+                uint32_t payload_len{};
+                std::memcpy(&payload_len, buffer.data() + 4, sizeof(payload_len));
+                expected = header_size + ntohl(payload_len);
+            }
+            continue;
+        }
+
+        if (n == 0) {
+            return std::nullopt; // peer closed before a full frame arrived
+        }
+
+        // n < 0: on a non-blocking socket EAGAIN/EWOULDBLOCK just means "not yet".
+        if (errno != EAGAIN and errno != EWOULDBLOCK and errno != EINTR) {
+            return std::nullopt;
+        }
+
+        if (clock::now() >= deadline) {
+            return std::nullopt;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    return buffer;
+}
+
+} // namespace
+
+SCENARIO("session_start guard check - invalid/closed fd") {
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [](auto) {};
+
+    auto controller = make_controller(false, callbacks);
+
+    WHEN("start_session gets an invalid/closed fd") {
+        const auto ok = controller.start_session(-1);
+
+        THEN("Session not started") {
+            REQUIRE(ok == iso15118::StartSessionResult::FdNotValid);
+            REQUIRE_FALSE(controller.has_active_session());
+        }
+    }
+}
+
+SCENARIO("session_start guard check - enable_sdp_server: true") {
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [](auto) {};
+
+    auto controller = make_controller(true, callbacks);
+
+    const auto fds = make_nonblocking_socketpair();
+
+    WHEN("start_session - sdp_server is enabled") {
+        const auto ok = controller.start_session(fds.at(0));
+
+        THEN("Session not started") {
+            REQUIRE(ok == iso15118::StartSessionResult::KeepFdOpen);
+            REQUIRE_FALSE(controller.has_active_session());
+            REQUIRE(fd_is_open(fds.at(0)));
+        }
+    }
+
+    close(fds.at(0));
+    close(fds.at(1));
+}
+
+SCENARIO("session_start guard check - session already started") {
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [](auto) {};
+
+    auto controller = make_controller(false, callbacks);
+
+    controller.tick();
+
+    REQUIRE(controller.has_active_session());
+
+    const auto fds = make_nonblocking_socketpair();
+
+    WHEN("start_session - session already started") {
+        const auto ok = controller.start_session(fds.at(0));
+
+        THEN("Start session does not end already started session") {
+            REQUIRE(ok == iso15118::StartSessionResult::KeepFdOpen);
+            REQUIRE(controller.has_active_session());
+            REQUIRE(fd_is_open(fds.at(0)));
+        }
+    }
+
+    close(fds.at(0));
+    close(fds.at(1));
+}
+
+SCENARIO("session_start functionality") {
+    iso15118::session::feedback::Callbacks callbacks;
+    callbacks.signal = [](auto) {};
+
+    auto controller = make_controller(false, callbacks);
+
+    const auto fds = make_nonblocking_socketpair();
+
+    iso15118::StartSessionResult ok{iso15118::StartSessionResult::KeepFdOpen};
+
+    WHEN("start_session") {
+        std::thread start_session_thread([&] { ok = controller.start_session(fds.at(0)); });
+
+        // Watchdog: if start_session() never returns (e.g. the session fails to finish), force it out
+        // with shutdown() so the test cannot hang forever. Stays armed across the join below.
+        std::mutex watchdog_mutex;
+        std::condition_variable watchdog_cv;
+        bool watchdog_done{false};
+        std::atomic_bool timed_out{false};
+        std::thread watchdog_thread([&] {
+            std::unique_lock<std::mutex> lock(watchdog_mutex);
+            if (not watchdog_cv.wait_for(lock, std::chrono::seconds(20), [&] { return watchdog_done; })) {
+                timed_out.store(true);
+                controller.shutdown();
+            }
+        });
+
+        // Create a V2GTP message (8-byte header + SupportedAppProtocolReq EXI payload) and send it
+        // through the client end of the socketpair.
+        const auto request_frame = make_v2gtp_frame(iso15118::io::v2gtp::PayloadType::SAP, sap_req, sizeof(sap_req));
+        const auto written = ::write(fds.at(1), request_frame.data(), request_frame.size());
+
+        // Wait for the SupportedAppProtocolRes the server writes back.
+        const auto response = read_v2gtp_frame(fds.at(1), std::chrono::seconds(5));
+
+        // Tear down before asserting: closing the client end signals EOF to the server, so its session
+        // finishes and start_session() returns. shutdown() is a belt-and-suspenders unblock. Both
+        // worker threads are joined here so no assertion below can throw with a thread still running.
+        close(fds.at(1));
+        controller.shutdown();
+        start_session_thread.join();
+
+        {
+            std::lock_guard<std::mutex> lock(watchdog_mutex);
+            watchdog_done = true;
+        }
+        watchdog_cv.notify_all();
+        watchdog_thread.join();
+
+        THEN("the server answers with a valid SupportedAppProtocolRes and the session ends cleanly") {
+            REQUIRE_FALSE(timed_out.load());
+            REQUIRE(written == static_cast<ssize_t>(request_frame.size()));
+
+            // The response is a well-formed V2GTP SAP frame.
+            constexpr std::size_t header_size = iso15118::io::SdpPacket::V2GTP_HEADER_SIZE;
+            REQUIRE(response.has_value());
+            REQUIRE(response->size() > header_size);
+            REQUIRE(response->at(0) == iso15118::io::SDP_PROTOCOL_VERSION);
+            REQUIRE(response->at(1) == iso15118::io::SDP_INVERSE_PROTOCOL_VERSION);
+
+            uint16_t response_type{};
+            std::memcpy(&response_type, response->data() + 2, sizeof(response_type));
+            REQUIRE(ntohs(response_type) == static_cast<uint16_t>(iso15118::io::v2gtp::PayloadType::SAP));
+
+            // Decode the payload to a SupportedAppProtocolResponse via the library Variant.
+            const uint8_t* payload = response->data() + header_size;
+            const std::size_t payload_len = response->size() - header_size;
+
+            const iso15118::io::StreamInputView view{payload, payload_len};
+            const iso15118::message_20::Variant variant(iso15118::io::v2gtp::PayloadType::SAP, view);
+            REQUIRE(variant.get_type() == iso15118::message_20::Type::SupportedAppProtocolRes);
+
+            const auto& sap_res = variant.get<iso15118::message_20::SupportedAppProtocolResponse>();
+            REQUIRE(sap_res.response_code ==
+                    iso15118::message_20::SupportedAppProtocolResponse::ResponseCode::OK_SuccessfulNegotiation);
+            REQUIRE(sap_res.schema_id.has_value());
+
+            // start_session() returned true and reaped the session; ConnectionPlain::close() closed the fd.
+            REQUIRE(ok == iso15118::StartSessionResult::SessionComplete);
+            REQUIRE_FALSE(controller.has_active_session());
+            REQUIRE_FALSE(fd_is_open(fds.at(0)));
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes
This PR adds a start_session() that runs a single ISO15118 session over an externally-provided, already-connected socket.

## Issue ticket number and link
Previously the controller could only obtain sessions through the SDP server and/or the listening TCP/TLS socket. This change enables applications that manage their own connection setup, without the SDP server being active.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

