### PR TITLE
fix(System): Use SIGTERM instead of SIGINT for System module rese

### DIFF
--- a/modules/Misc/System/main/systemImpl.cpp
+++ b/modules/Misc/System/main/systemImpl.cpp
@@ -530,10 +530,10 @@ void systemImpl::handle_reset(types::system::ResetType& type, bool& scheduled) {
 
         if (type == types::system::ResetType::Soft) {
             EVLOG_info << "Performing soft reset now.";
-            kill(getpid(), SIGINT);
+            kill(getpid(), SIGTERM);
         } else {
             EVLOG_info << "Performing hard reset now.";
-            kill(getpid(), SIGINT); // FIXME(piet): Define appropriate behavior for hard reset
+            kill(getpid(), SIGTERM); // FIXME(piet): Define appropriate behavior for hard reset
         }
     }).detach();
 }


### PR DESCRIPTION

## Describe your changes

Since d187e979f (PR #2048), the manager blocks SIGINT via sigprocmask to poll them through a signalfd, and forked module processes inherit that mask. The child-side fork code only unblocks SIGTERM and SIGCHLD; SIGINT is kept blocked.

Consequence: kill(getpid(), SIGINT) in a module no longer terminates it; the signal just sits pending forever, so handle_reset had become a silent no-op

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

