### PR TITLE
fix(cmake): make everest_api_types buildable in EVEREST_LIBS_ONLY mode

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -146,7 +146,7 @@ grpc-extended-cpp-plugin:
 nlohmann_json:
   git: https://github.com/nlohmann/json
   git_tag: v3.12.0
-  cmake_condition: "NOT EVEREST_LIBS_ONLY OR EVEREST_BUILD_LIB_ocpp OR EVEREST_BUILD_LIB_framework OR EVEREST_BUILD_LIB_helpers"
+  cmake_condition: "NOT EVEREST_LIBS_ONLY OR EVEREST_BUILD_LIB_ocpp OR EVEREST_BUILD_LIB_framework OR EVEREST_BUILD_LIB_helpers OR EVEREST_BUILD_LIB_everest_api_types"
   options: ["JSON_BuildTests OFF", "JSON_MultipleHeaders ON"]
 nlohmann_json_schema_validator:
   git: https://github.com/pboettch/json-schema-validator

--- a/lib/everest/everest_api_types/CMakeLists.txt
+++ b/lib/everest/everest_api_types/CMakeLists.txt
@@ -7,8 +7,6 @@ add_library(everest_api_types SHARED)
 add_library(everest::everest_api_types ALIAS everest_api_types)
 ev_register_library_target(everest_api_types)
 
-add_dependencies(everest_api_types generate_cpp_files)
-
 target_compile_options(everest_api_types
   PUBLIC  -Wall -Wextra -pedantic -Werror=switch)
 
