### PR TITLE
chore(sqlite): Add per-transaction fkey modes and harden transactions

### DIFF
--- a/lib/everest/ocpp/tests/lib/ocpp/v16/database_stub.hpp
+++ b/lib/everest/ocpp/tests/lib/ocpp/v16/database_stub.hpp
@@ -103,6 +103,15 @@ struct DatabaseConnectionTest : public ConnectionInterface {
     virtual std::unique_ptr<TransactionInterface> begin_transaction() {
         return std::unique_ptr<TransactionInterface>{};
     }
+    virtual std::unique_ptr<TransactionInterface> begin_transaction_with_enforced_fkeys() {
+        return std::unique_ptr<TransactionInterface>{};
+    }
+    virtual std::unique_ptr<TransactionInterface> begin_transaction_with_deferred_fkeys() {
+        return std::unique_ptr<TransactionInterface>{};
+    }
+    virtual std::unique_ptr<TransactionInterface> begin_transaction_with_disabled_fkeys() {
+        return std::unique_ptr<TransactionInterface>{};
+    }
     virtual bool commit_transaction() {
         return true;
     }

--- a/lib/everest/sqlite/include/everest/database/sqlite/connection.hpp
+++ b/lib/everest/sqlite/include/everest/database/sqlite/connection.hpp
@@ -48,6 +48,8 @@ public:
     virtual bool close_connection() = 0;
 
     /// \brief Start a transaction on the database. Returns an object holding the transaction.
+    ///        The connection's current foreign-key enforcement state is inherited and left
+    ///        untouched.
     /// \note This function can block until the previous transaction is finished.
     [[nodiscard]] virtual std::unique_ptr<TransactionInterface> begin_transaction() = 0;
 
@@ -72,6 +74,21 @@ public:
 
     /// \brief Helper function to get the user version of the database.
     virtual uint32_t get_user_version() = 0;
+
+    /// \brief Same as begin_transaction() but foreign_keys constraints are enforced for the
+    ///        duration of the transaction; the connection's previous foreign-key state is
+    ///        restored when the transaction ends
+    [[nodiscard]] virtual std::unique_ptr<TransactionInterface> begin_transaction_with_enforced_fkeys() = 0;
+
+    /// \brief Same as begin_transaction_with_enforced_fkeys() but constraints are only checked
+    ///        at commit time (deferred)
+    [[nodiscard]] virtual std::unique_ptr<TransactionInterface> begin_transaction_with_deferred_fkeys() = 0;
+
+    /// \brief Same as begin_transaction() but foreign_keys constraints are disabled for the
+    ///        duration of the transaction; the connection's previous foreign-key state is
+    ///        restored when the transaction ends. Intended for schema migrations that drop and
+    ///        recreate referenced tables.
+    [[nodiscard]] virtual std::unique_ptr<TransactionInterface> begin_transaction_with_disabled_fkeys() = 0;
 };
 
 class Connection : public ConnectionInterface {
@@ -92,11 +109,17 @@ public:
     bool close_connection() override;
 
     [[nodiscard]] std::unique_ptr<TransactionInterface> begin_transaction() override;
+    [[nodiscard]] std::unique_ptr<TransactionInterface> begin_transaction_with_enforced_fkeys() override;
+    [[nodiscard]] std::unique_ptr<TransactionInterface> begin_transaction_with_deferred_fkeys() override;
+    [[nodiscard]] std::unique_ptr<TransactionInterface> begin_transaction_with_disabled_fkeys() override;
 
     bool execute_statement(const std::string& statement) override;
     std::unique_ptr<StatementInterface> new_statement(const std::string& sql) override;
 
     const char* get_error_message() override;
+
+    /// \brief Returns true while a transaction is open on this connection (autocommit disabled).
+    [[nodiscard]] bool has_pending_transaction() const;
 
     bool clear_table(const std::string& table) override;
 

--- a/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
+++ b/lib/everest/sqlite/lib/everest/database/sqlite/connection.cpp
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <optional>
+#include <stdexcept>
 
 #include <everest/database/exceptions.hpp>
 #include <everest/database/sqlite/connection.hpp>
@@ -18,37 +20,146 @@ constexpr auto UNKNOWN_SQL_ERROR{"<unknown>"};
 
 namespace everest::db::sqlite {
 
+/// \brief Foreign key handling for the duration of one transaction.
+///
+/// Except for Inherit, the connection-wide "PRAGMA foreign_keys" state is captured before the
+/// transaction begins and restored after it ends, so a transaction never leaks its foreign-key
+/// mode into subsequent statements on the (possibly shared) connection.
+enum class FkMode {
+    Inherit,  ///< keep whatever foreign-key state the connection currently has
+    Enforced, ///< constraints are enforced on every statement
+    Deferred, ///< constraints are enforced at commit time only
+    Disabled  ///< constraints are not enforced (e.g. for schema migrations)
+};
+
 class DatabaseTransaction : public TransactionInterface {
 private:
     Connection& database;
-    std::unique_lock<std::timed_mutex> mutex;
+    std::unique_lock<std::timed_mutex> lock;
+    bool is_active = false;
+    std::optional<bool> restore_fk_state;
+
+    bool query_fk_state() {
+        auto statement = this->database.new_statement("PRAGMA foreign_keys;");
+        if (statement->step() != SQLITE_ROW) {
+            throw QueryExecutionException("Failed to query foreign_keys state");
+        }
+        return statement->column_int(0) != 0;
+    }
+
+    // Restore the connection-wide "PRAGMA foreign_keys" state captured in the constructor. Must
+    // run after COMMIT/ROLLBACK (the pragma is a no-op while a transaction is pending) and while
+    // the transaction mutex is still held, so no other transaction can observe the temporary
+    // state.
+    void restore_fk_state_if_needed() noexcept {
+        if (!this->restore_fk_state.has_value()) {
+            return;
+        }
+        const bool value = this->restore_fk_state.value();
+        this->restore_fk_state.reset();
+        if (!this->database.execute_statement(value ? "PRAGMA foreign_keys = ON;" : "PRAGMA foreign_keys = OFF;")) {
+            EVLOG_critical << "Failed to restore foreign_keys state after transaction: "
+                           << this->database.get_error_message();
+        }
+    }
 
 public:
-    DatabaseTransaction(Connection& database, std::unique_lock<std::timed_mutex> mutex) :
-        database{database}, mutex{std::move(mutex)} {
-        this->database.execute_statement("BEGIN TRANSACTION");
+    DatabaseTransaction(Connection& database, std::unique_lock<std::timed_mutex> lock, FkMode fk_mode) :
+        database{database}, lock{std::move(lock)} {
+        if (!this->lock.owns_lock()) {
+            throw std::logic_error("DatabaseTransaction requires ownership of the transaction mutex");
+        }
+
+        // All pragmas run *before* BEGIN. "PRAGMA foreign_keys" would be a no-op while a
+        // BEGIN/SAVEPOINT is pending. "PRAGMA defer_foreign_keys" applies to the next transaction
+        // and resets at COMMIT/ROLLBACK; it allows constraints to be broken temporarily within the
+        // transaction. Ordering them before BEGIN also means no exception can escape this
+        // constructor while a transaction is open.
+        //
+        // "PRAGMA foreign_keys" is sticky on the connection (it survives COMMIT/ROLLBACK), so the
+        // previous state is captured here and restored when the transaction ends. FkMode::Inherit
+        // leaves the connection state untouched.
+        if (fk_mode != FkMode::Inherit) {
+            const bool desired = (fk_mode != FkMode::Disabled);
+            const bool current = query_fk_state();
+            if (current != desired) {
+                if (!this->database.execute_statement(desired ? "PRAGMA foreign_keys = ON;"
+                                                              : "PRAGMA foreign_keys = OFF;")) {
+                    throw QueryExecutionException("Failed to set foreign_keys state");
+                }
+                this->restore_fk_state = current;
+            }
+            if (fk_mode == FkMode::Deferred && !this->database.execute_statement("PRAGMA defer_foreign_keys = ON;")) {
+                restore_fk_state_if_needed();
+                throw QueryExecutionException("Failed to defer foreign keys");
+            }
+        }
+
+        if (!this->database.execute_statement("BEGIN TRANSACTION")) {
+            restore_fk_state_if_needed();
+            throw QueryExecutionException("Failed to begin transaction");
+        }
+        is_active = true;
     }
+    DatabaseTransaction(const DatabaseTransaction&) = delete;
+    DatabaseTransaction& operator=(const DatabaseTransaction&) = delete;
 
     // Will by default rollback the transaction if destructed
     ~DatabaseTransaction() override {
-        if (this->mutex.owns_lock()) {
-            this->rollback();
+        if (is_active) {
+            if (!this->database.execute_statement("ROLLBACK TRANSACTION")) {
+                EVLOG_critical << "Failed to rollback transaction in destructor. Database may be in an inconsistent "
+                                  "state: "
+                               << this->database.get_error_message();
+            }
         }
+        // No-op if commit()/rollback() already ran (they restore before releasing the lock).
+        restore_fk_state_if_needed();
     }
 
     void commit() override {
-        const auto retval = this->database.execute_statement("COMMIT TRANSACTION");
-        this->mutex.unlock();
-        if (not retval) {
-            throw QueryExecutionException(this->database.get_error_message());
+        if (!is_active) {
+            return;
         }
+        is_active = false;
+        if (this->database.execute_statement("COMMIT TRANSACTION")) {
+            restore_fk_state_if_needed();
+            this->lock.unlock();
+            return;
+        }
+        // A failed COMMIT (e.g. SQLITE_BUSY) can leave the transaction open.
+        // Resolve that state before releasing the lock.
+        // The error message is captured first: the ROLLBACK below would overwrite it.
+        const std::string error_message = this->database.get_error_message();
+        if (this->database.has_pending_transaction() && !this->database.execute_statement("ROLLBACK TRANSACTION")) {
+            EVLOG_critical << "Failed to rollback after failed commit. Database may be in an inconsistent state: "
+                           << this->database.get_error_message();
+        }
+        restore_fk_state_if_needed();
+        this->lock.unlock();
+        throw QueryExecutionException(error_message);
     }
+
     void rollback() override {
-        const auto retval = this->database.execute_statement("ROLLBACK TRANSACTION");
-        this->mutex.unlock();
-        if (not retval) {
-            throw QueryExecutionException(this->database.get_error_message());
+        if (!is_active) {
+            return;
         }
+        is_active = false;
+        if (this->database.execute_statement("ROLLBACK TRANSACTION")) {
+            restore_fk_state_if_needed();
+            this->lock.unlock();
+            return;
+        }
+        // A failed ROLLBACK can leave the transaction open and is not mitigated.
+        const std::string error_message = this->database.get_error_message();
+        if (this->database.has_pending_transaction()) {
+            EVLOG_critical << "Transaction still pending after failed rollback. Database may be in an inconsistent "
+                              "state: "
+                           << error_message;
+        }
+        restore_fk_state_if_needed();
+        this->lock.unlock();
+        throw QueryExecutionException(error_message);
     }
 };
 
@@ -75,12 +186,25 @@ bool Connection::open_connection() {
                            this->database_file_path.string().find("mode=memory") != std::string::npos;
 
     if (!in_memory && !fs::exists(this->database_file_path.parent_path())) {
-        fs::create_directories(this->database_file_path.parent_path());
+        try {
+            fs::create_directories(this->database_file_path.parent_path());
+        } catch (...) {
+            // A failed open attempt must not count as an open, otherwise every subsequent
+            // open_connection() call would short-circuit to "already opened" with an
+            // unusable handle.
+            this->open_count.fetch_sub(1);
+            throw;
+        }
     }
 
     if (sqlite3_open_v2(this->database_file_path.c_str(), &this->db,
                         SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI, nullptr) != SQLITE_OK) {
         EVLOG_error << "Error opening database at " << this->database_file_path << ": " << sqlite3_errmsg(db);
+        // sqlite3_open_v2 usually allocates a handle even on failure; release it so a later
+        // attempt starts from a clean state, and undo the refcount increment (see above).
+        sqlite3_close_v2(this->db);
+        this->db = nullptr;
+        this->open_count.fetch_sub(1);
         return false;
     }
     // Retry briefly on SQLITE_BUSY instead of failing immediately, so a reader that races with a
@@ -159,8 +283,24 @@ const char* Connection::get_error_message() {
     return sqlite3_errmsg(this->db);
 }
 
+bool Connection::has_pending_transaction() const {
+    return sqlite3_get_autocommit(this->db) == 0;
+}
+
 std::unique_ptr<TransactionInterface> Connection::begin_transaction() {
-    return std::make_unique<DatabaseTransaction>(*this, std::unique_lock(this->transaction_mutex));
+    return std::make_unique<DatabaseTransaction>(*this, std::unique_lock(this->transaction_mutex), FkMode::Inherit);
+}
+
+std::unique_ptr<TransactionInterface> Connection::begin_transaction_with_enforced_fkeys() {
+    return std::make_unique<DatabaseTransaction>(*this, std::unique_lock(this->transaction_mutex), FkMode::Enforced);
+}
+
+std::unique_ptr<TransactionInterface> Connection::begin_transaction_with_deferred_fkeys() {
+    return std::make_unique<DatabaseTransaction>(*this, std::unique_lock(this->transaction_mutex), FkMode::Deferred);
+}
+
+std::unique_ptr<TransactionInterface> Connection::begin_transaction_with_disabled_fkeys() {
+    return std::make_unique<DatabaseTransaction>(*this, std::unique_lock(this->transaction_mutex), FkMode::Disabled);
 }
 
 std::unique_ptr<StatementInterface> Connection::new_statement(const std::string& sql) {

--- a/lib/everest/sqlite/lib/everest/database/sqlite/schema_updater.cpp
+++ b/lib/everest/sqlite/lib/everest/database/sqlite/schema_updater.cpp
@@ -153,14 +153,14 @@ bool SchemaUpdater::apply_migration_files(const fs::path& migration_file_directo
     try {
         this->database->open_connection();
         current_version = this->database->get_user_version();
-        EVLOG_info << "Target version: " << target_schema_version << ", current version: " << current_version;
+        EVLOG_debug << "Target version: " << target_schema_version << ", current version: " << current_version;
     } catch (std::runtime_error& e) {
         EVLOG_error << "Failure during migration file apply: " << e.what();
         return false;
     }
 
     if (current_version == target_schema_version) {
-        EVLOG_info << "No migrations to apply since versions match";
+        EVLOG_debug << "No migrations to apply since versions match";
         this->database->close_connection();
         return true;
     }
@@ -182,7 +182,12 @@ bool SchemaUpdater::apply_migration_files(const fs::path& migration_file_directo
 
     bool retval = true;
     try {
-        auto transaction = this->database->begin_transaction();
+        // Migrations may drop and recreate tables that other tables reference, so foreign-key
+        // enforcement must be disabled for the duration of the migration transaction. Setting
+        // the mode here is authoritative: "PRAGMA foreign_keys" statements inside the migration
+        // files themselves would be silent no-ops, because that pragma does nothing while a
+        // transaction is pending.
+        auto transaction = this->database->begin_transaction_with_disabled_fkeys();
 
         for (const auto& item : list.value()) {
             const std::ifstream stream{item.path.string()};

--- a/lib/everest/sqlite/tests/CMakeLists.txt
+++ b/lib/everest/sqlite/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${TEST_TARGET_NAME} PRIVATE
     test_connection.cpp
     test_database_schema_updater.cpp
     test_sqlite_statement.cpp
+    test_transaction.cpp
 )
 
 target_include_directories(${TEST_TARGET_NAME} PRIVATE

--- a/lib/everest/sqlite/tests/test_connection.cpp
+++ b/lib/everest/sqlite/tests/test_connection.cpp
@@ -54,6 +54,23 @@ TEST_F(ConnectionWalTest, InMemoryDatabaseOpensWithoutWalFailure) {
     db.close_connection();
 }
 
+TEST_F(ConnectionWalTest, FailedOpenDoesNotLeakOpenCount) {
+    // A directory cannot be opened as a database file, so every open attempt fails.
+    fs::create_directories(db_path);
+    Connection db(db_path);
+
+    EXPECT_FALSE(db.open_connection());
+    // Before the refcount fix the failed attempt above leaked an open_count increment,
+    // making this second call short-circuit to "already opened" with an unusable handle.
+    EXPECT_FALSE(db.open_connection());
+
+    // Once the obstacle is gone, the same Connection can be opened normally.
+    fs::remove(db_path);
+    EXPECT_TRUE(db.open_connection());
+    EXPECT_TRUE(db.execute_statement("CREATE TABLE t(id INTEGER);"));
+    db.close_connection();
+}
+
 TEST_F(ConnectionWalTest, ExistingRollbackDatabaseMigratesToWal) {
     sqlite3* raw = nullptr;
     ASSERT_EQ(sqlite3_open_v2(db_path.c_str(), &raw, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr), SQLITE_OK);

--- a/lib/everest/sqlite/tests/test_transaction.cpp
+++ b/lib/everest/sqlite/tests/test_transaction.cpp
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2025 Pionix GmbH and Contributors to EVerest
+
+#include <everest/database/exceptions.hpp>
+#include <everest/database/sqlite/connection.hpp>
+#include <everest/database/sqlite/statement.hpp>
+#include <gtest/gtest.h>
+#include <sqlite3.h>
+
+#include <filesystem>
+#include <memory>
+
+namespace fs = std::filesystem;
+
+namespace everest::db::sqlite {
+
+class TransactionTest : public ::testing::Test {
+protected:
+    std::unique_ptr<Connection> db;
+
+    void SetUp() override {
+        db = std::make_unique<Connection>(fs::path("file::memory:?cache=shared"));
+        ASSERT_TRUE(db->open_connection());
+
+        // Enforce foreign key constraints so the deferred-fkeys behaviour is observable.
+        ASSERT_TRUE(db->execute_statement("PRAGMA foreign_keys = ON;"));
+
+        ASSERT_TRUE(db->execute_statement("CREATE TABLE parent (id INTEGER PRIMARY KEY);"));
+        ASSERT_TRUE(db->execute_statement(
+            "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));"));
+    }
+
+    void TearDown() override {
+        db->close_connection();
+    }
+
+    int count_rows(const std::string& table) {
+        auto stmt = db->new_statement("SELECT COUNT(*) FROM " + table + ";");
+        EXPECT_EQ(stmt->step(), SQLITE_ROW);
+        return stmt->column_int(0);
+    }
+
+    void insert_parent(int id) {
+        ASSERT_TRUE(db->execute_statement("INSERT INTO parent (id) VALUES (" + std::to_string(id) + ");"));
+    }
+
+    bool try_insert_child(int id, int parent_id) {
+        auto stmt = db->new_statement("INSERT INTO child (id, parent_id) VALUES (?, ?);");
+        stmt->bind_int(1, id);
+        stmt->bind_int(2, parent_id);
+        return stmt->step() == SQLITE_DONE;
+    }
+
+    int foreign_keys_state() {
+        auto stmt = db->new_statement("PRAGMA foreign_keys;");
+        EXPECT_EQ(stmt->step(), SQLITE_ROW);
+        return stmt->column_int(0);
+    }
+};
+
+TEST_F(TransactionTest, BeginTransactionReturnsValidObject) {
+    auto transaction = db->begin_transaction();
+    ASSERT_NE(transaction, nullptr);
+}
+
+TEST_F(TransactionTest, CommitPersistsChanges) {
+    {
+        auto transaction = db->begin_transaction();
+        insert_parent(1);
+        transaction->commit();
+    }
+
+    EXPECT_EQ(count_rows("parent"), 1);
+}
+
+TEST_F(TransactionTest, RollbackDiscardsChanges) {
+    {
+        auto transaction = db->begin_transaction();
+        insert_parent(1);
+        transaction->rollback();
+    }
+
+    EXPECT_EQ(count_rows("parent"), 0);
+}
+
+TEST_F(TransactionTest, DestructorRollsBackUncommittedTransaction) {
+    {
+        auto transaction = db->begin_transaction();
+        insert_parent(1);
+        // No commit(): destruction must roll back.
+    }
+
+    EXPECT_EQ(count_rows("parent"), 0);
+}
+
+TEST_F(TransactionTest, DoubleCommitIsNoOp) {
+    auto transaction = db->begin_transaction();
+    insert_parent(1);
+    transaction->commit();
+    // Second commit must be a safe no-op and not throw.
+    EXPECT_NO_THROW(transaction->commit());
+
+    EXPECT_EQ(count_rows("parent"), 1);
+}
+
+TEST_F(TransactionTest, CommitAfterRollbackIsNoOp) {
+    auto transaction = db->begin_transaction();
+    insert_parent(1);
+    transaction->rollback();
+    EXPECT_NO_THROW(transaction->commit());
+
+    EXPECT_EQ(count_rows("parent"), 0);
+}
+
+TEST_F(TransactionTest, SequentialTransactionsReuseConnection) {
+    {
+        auto transaction = db->begin_transaction();
+        insert_parent(1);
+        transaction->commit();
+    }
+    {
+        auto transaction = db->begin_transaction();
+        insert_parent(2);
+        transaction->commit();
+    }
+
+    EXPECT_EQ(count_rows("parent"), 2);
+}
+
+TEST_F(TransactionTest, NonDeferredTransactionRejectsOutOfOrderInsert) {
+    auto transaction = db->begin_transaction_with_enforced_fkeys();
+    // Without deferred foreign keys the constraint is checked immediately, so
+    // inserting a child before its parent must fail.
+    EXPECT_FALSE(try_insert_child(1, 42));
+    transaction->rollback();
+}
+
+TEST_F(TransactionTest, PlainTransactionInheritsFkStateFromConnection) {
+    // A plain transaction inherits the connection's foreign-key state. The fixture
+    // enabled enforcement, so the violating insert is rejected.
+    {
+        auto transaction = db->begin_transaction();
+        EXPECT_FALSE(try_insert_child(1, 42));
+        transaction->rollback();
+    }
+
+    // With enforcement disabled on the connection, the same insert passes.
+    ASSERT_TRUE(db->execute_statement("PRAGMA foreign_keys = OFF;"));
+    {
+        auto transaction = db->begin_transaction();
+        EXPECT_TRUE(try_insert_child(1, 42));
+        transaction->rollback();
+    }
+    EXPECT_EQ(foreign_keys_state(), 0);
+}
+
+TEST_F(TransactionTest, PlainTransactionLeavesFkStateUntouched) {
+    // Regression guard: consumers (e.g. libocpp) enable foreign_keys once on the
+    // connection and expect plain transactions not to change that state.
+    {
+        auto transaction = db->begin_transaction();
+        insert_parent(1);
+        transaction->commit();
+    }
+
+    EXPECT_EQ(foreign_keys_state(), 1);
+    // Enforcement must still be active outside any transaction.
+    EXPECT_FALSE(try_insert_child(1, 42));
+}
+
+TEST_F(TransactionTest, EnforcedFkeysRestoresPriorStateAfterCommit) {
+    ASSERT_TRUE(db->execute_statement("PRAGMA foreign_keys = OFF;"));
+    {
+        auto transaction = db->begin_transaction_with_enforced_fkeys();
+        EXPECT_FALSE(try_insert_child(1, 42));
+        insert_parent(1);
+        transaction->commit();
+    }
+
+    // The transaction enforced constraints, but the connection state is restored.
+    EXPECT_EQ(foreign_keys_state(), 0);
+}
+
+TEST_F(TransactionTest, DeferredFkeysRestoresPriorStateAfterFailedCommit) {
+    ASSERT_TRUE(db->execute_statement("PRAGMA foreign_keys = OFF;"));
+    auto transaction = db->begin_transaction_with_deferred_fkeys();
+    ASSERT_TRUE(try_insert_child(1, 99));
+    EXPECT_THROW(transaction->commit(), QueryExecutionException);
+
+    EXPECT_FALSE(db->has_pending_transaction());
+    EXPECT_EQ(foreign_keys_state(), 0);
+}
+
+TEST_F(TransactionTest, DisabledFkeysAllowsViolationsAndRestoresState) {
+    {
+        auto transaction = db->begin_transaction_with_disabled_fkeys();
+        // A dangling reference is permitted while enforcement is disabled.
+        EXPECT_TRUE(try_insert_child(1, 42));
+        transaction->commit();
+    }
+
+    // The fixture's enforcement state is restored after the transaction.
+    EXPECT_EQ(foreign_keys_state(), 1);
+    EXPECT_FALSE(try_insert_child(2, 43));
+}
+
+TEST_F(TransactionTest, DisabledFkeysRestoresStateOnRollback) {
+    {
+        auto transaction = db->begin_transaction_with_disabled_fkeys();
+        EXPECT_TRUE(try_insert_child(1, 42));
+        transaction->rollback();
+    }
+
+    EXPECT_EQ(foreign_keys_state(), 1);
+}
+
+TEST_F(TransactionTest, DisabledFkeysRestoresStateOnDestruction) {
+    {
+        auto transaction = db->begin_transaction_with_disabled_fkeys();
+        EXPECT_TRUE(try_insert_child(1, 42));
+        // No commit(): destruction must roll back and restore the state.
+    }
+
+    EXPECT_EQ(foreign_keys_state(), 1);
+    EXPECT_EQ(count_rows("child"), 0);
+}
+
+TEST_F(TransactionTest, DeferredFkeysAllowsOutOfOrderInsert) {
+    {
+        auto transaction = db->begin_transaction_with_deferred_fkeys();
+        // Child references a parent that does not exist yet; deferral postpones the
+        // constraint check until commit.
+        ASSERT_TRUE(try_insert_child(1, 1));
+        insert_parent(1);
+        transaction->commit();
+    }
+
+    EXPECT_EQ(count_rows("child"), 1);
+    EXPECT_EQ(count_rows("parent"), 1);
+}
+
+TEST_F(TransactionTest, DeferredFkeysStillEnforcedAtCommit) {
+    auto transaction = db->begin_transaction_with_deferred_fkeys();
+    // Insert a child that references a parent which is never created. The
+    // violation is only detected at commit time, which must fail.
+    ASSERT_TRUE(try_insert_child(1, 99));
+    EXPECT_THROW(transaction->commit(), QueryExecutionException);
+
+    // The failed commit must resolve the transaction itself (rollback) before
+    // releasing the connection, so no pending transaction may remain.
+    EXPECT_FALSE(db->has_pending_transaction());
+    EXPECT_EQ(count_rows("child"), 0);
+
+    // The connection must be immediately usable for a follow-up transaction.
+    auto next_transaction = db->begin_transaction();
+    insert_parent(1);
+    next_transaction->commit();
+    EXPECT_EQ(count_rows("parent"), 1);
+}
+
+} // namespace everest::db::sqlite


### PR DESCRIPTION
## Describe your changes

Refactor sqlite lib.

DatabaseTransaction gains explicit foreign-key handling:
- begin_transaction() inherits the connection's foreign_keys state and never touches the pragma (unchanged behavior for existing consumers such as libocpp)
- begin_transaction_with_enforced_fkeys() / _deferred_fkeys() enforce constraints for the duration of the transaction (deferred: checked at commit time)
- new begin_transaction_with_disabled_fkeys() disables enforcement, for schema migrations that drop and recreate referenced tables

This refactor is preparing the bigger internal ConfigService changes.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

