### PR TITLE
feat(libiso15118): Now it is possible to pass along the vehicle cert hash while using an already open socket

### DIFF
--- a/lib/everest/iso15118/include/iso15118/io/connection_plain.hpp
+++ b/lib/everest/iso15118/include/iso15118/io/connection_plain.hpp
@@ -12,7 +12,7 @@ namespace iso15118::io {
 class ConnectionPlain : public IConnection {
 public:
     ConnectionPlain(PollManager&, const std::string& interface_name);
-    ConnectionPlain(PollManager&, int connected_fd);
+    ConnectionPlain(PollManager&, int connected_fd, const std::optional<sha512_hash_t>& vehicle_cert_hash);
 
     void set_event_callback(const ConnectionEventCallback&) final;
     Ipv6EndPoint get_public_endpoint() const final;
@@ -22,13 +22,15 @@ public:
 
     void close() final;
 
-    std::optional<sha512_hash_t> get_vehicle_cert_hash() const final {
-        return std::nullopt;
+    [[nodiscard]] std::optional<sha512_hash_t> get_vehicle_cert_hash() const final {
+        return vehicle_cert_hash;
     }
 
     ~ConnectionPlain();
 
 private:
+    ConnectionPlain(PollManager&, int connected_fd);
+
     PollManager& poll_manager;
 
     Ipv6EndPoint end_point;
@@ -38,6 +40,8 @@ private:
     bool connection_open{false};
 
     ConnectionEventCallback event_callback{nullptr};
+
+    std::optional<sha512_hash_t> vehicle_cert_hash{std::nullopt};
 
     void handle_connect();
     void handle_data();

--- a/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
+++ b/lib/everest/iso15118/include/iso15118/tbd_controller.hpp
@@ -58,6 +58,7 @@ public:
     // Mutually exclusive with the other driver; see the class note. Refuses (logs and returns false) if the other
     // driver is already running.
     StartSessionResult start_session(int connected_fd);
+    StartSessionResult start_session(int connected_fd, const std::optional<io::sha512_hash_t>& vehicle_cert_hash);
     void tick();
 
     bool has_active_session() const {

--- a/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
+++ b/lib/everest/iso15118/src/iso15118/io/connection_plain.cpp
@@ -21,7 +21,7 @@ static constexpr auto DEFAULT_SOCKET_BACKLOG = 4;
 
 ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& interface_name) :
     poll_manager(poll_manager_) {
-    sockaddr_in6 address;
+    sockaddr_in6 address{};
     if (not get_first_sockaddr_in6_for_interface(interface_name, address)) {
         const auto msg = "Failed to get ipv6 socket address for interface " + interface_name;
         log_and_throw(msg.c_str());
@@ -65,7 +65,12 @@ ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, const std::string& 
 }
 
 ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, int connected_fd) :
-    poll_manager(poll_manager_), fd(connected_fd) {
+    ConnectionPlain(poll_manager_, connected_fd, std::nullopt) {
+}
+
+ConnectionPlain::ConnectionPlain(PollManager& poll_manager_, int connected_fd,
+                                 const std::optional<sha512_hash_t>& vehicle_cert_hash_) :
+    poll_manager(poll_manager_), fd(connected_fd), vehicle_cert_hash(vehicle_cert_hash_) {
 
     sockaddr_in6 local_adr{};
     socklen_t length = sizeof(local_adr);

--- a/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
+++ b/lib/everest/iso15118/src/iso15118/tbd_controller.cpp
@@ -142,6 +142,11 @@ void TbdController::loop() {
 // The caller of this function needs to provide a non-blocking, keepalive fd.
 // ConnectionPlain::read() depends on the socket being non-blocking
 StartSessionResult TbdController::start_session(int connected_fd) {
+    return start_session(connected_fd, std::nullopt);
+}
+
+StartSessionResult TbdController::start_session(int connected_fd,
+                                                const std::optional<io::sha512_hash_t>& vehicle_cert_hash) {
     if (driver_running.exchange(true)) {
         logf_error("Another driver (loop/start_session) is already running; refusing concurrent entry");
         return StartSessionResult::KeepFdOpen;
@@ -167,7 +172,7 @@ StartSessionResult TbdController::start_session(int connected_fd) {
     // Reseting because this could cancel service_active_session.
     terminate_session_requested.store(false);
 
-    auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, connected_fd);
+    auto connection = std::make_unique<io::ConnectionPlain>(poll_manager, connected_fd, vehicle_cert_hash);
     session = std::make_unique<Session>(std::move(connection), d20::SessionConfig(*evse_setup.handle()), callbacks,
                                         pause_ctx);
     shutdown_active.store(false);


### PR DESCRIPTION
## Describe your changes
See title

## Issue ticket number and link
Before this PR, the vehicle cert hash could not be passed into the v2g session for potential pause/resume.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