@@ -25,7 +23,6 @@ target_include_directories(everest_api_types
 
   PRIVATE   "private_include/everest_api_types"
   PRIVATE   "include/everest_api_types"
-  PRIVATE   "${CMAKE_BINARY_DIR}/generated/include"
 )
 
 target_sources(everest_api_types
@@ -33,89 +30,69 @@ target_sources(everest_api_types
 
   src/everest_api_types/auth/codec.cpp
   src/everest_api_types/auth/json_codec.cpp
-  src/everest_api_types/auth/wrapper.cpp
 
   src/everest_api_types/dc_external_derate/codec.cpp
   src/everest_api_types/dc_external_derate/json_codec.cpp
-  src/everest_api_types/dc_external_derate/wrapper.cpp
 
   src/everest_api_types/display_message/codec.cpp
   src/everest_api_types/display_message/json_codec.cpp
-  src/everest_api_types/display_message/wrapper.cpp
 
   src/everest_api_types/energy/codec.cpp
   src/everest_api_types/energy/json_codec.cpp
-  src/everest_api_types/energy/wrapper.cpp
 
   src/everest_api_types/entrypoint/codec.cpp
   src/everest_api_types/entrypoint/json_codec.cpp
 
   src/everest_api_types/error_history/codec.cpp
   src/everest_api_types/error_history/json_codec.cpp
-  src/everest_api_types/error_history/wrapper.cpp
 
   src/everest_api_types/ev_board_support/codec.cpp
   src/everest_api_types/ev_board_support/json_codec.cpp
-  src/everest_api_types/ev_board_support/wrapper.cpp
 
   src/everest_api_types/evse_board_support/codec.cpp
   src/everest_api_types/evse_board_support/json_codec.cpp
-  src/everest_api_types/evse_board_support/wrapper.cpp
 
   src/everest_api_types/evse_manager/codec.cpp
   src/everest_api_types/evse_manager/json_codec.cpp
-  src/everest_api_types/evse_manager/wrapper.cpp
 
   src/everest_api_types/evse_security/codec.cpp
   src/everest_api_types/evse_security/json_codec.cpp
-  src/everest_api_types/evse_security/wrapper.cpp
 
   src/everest_api_types/money/codec.cpp
   src/everest_api_types/money/json_codec.cpp
-  src/everest_api_types/money/wrapper.cpp
 
   src/everest_api_types/iso15118_charger/codec.cpp
   src/everest_api_types/iso15118_charger/json_codec.cpp
-  src/everest_api_types/iso15118_charger/wrapper.cpp
 
   src/everest_api_types/isolation_monitor/codec.cpp
   src/everest_api_types/isolation_monitor/json_codec.cpp
-  src/everest_api_types/isolation_monitor/wrapper.cpp
 
   src/everest_api_types/ocpp/codec.cpp
   src/everest_api_types/ocpp/json_codec.cpp
-  src/everest_api_types/ocpp/wrapper.cpp
 
   src/everest_api_types/over_voltage_monitor/codec.cpp
   src/everest_api_types/over_voltage_monitor/json_codec.cpp
 
   src/everest_api_types/power_supply_DC/codec.cpp
   src/everest_api_types/power_supply_DC/json_codec.cpp
-  src/everest_api_types/power_supply_DC/wrapper.cpp
 
   src/everest_api_types/powermeter/codec.cpp
   src/everest_api_types/powermeter/json_codec.cpp
-  src/everest_api_types/powermeter/wrapper.cpp
 
   src/everest_api_types/session_cost/codec.cpp
   src/everest_api_types/session_cost/json_codec.cpp
-  src/everest_api_types/session_cost/wrapper.cpp
 
   src/everest_api_types/slac/codec.cpp
   src/everest_api_types/slac/json_codec.cpp
-  src/everest_api_types/slac/wrapper.cpp
 
   src/everest_api_types/system/codec.cpp
   src/everest_api_types/system/json_codec.cpp
-  src/everest_api_types/system/wrapper.cpp
 
   src/everest_api_types/text_message/codec.cpp
   src/everest_api_types/text_message/json_codec.cpp
-  src/everest_api_types/text_message/wrapper.cpp
 
   src/everest_api_types/uk_random_delay/codec.cpp
   src/everest_api_types/uk_random_delay/json_codec.cpp
-  src/everest_api_types/uk_random_delay/wrapper.cpp
 
   src/everest_api_types/telemetry/codec.cpp
   src/everest_api_types/telemetry/json_codec.cpp
@@ -127,6 +104,43 @@ target_sources(everest_api_types
   src/everest_api_types/utilities/codec.cpp
   src/everest_api_types/utilities/Topics.cpp
 )
+
+# The wrapper layer converts between the stable API structs and the internal
+# ev-cli generated types, so it can only be built in a full everest-core
+# configure where code generation runs. In EVEREST_LIBS_ONLY mode the
+# generate_cpp_files target does not exist and the library is codec-only.
+if(TARGET generate_cpp_files)
+  add_dependencies(everest_api_types generate_cpp_files)
+
+  target_include_directories(everest_api_types
+    PRIVATE "${CMAKE_BINARY_DIR}/generated/include"
+  )
+
+  target_sources(everest_api_types
+    PRIVATE
+
+    src/everest_api_types/auth/wrapper.cpp
+    src/everest_api_types/dc_external_derate/wrapper.cpp
+    src/everest_api_types/display_message/wrapper.cpp
+    src/everest_api_types/energy/wrapper.cpp
+    src/everest_api_types/error_history/wrapper.cpp
+    src/everest_api_types/ev_board_support/wrapper.cpp
+    src/everest_api_types/evse_board_support/wrapper.cpp
+    src/everest_api_types/evse_manager/wrapper.cpp
+    src/everest_api_types/evse_security/wrapper.cpp
+    src/everest_api_types/money/wrapper.cpp
+    src/everest_api_types/iso15118_charger/wrapper.cpp
+    src/everest_api_types/isolation_monitor/wrapper.cpp
+    src/everest_api_types/ocpp/wrapper.cpp
+    src/everest_api_types/power_supply_DC/wrapper.cpp
+    src/everest_api_types/powermeter/wrapper.cpp
+    src/everest_api_types/session_cost/wrapper.cpp
+    src/everest_api_types/slac/wrapper.cpp
+    src/everest_api_types/system/wrapper.cpp
+    src/everest_api_types/text_message/wrapper.cpp
+    src/everest_api_types/uk_random_delay/wrapper.cpp
+  )
+endif()
 
 target_link_libraries(everest_api_types
   PRIVATE nlohmann_json::nlohmann_json


### PR DESCRIPTION

## Describe your changes

The library unconditionally depended on the generate_cpp_files target, which is only created by ev-project-bootstrap and therefore does not exist in EVEREST_LIBS_ONLY configures. In addition, nlohmann_json's cmake_condition did not cover EVEREST_BUILD_LIB_everest_api_types, so the nlohmann_json::nlohmann_json target it links was never added.

Split the library into a self-contained codec core and a wrapper layer: the generate_cpp_files dependency, the generated include dir and the wrapper sources (which convert to ev-cli generated internal types) are now guarded by if(TARGET generate_cpp_files). Full builds are unaffected; libs-only builds get a codec-only library. Also add EVEREST_BUILD_LIB_everest_api_types to nlohmann_json's cmake_condition.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

