### PR TITLE
Fix(manager): Don't guess CLI options

### DIFF
--- a/applications/utils/docker/everest-docker-image/Dockerfile
+++ b/applications/utils/docker/everest-docker-image/Dockerfile
@@ -115,4 +115,4 @@ WORKDIR /opt/everest
 COPY --from=builder /opt/everest ./
 COPY ./scripts/initialize.sh /opt/everest
 
-CMD [ "/opt/everest/bin/manager", "--conf", "/opt/everest/config/config.yaml" ]
+CMD [ "/opt/everest/bin/manager", "--config", "/opt/everest/config/config.yaml" ]

--- a/applications/utils/docker/everest-docker-image/run-config-fallback.sh
+++ b/applications/utils/docker/everest-docker-image/run-config-fallback.sh
@@ -10,7 +10,7 @@ usage() {
 
 export EVEREST_CONFIG=config-fallback.yaml
 export OCPP_CONFIG=ocpp-config.json
-export EVEREST_COMMAND="sh -c '/opt/everest/bin/manager --conf /opt/everest/config/config.yaml'"
+export EVEREST_COMMAND="sh -c '/opt/everest/bin/manager --config /opt/everest/config/config.yaml'"
 
 while [ ! -z "$1" ]; do
     if [ "$1" == "--conf" ]; then

--- a/applications/utils/docker/everest-docker-image/scripts/initialize.sh
+++ b/applications/utils/docker/everest-docker-image/scripts/initialize.sh
@@ -4,4 +4,4 @@ echo "initialize.sh script used to re-initialize EVerest OCPP 2.0.1 device model
 
 python3 /opt/everest/ocpp201config/init_device_model_db.py --db /opt/everest/share/everest/modules/OCPP201/device_model_storage.db --config /opt/everest/config/ocpp-config.json --schemas /opt/everest/ocpp201config/component_schemas/ init insert
 
-/opt/everest/bin/manager --conf /opt/everest/config/config.yaml
+/opt/everest/bin/manager --config /opt/everest/config/config.yaml

--- a/cmake/assets/run_template.sh.in
+++ b/cmake/assets/run_template.sh.in
@@ -2,6 +2,6 @@ LD_LIBRARY_PATH=@LD_LIBRARY_VAR@:$LD_LIBRARY_PATH \
 PATH=@PATH_VAR@:$PATH \
 manager \
     --prefix @CMAKE_INSTALL_PREFIX@ \
-    --conf @CONFIG_FILE@ \
+    --config @CONFIG_FILE@ \
     @ADDITIONAL_ARGUMENTS@
     $@

--- a/config/bringup/run_tmux_helper.sh
+++ b/config/bringup/run_tmux_helper.sh
@@ -43,7 +43,7 @@ done
 tmux new-session -d -s EVerest
 tmux set -g mouse on
 
-tmux send -t EVerest:0.0 "$PREFIX/bin/manager --prefix $PREFIX" SPACE "--conf " $EVEREST_CONFIG_FILE ENTER
+tmux send -t EVerest:0.0 "$PREFIX/bin/manager --prefix $PREFIX" SPACE "--config " $EVEREST_CONFIG_FILE ENTER
 LEN=${#NAMES[@]}
 
 for (( j=0; j<$LEN; j++ ));

--- a/docs/source/how-to-guides/pionix-belay-box.rst
+++ b/docs/source/how-to-guides/pionix-belay-box.rst
@@ -494,7 +494,7 @@ Then you can run your self-compiled version like this:
 
 .. code-block:: bash
 
-  /var/everest/bin/manager --conf /path/to/my/configfile
+  /var/everest/bin/manager --config /path/to/my/configfile
 
 .. _belaybox_yeti_flash:
 

--- a/docs/source/how-to-guides/renesas-mpu/index.rst
+++ b/docs/source/how-to-guides/renesas-mpu/index.rst
@@ -53,7 +53,7 @@ Here is how to set it up and run an EVerest simulation:
 
    .. code-block:: bash
 
-      /usr/bin/manager --conf /etc/everest/config-sil.yaml
+      /usr/bin/manager --config /etc/everest/config-sil.yaml
 
 If everything has been set up correctly, you will now be able to run simulation
 steps with EVerest. See the :ref:`Quick Start Guide <htg_getting_started_sw>`

--- a/docs/source/tutorials/develop-new-module.rst
+++ b/docs/source/tutorials/develop-new-module.rst
@@ -458,7 +458,7 @@ Up to path substitution this will have the following content::
     PATH=$EVEREST_TUTORIAL_DIR/dist/bin:$PATH \
     manager \
         --prefix $EVEREST_TUTORIAL_DIR/dist \
-        --conf $EVEREST_TUTORIAL_DIR/config/config-modules-tutorial.yaml
+        --config $EVEREST_TUTORIAL_DIR/config/config-modules-tutorial.yaml
 
 It puts the compiled libraries and binaries into the respective paths, and
 then runs EVerest by calling the `manager` binary with the respective
@@ -550,7 +550,7 @@ With EVerest built as described before, but with the additonal option
 
     LD_LIBRARY_PATH=$EVEREST_TUTORIAL_DIR/dist/lib:$LD_LIBRARY_PATH \
     PATH=$EVEREST_TUTORIAL_DIR/dist/bin:$PATH \
-    manager --prefix $EVEREST_TUTORIAL_DIR/dist  --conf $EVEREST_TUTORIAL_DIR/config/config-modules-tutorial.yaml --standalone tutorial_module_instance
+    manager --prefix $EVEREST_TUTORIAL_DIR/dist --config $EVEREST_TUTORIAL_DIR/config/config-modules-tutorial.yaml --standalone tutorial_module_instance
 
 This starts EVerest, but without your module. Instead, the output contains a
 line::
@@ -567,7 +567,7 @@ Now open a second terminal (while keeping EVerest running in the frist
 terminal), and start your  module via ``gdb``::
 
     cd $EVEREST_TUTORIAL_DIR/build
-    gdb --args ./modules/TutorialModule/TutorialModule --module tutorial_module_instance  --conf $EVEREST_TUTORIAL_DIR/config/config-modules-tutorial.yaml --prefix $EVEREST_TUTORIAL_DIR/dist
+    gdb --args ./modules/TutorialModule/TutorialModule --module tutorial_module_instance --config $EVEREST_TUTORIAL_DIR/config/config-modules-tutorial.yaml --prefix $EVEREST_TUTORIAL_DIR/dist
 
 
 In gdb, we set a break in the line that returns the payload when  your test

--- a/lib/everest/framework/src/manager.cpp
+++ b/lib/everest/framework/src/manager.cpp
@@ -622,21 +622,33 @@ int Manager::run() {
 
     const auto prefix_opt = parse_string_option(vm_, "prefix");
     const auto config_opt = parse_string_option(vm_, "config");
+    const auto conf_opt = parse_string_option(vm_, "conf");
     const auto db_opt = parse_string_option(vm_, "db");
     const auto db_init = vm_.count("db-init") != 0;
     ConfigBootMode boot_mode = parse_config_boot_mode(config_opt, db_opt, db_init);
+
+    // --conf is a deprecated alias for --config; using both at once is ambiguous, so reject it.
+    if (vm_.count("conf") != 0) {
+        EVLOG_warning << "The '--conf' option is deprecated and will be removed in a future version. Please use "
+                         "'--config' instead.";
+    }
+    if (vm_.count("config") != 0 && vm_.count("conf") != 0) {
+        throw BootException("--config and --conf are mutually exclusive; --conf is a deprecated alias for --config.");
+    }
+    // Resolve the deprecated alias: fall back to --conf when --config is not given.
+    const auto config_path = config_opt.empty() ? conf_opt : config_opt;
 
     ManagerSettings ms;
 
     switch (boot_mode) {
     case ConfigBootMode::YamlFile:
-        ms = ManagerSettings(prefix_opt, config_opt);
+        ms = ManagerSettings(prefix_opt, config_path);
         break;
     case ConfigBootMode::Database:
         ms = ManagerSettings(prefix_opt, db_opt, DatabaseTag{});
         break;
     case ConfigBootMode::DatabaseInit:
-        ms = ManagerSettings(prefix_opt, config_opt, db_opt);
+        ms = ManagerSettings(prefix_opt, config_path, db_opt);
         break;
     default:
         throw BootException(fmt::format("Invalid boot source: {}", static_cast<int>(boot_mode)));
@@ -1459,6 +1471,7 @@ int main(int argc, char* argv[]) {
     desc.add_options()("config", po::value<std::string>(),
                        "Full path to a config file.  If the file does not exist and has no extension, it will be "
                        "looked up in the default config directory");
+    desc.add_options()("conf", po::value<std::string>(), "Deprecated: Same as --config. Do not use both.");
     desc.add_options()("db", po::value<std::string>(), "Full path to the configuration database file");
     desc.add_options()("db-init", "Indicator to initialize the database if it does not contain a valid configuration. "
                                   "Requires --config and --db to be set.");
@@ -1484,7 +1497,9 @@ int main(int argc, char* argv[]) {
         if (fs::exists(default_logging_cfg)) {
             Logging::init(default_logging_cfg.string());
         }
-        po::store(po::parse_command_line(argc, argv, desc), vm);
+        int style = po::command_line_style::default_style & ~po::command_line_style::allow_guessing;
+
+        po::store(po::parse_command_line(argc, argv, desc, style), vm);
         po::notify(vm);
 
         if (vm.count("help") != 0) {

--- a/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/tests/test.sh
+++ b/modules/HardwareDrivers/PowerMeters/CarloGavazzi_EM580/tests/test.sh
@@ -65,7 +65,7 @@ fi
 
 # Start manager first, then powermeters. When the manager window closes, all others will be closed as well.
 # Important: run with CWD in ${DIST_ETC_DIR} (matches previous scripts and avoids any CWD-sensitive behavior).
-xterm -bg black -fg white -geometry 400x150 -e bash -lc "cd \"${DIST_ETC_DIR}\" && \"${MANAGER_BIN}\" --prefix \"${DIST_DIR}\" --conf \"${config_file}\"" &
+xterm -bg black -fg white -geometry 400x150 -e bash -lc "cd \"${DIST_ETC_DIR}\" && \"${MANAGER_BIN}\" --prefix \"${DIST_DIR}\" --config \"${config_file}\"" &
 manager_pid=$!
 
 for i in $(seq 1 "${device_count}"); do

--- a/yocto/kirkstone/meta-everest/recipes-core/everest/everest-core/everest.service
+++ b/yocto/kirkstone/meta-everest/recipes-core/everest/everest-core/everest.service
@@ -7,7 +7,7 @@ ConditionFileNotEmpty=/etc/everest/config.yaml
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/manager --conf /etc/everest/config.yaml
+ExecStart=/usr/bin/manager --config /etc/everest/config.yaml
 
 [Install]
 WantedBy=multi-user.target

--- a/yocto/scarthgap/meta-everest/recipes-core/everest/everest-core/everest.service
+++ b/yocto/scarthgap/meta-everest/recipes-core/everest/everest-core/everest.service
@@ -7,7 +7,7 @@ ConditionFileNotEmpty=/etc/everest/config.yaml
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/manager --conf /etc/everest/config.yaml
+ExecStart=/usr/bin/manager --config /etc/everest/config.yaml
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Describe your changes

The manager executable does fuzzy matching of CLI arguments (implemented by Boost.Program_options).

This PR disables the fuzzyness: forbids boost::po to guess the best match.

To fix this in a non-breaking way, "--conf" was added as an explicit option (in addition to "--config").

### Reason

The CLI option in question is "--config". However, the auto-generated run-scripts and many examples used "--conf".
Introduction of a "--configuration-api" option (to come in a later PR) created a collision: The fuzzy matcher could not longer match "--conf" to "--config" since "--configuration-api" is an equally good match).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

