### PR TITLE
Feature(framework): Allow to set an MQTT LWT

### DIFF
--- a/lib/everest/framework/include/utils/mqtt_abstraction.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction.hpp
@@ -52,6 +52,20 @@ public:
     /// \brief unsubscribes from the given \p topic
     virtual void unsubscribe(const std::string& topic) = 0;
 
+    /// \brief sets a last-will-testament publishing \p json on the given \p topic
+    ///
+    /// MQTT allows exactly one last-will-testament per connection, and it must be set before connect().
+    /// \returns true if the last-will-testament was set, false otherwise (already set, called after connect,
+    ///          empty topic, or an underlying error)
+    virtual bool set_lwt(const std::string& topic, const nlohmann::json& json, QOS qos = QOS::QOS2,
+                         bool retain = true) = 0;
+
+    /// \brief sets a last-will-testament publishing \p data on the given \p topic
+    ///
+    /// \see set_lwt(const std::string&, const nlohmann::json&, QOS, bool)
+    virtual bool set_lwt(const std::string& topic, const std::string& data, QOS qos = QOS::QOS2,
+                         bool retain = true) = 0;
+
     /// \brief clears any previously published topics that had the retain flag set
     virtual void clear_retained_topics() = 0;
 

--- a/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
+++ b/lib/everest/framework/include/utils/mqtt_abstraction_impl.hpp
@@ -58,6 +58,9 @@ public:
     void subscribe(const std::string& topic, QOS qos) override;
     void unsubscribe(const std::string& topic) override;
     void clear_retained_topics() override;
+    bool set_lwt(const std::string& topic, const nlohmann::json& json, QOS qos = QOS::QOS2,
+                 bool retain = true) override;
+    bool set_lwt(const std::string& topic, const std::string& data, QOS qos = QOS::QOS2, bool retain = true) override;
     nlohmann::json get(const MQTTRequest& request, std::size_t retries = 0) override;
     nlohmann::json get(const std::string& topic, QOS qos, std::size_t retries = 0) override;
     const std::string& get_everest_prefix() const override;
@@ -84,6 +87,7 @@ private:
 
     std::atomic_bool mqtt_is_connected;
     std::atomic_bool running;
+    std::atomic_bool lwt_set{false};
     MessageHandler message_handler;
     everest::lib::util::simple_queue<Message> message_queue;
 

--- a/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
+++ b/lib/everest/framework/lib/mqtt_abstraction_impl.cpp
@@ -197,6 +197,44 @@ void MQTTAbstractionImpl::publish(const std::string& topic, const std::string& d
                                  static_cast<int>(qos), static_cast<int>(retain));
 }
 
+bool MQTTAbstractionImpl::set_lwt(const std::string& topic, const json& json, QOS qos, bool retain) {
+    BOOST_LOG_FUNCTION();
+
+    return set_lwt(topic, json.dump(), qos, retain);
+}
+
+bool MQTTAbstractionImpl::set_lwt(const std::string& topic, const std::string& data, QOS qos, bool retain) {
+    BOOST_LOG_FUNCTION();
+
+    if (topic.empty()) {
+        EVLOG_warning << "Ignoring last-will-testament with empty topic";
+        return false;
+    }
+
+    // An MQTT connection allows only a single last-will-testament, and it must be registered before connect().
+    if (this->mqtt_is_connected) {
+        EVLOG_error << "Cannot set last-will-testament after the MQTT connection has been established";
+        return false;
+    }
+    if (this->lwt_set) {
+        EVLOG_error << "A last-will-testament has already been set; it can only be set once";
+        return false;
+    }
+
+    const auto mqtt_qos = to_io_qos(qos, everest::lib::io::mqtt::mqtt_client::QoS::at_most_once);
+    const auto error = this->mqtt_client->set_will(topic, data, mqtt_qos, retain, {});
+    if (error != everest::lib::io::mqtt::ErrorCode::Success) {
+        EVLOG_error << "MQTT error while setting last-will-testament";
+        // leave lwt_set false so a corrected call may retry
+        return false;
+    }
+
+    this->lwt_set = true;
+    EVLOG_verbose << fmt::format("set last-will-testament on topic: {} with payload: {} and qos: {} and retain: {}",
+                                 topic, data, static_cast<int>(qos), static_cast<int>(retain));
+    return true;
+}
+
 void MQTTAbstractionImpl::subscribe(const std::string& topic) {
     BOOST_LOG_FUNCTION();
 

--- a/lib/everest/framework/tests/CMakeLists.txt
+++ b/lib/everest/framework/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(${TEST_TARGET_NAME} PRIVATE
     test_helpers.cpp
     test_message_handler.cpp
     test_message_handler_scaling_policy.cpp
+    test_mqtt_abstraction.cpp
     helpers.cpp
 )
 
@@ -35,6 +36,7 @@ add_subdirectory(controller)
 target_link_libraries(${TEST_TARGET_NAME}
     PRIVATE
         everest::framework
+        everest::io
         everest::log
         everest::sqlite
         Catch2::Catch2WithMain

--- a/lib/everest/framework/tests/include/tests/mock_mqtt_abstraction.hpp
+++ b/lib/everest/framework/tests/include/tests/mock_mqtt_abstraction.hpp
@@ -51,6 +51,11 @@ public:
         return m_handlers;
     }
 
+    /// \brief Returns the (topic, payload) of the last last-will-testament set via set_lwt(), if any.
+    const std::optional<std::pair<std::string, nlohmann::json>>& last_lwt() const {
+        return m_lwt;
+    }
+
     // --- MQTTAbstraction overrides ---
 
     nlohmann::json get(const MQTTRequest& request, std::size_t /*retries*/ = 0) override {
@@ -102,6 +107,16 @@ public:
     }
     void unsubscribe(const std::string& /*topic*/) override {
     }
+    bool set_lwt(const std::string& topic, const nlohmann::json& json, QOS /*qos*/ = QOS::QOS2,
+                 bool /*retain*/ = true) override {
+        m_lwt = std::make_pair(topic, json);
+        return true;
+    }
+    bool set_lwt(const std::string& topic, const std::string& data, QOS /*qos*/ = QOS::QOS2,
+                 bool /*retain*/ = true) override {
+        m_lwt = std::make_pair(topic, nlohmann::json(data));
+        return true;
+    }
     void clear_retained_topics() override {
     }
     std::shared_future<void> spawn_main_loop_thread() override {
@@ -126,6 +141,7 @@ private:
     std::optional<MQTTRequest> m_last_get_request;
     std::vector<std::pair<std::string, nlohmann::json>> m_published;
     std::unordered_map<std::string, std::shared_ptr<TypedHandler>> m_handlers;
+    std::optional<std::pair<std::string, nlohmann::json>> m_lwt;
 };
 
 } // namespace tests

