### PR TITLE
fix(EvseManager): handle unplug, disable and fatal errors in timed charger states

### DIFF
--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -286,7 +286,10 @@ void Charger::run_state_machine() {
                     error_handling->raise_internal_error("Unsupported charging mode.");
                 }
 
-                if (hlc_use_5percent_current_session) {
+                // Skip the SLAC readiness sleep and do not enable 5 percent PWM if the EV is
+                // already unplugged: the checks directly below this initialization will bail
+                // out to Finished in the same state machine pass.
+                if (hlc_use_5percent_current_session and shared_context.flag_ev_plugged_in) {
                     // FIXME: wait for SLAC to be ready. Teslas are really fast with sending the first slac packet after
                     // enabling PWM.
                     std::this_thread::sleep_for(
@@ -584,11 +587,20 @@ void Charger::run_state_machine() {
                     cp_state_X1();
                 }
             }
-            if (time_in_current_state >= config_context.switch_3ph1ph_delay_s * 1000) {
-                session_log.evse(false, "Exit switching phases");
-                bsp->switch_three_phases_while_charging(shared_context.switch_3ph1ph_threephase);
-                shared_context.switch_3ph1ph_threephase_ongoing = false;
-                shared_context.current_state = internal_context.switching_phases_return_state;
+            {
+                const bool fatal_error = stop_charging_on_fatal_error_internal();
+                if (fatal_error or not shared_context.flag_ev_plugged_in or shared_context.flag_disable_requested) {
+                    // Unplug, disable or a fatal error during the switching break. Go back to
+                    // the return state, its checks will tear down the session. The pending
+                    // relay switch is still executed by the generic SwitchPhases cleanup above.
+                    session_log.evse(false, fmt::format("Exit switching phases: {}", stop_reason_flags(fatal_error)));
+                    shared_context.current_state = internal_context.switching_phases_return_state;
+                } else if (time_in_current_state >= config_context.switch_3ph1ph_delay_s * 1000) {
+                    session_log.evse(false, "Exit switching phases");
+                    bsp->switch_three_phases_while_charging(shared_context.switch_3ph1ph_threephase);
+                    shared_context.switch_3ph1ph_threephase_ongoing = false;
+                    shared_context.current_state = internal_context.switching_phases_return_state;
+                }
             }
             break;
 
@@ -597,6 +609,18 @@ void Charger::run_state_machine() {
                 session_log.evse(false, "Enter T_step_EF");
                 internal_context.t_step_ef_x1_pause = false;
                 cp_state_F();
+            }
+            {
+                const bool fatal_error = stop_charging_on_fatal_error_internal();
+                if (fatal_error or not shared_context.flag_ev_plugged_in or shared_context.flag_disable_requested) {
+                    // Unplug, disable or a fatal error during the sequence. Leave state F, but
+                    // do not restore PWM: go back to the return state, its checks will tear
+                    // down the session.
+                    session_log.evse(false, fmt::format("Exit T_step_EF: {}", stop_reason_flags(fatal_error)));
+                    cp_state_X1();
+                    shared_context.current_state = internal_context.t_step_EF_return_state;
+                    break;
+                }
             }
             if (time_in_current_state >= T_STEP_EF + STAY_IN_X1_AFTER_TSTEP_EF_MS) {
                 session_log.evse(false, "Exit T_step_EF");
@@ -622,6 +646,17 @@ void Charger::run_state_machine() {
             if (initialize_state) {
                 session_log.evse(false, "Enter T_step_X1");
                 cp_state_X1();
+            }
+            {
+                const bool fatal_error = stop_charging_on_fatal_error_internal();
+                if (fatal_error or not shared_context.flag_ev_plugged_in or shared_context.flag_disable_requested) {
+                    // Unplug, disable or a fatal error during the sequence. CP is already in
+                    // X1, do not restore PWM: go back to the return state, its checks will
+                    // tear down the session.
+                    session_log.evse(false, fmt::format("Exit T_step_X1: {}", stop_reason_flags(fatal_error)));
+                    shared_context.current_state = internal_context.t_step_X1_return_state;
+                    break;
+                }
             }
             if (time_in_current_state >= T_STEP_X1) {
                 session_log.evse(false, "Exit T_step_X1");


### PR DESCRIPTION
## Describe your changes

The `T_step_EF`, `T_step_X1` and `SwitchPhases` states of the charger state machine only checked their sequence timers. An unplug (or a disable request / fatal error) during these sequences was ignored until the timer expired:

- The session teardown was delayed by up to 3 s (`T_step_X1`), 4.75 s (`T_step_EF`) or the configured `switch_3ph1ph_delay_s`.
- On timer expiry the exit code unconditionally restored PWM (nominal in the legacy wakeup case, or 5 %), briefly signalling on an unplugged connector before the return state noticed the unplug.
- `SwitchPhases` actuated the phase switch relay for an EV that was already gone before unwinding.

These states now bail out to their stored return state immediately, without restoring PWM. The return state's existing flag checks decide the teardown path, so these transitional states do not have to decide themselves whether `StoppingCharging` is appropriate (charging may not have been started yet). For `SwitchPhases`, a pending relay switch is still executed exactly once by the generic SwitchPhases cleanup at the top of `run_state_machine()`.

Additionally, when entering `WaitingForAuthentication` with the EV already unplugged (e.g. returning from one of the states above), the SLAC readiness sleep (`sleep_before_enabling_pwm_hlc_mode_ms`, default 1 s, taken while holding the state machine mutex) and the 5 % PWM enable are skipped, so the bail-out to `Finished` is no longer delayed and does not flash 5 % PWM on a dead connector. The rest of the state entry (session start, `AuthRequired` event) is unchanged.

A side benefit: the window in which a fast unplug→replug loses the `CarPluggedIn` event (leaving a plugged EV stranded in `Idle`) shrinks from seconds to one state machine tick in these states, matching all other states.

## Issue ticket number and link

None.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://everest.github.io/nightly/project/contributing.html) and made sure that my changes meet its requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)