--- a/lib/everest/framework/tests/test_mqtt_abstraction.cpp
+++ b/lib/everest/framework/tests/test_mqtt_abstraction.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <utils/config/mqtt_settings.hpp>
+#include <utils/mqtt_abstraction_impl.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <string>
+
+using namespace Everest;
+
+namespace {
+
+// The instance is never connected; set_lwt() only operates on the local mosquitto
+// handle, so no broker is required.
+MQTTSettings test_settings() {
+    return create_mqtt_settings("localhost", 1883, "everest/", "external/");
+}
+
+} // namespace
+
+TEST_CASE("set_lwt rejects an empty topic", "[mqtt][lwt]") {
+    MQTTAbstractionImpl impl{test_settings()};
+
+    CHECK_FALSE(impl.set_lwt("", std::string{"payload"}));
+
+    SECTION("json overload") {
+        CHECK_FALSE(impl.set_lwt("", nlohmann::json{{"key", "value"}}));
+    }
+
+    SECTION("a rejected call does not consume the single LWT slot") {
+        CHECK(impl.set_lwt("some/topic", std::string{"payload"}));
+    }
+}
+
+TEST_CASE("set_lwt succeeds before connect", "[mqtt][lwt]") {
+    MQTTAbstractionImpl impl{test_settings()};
+
+    SECTION("string overload") {
+        CHECK(impl.set_lwt("some/topic", std::string{"payload"}));
+    }
+
+    SECTION("json overload") {
+        CHECK(impl.set_lwt("some/topic", nlohmann::json{{"key", "value"}}));
+    }
+}
+
+TEST_CASE("set_lwt can only be set once", "[mqtt][lwt]") {
+    MQTTAbstractionImpl impl{test_settings()};
+
+    REQUIRE(impl.set_lwt("some/topic", std::string{"payload"}));
+
+    SECTION("same topic, string overload") {
+        CHECK_FALSE(impl.set_lwt("some/topic", std::string{"other payload"}));
+    }
+
+    SECTION("different topic, string overload") {
+        CHECK_FALSE(impl.set_lwt("other/topic", std::string{"payload"}));
+    }
+
+    SECTION("json overload") {
+        CHECK_FALSE(impl.set_lwt("other/topic", nlohmann::json{{"key", "value"}}));
+    }
+}

--- a/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
+++ b/modules/EVSE/OCPPmulti/tests/stubs/interfaces_stub.hpp
@@ -49,6 +49,12 @@ struct MqttStub : public Everest::MQTTAbstraction {
     }
     void unsubscribe(const std::string& topic) override {
     }
+    bool set_lwt(const std::string& topic, const json& json, QOS qos = QOS::QOS2, bool retain = true) override {
+        return true;
+    }
+    bool set_lwt(const std::string& topic, const std::string& data, QOS qos = QOS::QOS2, bool retain = true) override {
+        return true;
+    }
     void clear_retained_topics() override {
     }
     nlohmann::json get(const std::string& topic, QOS qos, std::size_t retries = 0) override {


### PR DESCRIPTION
## Describe your changes

This PR allows to set a last-will-and-testament (LWT) via the mqtt_abstraction. This feature is not available from the modules but only from the manager.
In MQTT LWT works such, that for one connection only a single LWT can be defined. The implementation will therefore accept setting the LWT once and fail any further attempts. Setting the LWT must happen before the connection is set up.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

